### PR TITLE
feat: add frontend phase 2 operations screens

### DIFF
--- a/backend/internal/domain/repository/order.go
+++ b/backend/internal/domain/repository/order.go
@@ -12,4 +12,5 @@ type OrderClient interface {
 	CancelOrder(ctx context.Context, symbolID, orderID int64) ([]entity.Order, error)
 	GetOrders(ctx context.Context, symbolID int64) ([]entity.Order, error)
 	GetPositions(ctx context.Context, symbolID int64) ([]entity.Position, error)
+	GetMyTrades(ctx context.Context, symbolID int64) ([]entity.MyTrade, error)
 }

--- a/backend/internal/interfaces/api/api_test.go
+++ b/backend/internal/interfaces/api/api_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -11,6 +12,32 @@ import (
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase"
 )
+
+type mockOrderClient struct{}
+
+func (m *mockOrderClient) CreateOrder(_ context.Context, _ entity.OrderRequest) ([]entity.Order, error) {
+	return nil, nil
+}
+
+func (m *mockOrderClient) CancelOrder(_ context.Context, _, _ int64) ([]entity.Order, error) {
+	return nil, nil
+}
+
+func (m *mockOrderClient) GetOrders(_ context.Context, _ int64) ([]entity.Order, error) {
+	return nil, nil
+}
+
+func (m *mockOrderClient) GetPositions(_ context.Context, _ int64) ([]entity.Position, error) {
+	return []entity.Position{
+		{ID: 1, SymbolID: 7, OrderSide: entity.OrderSideBuy, Price: 4500000, RemainingAmount: 0.01, FloatingProfit: 1200},
+	}, nil
+}
+
+func (m *mockOrderClient) GetMyTrades(_ context.Context, _ int64) ([]entity.MyTrade, error) {
+	return []entity.MyTrade{
+		{ID: 10, SymbolID: 7, OrderSide: entity.OrderSideBuy, Price: 4400000, Amount: 0.01, Profit: 900, Fee: 10, CreatedAt: 1700000000000},
+	}, nil
+}
 
 func setupRouter() *httptest.Server {
 	riskMgr := usecase.NewRiskManager(entity.RiskConfig{
@@ -26,6 +53,7 @@ func setupRouter() *httptest.Server {
 		RiskManager:         riskMgr,
 		LLMService:          llmSvc,
 		IndicatorCalculator: nil,
+		OrderClient:         &mockOrderClient{},
 	}
 
 	router := NewRouter(deps)
@@ -131,6 +159,70 @@ func TestGetPnL(t *testing.T) {
 	json.NewDecoder(resp.Body).Decode(&body)
 	if body["balance"] != float64(10000) {
 		t.Fatalf("expected balance 10000, got %v", body["balance"])
+	}
+}
+
+func TestBotStartStop(t *testing.T) {
+	ts := setupRouter()
+	defer ts.Close()
+
+	stopReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/stop", nil)
+	stopResp, err := http.DefaultClient.Do(stopReq)
+	if err != nil {
+		t.Fatalf("stop request failed: %v", err)
+	}
+	defer stopResp.Body.Close()
+
+	if stopResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 from stop, got %d", stopResp.StatusCode)
+	}
+
+	statusResp, err := http.Get(ts.URL + "/api/v1/status")
+	if err != nil {
+		t.Fatalf("status request failed: %v", err)
+	}
+	defer statusResp.Body.Close()
+
+	var statusBody map[string]interface{}
+	if err := json.NewDecoder(statusResp.Body).Decode(&statusBody); err != nil {
+		t.Fatalf("failed to decode status: %v", err)
+	}
+	if statusBody["status"] != "stopped" {
+		t.Fatalf("expected stopped status, got %v", statusBody["status"])
+	}
+
+	startReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/start", nil)
+	startResp, err := http.DefaultClient.Do(startReq)
+	if err != nil {
+		t.Fatalf("start request failed: %v", err)
+	}
+	defer startResp.Body.Close()
+
+	if startResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 from start, got %d", startResp.StatusCode)
+	}
+}
+
+func TestGetTrades(t *testing.T) {
+	ts := setupRouter()
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/api/v1/trades?symbolId=7")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var trades []entity.MyTrade
+	if err := json.NewDecoder(resp.Body).Decode(&trades); err != nil {
+		t.Fatalf("failed to decode trades: %v", err)
+	}
+	if len(trades) != 1 {
+		t.Fatalf("expected 1 trade, got %d", len(trades))
 	}
 }
 

--- a/backend/internal/interfaces/api/handler/bot.go
+++ b/backend/internal/interfaces/api/handler/bot.go
@@ -1,0 +1,36 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase"
+)
+
+type BotHandler struct {
+	riskMgr *usecase.RiskManager
+}
+
+func NewBotHandler(riskMgr *usecase.RiskManager) *BotHandler {
+	return &BotHandler{riskMgr: riskMgr}
+}
+
+func (h *BotHandler) Start(c *gin.Context) {
+	h.riskMgr.StartTrading()
+	status := h.riskMgr.GetStatus()
+	c.JSON(http.StatusOK, gin.H{
+		"status":          "running",
+		"tradingHalted":   status.TradingHalted,
+		"manuallyStopped": status.ManuallyStopped,
+	})
+}
+
+func (h *BotHandler) Stop(c *gin.Context) {
+	h.riskMgr.StopTrading()
+	status := h.riskMgr.GetStatus()
+	c.JSON(http.StatusOK, gin.H{
+		"status":          "stopped",
+		"tradingHalted":   status.TradingHalted,
+		"manuallyStopped": status.ManuallyStopped,
+	})
+}

