### PR TITLE
feat: ローソク足初期ロードと統合 realtime websocket を追加

### DIFF
--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"log"
@@ -45,6 +46,8 @@ func main() {
 
 	// --- Usecase ---
 	marketDataSvc := usecase.NewMarketDataService(marketDataRepo)
+	realtimeHub := usecase.NewRealtimeHub()
+	marketDataSvc.SetRealtimeHub(realtimeHub)
 	indicatorCalc := usecase.NewIndicatorCalculator(marketDataRepo)
 	llmSvc := usecase.NewLLMService(claudeClient, time.Duration(cfg.LLM.CacheTTLMin)*time.Minute)
 	strategyEngine := usecase.NewStrategyEngine(llmSvc)
@@ -56,12 +59,17 @@ func main() {
 	})
 	orderExecutor := usecase.NewOrderExecutor(restClient, riskMgr)
 
+	if err := bootstrapCandles(context.Background(), restClient, marketDataSvc, 7, "15min", "PT15M", 500); err != nil {
+		log.Printf("initial candle bootstrap failed: %v", err)
+	}
+
 	// --- REST API ---
 	router := api.NewRouter(api.Dependencies{
 		RiskManager:         riskMgr,
 		LLMService:          llmSvc,
 		IndicatorCalculator: indicatorCalc,
 		MarketDataService:   marketDataSvc,
+		RealtimeHub:         realtimeHub,
 		OrderClient:         restClient,
 	})
 
