### PR TITLE
feat: フロントエンドのリアルタイム更新を追加

### DIFF
--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"log"
 	"os"
 	"os/signal"
@@ -83,12 +84,11 @@ func main() {
 	log.Printf("Config: maxPosition=%.0f, maxDailyLoss=%.0f, stopLoss=%.1f%%, capital=%.0f",
 		cfg.Risk.MaxPositionAmount, cfg.Risk.MaxDailyLoss, cfg.Risk.StopLossPercent, cfg.Risk.InitialCapital)
 
+	go startTickerRelay(ctx, wsClient, marketDataSvc, 7)
+
 	// コンポーネントの参照を保持（Trading Pipeline実装時に使用）
-	_ = marketDataSvc
 	_ = strategyEngine
 	_ = orderExecutor
-	_ = wsClient
-	_ = ctx
 
 	// TODO: WebSocket接続 → Ticker受信ループ → 指標計算 → 戦略判定 → 注文実行
 	// 現時点ではREST APIサーバーとして稼働し、Trading Pipelineは次のイテレーションで実装
@@ -102,4 +102,68 @@ func main() {
 	}
 
 	log.Println("Trading Engine stopped")
+}
+
+func startTickerRelay(ctx context.Context, wsClient *rakuten.WSClient, marketDataSvc *usecase.MarketDataService, symbolID int64) {
+	if wsClient == nil || marketDataSvc == nil {
+		return
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			_ = wsClient.Close()
+			return
+		default:
+		}
+
+		msgCh, err := wsClient.Connect(ctx)
+		if err != nil {
+			log.Printf("market websocket connect failed: %v", err)
+			waitForReconnect(ctx)
+			continue
+		}
+
+		if err := wsClient.Subscribe(ctx, symbolID, rakuten.DataTypeTicker); err != nil {
+			log.Printf("market websocket subscribe failed: %v", err)
+			_ = wsClient.Close()
+			waitForReconnect(ctx)
+			continue
+		}
+
+		log.Printf("market websocket subscribed: symbol=%d", symbolID)
+
+		reconnect := false
+		for !reconnect {
+			select {
+			case <-ctx.Done():
+				_ = wsClient.Close()
+				return
+			case raw, ok := <-msgCh:
+				if !ok {
+					reconnect = true
+					break
+				}
+
+				var ticker entity.Ticker
+				if err := json.Unmarshal(raw, &ticker); err != nil {
+					log.Printf("market websocket decode failed: %v", err)
+					continue
+				}
+
+				marketDataSvc.HandleTicker(ctx, ticker)
+			}
+		}
+
+		log.Println("market websocket disconnected, reconnecting")
+		_ = wsClient.Close()
+		waitForReconnect(ctx)
+	}
+}
+
+func waitForReconnect(ctx context.Context) {
+	select {
+	case <-ctx.Done():
+	case <-time.After(3 * time.Second):
+	}
 }

--- a/backend/internal/interfaces/api/handler/realtime.go
+++ b/backend/internal/interfaces/api/handler/realtime.go
@@ -1,0 +1,96 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log"
+	"strconv"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase"
+	"nhooyr.io/websocket"
+)
+
+type RealtimeHandler struct {
+	marketDataSvc *usecase.MarketDataService
+}
+
+type realtimeMessage struct {
+	Type string        `json:"type"`
+	Data entity.Ticker `json:"data"`
+}
+
+func NewRealtimeHandler(marketDataSvc *usecase.MarketDataService) *RealtimeHandler {
+	return &RealtimeHandler{marketDataSvc: marketDataSvc}
+}
+
+func (h *RealtimeHandler) StreamTicker(c *gin.Context) {
+	symbolStr := c.DefaultQuery("symbolId", "7")
+	symbolID, err := strconv.ParseInt(symbolStr, 10, 64)
+	if err != nil {
+		c.JSON(400, gin.H{"error": "invalid symbol ID"})
+		return
+	}
+
+	conn, err := websocket.Accept(c.Writer, c.Request, &websocket.AcceptOptions{
+		OriginPatterns: []string{"localhost:*", "127.0.0.1:*"},
+	})
+	if err != nil {
+		return
+	}
+	defer conn.Close(websocket.StatusNormalClosure, "")
+
+	ctx := c.Request.Context()
+	if latest, err := h.marketDataSvc.GetLatestTicker(ctx, symbolID); err == nil && latest != nil {
+		if err := conn.Write(ctx, websocket.MessageText, mustMarshalRealtimeMessage(*latest)); err != nil {
+			return
+		}
+	}
+
+	sub := h.marketDataSvc.SubscribeTicker()
+	defer h.marketDataSvc.UnsubscribeTicker(sub)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case ticker, ok := <-sub:
+			if !ok {
+				return
+			}
+			if ticker.SymbolID != symbolID {
+				continue
+			}
+
+			writeCtx, cancel := context.WithTimeout(ctx, websocketWriteTimeout)
+			err := conn.Write(writeCtx, websocket.MessageText, mustMarshalRealtimeMessage(ticker))
+			cancel()
+			if err != nil {
+				if !errors.Is(err, context.Canceled) {
+					log.Printf("frontend websocket write failed: %v", err)
+				}
+				return
+			}
+		}
+	}
+}
+
+const websocketWriteTimeout = 5 * time.Second
+
+func mustMarshalRealtimeMessage(ticker entity.Ticker) []byte {
+	payload, err := jsonMarshal(realtimeMessage{
+		Type: "ticker",
+		Data: ticker,
+	})
+	if err != nil {
+		panic(err)
+	}
+	return payload
+}
+
+var jsonMarshal = func(v any) ([]byte, error) {
+	return json.Marshal(v)
+}

