### PR TITLE
fix: 楽天WS文字列数値デコードとDocker環境変数の修正

### DIFF
--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -165,13 +165,61 @@ func startMarketRelay(ctx context.Context, wsClient *rakuten.WSClient, marketDat
 	}
 }
 
+// Raw structures for decoding Rakuten WebSocket messages where numeric values
+// are delivered as JSON strings (e.g. "12345.67").
+type rawTicker struct {
+	SymbolID  int64                `json:"symbolId"`
+	BestAsk   entity.StringFloat64 `json:"bestAsk"`
+	BestBid   entity.StringFloat64 `json:"bestBid"`
+	Open      entity.StringFloat64 `json:"open"`
+	High      entity.StringFloat64 `json:"high"`
+	Low       entity.StringFloat64 `json:"low"`
+	Last      entity.StringFloat64 `json:"last"`
+	Volume    entity.StringFloat64 `json:"volume"`
+	Timestamp int64                `json:"timestamp"`
+}
+
+type rawOrderbookEntry struct {
+	Price  entity.StringFloat64 `json:"price"`
+	Amount entity.StringFloat64 `json:"amount"`
+}
+
+type rawOrderbook struct {
+	SymbolID  int64               `json:"symbolId"`
+	Asks      []rawOrderbookEntry `json:"asks"`
+	Bids      []rawOrderbookEntry `json:"bids"`
+	BestAsk   entity.StringFloat64 `json:"bestAsk"`
+	BestBid   entity.StringFloat64 `json:"bestBid"`
+	MidPrice  entity.StringFloat64 `json:"midPrice"`
+	Spread    entity.StringFloat64 `json:"spread"`
+	Timestamp int64                `json:"timestamp"`
+}
+
 func handleMarketMessage(ctx context.Context, raw []byte, marketDataSvc *usecase.MarketDataService, realtimeHub *usecase.RealtimeHub) {
 	switch {
 	case bytes.Contains(raw, []byte(`"asks"`)):
-		var orderbook entity.Orderbook
-		if err := json.Unmarshal(raw, &orderbook); err != nil {
+		var r rawOrderbook
+		if err := json.Unmarshal(raw, &r); err != nil {
 			log.Printf("market websocket orderbook decode failed: %v", err)
 			return
+		}
+		asks := make([]entity.OrderbookEntry, len(r.Asks))
+		for i, a := range r.Asks {
+			asks[i] = entity.OrderbookEntry{Price: a.Price.Float64(), Amount: a.Amount.Float64()}
+		}
+		bids := make([]entity.OrderbookEntry, len(r.Bids))
+		for i, b := range r.Bids {
+			bids[i] = entity.OrderbookEntry{Price: b.Price.Float64(), Amount: b.Amount.Float64()}
+		}
+		orderbook := entity.Orderbook{
+			SymbolID:  r.SymbolID,
+			Asks:      asks,
+			Bids:      bids,
+			BestAsk:   r.BestAsk.Float64(),
+			BestBid:   r.BestBid.Float64(),
+			MidPrice:  r.MidPrice.Float64(),
+			Spread:    r.Spread.Float64(),
+			Timestamp: r.Timestamp,
 		}
 		if realtimeHub != nil {
 			_ = realtimeHub.PublishData("orderbook", orderbook.SymbolID, orderbook)
@@ -186,10 +234,21 @@ func handleMarketMessage(ctx context.Context, raw []byte, marketDataSvc *usecase
 			_ = realtimeHub.PublishData("market_trades", trades.SymbolID, trades)
 		}
 	default:
-		var ticker entity.Ticker
-		if err := json.Unmarshal(raw, &ticker); err != nil {
+		var r rawTicker
+		if err := json.Unmarshal(raw, &r); err != nil {
 			log.Printf("market websocket ticker decode failed: %v", err)
 			return
+		}
+		ticker := entity.Ticker{
+			SymbolID:  r.SymbolID,
+			BestAsk:   r.BestAsk.Float64(),
+			BestBid:   r.BestBid.Float64(),
+			Open:      r.Open.Float64(),
+			High:      r.High.Float64(),
+			Low:       r.Low.Float64(),
+			Last:      r.Last.Float64(),
+			Volume:    r.Volume.Float64(),
+			Timestamp: r.Timestamp,
 		}
 		marketDataSvc.HandleTicker(ctx, ticker)
 	}

--- a/backend/internal/domain/entity/stringfloat.go
+++ b/backend/internal/domain/entity/stringfloat.go
@@ -1,0 +1,41 @@
+package entity
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+// StringFloat64 unmarshals a JSON value that may be either a number or a
+// string-encoded number (e.g. "12345.67") into a float64.
+type StringFloat64 float64
+
+func (sf *StringFloat64) UnmarshalJSON(data []byte) error {
+	// Try number first.
+	var f float64
+	if err := json.Unmarshal(data, &f); err == nil {
+		*sf = StringFloat64(f)
+		return nil
+	}
+
+	// Try quoted string.
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return fmt.Errorf("StringFloat64: cannot unmarshal %s", string(data))
+	}
+
+	f, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return fmt.Errorf("StringFloat64: cannot parse %q: %w", s, err)
+	}
+	*sf = StringFloat64(f)
+	return nil
+}
+
+func (sf StringFloat64) MarshalJSON() ([]byte, error) {
+	return json.Marshal(float64(sf))
+}
+
+func (sf StringFloat64) Float64() float64 {
+	return float64(sf)
+}

--- a/compose.yaml
+++ b/compose.yaml
@@ -3,16 +3,11 @@ services:
     build:
       context: ./backend
       dockerfile: Dockerfile
+    env_file:
+      - ./backend/.env
     environment:
       SERVER_PORT: "8080"
       DATABASE_PATH: /app/backend/data/trading.db
-      RAKUTEN_API_BASE_URL: ${RAKUTEN_API_BASE_URL:-https://exchange.rakuten-wallet.co.jp}
-      RAKUTEN_WS_URL: ${RAKUTEN_WS_URL:-wss://exchange.rakuten-wallet.co.jp/ws}
-      RAKUTEN_API_KEY: ${RAKUTEN_API_KEY:-}
-      RAKUTEN_API_SECRET: ${RAKUTEN_API_SECRET:-}
-      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
-      LLM_MODEL: ${LLM_MODEL:-claude-haiku-3-5-latest}
-      LLM_CACHE_TTL_MIN: ${LLM_CACHE_TTL_MIN:-15}
     ports:
       - "38080:8080"
     volumes:


### PR DESCRIPTION
## 概要

Realtime Ticker（BTC/JPY ライブ価格）が表示されない問題と、positions API が 500 エラーを返す問題を修正。

## 原因と対応

### 1. Ticker が表示されない
- **原因**: 楽天 WebSocket が数値フィールドを JSON 文字列（`"12345.67"`）で返すが、Go の struct は `float64` で定義していたため `json.Unmarshal` が全件失敗しデータがドロップされていた
- **対応**: `StringFloat64` カスタム型を導入し、文字列・数値の両方をデコール可能にした。内部の `entity.Ticker` は `float64` のまま維持し、受信時に raw 構造体経由で変換する方式で影響範囲を最小化

### 2. Positions API 500 エラー
- **原因**: `compose.yaml` の `environment` ブロックが `${RAKUTEN_API_KEY:-}` のようにホスト環境変数を参照し、未設定時に空文字で `env_file` の値を上書きしていた
- **対応**: 秘匿情報・API設定は `env_file: ./backend/.env` に一任し、`environment` からは Docker 固有の設定（`DATABASE_PATH` 等）のみを指定する形に整理

## 変更ファイル
- `backend/internal/domain/entity/stringfloat.go` — 新規: `StringFloat64` カスタム型
- `backend/cmd/main.go` — 楽天WS受信部分で raw 構造体経由のデコードに変更
- `compose.yaml` — `env_file` 追加、重複する `environment` 変数を削除

## テスト
- Playwright MCP でブラウザ上の表示を確認済み
  - Ticker: リアルタイムで BTC/JPY 価格が表示される
  - Positions: 500 エラー解消、`ポジションなし` が正常表示
  - コンソールエラー: 0 件

🤖 Generated with [Claude Code](https://claude.com/claude-code)