--- a/backend/internal/interfaces/api/handler/status.go
+++ b/backend/internal/interfaces/api/handler/status.go
@@ -17,11 +17,17 @@ func NewStatusHandler(riskMgr *usecase.RiskManager) *StatusHandler {
 
 func (h *StatusHandler) GetStatus(c *gin.Context) {
 	status := h.riskMgr.GetStatus()
+	engineStatus := "running"
+	if status.ManuallyStopped {
+		engineStatus = "stopped"
+	}
+
 	c.JSON(http.StatusOK, gin.H{
-		"status":        "running",
-		"tradingHalted": status.TradingHalted,
-		"balance":       status.Balance,
-		"dailyLoss":     status.DailyLoss,
-		"totalPosition": status.TotalPosition,
+		"status":          engineStatus,
+		"tradingHalted":   status.TradingHalted,
+		"manuallyStopped": status.ManuallyStopped,
+		"balance":         status.Balance,
+		"dailyLoss":       status.DailyLoss,
+		"totalPosition":   status.TotalPosition,
 	})
 }

--- a/backend/internal/interfaces/api/handler/trade.go
+++ b/backend/internal/interfaces/api/handler/trade.go
@@ -1,0 +1,34 @@
+package handler
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/repository"
+)
+
+type TradeHandler struct {
+	orderClient repository.OrderClient
+}
+
+func NewTradeHandler(orderClient repository.OrderClient) *TradeHandler {
+	return &TradeHandler{orderClient: orderClient}
+}
+
+func (h *TradeHandler) GetTrades(c *gin.Context) {
+	symbolStr := c.DefaultQuery("symbolId", "7")
+	symbolID, err := strconv.ParseInt(symbolStr, 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid symbol ID"})
+		return
+	}
+
+	trades, err := h.orderClient.GetMyTrades(c.Request.Context(), symbolID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, trades)
+}