--- a/backend/internal/interfaces/api/router.go
+++ b/backend/internal/interfaces/api/router.go
@@ -48,6 +48,9 @@ func NewRouter(deps Dependencies) *gin.Engine {
 	if deps.MarketDataService != nil {
 		candleHandler := handler.NewCandleHandler(deps.MarketDataService)
 		v1.GET("/candles/:symbol", candleHandler.GetCandles)
+
+		realtimeHandler := handler.NewRealtimeHandler(deps.MarketDataService)
+		v1.GET("/ws/market", realtimeHandler.StreamTicker)
 	}
 
 	if deps.OrderClient != nil {

--- a/backend/internal/usecase/market_data.go
+++ b/backend/internal/usecase/market_data.go
@@ -69,6 +69,11 @@ func (s *MarketDataService) GetCandles(ctx context.Context, symbolID int64, inte
 	return s.repo.GetCandles(ctx, symbolID, interval, limit)
 }
 
+// GetLatestTicker returns the most recently persisted ticker for a symbol.
+func (s *MarketDataService) GetLatestTicker(ctx context.Context, symbolID int64) (*entity.Ticker, error) {
+	return s.repo.GetLatestTicker(ctx, symbolID)
+}
+
 // SaveCandles persists candlestick data.
 func (s *MarketDataService) SaveCandles(ctx context.Context, symbolID int64, interval string, candles []entity.Candle) error {
 	return s.repo.SaveCandles(ctx, symbolID, interval, candles)

--- a/backend/internal/usecase/market_data_test.go
+++ b/backend/internal/usecase/market_data_test.go
@@ -141,3 +141,20 @@ func TestMarketDataService_UnsubscribeTicker(t *testing.T) {
 		// Expected: timeout = no data
 	}
 }
+
+func TestMarketDataService_GetLatestTicker(t *testing.T) {
+	repo := newMockRepo()
+	svc := NewMarketDataService(repo)
+
+	ctx := context.Background()
+	svc.HandleTicker(ctx, entity.Ticker{SymbolID: 7, Last: 100, Timestamp: 1000})
+	svc.HandleTicker(ctx, entity.Ticker{SymbolID: 7, Last: 200, Timestamp: 2000})
+
+	ticker, err := svc.GetLatestTicker(ctx, 7)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ticker.Last != 200 {
+		t.Fatalf("expected latest last 200, got %f", ticker.Last)
+	}
+}

--- a/frontend/src/components/LiveTickerCard.tsx
+++ b/frontend/src/components/LiveTickerCard.tsx
@@ -1,0 +1,70 @@
+import type { LiveTicker } from '../lib/api'
+
+type LiveTickerCardProps = {
+  ticker: LiveTicker | null
+  connectionState: 'connecting' | 'connected' | 'disconnected'
+}
+
+function formatYen(value: number | null | undefined) {
+  if (value === null || value === undefined) return '\u2014'
+  return `¥${value.toLocaleString('ja-JP', { maximumFractionDigits: 0 })}`
+}
+
+function formatTime(timestamp: number | null | undefined) {
+  if (!timestamp) return '\u2014'
+  return new Date(timestamp).toLocaleTimeString('ja-JP')
+}
+
+export function LiveTickerCard({ ticker, connectionState }: LiveTickerCardProps) {
+  const delta = ticker ? ticker.last - ticker.open : null
+  const deltaClass = delta !== null && delta < 0 ? 'text-accent-red' : 'text-accent-green'
+
+  return (
+    <section className="rounded-3xl border border-white/8 bg-bg-card/90 p-5 shadow-[0_12px_40px_rgba(0,0,0,0.22)]">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <p className="text-xs uppercase tracking-[0.28em] text-text-secondary">Realtime Ticker</p>
+          <h2 className="mt-2 text-xl font-semibold text-white">BTC/JPY ライブ価格</h2>
+        </div>
+        <span className={`rounded-full px-3 py-1 text-xs font-medium ${
+          connectionState === 'connected'
+            ? 'bg-accent-green/18 text-accent-green'
+            : connectionState === 'connecting'
+              ? 'bg-cyan-200/16 text-cyan-200'
+              : 'bg-accent-red/18 text-accent-red'
+        }`}>
+          {connectionState}
+        </span>
+      </div>
+
+      <div className="mt-5 grid gap-4 sm:grid-cols-2">
+        <div>
+          <p className="text-3xl font-semibold text-white">{formatYen(ticker?.last)}</p>
+          <p className={`mt-2 text-sm ${deltaClass}`}>
+            {delta === null ? '\u2014' : `${delta >= 0 ? '+' : ''}${formatYen(delta)}`}
+          </p>
+        </div>
+        <div className="grid grid-cols-2 gap-3 text-sm">
+          <Metric label="Best Ask" value={formatYen(ticker?.bestAsk)} />
+          <Metric label="Best Bid" value={formatYen(ticker?.bestBid)} />
+          <Metric label="Volume" value={ticker?.volume?.toLocaleString('ja-JP') ?? '\u2014'} />
+          <Metric label="Updated" value={formatTime(ticker?.timestamp)} />
+        </div>
+      </div>
+    </section>
+  )
+}
+
+type MetricProps = {
+  label: string
+  value: string
+}
+
+function Metric({ label, value }: MetricProps) {
+  return (
+    <div className="rounded-2xl border border-white/6 bg-white/4 p-3">
+      <p className="text-xs uppercase tracking-[0.18em] text-text-secondary">{label}</p>
+      <p className="mt-2 font-medium text-white">{value}</p>
+    </div>
+  )
+}

--- a/frontend/src/hooks/useMarketTickerStream.ts
+++ b/frontend/src/hooks/useMarketTickerStream.ts
@@ -1,0 +1,72 @@
+import { useEffect, useRef, useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import { buildMarketWebSocketUrl, type LiveTicker, type MarketStreamMessage } from '../lib/api'
+
+type ConnectionState = 'connecting' | 'connected' | 'disconnected'
+
+export function useMarketTickerStream(symbolId: number) {
+  const queryClient = useQueryClient()
+  const [ticker, setTicker] = useState<LiveTicker | null>(null)
+  const [connectionState, setConnectionState] = useState<ConnectionState>('connecting')
+  const lastInvalidateRef = useRef(0)
+
+  useEffect(() => {
+    let active = true
+    let socket: WebSocket | null = null
+    let retryTimer: ReturnType<typeof setTimeout> | null = null
+
+    const connect = () => {
+      setConnectionState('connecting')
+      socket = new WebSocket(buildMarketWebSocketUrl(symbolId))
+
+      socket.addEventListener('open', () => {
+        if (!active) return
+        setConnectionState('connected')
+      })
+
+      socket.addEventListener('message', (event) => {
+        if (!active) return
+
+        let payload: MarketStreamMessage
+        try {
+          payload = JSON.parse(event.data) as MarketStreamMessage
+        } catch {
+          return
+        }
+        if (payload.type !== 'ticker') return
+
+        setTicker(payload.data)
+
+        const now = Date.now()
+        if (now - lastInvalidateRef.current >= 30_000) {
+          lastInvalidateRef.current = now
+          void queryClient.invalidateQueries({ queryKey: ['indicators', symbolId] })
+          void queryClient.invalidateQueries({ queryKey: ['candles', symbolId] })
+        }
+      })
+
+      socket.addEventListener('close', () => {
+        if (!active) return
+        setConnectionState('disconnected')
+        retryTimer = setTimeout(connect, 2_000)
+      })
+
+      socket.addEventListener('error', () => {
+        socket?.close()
+      })
+    }
+
+    connect()
+
+    return () => {
+      active = false
+      if (retryTimer) clearTimeout(retryTimer)
+      socket?.close()
+    }
+  }, [queryClient, symbolId])
+
+  return {
+    ticker,
+    connectionState,
+  }
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,5 @@
 export const API_BASE = 'http://localhost:8080/api/v1'
+export const WS_BASE = 'ws://localhost:8080/api/v1'
 
 export type StatusResponse = {
   status: 'running' | 'stopped'
@@ -80,6 +81,23 @@ export type TradeHistoryItem = {
   createdAt: number
 }
 
+export type LiveTicker = {
+  symbolId: number
+  bestAsk: number
+  bestBid: number
+  open: number
+  high: number
+  low: number
+  last: number
+  volume: number
+  timestamp: number
+}
+
+export type MarketStreamMessage = {
+  type: 'ticker'
+  data: LiveTicker
+}
+
 export async function fetchApi<T>(path: string): Promise<T> {
   const res = await fetch(`${API_BASE}${path}`)
   if (!res.ok) {
@@ -104,4 +122,14 @@ export async function sendApi<TResponse, TBody = undefined>(
   }
 
   return res.json()
+}
+
+export function buildMarketWebSocketUrl(symbolId: number): string {
+  if (typeof window === 'undefined') {
+    return `${WS_BASE}/ws/market?symbolId=${symbolId}`
+  }
+
+  const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
+  const host = window.location.hostname === 'localhost' ? 'localhost:8080' : window.location.host
+  return `${protocol}//${host}/api/v1/ws/market?symbolId=${symbolId}`
 }

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -5,6 +5,7 @@ import { CandlestickChart } from '../components/CandlestickChart'
 import { IndicatorPanel } from '../components/IndicatorPanel'
 import { PositionPanel } from '../components/PositionPanel'
 import { BotControlCard } from '../components/BotControlCard'
+import { LiveTickerCard } from '../components/LiveTickerCard'
 import { useStatus } from '../hooks/useStatus'
 import { usePnl } from '../hooks/usePnl'
 import { useStrategy } from '../hooks/useStrategy'
@@ -12,6 +13,7 @@ import { useIndicators } from '../hooks/useIndicators'
 import { useCandles } from '../hooks/useCandles'
 import { usePositions } from '../hooks/usePositions'
 import { useStartBot, useStopBot } from '../hooks/useBotControl'
+import { useMarketTickerStream } from '../hooks/useMarketTickerStream'
 
 export const Route = createFileRoute('/')({ component: Dashboard })
 
@@ -24,6 +26,7 @@ function Dashboard() {
   const { data: positions } = usePositions(7)
   const startBot = useStartBot()
   const stopBot = useStopBot()
+  const { ticker, connectionState } = useMarketTickerStream(7)
 
   const statusLabel = status?.tradingHalted
     ? 'リスク停止'
@@ -63,6 +66,7 @@ function Dashboard() {
 
       <div className="mt-4 grid gap-4 xl:grid-cols-[minmax(0,2fr)_minmax(320px,1fr)]">
         <section className="space-y-4">
+          <LiveTickerCard ticker={ticker} connectionState={connectionState} />
           <CandlestickChart candles={candles ?? []} />
           <div className="rounded-3xl border border-white/8 bg-bg-card/90 p-5 shadow-[0_12px_40px_rgba(0,0,0,0.22)]">
             <div className="flex items-center justify-between">


### PR DESCRIPTION
## 概要
- 楽天 WebSocket の ticker を backend で受信して frontend 向けに中継する WebSocket エンドポイントを追加
- dashboard にリアルタイム価格カードを追加し、ライブ接続状態を表示
- ライブ ticker を受けた際に indicators / candles の再取得をトリガーする hook を追加

## 変更内容
- backend に  を追加
-  で Rakuten WebSocket の ticker relay ループを起動
-  に最新 ticker 取得を追加
- frontend に  と  を追加
- dashboard にリアルタイム価格表示を組み込み

## 動作確認
- 
- 
- 
-  ERR_PNPM_NO_IMPORTER_MANIFEST_FOUND  No package.json (or package.yaml, or package.json5) was found in "/Users/h.aiso".

## 補足
- sandbox 制約により、ローカル listen socket を使う  ベースの API テストはこの環境では実行していません
- 作業ツリーには検証用の  が untracked で残っています