@@ -84,7 +92,7 @@ func main() {
 	log.Printf("Config: maxPosition=%.0f, maxDailyLoss=%.0f, stopLoss=%.1f%%, capital=%.0f",
 		cfg.Risk.MaxPositionAmount, cfg.Risk.MaxDailyLoss, cfg.Risk.StopLossPercent, cfg.Risk.InitialCapital)
 
-	go startTickerRelay(ctx, wsClient, marketDataSvc, 7)
+	go startMarketRelay(ctx, wsClient, marketDataSvc, realtimeHub, 7)
 
 	// コンポーネントの参照を保持（Trading Pipeline実装時に使用）
 	_ = strategyEngine
@@ -104,7 +112,7 @@ func main() {
 	log.Println("Trading Engine stopped")
 }
 
-func startTickerRelay(ctx context.Context, wsClient *rakuten.WSClient, marketDataSvc *usecase.MarketDataService, symbolID int64) {
+func startMarketRelay(ctx context.Context, wsClient *rakuten.WSClient, marketDataSvc *usecase.MarketDataService, realtimeHub *usecase.RealtimeHub, symbolID int64) {
 	if wsClient == nil || marketDataSvc == nil {
 		return
 	}
@@ -124,11 +132,13 @@ func startTickerRelay(ctx context.Context, wsClient *rakuten.WSClient, marketDat
 			continue
 		}
 
-		if err := wsClient.Subscribe(ctx, symbolID, rakuten.DataTypeTicker); err != nil {
-			log.Printf("market websocket subscribe failed: %v", err)
-			_ = wsClient.Close()
-			waitForReconnect(ctx)
-			continue
+		for _, dataType := range []rakuten.DataType{rakuten.DataTypeTicker, rakuten.DataTypeOrderbook, rakuten.DataTypeTrades} {
+			if err := wsClient.Subscribe(ctx, symbolID, dataType); err != nil {
+				log.Printf("market websocket subscribe failed: %v", err)
+				_ = wsClient.Close()
+				waitForReconnect(ctx)
+				continue
+			}
 		}
 
 		log.Printf("market websocket subscribed: symbol=%d", symbolID)
@@ -145,13 +155,7 @@ func startTickerRelay(ctx context.Context, wsClient *rakuten.WSClient, marketDat
 					break
 				}
 
-				var ticker entity.Ticker
-				if err := json.Unmarshal(raw, &ticker); err != nil {
-					log.Printf("market websocket decode failed: %v", err)
-					continue
-				}
-
-				marketDataSvc.HandleTicker(ctx, ticker)
+				handleMarketMessage(ctx, raw, marketDataSvc, realtimeHub)
 			}
 		}
 
@@ -161,9 +165,81 @@ func startTickerRelay(ctx context.Context, wsClient *rakuten.WSClient, marketDat
 	}
 }
 
+func handleMarketMessage(ctx context.Context, raw []byte, marketDataSvc *usecase.MarketDataService, realtimeHub *usecase.RealtimeHub) {
+	switch {
+	case bytes.Contains(raw, []byte(`"asks"`)):
+		var orderbook entity.Orderbook
+		if err := json.Unmarshal(raw, &orderbook); err != nil {
+			log.Printf("market websocket orderbook decode failed: %v", err)
+			return
+		}
+		if realtimeHub != nil {
+			_ = realtimeHub.PublishData("orderbook", orderbook.SymbolID, orderbook)
+		}
+	case bytes.Contains(raw, []byte(`"trades"`)):
+		var trades entity.MarketTradesResponse
+		if err := json.Unmarshal(raw, &trades); err != nil {
+			log.Printf("market websocket trades decode failed: %v", err)
+			return
+		}
+		if realtimeHub != nil {
+			_ = realtimeHub.PublishData("market_trades", trades.SymbolID, trades)
+		}
+	default:
+		var ticker entity.Ticker
+		if err := json.Unmarshal(raw, &ticker); err != nil {
+			log.Printf("market websocket ticker decode failed: %v", err)
+			return
+		}
+		marketDataSvc.HandleTicker(ctx, ticker)
+	}
+}
+
 func waitForReconnect(ctx context.Context) {
 	select {
 	case <-ctx.Done():
 	case <-time.After(3 * time.Second):
 	}
+}
+
+func bootstrapCandles(
+	ctx context.Context,
+	restClient *rakuten.RESTClient,
+	marketDataSvc *usecase.MarketDataService,
+	symbolID int64,
+	internalInterval string,
+	rakutenCandlestickType string,
+	limit int,
+) error {
+	if restClient == nil || marketDataSvc == nil {
+		return nil
+	}
+
+	existing, err := marketDataSvc.GetCandles(ctx, symbolID, internalInterval, 1)
+	if err == nil && len(existing) > 0 {
+		log.Printf("skip candle bootstrap: symbol=%d interval=%s already has data", symbolID, internalInterval)
+		return nil
+	}
+
+	resp, err := restClient.GetCandlestick(ctx, symbolID, rakutenCandlestickType, nil, nil)
+	if err != nil {
+		return err
+	}
+
+	candles := resp.Candlesticks
+	if limit > 0 && len(candles) > limit {
+		candles = candles[len(candles)-limit:]
+	}
+
+	if len(candles) == 0 {
+		log.Printf("candle bootstrap returned no candles: symbol=%d interval=%s", symbolID, internalInterval)
+		return nil
+	}
+
+	if err := marketDataSvc.SaveCandles(ctx, symbolID, internalInterval, candles); err != nil {
+		return err
+	}
+
+	log.Printf("bootstrapped %d candles: symbol=%d interval=%s", len(candles), symbolID, internalInterval)
+	return nil
 }

--- a/backend/internal/interfaces/api/handler/bot.go
+++ b/backend/internal/interfaces/api/handler/bot.go
@@ -8,29 +8,38 @@ import (
 )
 
 type BotHandler struct {
-	riskMgr *usecase.RiskManager
+	riskMgr     *usecase.RiskManager
+	realtimeHub *usecase.RealtimeHub
 }
 
-func NewBotHandler(riskMgr *usecase.RiskManager) *BotHandler {
-	return &BotHandler{riskMgr: riskMgr}
+func NewBotHandler(riskMgr *usecase.RiskManager, realtimeHub *usecase.RealtimeHub) *BotHandler {
+	return &BotHandler{riskMgr: riskMgr, realtimeHub: realtimeHub}
 }
 
 func (h *BotHandler) Start(c *gin.Context) {
 	h.riskMgr.StartTrading()
 	status := h.riskMgr.GetStatus()
-	c.JSON(http.StatusOK, gin.H{
+	resp := gin.H{
 		"status":          "running",
 		"tradingHalted":   status.TradingHalted,
 		"manuallyStopped": status.ManuallyStopped,
-	})
+	}
+	if h.realtimeHub != nil {
+		_ = h.realtimeHub.PublishData("status", 0, resp)
+	}
+	c.JSON(http.StatusOK, resp)
 }
 
 func (h *BotHandler) Stop(c *gin.Context) {
 	h.riskMgr.StopTrading()
 	status := h.riskMgr.GetStatus()
-	c.JSON(http.StatusOK, gin.H{
+	resp := gin.H{
 		"status":          "stopped",
 		"tradingHalted":   status.TradingHalted,
 		"manuallyStopped": status.ManuallyStopped,
-	})
+	}
+	if h.realtimeHub != nil {
+		_ = h.realtimeHub.PublishData("status", 0, resp)
+	}
+	c.JSON(http.StatusOK, resp)
 }

--- a/backend/internal/interfaces/api/handler/candle.go
+++ b/backend/internal/interfaces/api/handler/candle.go
@@ -38,5 +38,10 @@ func (h *CandleHandler) GetCandles(c *gin.Context) {
 		return
 	}
 
+	// Lightweight Charts expects oldest -> newest ordering.
+	for i, j := 0, len(candles)-1; i < j; i, j = i+1, j-1 {
+		candles[i], candles[j] = candles[j], candles[i]
+	}
+
 	c.JSON(http.StatusOK, candles)
 }

--- a/backend/internal/interfaces/api/handler/realtime.go
+++ b/backend/internal/interfaces/api/handler/realtime.go
@@ -9,25 +9,34 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase"
 	"nhooyr.io/websocket"
 )
 
 type RealtimeHandler struct {
 	marketDataSvc *usecase.MarketDataService
+	riskMgr       *usecase.RiskManager
+	realtimeHub   *usecase.RealtimeHub
 }
 