--- a/backend/internal/interfaces/api/router.go
+++ b/backend/internal/interfaces/api/router.go
@@ -30,6 +30,9 @@ func NewRouter(deps Dependencies) *gin.Engine {
 
 	statusHandler := handler.NewStatusHandler(deps.RiskManager)
 	v1.GET("/status", statusHandler.GetStatus)
+	botHandler := handler.NewBotHandler(deps.RiskManager)
+	v1.POST("/start", botHandler.Start)
+	v1.POST("/stop", botHandler.Stop)
 
 	riskHandler := handler.NewRiskHandler(deps.RiskManager)
 	v1.GET("/config", riskHandler.GetConfig)
@@ -50,6 +53,9 @@ func NewRouter(deps Dependencies) *gin.Engine {
 	if deps.OrderClient != nil {
 		positionHandler := handler.NewPositionHandler(deps.OrderClient)
 		v1.GET("/positions", positionHandler.GetPositions)
+
+		tradeHandler := handler.NewTradeHandler(deps.OrderClient)
+		v1.GET("/trades", tradeHandler.GetTrades)
 	}
 
 	return r

--- a/backend/internal/usecase/order_test.go
+++ b/backend/internal/usecase/order_test.go
@@ -50,6 +50,10 @@ func (m *mockOrderClient) GetPositions(ctx context.Context, symbolID int64) ([]e
 	return m.positions, nil
 }
 
+func (m *mockOrderClient) GetMyTrades(ctx context.Context, symbolID int64) ([]entity.MyTrade, error) {
+	return nil, nil
+}
+
 func TestOrderExecutor_ExecuteSignal_Buy(t *testing.T) {
 	orderClient := &mockOrderClient{
 		createdOrders: []entity.Order{

--- a/backend/internal/usecase/risk.go
+++ b/backend/internal/usecase/risk.go
@@ -13,6 +13,7 @@ type RiskStatus struct {
 	DailyLoss     float64           `json:"dailyLoss"`
 	TotalPosition float64           `json:"totalPosition"`
 	TradingHalted bool              `json:"tradingHalted"`
+	ManuallyStopped bool            `json:"manuallyStopped"`
 	Config        entity.RiskConfig `json:"config"`
 }
 
@@ -22,6 +23,7 @@ type RiskManager struct {
 	balance   float64
 	dailyLoss float64
 	positions []entity.Position
+	manualStop bool
 }
 
 func NewRiskManager(config entity.RiskConfig) *RiskManager {
@@ -40,6 +42,13 @@ func (rm *RiskManager) CheckOrder(ctx context.Context, proposal entity.OrderProp
 	defer rm.mu.RUnlock()
 
 	orderValue := proposal.Amount * proposal.Price
+
+	if rm.manualStop {
+		return entity.RiskCheckResult{
+			Approved: false,
+			Reason:   "trading is manually stopped",
+		}
+	}
 
 	if rm.dailyLoss >= rm.config.MaxDailyLoss {
 		return entity.RiskCheckResult{
@@ -118,15 +127,28 @@ func (rm *RiskManager) UpdateConfig(config entity.RiskConfig) {
 	rm.config = config
 }
 
+func (rm *RiskManager) StartTrading() {
+	rm.mu.Lock()
+	defer rm.mu.Unlock()
+	rm.manualStop = false
+}
+
+func (rm *RiskManager) StopTrading() {
+	rm.mu.Lock()
+	defer rm.mu.Unlock()
+	rm.manualStop = true
+}
+
 func (rm *RiskManager) GetStatus() RiskStatus {
 	rm.mu.RLock()
 	defer rm.mu.RUnlock()
 	return RiskStatus{
-		Balance:       rm.balance,
-		DailyLoss:     rm.dailyLoss,
-		TotalPosition: rm.calcTotalPositionValue(),
-		TradingHalted: rm.dailyLoss >= rm.config.MaxDailyLoss,
-		Config:        rm.config,
+		Balance:         rm.balance,
+		DailyLoss:       rm.dailyLoss,
+		TotalPosition:   rm.calcTotalPositionValue(),
+		TradingHalted:   rm.dailyLoss >= rm.config.MaxDailyLoss,
+		ManuallyStopped: rm.manualStop,
+		Config:          rm.config,
 	}
 }
 

--- a/frontend/src/components/AppFrame.tsx
+++ b/frontend/src/components/AppFrame.tsx
@@ -1,0 +1,44 @@
+import type { ReactNode } from 'react'
+import { Link } from '@tanstack/react-router'
+
+type AppFrameProps = {
+  title: string
+  subtitle: string
+  children: ReactNode
+}
+
+const navItems = [
+  { to: '/', label: 'Dashboard' },
+  { to: '/settings', label: 'Settings' },
+  { to: '/history', label: 'History' },
+] as const
+
+export function AppFrame({ title, subtitle, children }: AppFrameProps) {
+  return (
+    <main className="mx-auto min-h-screen w-full max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+      <header className="mb-6 overflow-hidden rounded-3xl border border-white/8 bg-[linear-gradient(135deg,rgba(55,66,250,0.24),rgba(8,12,32,0.92)_45%,rgba(0,212,170,0.18))] p-6 shadow-[0_20px_80px_rgba(0,0,0,0.35)]">
+        <div className="flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <p className="text-[0.7rem] uppercase tracking-[0.35em] text-cyan-200/70">Rakuten CFD Bot</p>
+            <h1 className="mt-2 text-3xl font-semibold tracking-tight text-white sm:text-4xl">{title}</h1>
+            <p className="mt-2 max-w-2xl text-sm text-slate-300">{subtitle}</p>
+          </div>
+          <nav className="flex flex-wrap gap-2">
+            {navItems.map((item) => (
+              <Link
+                key={item.to}
+                to={item.to}
+                activeProps={{ className: 'bg-white text-slate-950 shadow-lg' }}
+                inactiveProps={{ className: 'bg-white/8 text-slate-200 hover:bg-white/14' }}
+                className="rounded-full px-4 py-2 text-sm font-medium transition"
+              >
+                {item.label}
+              </Link>
+            ))}
+          </nav>
+        </div>
+      </header>
+      {children}
+    </main>
+  )
+}

--- a/frontend/src/components/BotControlCard.tsx
+++ b/frontend/src/components/BotControlCard.tsx
@@ -1,0 +1,54 @@
+import type { StatusResponse } from '../lib/api'
+
+type BotControlCardProps = {
+  status: StatusResponse | undefined
+  onStart: () => void
+  onStop: () => void
+  isPending: boolean
+}
+
+function getStatusLabel(status: StatusResponse | undefined): string {
+  if (!status) return 'loading'
+  if (status.manuallyStopped) return 'manual stop'
+  if (status.tradingHalted) return 'risk halted'
+  return 'running'
+}
+
+export function BotControlCard({ status, onStart, onStop, isPending }: BotControlCardProps) {
+  const current = getStatusLabel(status)
+  const disabled = isPending
+
+  return (
+    <section className="rounded-3xl border border-white/8 bg-bg-card/90 p-5 shadow-[0_12px_40px_rgba(0,0,0,0.22)]">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <p className="text-xs uppercase tracking-[0.28em] text-text-secondary">Bot Control</p>
+          <h2 className="mt-2 text-xl font-semibold text-white">起動 / 停止</h2>
+          <p className="mt-2 text-sm text-slate-300">現在状態: <span className="font-medium text-white">{current}</span></p>
+        </div>
+        <div className="rounded-full border border-white/10 bg-white/6 px-3 py-1 text-xs text-slate-300">
+          {status?.status ?? 'unknown'}
+        </div>
+      </div>
+
+      <div className="mt-5 flex gap-3">
+        <button
+          type="button"
+          onClick={onStart}
+          disabled={disabled}
+          className="rounded-full bg-accent-green px-4 py-2 text-sm font-semibold text-slate-950 transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          Start
+        </button>
+        <button
+          type="button"
+          onClick={onStop}
+          disabled={disabled}
+          className="rounded-full bg-accent-red px-4 py-2 text-sm font-semibold text-white transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          Stop
+        </button>
+      </div>
+    </section>
+  )
+}

--- a/frontend/src/components/CandlestickChart.tsx
+++ b/frontend/src/components/CandlestickChart.tsx
@@ -1,13 +1,6 @@
 import { useEffect, useRef } from 'react'
 import { createChart, CandlestickSeries, type IChartApi, type ISeriesApi, type CandlestickData, type Time } from 'lightweight-charts'
-
-type Candle = {
-  open: number
-  high: number
-  low: number
-  close: number
-  time: number
-}
+import type { Candle } from '../lib/api'
 
 type CandlestickChartProps = {
   candles: Candle[]
@@ -80,7 +73,7 @@ export function CandlestickChart({ candles }: CandlestickChartProps) {
 
   return (
     <div className="bg-bg-card rounded-lg p-4">
-      <div className="text-text-secondary text-xs mb-2">BTC/JPY</div>
+      <div className="mb-2 text-text-secondary text-xs">BTC/JPY</div>
       <div ref={containerRef} />
     </div>
   )

--- a/frontend/src/components/IndicatorPanel.tsx
+++ b/frontend/src/components/IndicatorPanel.tsx
@@ -1,13 +1,4 @@
-type IndicatorSet = {
-  sma20: number | null
-  sma50: number | null
-  ema12: number | null
-  ema26: number | null
-  rsi14: number | null
-  macdLine: number | null
-  signalLine: number | null
-  histogram: number | null
-}
+import type { IndicatorSet } from '../lib/api'
 
 type IndicatorPanelProps = {
   indicators: IndicatorSet | undefined

--- a/frontend/src/components/KpiCard.tsx
+++ b/frontend/src/components/KpiCard.tsx
@@ -6,7 +6,7 @@ type KpiCardProps = {
 
 export function KpiCard({ label, value, color = 'text-text-primary' }: KpiCardProps) {
   return (
-    <div className="bg-bg-card rounded-lg p-4 text-center">
+    <div className="rounded-3xl border border-white/8 bg-bg-card/90 p-4 text-center shadow-[0_12px_36px_rgba(0,0,0,0.18)]">
       <div className={`text-2xl font-bold ${color}`}>{value}</div>
       <div className="text-text-secondary text-xs mt-1">{label}</div>
     </div>

--- a/frontend/src/components/PositionPanel.tsx
+++ b/frontend/src/components/PositionPanel.tsx
@@ -1,11 +1,4 @@
-type Position = {
-  id: number
-  symbolId: number
-  orderSide: string
-  price: number
-  remainingAmount: number
-  floatingProfit: number
-}
+import type { Position } from '../lib/api'
 
 type PositionPanelProps = {
   positions: Position[] | undefined
@@ -20,13 +13,18 @@ export function PositionPanel({ positions }: PositionPanelProps) {
       ) : (
         <div className="space-y-2">
           {positions.map((pos) => (
-            <div key={pos.id} className="flex justify-between text-sm">
-              <span className={pos.orderSide === 'BUY' ? 'text-accent-green' : 'text-accent-red'}>
-                {pos.orderSide === 'BUY' ? 'LONG' : 'SHORT'} {pos.remainingAmount}
-              </span>
-              <span className="text-text-secondary">
+            <div key={pos.id} className="rounded-2xl border border-white/6 bg-white/3 p-3 text-sm">
+              <div className="flex justify-between">
+                <span className={pos.orderSide === 'BUY' ? 'text-accent-green' : 'text-accent-red'}>
+                  {pos.orderSide === 'BUY' ? 'LONG' : 'SHORT'} {pos.remainingAmount}
+                </span>
+                <span className={pos.floatingProfit >= 0 ? 'text-accent-green' : 'text-accent-red'}>
+                  {pos.floatingProfit >= 0 ? '+' : ''}¥{pos.floatingProfit.toLocaleString()}
+                </span>
+              </div>
+              <div className="mt-1 text-text-secondary">
                 @ ¥{pos.price.toLocaleString()}
-              </span>
+              </div>
             </div>
           ))}
         </div>

--- a/frontend/src/components/TradeHistoryTable.tsx
+++ b/frontend/src/components/TradeHistoryTable.tsx
@@ -1,0 +1,62 @@
+import type { TradeHistoryItem } from '../lib/api'
+
+type TradeHistoryTableProps = {
+  trades: TradeHistoryItem[]
+}
+
+function formatYen(value: number) {
+  return `¥${value.toLocaleString('ja-JP', { maximumFractionDigits: 0 })}`
+}
+
+function formatTimestamp(timestamp: number) {
+  return new Date(timestamp).toLocaleString('ja-JP')
+}
+
+export function TradeHistoryTable({ trades }: TradeHistoryTableProps) {
+  return (
+    <div className="overflow-hidden rounded-3xl border border-white/8 bg-bg-card/90 shadow-[0_12px_40px_rgba(0,0,0,0.22)]">
+      <div className="border-b border-white/8 px-5 py-4">
+        <p className="text-xs uppercase tracking-[0.28em] text-text-secondary">Trade History</p>
+        <h2 className="mt-2 text-xl font-semibold text-white">約定履歴</h2>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="min-w-full text-sm">
+          <thead className="bg-white/4 text-left text-text-secondary">
+            <tr>
+              <th className="px-5 py-3 font-medium">日時</th>
+              <th className="px-5 py-3 font-medium">方向</th>
+              <th className="px-5 py-3 font-medium">数量</th>
+              <th className="px-5 py-3 font-medium">価格</th>
+              <th className="px-5 py-3 font-medium">損益</th>
+              <th className="px-5 py-3 font-medium">Fee</th>
+            </tr>
+          </thead>
+          <tbody>
+            {trades.length === 0 ? (
+              <tr>
+                <td colSpan={6} className="px-5 py-10 text-center text-text-secondary">
+                  約定履歴はありません
+                </td>
+              </tr>
+            ) : (
+              trades.map((trade) => (
+                <tr key={trade.id} className="border-t border-white/6 text-slate-100">
+                  <td className="px-5 py-4">{formatTimestamp(trade.createdAt)}</td>
+                  <td className={`px-5 py-4 font-medium ${trade.orderSide === 'BUY' ? 'text-accent-green' : 'text-accent-red'}`}>
+                    {trade.orderSide}
+                  </td>
+                  <td className="px-5 py-4">{trade.amount}</td>
+                  <td className="px-5 py-4">{formatYen(trade.price)}</td>
+                  <td className={`px-5 py-4 ${trade.profit >= 0 ? 'text-accent-green' : 'text-accent-red'}`}>
+                    {formatYen(trade.profit)}
+                  </td>
+                  <td className="px-5 py-4">{formatYen(trade.fee)}</td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/hooks/useBotControl.ts
+++ b/frontend/src/hooks/useBotControl.ts
@@ -1,0 +1,22 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { sendApi, type BotControlResponse } from '../lib/api'
+
+function useBotMutation(path: '/start' | '/stop') {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: () => sendApi<BotControlResponse>(path, 'POST'),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['status'] })
+      void queryClient.invalidateQueries({ queryKey: ['pnl'] })
+    },
+  })
+}
+
+export function useStartBot() {
+  return useBotMutation('/start')
+}
+
+export function useStopBot() {
+  return useBotMutation('/stop')
+}

--- a/frontend/src/hooks/useCandles.ts
+++ b/frontend/src/hooks/useCandles.ts
@@ -1,14 +1,5 @@
 import { useQuery } from '@tanstack/react-query'
-import { fetchApi } from '../lib/api'
-
-type Candle = {
-  open: number
-  high: number
-  low: number
-  close: number
-  volume: number
-  time: number
-}
+import { fetchApi, type Candle } from '../lib/api'
 
 export function useCandles(symbolId: number) {
   return useQuery({

--- a/frontend/src/hooks/useConfig.ts
+++ b/frontend/src/hooks/useConfig.ts
@@ -1,0 +1,22 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { fetchApi, sendApi, type RiskConfig } from '../lib/api'
+
+export function useConfig() {
+  return useQuery({
+    queryKey: ['config'],
+    queryFn: () => fetchApi<RiskConfig>('/config'),
+  })
+}
+
+export function useUpdateConfig() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (config: RiskConfig) => sendApi<RiskConfig, RiskConfig>('/config', 'PUT', config),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['config'] })
+      void queryClient.invalidateQueries({ queryKey: ['status'] })
+      void queryClient.invalidateQueries({ queryKey: ['pnl'] })
+    },
+  })
+}

--- a/frontend/src/hooks/useIndicators.ts
+++ b/frontend/src/hooks/useIndicators.ts
@@ -1,18 +1,5 @@
 import { useQuery } from '@tanstack/react-query'
-import { fetchApi } from '../lib/api'
-
-type IndicatorSet = {
-  symbolId: number
-  sma20: number | null
-  sma50: number | null
-  ema12: number | null
-  ema26: number | null
-  rsi14: number | null
-  macdLine: number | null
-  signalLine: number | null
-  histogram: number | null
-  timestamp: number
-}
+import { fetchApi, type IndicatorSet } from '../lib/api'
 
 export function useIndicators(symbolId: number) {
   return useQuery({

--- a/frontend/src/hooks/usePnl.ts
+++ b/frontend/src/hooks/usePnl.ts
@@ -1,17 +1,10 @@
 import { useQuery } from '@tanstack/react-query'
-import { fetchApi } from '../lib/api'
-
-type PnL = {
-  balance: number
-  dailyLoss: number
-  totalPosition: number
-  tradingHalted: boolean
-}
+import { fetchApi, type PnlResponse } from '../lib/api'
 
 export function usePnl() {
   return useQuery({
     queryKey: ['pnl'],
-    queryFn: () => fetchApi<PnL>('/pnl'),
+    queryFn: () => fetchApi<PnlResponse>('/pnl'),
     refetchInterval: 10_000,
   })
 }

--- a/frontend/src/hooks/usePositions.ts
+++ b/frontend/src/hooks/usePositions.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query'
+import { fetchApi, type Position } from '../lib/api'
+
+export function usePositions(symbolId: number) {
+  return useQuery({
+    queryKey: ['positions', symbolId],
+    queryFn: () => fetchApi<Position[]>(`/positions?symbolId=${symbolId}`),
+    refetchInterval: 10_000,
+  })
+}

--- a/frontend/src/hooks/useStatus.ts
+++ b/frontend/src/hooks/useStatus.ts
@@ -1,18 +1,10 @@
 import { useQuery } from '@tanstack/react-query'
-import { fetchApi } from '../lib/api'
-
-type Status = {
-  status: string
-  tradingHalted: boolean
-  balance: number
-  dailyLoss: number
-  totalPosition: number
-}
+import { fetchApi, type StatusResponse } from '../lib/api'
 
 export function useStatus() {
   return useQuery({
     queryKey: ['status'],
-    queryFn: () => fetchApi<Status>('/status'),
+    queryFn: () => fetchApi<StatusResponse>('/status'),
     refetchInterval: 10_000,
   })
 }

--- a/frontend/src/hooks/useStrategy.ts
+++ b/frontend/src/hooks/useStrategy.ts
@@ -1,15 +1,10 @@
 import { useQuery } from '@tanstack/react-query'
-import { fetchApi } from '../lib/api'
-
-type Strategy = {
-  stance: string
-  reasoning: string
-}
+import { fetchApi, type StrategyResponse } from '../lib/api'
 
 export function useStrategy() {
   return useQuery({
     queryKey: ['strategy'],
-    queryFn: () => fetchApi<Strategy>('/strategy'),
+    queryFn: () => fetchApi<StrategyResponse>('/strategy'),
     refetchInterval: 30_000,
   })
 }

--- a/frontend/src/hooks/useTradeHistory.ts
+++ b/frontend/src/hooks/useTradeHistory.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query'
+import { fetchApi, type TradeHistoryItem } from '../lib/api'
+
+export function useTradeHistory(symbolId: number) {
+  return useQuery({
+    queryKey: ['trades', symbolId],
+    queryFn: () => fetchApi<TradeHistoryItem[]>(`/trades?symbolId=${symbolId}`),
+    refetchInterval: 15_000,
+  })
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,9 +1,107 @@
-const API_BASE = 'http://localhost:8080/api/v1'
+export const API_BASE = 'http://localhost:8080/api/v1'
+
+export type StatusResponse = {
+  status: 'running' | 'stopped'
+  tradingHalted: boolean
+  manuallyStopped: boolean
+  balance: number
+  dailyLoss: number
+  totalPosition: number
+}
+
+export type PnlResponse = {
+  balance: number
+  dailyLoss: number
+  totalPosition: number
+  tradingHalted: boolean
+}
+
+export type StrategyResponse = {
+  stance: string
+  reasoning: string
+}
+
+export type IndicatorSet = {
+  symbolId: number
+  sma20: number | null
+  sma50: number | null
+  ema12: number | null
+  ema26: number | null
+  rsi14: number | null
+  macdLine: number | null
+  signalLine: number | null
+  histogram: number | null
+  timestamp: number
+}
+
+export type Candle = {
+  open: number
+  high: number
+  low: number
+  close: number
+  volume: number
+  time: number
+}
+
+export type Position = {
+  id: number
+  symbolId: number
+  orderSide: 'BUY' | 'SELL'
+  price: number
+  remainingAmount: number
+  floatingProfit: number
+}
+
+export type RiskConfig = {
+  maxPositionAmount: number
+  maxDailyLoss: number
+  stopLossPercent: number
+  initialCapital: number
+}
+
+export type BotControlResponse = {
+  status: 'running' | 'stopped'
+  tradingHalted: boolean
+  manuallyStopped: boolean
+}
+
+export type TradeHistoryItem = {
+  id: number
+  symbolId: number
+  orderSide: 'BUY' | 'SELL'
+  price: number
+  amount: number
+  profit: number
+  fee: number
+  positionFee: number
+  closeTradeProfit: number
+  orderId: number
+  positionId: number
+  createdAt: number
+}
 
 export async function fetchApi<T>(path: string): Promise<T> {
   const res = await fetch(`${API_BASE}${path}`)
   if (!res.ok) {
     throw new Error(`API error: ${res.status} ${res.statusText}`)
   }
+  return res.json()
+}
+
+export async function sendApi<TResponse, TBody = undefined>(
+  path: string,
+  method: 'POST' | 'PUT',
+  body?: TBody,
+): Promise<TResponse> {
+  const res = await fetch(`${API_BASE}${path}`, {
+    method,
+    headers: body === undefined ? undefined : { 'Content-Type': 'application/json' },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  })
+
+  if (!res.ok) {
+    throw new Error(`API error: ${res.status} ${res.statusText}`)
+  }
+
   return res.json()
 }

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -9,8 +9,20 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as SettingsRouteImport } from './routes/settings'
+import { Route as HistoryRouteImport } from './routes/history'
 import { Route as IndexRouteImport } from './routes/index'
 
+const SettingsRoute = SettingsRouteImport.update({
+  id: '/settings',
+  path: '/settings',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const HistoryRoute = HistoryRouteImport.update({
+  id: '/history',
+  path: '/history',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
@@ -19,28 +31,50 @@ const IndexRoute = IndexRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/history': typeof HistoryRoute
+  '/settings': typeof SettingsRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/history': typeof HistoryRoute
+  '/settings': typeof SettingsRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/history': typeof HistoryRoute
+  '/settings': typeof SettingsRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/'
+  fullPaths: '/' | '/history' | '/settings'
   fileRoutesByTo: FileRoutesByTo
-  to: '/'
-  id: '__root__' | '/'
+  to: '/' | '/history' | '/settings'
+  id: '__root__' | '/' | '/history' | '/settings'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  HistoryRoute: typeof HistoryRoute
+  SettingsRoute: typeof SettingsRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/settings': {
+      id: '/settings'
+      path: '/settings'
+      fullPath: '/settings'
+      preLoaderRoute: typeof SettingsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/history': {
+      id: '/history'
+      path: '/history'
+      fullPath: '/history'
+      preLoaderRoute: typeof HistoryRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
       id: '/'
       path: '/'
@@ -53,6 +87,8 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  HistoryRoute: HistoryRoute,
+  SettingsRoute: SettingsRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/frontend/src/routes/history.tsx
+++ b/frontend/src/routes/history.tsx
@@ -1,0 +1,48 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { AppFrame } from '../components/AppFrame'
+import { TradeHistoryTable } from '../components/TradeHistoryTable'
+import { useTradeHistory } from '../hooks/useTradeHistory'
+
+export const Route = createFileRoute('/history')({ component: HistoryPage })
+
+function HistoryPage() {
+  const { data: trades } = useTradeHistory(7)
+  const safeTrades = trades ?? []
+  const totalProfit = safeTrades.reduce((sum, trade) => sum + trade.profit, 0)
+
+  return (
+    <AppFrame
+      title="Trade History"
+      subtitle="楽天 private API の約定一覧を REST 経由で見せる Phase 2 画面です。最新損益の確認と異常検知を同じ導線に置きます。"
+    >
+      <div className="mb-4 grid gap-4 md:grid-cols-3">
+        <SummaryCard label="約定件数" value={safeTrades.length.toLocaleString()} />
+        <SummaryCard
+          label="累計損益"
+          value={`¥${totalProfit.toLocaleString('ja-JP', { maximumFractionDigits: 0 })}`}
+          color={totalProfit >= 0 ? 'text-accent-green' : 'text-accent-red'}
+        />
+        <SummaryCard
+          label="最新更新"
+          value={safeTrades[0] ? new Date(safeTrades[0].createdAt).toLocaleString('ja-JP') : '\u2014'}
+        />
+      </div>
+      <TradeHistoryTable trades={safeTrades} />
+    </AppFrame>
+  )
+}
+
+type SummaryCardProps = {
+  label: string
+  value: string
+  color?: string
+}
+
+function SummaryCard({ label, value, color = 'text-white' }: SummaryCardProps) {
+  return (
+    <section className="rounded-3xl border border-white/8 bg-bg-card/90 p-5 shadow-[0_12px_40px_rgba(0,0,0,0.22)]">
+      <p className="text-xs uppercase tracking-[0.28em] text-text-secondary">{label}</p>
+      <p className={`mt-3 text-xl font-semibold ${color}`}>{value}</p>
+    </section>
+  )
+}

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -1,13 +1,17 @@
-import { createFileRoute } from '@tanstack/react-router'
+import { createFileRoute, Link } from '@tanstack/react-router'
+import { AppFrame } from '../components/AppFrame'
 import { KpiCard } from '../components/KpiCard'
 import { CandlestickChart } from '../components/CandlestickChart'
 import { IndicatorPanel } from '../components/IndicatorPanel'
 import { PositionPanel } from '../components/PositionPanel'
+import { BotControlCard } from '../components/BotControlCard'
 import { useStatus } from '../hooks/useStatus'
 import { usePnl } from '../hooks/usePnl'
 import { useStrategy } from '../hooks/useStrategy'
 import { useIndicators } from '../hooks/useIndicators'
 import { useCandles } from '../hooks/useCandles'
+import { usePositions } from '../hooks/usePositions'
+import { useStartBot, useStopBot } from '../hooks/useBotControl'
 
 export const Route = createFileRoute('/')({ component: Dashboard })
 
@@ -17,11 +21,24 @@ function Dashboard() {
   const { data: strategy } = useStrategy()
   const { data: indicators } = useIndicators(7)
   const { data: candles } = useCandles(7)
+  const { data: positions } = usePositions(7)
+  const startBot = useStartBot()
+  const stopBot = useStopBot()
+
+  const statusLabel = status?.tradingHalted
+    ? 'リスク停止'
+    : status?.manuallyStopped
+      ? '手動停止'
+      : status?.status === 'running'
+        ? '稼働中'
+        : '\u2014'
 
   return (
-    <main className="max-w-7xl mx-auto p-4">
-      {/* KPI Cards */}
-      <div className="grid grid-cols-4 gap-4 mb-4">
+    <AppFrame
+      title="Trading Dashboard"
+      subtitle="KPI・戦略・ポジションを集約しつつ、Phase 2 の操作系を同じ導線に載せた監視画面です。"
+    >
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
         <KpiCard
           label="残高"
           value={pnl ? `¥${pnl.balance.toLocaleString()}` : '\u2014'}
@@ -35,25 +52,45 @@ function Dashboard() {
         <KpiCard
           label="戦略方針"
           value={strategy?.stance ?? '\u2014'}
-          color="text-accent-blue"
+          color="text-cyan-200"
         />
         <KpiCard
           label="ステータス"
-          value={status?.tradingHalted ? '停止中' : (status?.status ?? '\u2014')}
-          color={status?.tradingHalted ? 'text-accent-red' : 'text-accent-green'}
+          value={statusLabel}
+          color={status?.tradingHalted || status?.manuallyStopped ? 'text-accent-red' : 'text-accent-green'}
         />
       </div>
 
-      {/* Chart + Side Panel */}
-      <div className="grid grid-cols-3 gap-4">
-        <div className="col-span-2">
+      <div className="mt-4 grid gap-4 xl:grid-cols-[minmax(0,2fr)_minmax(320px,1fr)]">
+        <section className="space-y-4">
           <CandlestickChart candles={candles ?? []} />
-        </div>
-        <div className="space-y-4">
+          <div className="rounded-3xl border border-white/8 bg-bg-card/90 p-5 shadow-[0_12px_40px_rgba(0,0,0,0.22)]">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-xs uppercase tracking-[0.28em] text-text-secondary">Strategy Insight</p>
+                <h2 className="mt-2 text-xl font-semibold text-white">LLM reasoning</h2>
+              </div>
+              <Link to="/history" className="text-sm text-cyan-200 transition hover:text-cyan-100">
+                履歴を見る
+              </Link>
+            </div>
+            <p className="mt-4 text-sm leading-7 text-slate-300">
+              {strategy?.reasoning ?? '戦略コメントはまだ生成されていません。'}
+            </p>
+          </div>
+        </section>
+
+        <aside className="space-y-4">
+          <BotControlCard
+            status={status}
+            onStart={() => startBot.mutate()}
+            onStop={() => stopBot.mutate()}
+            isPending={startBot.isPending || stopBot.isPending}
+          />
           <IndicatorPanel indicators={indicators} />
-          <PositionPanel positions={undefined} />
-        </div>
+          <PositionPanel positions={positions} />
+        </aside>
       </div>
-    </main>
+    </AppFrame>
   )
 }

--- a/frontend/src/routes/settings.tsx
+++ b/frontend/src/routes/settings.tsx
@@ -1,0 +1,115 @@
+import { useEffect, useState } from 'react'
+import { createFileRoute } from '@tanstack/react-router'
+import { AppFrame } from '../components/AppFrame'
+import { BotControlCard } from '../components/BotControlCard'
+import { useConfig, useUpdateConfig } from '../hooks/useConfig'
+import { useStatus } from '../hooks/useStatus'
+import { useStartBot, useStopBot } from '../hooks/useBotControl'
+import type { RiskConfig } from '../lib/api'
+
+export const Route = createFileRoute('/settings')({ component: SettingsPage })
+
+function SettingsPage() {
+  const { data: config } = useConfig()
+  const { data: status } = useStatus()
+  const updateConfig = useUpdateConfig()
+  const startBot = useStartBot()
+  const stopBot = useStopBot()
+  const [form, setForm] = useState<RiskConfig>({
+    maxPositionAmount: 0,
+    maxDailyLoss: 0,
+    stopLossPercent: 0,
+    initialCapital: 0,
+  })
+
+  useEffect(() => {
+    if (config) {
+      setForm(config)
+    }
+  }, [config])
+
+  const handleNumberChange = (key: keyof RiskConfig, value: string) => {
+    setForm((current) => ({
+      ...current,
+      [key]: Number(value),
+    }))
+  }
+
+  return (
+    <AppFrame
+      title="Risk Settings"
+      subtitle="既存の `/config` API を操作画面として公開し、手動停止と合わせて運用パラメータを調整できるようにしました。"
+    >
+      <div className="grid gap-4 xl:grid-cols-[minmax(0,1.2fr)_minmax(320px,0.8fr)]">
+        <section className="rounded-3xl border border-white/8 bg-bg-card/90 p-5 shadow-[0_12px_40px_rgba(0,0,0,0.22)]">
+          <p className="text-xs uppercase tracking-[0.28em] text-text-secondary">Risk Config</p>
+          <h2 className="mt-2 text-xl font-semibold text-white">リスク設定</h2>
+
+          <div className="mt-5 grid gap-4 sm:grid-cols-2">
+            <Field
+              label="最大ポジション額"
+              value={form.maxPositionAmount}
+              onChange={(value) => handleNumberChange('maxPositionAmount', value)}
+            />
+            <Field
+              label="日次損失上限"
+              value={form.maxDailyLoss}
+              onChange={(value) => handleNumberChange('maxDailyLoss', value)}
+            />
+            <Field
+              label="損切り率 (%)"
+              value={form.stopLossPercent}
+              onChange={(value) => handleNumberChange('stopLossPercent', value)}
+            />
+            <Field
+              label="初期資金"
+              value={form.initialCapital}
+              onChange={(value) => handleNumberChange('initialCapital', value)}
+            />
+          </div>
+
+          <div className="mt-5 flex items-center justify-between gap-3">
+            <p className="text-sm text-slate-300">
+              {updateConfig.isSuccess ? '保存済み' : '変更後に Save で反映'}
+            </p>
+            <button
+              type="button"
+              onClick={() => updateConfig.mutate(form)}
+              disabled={updateConfig.isPending}
+              className="rounded-full bg-cyan-200 px-5 py-2 text-sm font-semibold text-slate-950 transition hover:bg-cyan-100 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              Save
+            </button>
+          </div>
+        </section>
+
+        <BotControlCard
+          status={status}
+          onStart={() => startBot.mutate()}
+          onStop={() => stopBot.mutate()}
+          isPending={startBot.isPending || stopBot.isPending}
+        />
+      </div>
+    </AppFrame>
+  )
+}
+
+type FieldProps = {
+  label: string
+  value: number
+  onChange: (value: string) => void
+}
+
+function Field({ label, value, onChange }: FieldProps) {
+  return (
+    <label className="block">
+      <span className="mb-2 block text-sm text-slate-300">{label}</span>
+      <input
+        type="number"
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        className="w-full rounded-2xl border border-white/10 bg-white/6 px-4 py-3 text-white outline-none transition placeholder:text-slate-500 focus:border-cyan-200"
+      />
+    </label>
+  )
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -5,8 +5,27 @@
   --color-bg-card: #1a1a3e;
   --color-bg-card-hover: #22224a;
   --color-text-primary: #e0e0e0;
-  --color-text-secondary: #666;
+  --color-text-secondary: #8b93af;
   --color-accent-green: #00d4aa;
   --color-accent-red: #ff4757;
   --color-accent-blue: #3742fa;
+}
+
+:root {
+  color-scheme: dark;
+}
+
+body {
+  margin: 0;
+  font-family: 'IBM Plex Sans', 'Hiragino Sans', sans-serif;
+  background:
+    radial-gradient(circle at top left, rgba(55, 66, 250, 0.28), transparent 28%),
+    radial-gradient(circle at top right, rgba(0, 212, 170, 0.14), transparent 24%),
+    linear-gradient(180deg, #11162d 0%, #0b0f1f 45%, #090c18 100%);
+  color: var(--color-text-primary);
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
 }


### PR DESCRIPTION
## Summary
- add Phase 2 frontend screens for dashboard navigation, settings, and trade history
- add bot start/stop and trade history REST endpoints to support the new UI flows
- wire new React Query hooks and shared API types into the dashboard and operations pages

## Testing
- ./node_modules/.bin/tsc --noEmit
- pnpm build
- GOCACHE=/Users/h.aiso/Projects/rakuten-api-leverage-exchange/.gocache go test ./internal/usecase
- GOCACHE=/Users/h.aiso/Projects/rakuten-api-leverage-exchange/.gocache go test -run '^$' ./internal/interfaces/api

## Notes
- full Go API tests that use httptest listeners could not run in this sandbox because opening local listen sockets is not permitted