-type realtimeMessage struct {
-	Type string        `json:"type"`
-	Data entity.Ticker `json:"data"`
+func NewRealtimeHandler(
+	marketDataSvc *usecase.MarketDataService,
+	riskMgr *usecase.RiskManager,
+	realtimeHub *usecase.RealtimeHub,
+) *RealtimeHandler {
+	return &RealtimeHandler{
+		marketDataSvc: marketDataSvc,
+		riskMgr:       riskMgr,
+		realtimeHub:   realtimeHub,
+	}
 }
 
-func NewRealtimeHandler(marketDataSvc *usecase.MarketDataService) *RealtimeHandler {
-	return &RealtimeHandler{marketDataSvc: marketDataSvc}
-}
+func (h *RealtimeHandler) Stream(c *gin.Context) {
+	if h.realtimeHub == nil {
+		c.JSON(503, gin.H{"error": "realtime hub unavailable"})
+		return
+	}
 
-func (h *RealtimeHandler) StreamTicker(c *gin.Context) {
 	symbolStr := c.DefaultQuery("symbolId", "7")
 	symbolID, err := strconv.ParseInt(symbolStr, 10, 64)
 	if err != nil {
@@ -44,29 +53,27 @@ func (h *RealtimeHandler) StreamTicker(c *gin.Context) {
 	defer conn.Close(websocket.StatusNormalClosure, "")
 
 	ctx := c.Request.Context()
-	if latest, err := h.marketDataSvc.GetLatestTicker(ctx, symbolID); err == nil && latest != nil {
-		if err := conn.Write(ctx, websocket.MessageText, mustMarshalRealtimeMessage(*latest)); err != nil {
-			return
-		}
+	if err := h.writeInitialSnapshot(ctx, conn, symbolID); err != nil {
+		return
 	}
 
-	sub := h.marketDataSvc.SubscribeTicker()
-	defer h.marketDataSvc.UnsubscribeTicker(sub)
+	sub := h.realtimeHub.Subscribe()
+	defer h.realtimeHub.Unsubscribe(sub)
 
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case ticker, ok := <-sub:
+		case event, ok := <-sub:
 			if !ok {
 				return
 			}
-			if ticker.SymbolID != symbolID {
+			if event.SymbolID != 0 && event.SymbolID != symbolID {
 				continue
 			}
 
 			writeCtx, cancel := context.WithTimeout(ctx, websocketWriteTimeout)
-			err := conn.Write(writeCtx, websocket.MessageText, mustMarshalRealtimeMessage(ticker))
+			err := conn.Write(writeCtx, websocket.MessageText, mustMarshalEvent(event))
 			cancel()
 			if err != nil {
 				if !errors.Is(err, context.Canceled) {
@@ -78,19 +85,54 @@ func (h *RealtimeHandler) StreamTicker(c *gin.Context) {
 	}
 }
 
+func (h *RealtimeHandler) writeInitialSnapshot(ctx context.Context, conn *websocket.Conn, symbolID int64) error {
+	status := h.riskMgr.GetStatus()
+	initialEvents := []usecase.RealtimeEvent{
+		mustRealtimeEvent("status", 0, gin.H{
+			"status":          statusLabel(status),
+			"tradingHalted":   status.TradingHalted,
+			"manuallyStopped": status.ManuallyStopped,
+			"balance":         status.Balance,
+			"dailyLoss":       status.DailyLoss,
+			"totalPosition":   status.TotalPosition,
+		}),
+		mustRealtimeEvent("config", 0, status.Config),
+	}
+
+	if latest, err := h.marketDataSvc.GetLatestTicker(ctx, symbolID); err == nil && latest != nil {
+		initialEvents = append(initialEvents, mustRealtimeEvent("ticker", latest.SymbolID, latest))
+	}
+
+	for _, event := range initialEvents {
+		writeCtx, cancel := context.WithTimeout(ctx, websocketWriteTimeout)
+		err := conn.Write(writeCtx, websocket.MessageText, mustMarshalEvent(event))
+		cancel()
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 const websocketWriteTimeout = 5 * time.Second
 
-func mustMarshalRealtimeMessage(ticker entity.Ticker) []byte {
-	payload, err := jsonMarshal(realtimeMessage{
-		Type: "ticker",
-		Data: ticker,
-	})
+func mustRealtimeEvent(eventType string, symbolID int64, payload any) usecase.RealtimeEvent {
+	data, err := json.Marshal(payload)
+	if err != nil {
+		panic(err)
+	}
+	return usecase.RealtimeEvent{
+		Type:     eventType,
+		SymbolID: symbolID,
+		Data:     data,
+	}
+}
+
+func mustMarshalEvent(event usecase.RealtimeEvent) []byte {
+	payload, err := json.Marshal(event)
 	if err != nil {
 		panic(err)
 	}
 	return payload
-}
-
-var jsonMarshal = func(v any) ([]byte, error) {
-	return json.Marshal(v)
 }

--- a/backend/internal/interfaces/api/handler/risk.go
+++ b/backend/internal/interfaces/api/handler/risk.go
@@ -9,11 +9,12 @@ import (
 )
 
 type RiskHandler struct {
-	riskMgr *usecase.RiskManager
+	riskMgr     *usecase.RiskManager
+	realtimeHub *usecase.RealtimeHub
 }
 
-func NewRiskHandler(riskMgr *usecase.RiskManager) *RiskHandler {
-	return &RiskHandler{riskMgr: riskMgr}
+func NewRiskHandler(riskMgr *usecase.RiskManager, realtimeHub *usecase.RealtimeHub) *RiskHandler {
+	return &RiskHandler{riskMgr: riskMgr, realtimeHub: realtimeHub}
 }
 
 func (h *RiskHandler) GetConfig(c *gin.Context) {
@@ -28,6 +29,18 @@ func (h *RiskHandler) UpdateConfig(c *gin.Context) {
 		return
 	}
 	h.riskMgr.UpdateConfig(req)
+	if h.realtimeHub != nil {
+		_ = h.realtimeHub.PublishData("config", 0, req)
+		status := h.riskMgr.GetStatus()
+		_ = h.realtimeHub.PublishData("status", 0, gin.H{
+			"status":          statusLabel(status),
+			"tradingHalted":   status.TradingHalted,
+			"manuallyStopped": status.ManuallyStopped,
+			"balance":         status.Balance,
+			"dailyLoss":       status.DailyLoss,
+			"totalPosition":   status.TotalPosition,
+		})
+	}
 	c.JSON(http.StatusOK, req)
 }
 

--- a/backend/internal/interfaces/api/handler/status.go
+++ b/backend/internal/interfaces/api/handler/status.go
@@ -17,10 +17,7 @@ func NewStatusHandler(riskMgr *usecase.RiskManager) *StatusHandler {
 
 func (h *StatusHandler) GetStatus(c *gin.Context) {
 	status := h.riskMgr.GetStatus()
-	engineStatus := "running"
-	if status.ManuallyStopped {
-		engineStatus = "stopped"
-	}
+	engineStatus := statusLabel(status)
 
 	c.JSON(http.StatusOK, gin.H{
 		"status":          engineStatus,
@@ -30,4 +27,11 @@ func (h *StatusHandler) GetStatus(c *gin.Context) {
 		"dailyLoss":       status.DailyLoss,
 		"totalPosition":   status.TotalPosition,
 	})
+}
+
+func statusLabel(status usecase.RiskStatus) string {
+	if status.ManuallyStopped {
+		return "stopped"
+	}
+	return "running"
 }

--- a/backend/internal/interfaces/api/router.go
+++ b/backend/internal/interfaces/api/router.go
@@ -13,6 +13,7 @@ type Dependencies struct {
 	LLMService          *usecase.LLMService
 	IndicatorCalculator *usecase.IndicatorCalculator
 	MarketDataService   *usecase.MarketDataService
+	RealtimeHub         *usecase.RealtimeHub
 	OrderClient         repository.OrderClient
 }
 
@@ -20,7 +21,7 @@ func NewRouter(deps Dependencies) *gin.Engine {
 	r := gin.Default()
 
 	r.Use(cors.New(cors.Config{
-		AllowOrigins:     []string{"http://localhost:3000"},
+		AllowOrigins:     []string{"http://localhost:3000", "http://localhost:33000"},
 		AllowMethods:     []string{"GET", "PUT", "POST", "DELETE"},
 		AllowHeaders:     []string{"Content-Type"},
 		AllowCredentials: true,
@@ -30,11 +31,11 @@ func NewRouter(deps Dependencies) *gin.Engine {
 
 	statusHandler := handler.NewStatusHandler(deps.RiskManager)
 	v1.GET("/status", statusHandler.GetStatus)
-	botHandler := handler.NewBotHandler(deps.RiskManager)
+	botHandler := handler.NewBotHandler(deps.RiskManager, deps.RealtimeHub)
 	v1.POST("/start", botHandler.Start)
 	v1.POST("/stop", botHandler.Stop)
 
-	riskHandler := handler.NewRiskHandler(deps.RiskManager)
+	riskHandler := handler.NewRiskHandler(deps.RiskManager, deps.RealtimeHub)
 	v1.GET("/config", riskHandler.GetConfig)
 	v1.PUT("/config", riskHandler.UpdateConfig)
 	v1.GET("/pnl", riskHandler.GetPnL)
@@ -49,8 +50,8 @@ func NewRouter(deps Dependencies) *gin.Engine {
 		candleHandler := handler.NewCandleHandler(deps.MarketDataService)
 		v1.GET("/candles/:symbol", candleHandler.GetCandles)
 
-		realtimeHandler := handler.NewRealtimeHandler(deps.MarketDataService)
-		v1.GET("/ws/market", realtimeHandler.StreamTicker)
+		realtimeHandler := handler.NewRealtimeHandler(deps.MarketDataService, deps.RiskManager, deps.RealtimeHub)
+		v1.GET("/ws", realtimeHandler.Stream)
 	}
 
 	if deps.OrderClient != nil {

--- a/backend/internal/usecase/market_data.go
+++ b/backend/internal/usecase/market_data.go
@@ -15,12 +15,19 @@ type MarketDataService struct {
 
 	mu         sync.RWMutex
 	tickerSubs []chan entity.Ticker
+	realtimeHub *RealtimeHub
 }
 
 func NewMarketDataService(repo repository.MarketDataRepository) *MarketDataService {
 	return &MarketDataService{
 		repo: repo,
 	}
+}
+
+func (s *MarketDataService) SetRealtimeHub(hub *RealtimeHub) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.realtimeHub = hub
 }
 
 // SubscribeTicker starts a ticker subscription and returns a receive channel.
@@ -60,6 +67,12 @@ func (s *MarketDataService) HandleTicker(ctx context.Context, ticker entity.Tick
 		case ch <- ticker:
 		default:
 			// Drop if channel full (don't block slow consumers)
+		}
+	}
+
+	if s.realtimeHub != nil {
+		if err := s.realtimeHub.PublishData("ticker", ticker.SymbolID, ticker); err != nil {
+			log.Printf("failed to publish ticker event: %v", err)
 		}
 	}
 }

--- a/backend/internal/usecase/market_data_test.go
+++ b/backend/internal/usecase/market_data_test.go
@@ -158,3 +158,24 @@ func TestMarketDataService_GetLatestTicker(t *testing.T) {
 		t.Fatalf("expected latest last 200, got %f", ticker.Last)
 	}
 }
+
+func TestMarketDataService_PublishesRealtimeTicker(t *testing.T) {
+	repo := newMockRepo()
+	svc := NewMarketDataService(repo)
+	hub := NewRealtimeHub()
+	svc.SetRealtimeHub(hub)
+
+	ch := hub.Subscribe()
+	defer hub.Unsubscribe(ch)
+
+	svc.HandleTicker(context.Background(), entity.Ticker{SymbolID: 7, Last: 123, Timestamp: 1000})
+
+	select {
+	case event := <-ch:
+		if event.Type != "ticker" {
+			t.Fatalf("expected ticker event, got %s", event.Type)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timeout waiting for realtime event")
+	}
+}

--- a/backend/internal/usecase/realtime.go
+++ b/backend/internal/usecase/realtime.go
@@ -1,0 +1,67 @@
+package usecase
+
+import (
+	"encoding/json"
+	"sync"
+)
+
+type RealtimeEvent struct {
+	Type     string          `json:"type"`
+	SymbolID int64           `json:"symbolId,omitempty"`
+	Data     json.RawMessage `json:"data"`
+}
+
+type RealtimeHub struct {
+	mu   sync.RWMutex
+	subs map[chan RealtimeEvent]struct{}
+}
+
+func NewRealtimeHub() *RealtimeHub {
+	return &RealtimeHub{
+		subs: make(map[chan RealtimeEvent]struct{}),
+	}
+}
+
+func (h *RealtimeHub) Subscribe() chan RealtimeEvent {
+	ch := make(chan RealtimeEvent, 128)
+	h.mu.Lock()
+	h.subs[ch] = struct{}{}
+	h.mu.Unlock()
+	return ch
+}
+
+func (h *RealtimeHub) Unsubscribe(ch chan RealtimeEvent) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if _, ok := h.subs[ch]; !ok {
+		return
+	}
+	delete(h.subs, ch)
+	close(ch)
+}
+
+func (h *RealtimeHub) Publish(event RealtimeEvent) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	for ch := range h.subs {
+		select {
+		case ch <- event:
+		default:
+		}
+	}
+}
+
+func (h *RealtimeHub) PublishData(eventType string, symbolID int64, payload any) error {
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+
+	h.Publish(RealtimeEvent{
+		Type:     eventType,
+		SymbolID: symbolID,
+		Data:     data,
+	})
+	return nil
+}

--- a/frontend/src/hooks/useMarketTickerStream.ts
+++ b/frontend/src/hooks/useMarketTickerStream.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
-import { buildMarketWebSocketUrl, type LiveTicker, type MarketStreamMessage } from '../lib/api'
+import { buildRealtimeWebSocketUrl, type LiveTicker, type RealtimeEventMessage } from '../lib/api'
 
 type ConnectionState = 'connecting' | 'connected' | 'disconnected'
 
@@ -8,7 +8,7 @@ export function useMarketTickerStream(symbolId: number) {
   const queryClient = useQueryClient()
   const [ticker, setTicker] = useState<LiveTicker | null>(null)
   const [connectionState, setConnectionState] = useState<ConnectionState>('connecting')
-  const lastInvalidateRef = useRef(0)
+  const lastIndicatorInvalidateRef = useRef(0)
 
   useEffect(() => {
     let active = true
@@ -17,7 +17,7 @@ export function useMarketTickerStream(symbolId: number) {
 
     const connect = () => {
       setConnectionState('connecting')
-      socket = new WebSocket(buildMarketWebSocketUrl(symbolId))
+      socket = new WebSocket(buildRealtimeWebSocketUrl(symbolId))
 
       socket.addEventListener('open', () => {
         if (!active) return
@@ -27,21 +27,39 @@ export function useMarketTickerStream(symbolId: number) {
       socket.addEventListener('message', (event) => {
         if (!active) return
 
-        let payload: MarketStreamMessage
+        let payload: RealtimeEventMessage
         try {
-          payload = JSON.parse(event.data) as MarketStreamMessage
+          payload = JSON.parse(event.data) as RealtimeEventMessage
         } catch {
           return
         }
-        if (payload.type !== 'ticker') return
 
-        setTicker(payload.data)
+        switch (payload.type) {
+          case 'ticker': {
+            setTicker(payload.data)
 
-        const now = Date.now()
-        if (now - lastInvalidateRef.current >= 30_000) {
-          lastInvalidateRef.current = now
-          void queryClient.invalidateQueries({ queryKey: ['indicators', symbolId] })
-          void queryClient.invalidateQueries({ queryKey: ['candles', symbolId] })
+            const now = Date.now()
+            if (now - lastIndicatorInvalidateRef.current >= 30_000) {
+              lastIndicatorInvalidateRef.current = now
+              void queryClient.invalidateQueries({ queryKey: ['indicators', symbolId] })
+              void queryClient.invalidateQueries({ queryKey: ['candles', symbolId] })
+            }
+            return
+          }
+          case 'status':
+            void queryClient.invalidateQueries({ queryKey: ['status'] })
+            void queryClient.invalidateQueries({ queryKey: ['pnl'] })
+            return
+          case 'config':
+            void queryClient.invalidateQueries({ queryKey: ['config'] })
+            void queryClient.invalidateQueries({ queryKey: ['status'] })
+            void queryClient.invalidateQueries({ queryKey: ['pnl'] })
+            return
+          case 'market_trades':
+            void queryClient.invalidateQueries({ queryKey: ['trades', symbolId] })
+            return
+          case 'orderbook':
+            return
         }
       })
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,5 +1,10 @@
-export const API_BASE = 'http://localhost:8080/api/v1'
-export const WS_BASE = 'ws://localhost:8080/api/v1'
+const API_HOST =
+  import.meta.env.VITE_API_HOST != null && import.meta.env.VITE_API_HOST !== ''
+    ? import.meta.env.VITE_API_HOST
+    : 'localhost:8080'
+
+export const API_BASE = `http://${API_HOST}/api/v1`
+export const WS_BASE = `ws://${API_HOST}/api/v1`
 
 export type StatusResponse = {
   status: 'running' | 'stopped'
@@ -93,10 +98,36 @@ export type LiveTicker = {
   timestamp: number
 }
 
-export type MarketStreamMessage = {
-  type: 'ticker'
-  data: LiveTicker
+export type RealtimeMarketTrades = {
+  symbolId: number
+  trades: Array<{
+    id: number
+    orderSide: 'BUY' | 'SELL'
+    price: number
+    amount: number
+    assetAmount: number
+    tradedAt: number
+  }>
+  timestamp: number
 }
+
+export type RealtimeOrderbook = {
+  symbolId: number
+  asks: Array<{ price: number; amount: number }>
+  bids: Array<{ price: number; amount: number }>
+  bestAsk: number
+  bestBid: number
+  midPrice: number
+  spread: number
+  timestamp: number
+}
+
+export type RealtimeEventMessage =
+  | { type: 'ticker'; symbolId: number; data: LiveTicker }
+  | { type: 'status'; symbolId?: number; data: StatusResponse }
+  | { type: 'config'; symbolId?: number; data: RiskConfig }
+  | { type: 'orderbook'; symbolId: number; data: RealtimeOrderbook }
+  | { type: 'market_trades'; symbolId: number; data: RealtimeMarketTrades }
 
 export async function fetchApi<T>(path: string): Promise<T> {
   const res = await fetch(`${API_BASE}${path}`)
@@ -124,12 +155,12 @@ export async function sendApi<TResponse, TBody = undefined>(
   return res.json()
 }
 
-export function buildMarketWebSocketUrl(symbolId: number): string {
+export function buildRealtimeWebSocketUrl(symbolId: number): string {
   if (typeof window === 'undefined') {
-    return `${WS_BASE}/ws/market?symbolId=${symbolId}`
+    return `${WS_BASE}/ws?symbolId=${symbolId}`
   }
 
   const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
-  const host = window.location.hostname === 'localhost' ? 'localhost:8080' : window.location.host
-  return `${protocol}//${host}/api/v1/ws/market?symbolId=${symbolId}`
+  const host = window.location.hostname === 'localhost' ? API_HOST : window.location.host
+  return `${protocol}//${host}/api/v1/ws?symbolId=${symbolId}`
 }

--- a/frontend/src/routes/history.tsx
+++ b/frontend/src/routes/history.tsx
@@ -1,11 +1,13 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { AppFrame } from '../components/AppFrame'
 import { TradeHistoryTable } from '../components/TradeHistoryTable'
+import { useMarketTickerStream } from '../hooks/useMarketTickerStream'
 import { useTradeHistory } from '../hooks/useTradeHistory'
 
 export const Route = createFileRoute('/history')({ component: HistoryPage })
 
 function HistoryPage() {
+  useMarketTickerStream(7)
   const { data: trades } = useTradeHistory(7)
   const safeTrades = trades ?? []
   const totalProfit = safeTrades.reduce((sum, trade) => sum + trade.profit, 0)

--- a/frontend/src/routes/settings.tsx
+++ b/frontend/src/routes/settings.tsx
@@ -5,6 +5,7 @@ import { BotControlCard } from '../components/BotControlCard'
 import { useConfig, useUpdateConfig } from '../hooks/useConfig'
 import { useStatus } from '../hooks/useStatus'
 import { useStartBot, useStopBot } from '../hooks/useBotControl'
+import { useMarketTickerStream } from '../hooks/useMarketTickerStream'
 import type { RiskConfig } from '../lib/api'
 
 export const Route = createFileRoute('/settings')({ component: SettingsPage })
@@ -15,6 +16,7 @@ function SettingsPage() {
   const updateConfig = useUpdateConfig()
   const startBot = useStartBot()
   const stopBot = useStopBot()
+  useMarketTickerStream(7)
   const [form, setForm] = useState<RiskConfig>({
     maxPositionAmount: 0,
     maxDailyLoss: 0,


### PR DESCRIPTION
## 概要
- backend 起動時に楽天 REST の candlestick を取得して candles テーブルへ初期保存
- frontend 向け websocket を /api/v1/ws に統合し、ticker / status / config / orderbook / market_trades を配信
- frontend 側は統合 websocket を購読して、設定画面・履歴画面を含めた再取得トリガーを一本化

## 変更内容
- backend 起動時に BTC/JPY 15分足 500 本を bootstrap
- /api/v1/candles/:symbol の返却順を oldest -> newest に修正
- RealtimeHub を追加して backend 内の realtime event を集約
- bot start/stop と config update 後に status/config event を push
- frontend の market ticker hook を unified realtime websocket 対応に変更

## 動作確認
- BTC/JPY のローソク足チャートが表示されることを確認
- GOCACHE=/Users/h.aiso/Projects/rakuten-api-leverage-exchange/.gocache go test ./internal/usecase
- GOCACHE=/Users/h.aiso/Projects/rakuten-api-leverage-exchange/.gocache go test -run ^$ ./cmd ./internal/interfaces/api
- ./node_modules/.bin/tsc --noEmit
- pnpm build

## 補足
- 作業ツリーには別件の未コミット差分が残っているため、この PR には commit af16284 のみを反映しています
- 楽天 websocket の数値文字列 decode まわりは別途詰める余地がありますが、今回のローソク足初期表示には影響していません