### PR TITLE
feat: dashboard から取引銘柄を切替可能にする

### DIFF
--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -91,6 +91,36 @@ func main() {
 	// 起動時にポジション・残高を同期
 	pipeline.syncStateInitial(context.Background())
 
+	// --- Graceful Shutdown context ---
+	// NewRouter より先に ctx/cancel を定義する。onSymbolSwitch クロージャが ctx を
+	// キャプチャし、NewRouter に OnSymbolSwitch として渡すため。
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// --- Symbol Switch channel + callback ---
+	// symbolSwitchCh は pipeline 側から startMarketRelay に切替を伝える。
+	// バッファ1の上書き方式: 古い値が取り残されていたら drain して新しい値を入れる。
+	symbolSwitchCh := make(chan [2]int64, 1)
+
+	onSymbolSwitch := func(oldID, newID int64) {
+		// 新シンボルのローソク足を bootstrap（main の ctx を使う）
+		if err := bootstrapCandles(ctx, restClient, marketDataSvc, newID, "15min", "PT15M", 500); err != nil {
+			slog.Warn("candle bootstrap for new symbol failed", "symbolID", newID, "error", err)
+		}
+
+		// 上書き方式: 古い値を drain してから送信。
+		// SwitchSymbol は pipeline の switchMu でシリアライズされているため、
+		// この関数が並行実行されることはない（drain + send の atomicity は不要）。
+		select {
+		case <-symbolSwitchCh:
+		default:
+		}
+		select {
+		case symbolSwitchCh <- [2]int64{oldID, newID}:
+		case <-ctx.Done():
+		}
+	}
+
 	// --- REST API ---
 	router := api.NewRouter(api.Dependencies{
 		RiskManager:         riskMgr,
@@ -103,11 +133,8 @@ func main() {
 		Pipeline:            pipeline,
 		RESTClient:          restClient,
 		ClientOrderRepo:     clientOrderRepo,
+		OnSymbolSwitch:      onSymbolSwitch,
 	})
-
-	// --- Graceful Shutdown ---
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
@@ -127,7 +154,7 @@ func main() {
 		"capital", cfg.Risk.InitialCapital,
 	)
 
-	go startMarketRelay(ctx, wsClient, marketDataSvc, realtimeHub, symbolID)
+	go startMarketRelay(ctx, wsClient, marketDataSvc, realtimeHub, symbolID, symbolSwitchCh)
 	go startDailyLossReset(ctx, riskMgr)
 
 	slog.Info("Trading pipeline ready",
@@ -153,11 +180,19 @@ const (
 	wsMaxBackoff         = 60 * time.Second
 )
 
-func startMarketRelay(ctx context.Context, wsClient *rakuten.WSClient, marketDataSvc *usecase.MarketDataService, realtimeHub *usecase.RealtimeHub, symbolID int64) {
+func startMarketRelay(
+	ctx context.Context,
+	wsClient *rakuten.WSClient,
+	marketDataSvc *usecase.MarketDataService,
+	realtimeHub *usecase.RealtimeHub,
+	initialSymbolID int64,
+	symbolSwitchCh <-chan [2]int64,
+) {
 	if wsClient == nil || marketDataSvc == nil {
 		return
 	}
 
+	currentSymbolID := initialSymbolID
 	backoff := wsInitialBackoff
 
 	for {
@@ -176,17 +211,23 @@ func startMarketRelay(ctx context.Context, wsClient *rakuten.WSClient, marketDat
 			continue
 		}
 
+		// Subscribe — 失敗時は Close して外側ループで reconnect する
+		subscribeOK := true
 		for _, dataType := range []rakuten.DataType{rakuten.DataTypeTicker, rakuten.DataTypeOrderbook, rakuten.DataTypeTrades} {
-			if err := wsClient.Subscribe(ctx, symbolID, dataType); err != nil {
-				slog.Warn("market websocket subscribe failed", "error", err)
-				_ = wsClient.Close()
-				waitFor(ctx, backoff)
-				backoff = nextBackoff(backoff)
-				continue
+			if err := wsClient.Subscribe(ctx, currentSymbolID, dataType); err != nil {
+				slog.Warn("market websocket subscribe failed", "dataType", dataType, "error", err)
+				subscribeOK = false
+				break
 			}
 		}
+		if !subscribeOK {
+			_ = wsClient.Close()
+			waitFor(ctx, backoff)
+			backoff = nextBackoff(backoff)
+			continue
+		}
 
-		slog.Info("market websocket subscribed", "symbolID", symbolID)
+		slog.Info("market websocket subscribed", "symbolID", currentSymbolID)
 		backoff = wsInitialBackoff // 接続成功でバックオフリセット
 
 		// 2時間制限の事前再接続タイマー
@@ -202,6 +243,32 @@ func startMarketRelay(ctx context.Context, wsClient *rakuten.WSClient, marketDat
 			case <-sessionTimer.C:
 				slog.Info("market websocket session approaching 2h limit, reconnecting proactively")
 				reconnect = true
+			case ids := <-symbolSwitchCh:
+				oldID, newID := ids[0], ids[1]
+				slog.Info("switching websocket symbol subscription", "from", oldID, "to", newID)
+
+				// Unsubscribe（エラーはログのみ — 古いシンボルが既に無効でも続行する）
+				for _, dataType := range []rakuten.DataType{rakuten.DataTypeTicker, rakuten.DataTypeOrderbook, rakuten.DataTypeTrades} {
+					if err := wsClient.Unsubscribe(ctx, oldID, dataType); err != nil {
+						slog.Warn("market websocket unsubscribe failed", "dataType", dataType, "error", err)
+					}
+				}
+
+				// Subscribe（エラー時は reconnect。currentSymbolID は newID に進める）
+				switchOK := true
+				for _, dataType := range []rakuten.DataType{rakuten.DataTypeTicker, rakuten.DataTypeOrderbook, rakuten.DataTypeTrades} {
+					if err := wsClient.Subscribe(ctx, newID, dataType); err != nil {
+						slog.Error("market websocket re-subscribe failed, will reconnect", "dataType", dataType, "error", err)
+						switchOK = false
+						break
+					}
+				}
+				// pipeline 側は既に newID に切り替え済みなので、Subscribe 成否に関わらず
+				// currentSymbolID を newID にして reconnect 時に新シンボルで再接続する
+				currentSymbolID = newID
+				if !switchOK {
+					reconnect = true
+				}
 			case raw, ok := <-msgCh:
 				if !ok {
 					reconnect = true

--- a/backend/cmd/pipeline.go
+++ b/backend/cmd/pipeline.go
@@ -15,9 +15,18 @@ import (
 
 // TradingPipeline は自動売買パイプラインを管理する。
 // POST /start で Start、POST /stop で Stop を呼ぶ。
+//
+// Locking strategy:
+//   - switchMu: SwitchSymbol / Start / Stop を直列化する（これら3つが並行すると
+//     停止要求の握りつぶしや bootstrap 完了前の再開が発生するため）。
+//   - mu: symbolID / tradeAmount / cancel のフィールドアクセスを保護する。
+//     読み取りは snapshot() 経由でスナップショットを取る。
+//
+// ロック順序の原則: 必ず switchMu → mu の順で取得する。逆順で取るパスを作らないこと。
 type TradingPipeline struct {
-	mu     sync.Mutex
-	cancel context.CancelFunc
+	switchMu sync.Mutex   // SwitchSymbol / Start / Stop を直列化
+	mu       sync.RWMutex // フィールド保護（snapshot 経由で読む）
+	cancel   context.CancelFunc
 
 	symbolID    int64
 	interval    time.Duration
@@ -31,6 +40,21 @@ type TradingPipeline struct {
 	riskMgr          *usecase.RiskManager
 	tradeHistoryRepo repository.TradeHistoryRepository
 	riskStateRepo    repository.RiskStateRepository
+}
+
+// tradingSnapshot は evaluate / stopLoss ループで使う、ロック下にコピーしたフィールド束。
+type tradingSnapshot struct {
+	symbolID    int64
+	tradeAmount float64
+}
+
+func (p *TradingPipeline) snapshot() tradingSnapshot {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return tradingSnapshot{
+		symbolID:    p.symbolID,
+		tradeAmount: p.tradeAmount,
+	}
 }
 
 // TradingPipelineConfig はパイプラインの設定。
@@ -67,7 +91,16 @@ func NewTradingPipeline(
 }
 
 // Start はパイプラインを開始する。すでに実行中なら何もしない。
+// switchMu で SwitchSymbol との並行実行を防ぐ。
 func (p *TradingPipeline) Start() {
+	p.switchMu.Lock()
+	defer p.switchMu.Unlock()
+	p.startLocked()
+}
+
+// startLocked は switchMu を保持した状態で呼ぶこと。
+// SwitchSymbol から再利用するために分離されている。
+func (p *TradingPipeline) startLocked() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
@@ -85,7 +118,15 @@ func (p *TradingPipeline) Start() {
 }
 
 // Stop はパイプラインを停止する。
+// switchMu で SwitchSymbol との並行実行を防ぐ。
 func (p *TradingPipeline) Stop() {
+	p.switchMu.Lock()
+	defer p.switchMu.Unlock()
+	p.stopLocked()
+}
+
+// stopLocked は switchMu を保持した状態で呼ぶこと。
+func (p *TradingPipeline) stopLocked() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
@@ -101,13 +142,80 @@ func (p *TradingPipeline) Stop() {
 
 // Running はパイプラインが実行中かどうかを返す。
 func (p *TradingPipeline) Running() bool {
-	p.mu.Lock()
-	defer p.mu.Unlock()
+	p.mu.RLock()
+	defer p.mu.RUnlock()
 	return p.cancel != nil
+}
+
+// SymbolID は現在の取引対象シンボルIDを返す。
+func (p *TradingPipeline) SymbolID() int64 {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.symbolID
+}
+
+// TradeAmount は現在の1回あたりの注文金額を返す。
+func (p *TradingPipeline) TradeAmount() float64 {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.tradeAmount
+}
+
+// SwitchSymbol は取引対象シンボルを切り替える。
+// switchMu でシリアライズすることで:
+//   - 連続切替の順序保証（逆順適用を防ぐ）
+//   - SwitchSymbol 実行中の Start/Stop 割込みを防ぐ
+//
+// 処理順序: 停止 → フィールド更新 → onSwitch（bootstrap + WS切替）→ 再開
+// onSwitch は同期実行されるため HTTP レスポンスは bootstrap 完了まで待つ。
+//
+// ロック順序: switchMu → mu（startLocked/stopLocked 内部で mu を取る）
+func (p *TradingPipeline) SwitchSymbol(symbolID int64, tradeAmount float64, onSwitch func(oldID, newID int64)) {
+	p.switchMu.Lock()
+	defer p.switchMu.Unlock()
+
+	// 現在の状態を読み取り（switchMu 保持中なので Start/Stop は進行できない）
+	p.mu.RLock()
+	oldID := p.symbolID
+	wasRunning := p.cancel != nil
+	p.mu.RUnlock()
+
+	// 停止（switchMu 保持済みなので stopLocked を使う）
+	if wasRunning {
+		p.stopLocked()
+	}
+
+	// フィールド更新
+	p.mu.Lock()
+	p.symbolID = symbolID
+	if tradeAmount > 0 {
+		p.tradeAmount = tradeAmount
+	}
+	p.mu.Unlock()
+
+	// onSwitch（bootstrapCandles + WS切替）を同期実行
+	// switchMu で順序保証されているため、連続切替でも逆順適用されない
+	// この間 Start/Stop は switchMu 待ちでブロックされるので、
+	// bootstrap 完了前にパイプラインが動き出すことはない
+	if onSwitch != nil {
+		onSwitch(oldID, symbolID)
+	}
+
+	// 再開（switchMu 保持済みなので startLocked を使う）
+	// bootstrap 完了後に再開することで、新シンボルの指標計算が即座に可能になる
+	if wasRunning {
+		p.startLocked()
+	}
 }
 
 // runTradingLoop は一定間隔で指標計算→戦略判定→注文実行を行う。
 func (p *TradingPipeline) runTradingLoop(ctx context.Context) {
+	// テスト時に依存が nil の場合は評価ループを回さない（ロック挙動のみ検証する用途）
+	if p.marketDataSvc == nil || p.indicatorCalc == nil || p.strategyEngine == nil || p.restClient == nil || p.orderExecutor == nil {
+		<-ctx.Done()
+		return
+	}
+
 	ticker := time.NewTicker(p.interval)
 	defer ticker.Stop()
 
@@ -125,15 +233,17 @@ func (p *TradingPipeline) runTradingLoop(ctx context.Context) {
 }
 
 func (p *TradingPipeline) evaluate(ctx context.Context) {
+	snap := p.snapshot()
+
 	// 1. 最新ティッカーを取得
-	latestTicker, err := p.marketDataSvc.GetLatestTicker(ctx, p.symbolID)
+	latestTicker, err := p.marketDataSvc.GetLatestTicker(ctx, snap.symbolID)
 	if err != nil || latestTicker == nil {
 		slog.Warn("pipeline: failed to get latest ticker", "error", err)
 		return
 	}
 
 	// 2. テクニカル指標を計算
-	indicators, err := p.indicatorCalc.Calculate(ctx, p.symbolID, "15min")
+	indicators, err := p.indicatorCalc.Calculate(ctx, snap.symbolID, "15min")
 	if err != nil {
 		slog.Warn("pipeline: failed to calculate indicators", "error", err)
 		return
@@ -153,7 +263,7 @@ func (p *TradingPipeline) evaluate(ctx context.Context) {
 	}
 
 	// 4. 同一方向のポジションを保持中ならスキップ
-	positions, err := p.restClient.GetPositions(ctx, p.symbolID)
+	positions, err := p.restClient.GetPositions(ctx, snap.symbolID)
 	if err != nil {
 		slog.Warn("pipeline: failed to get positions", "error", err)
 		return
@@ -181,11 +291,11 @@ func (p *TradingPipeline) evaluate(ctx context.Context) {
 		return
 	}
 
-	amount := p.tradeAmount / price
+	amount := snap.tradeAmount / price
 	// 楽天の最小注文単位に丸める（BTC_JPY は 0.0001 BTC）
 	amount = math.Floor(amount*10000) / 10000
 	if amount <= 0 {
-		slog.Warn("pipeline: calculated amount is 0, skip", "tradeAmount", p.tradeAmount, "price", price)
+		slog.Warn("pipeline: calculated amount is 0, skip", "tradeAmount", snap.tradeAmount, "price", price)
 		return
 	}
 
@@ -198,7 +308,7 @@ func (p *TradingPipeline) evaluate(ctx context.Context) {
 
 	if result.Executed {
 		slog.Info("pipeline: order executed", "orderID", result.OrderID, "side", side, "amount", amount, "price", price)
-		p.recordTrade(ctx, p.symbolID, result.OrderID, string(side), "open", price, amount, signal.Reason, false)
+		p.recordTrade(ctx, snap.symbolID, result.OrderID, string(side), "open", price, amount, signal.Reason, false)
 		p.syncState(ctx)
 		p.persistRiskState(ctx)
 	} else {
@@ -208,6 +318,11 @@ func (p *TradingPipeline) evaluate(ctx context.Context) {
 
 // runStopLossMonitor は Ticker を監視し、損切り条件に達したポジションを即時決済する。
 func (p *TradingPipeline) runStopLossMonitor(ctx context.Context) {
+	// テスト時に依存が nil の場合は監視ループを回さない
+	if p.marketDataSvc == nil || p.riskMgr == nil || p.orderExecutor == nil {
+		<-ctx.Done()
+		return
+	}
 	tickerCh := p.marketDataSvc.SubscribeTicker()
 	defer p.marketDataSvc.UnsubscribeTicker(tickerCh)
 
@@ -219,7 +334,8 @@ func (p *TradingPipeline) runStopLossMonitor(ctx context.Context) {
 			if !ok {
 				return
 			}
-			if t.SymbolID != p.symbolID {
+			snap := p.snapshot()
+			if t.SymbolID != snap.symbolID {
 				continue
 			}
 
@@ -282,7 +398,8 @@ func (p *TradingPipeline) persistRiskState(ctx context.Context) {
 
 // syncState は楽天APIから現在のポジション・残高を取得し、RiskManagerに反映する。
 func (p *TradingPipeline) syncState(ctx context.Context) {
-	positions, err := p.restClient.GetPositions(ctx, p.symbolID)
+	snap := p.snapshot()
+	positions, err := p.restClient.GetPositions(ctx, snap.symbolID)
 	if err != nil {
 		slog.Warn("pipeline: failed to sync positions", "error", err)
 	} else {

--- a/backend/cmd/pipeline_test.go
+++ b/backend/cmd/pipeline_test.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// newTestPipelineForConcurrency は並行性テスト専用の TradingPipeline を返す。
+// runTradingLoop / runStopLossMonitor は依存 nil 時に即 wait するガードを持つので、
+// ロック挙動の検証だけを目的にフィールドだけ初期化する。
+func newTestPipelineForConcurrency(t *testing.T) *TradingPipeline {
+	t.Helper()
+	return &TradingPipeline{
+		symbolID:    7,
+		interval:    1 * time.Hour, // 評価ループを回す意図はない
+		tradeAmount: 1000,
+	}
+}
+
+// TestSwitchSymbol_ConcurrentStartStop は SwitchSymbol と Start/Stop が
+// 並行実行されても panic せず、最終状態が一貫することを検証する。
+// go test -race で実行すること。
+func TestSwitchSymbol_ConcurrentStartStop(t *testing.T) {
+	p := newTestPipelineForConcurrency(t)
+
+	var wg sync.WaitGroup
+	var switchCount atomic.Int64
+
+	// 100回並行して Switch/Start/Stop を呼ぶ
+	for i := 0; i < 100; i++ {
+		wg.Add(3)
+		go func(i int) {
+			defer wg.Done()
+			p.SwitchSymbol(int64(7+i%3), 1000, func(oldID, newID int64) {
+				// bootstrap の代わりに短い sleep で実処理を模擬
+				time.Sleep(100 * time.Microsecond)
+			})
+			switchCount.Add(1)
+		}(i)
+		go func() {
+			defer wg.Done()
+			p.Start()
+		}()
+		go func() {
+			defer wg.Done()
+			p.Stop()
+		}()
+	}
+
+	wg.Wait()
+
+	// 最終的に Stop しておく
+	p.Stop()
+	if p.Running() {
+		t.Errorf("pipeline should be stopped after final Stop, got Running=true")
+	}
+	if switchCount.Load() != 100 {
+		t.Errorf("expected 100 switches, got %d", switchCount.Load())
+	}
+}
+
+// TestSwitchSymbol_StopDuringSwitch は SwitchSymbol の onSwitch 実行中に
+// Stop が来ても、最終的に停止状態になることを検証する。
+// Codex #1 対応: switchMu が Start/Stop を直列化していなければ、
+// Stop が switchMu 待ちにならず SwitchSymbol の再開フェーズで上書きされてしまう。
+func TestSwitchSymbol_StopDuringSwitch(t *testing.T) {
+	p := newTestPipelineForConcurrency(t)
+
+	p.Start()
+	if !p.Running() {
+		t.Fatal("pipeline should be running after Start")
+	}
+
+	stopDone := make(chan struct{})
+	onSwitch := func(oldID, newID int64) {
+		// onSwitch 実行中に別 goroutine から Stop を叩く。
+		// switchMu 保持中なので Stop は SwitchSymbol 完了まで待たされる。
+		go func() {
+			p.Stop()
+			close(stopDone)
+		}()
+		// Stop が switchMu を待っている状態を作るため少し待つ
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	p.SwitchSymbol(8, 1000, onSwitch)
+
+	// SwitchSymbol 完了後、Stop が switchMu を取得して実行される
+	select {
+	case <-stopDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop did not complete within timeout")
+	}
+
+	if p.Running() {
+		t.Error("pipeline should be stopped, got Running=true")
+	}
+	if p.SymbolID() != 8 {
+		t.Errorf("symbolID should be 8 after switch, got %d", p.SymbolID())
+	}
+}
+
+// TestSwitchSymbol_StartDuringSwitch は SwitchSymbol の onSwitch 実行中に
+// Start が来ても、bootstrap 完了前にパイプラインが動き出さないことを検証する。
+// Codex #2 対応。
+func TestSwitchSymbol_StartDuringSwitch(t *testing.T) {
+	p := newTestPipelineForConcurrency(t)
+
+	// 最初は停止状態から開始（SwitchSymbol は wasRunning=false のまま終わる）
+	if p.Running() {
+		t.Fatal("pipeline should not be running initially")
+	}
+
+	var bootstrapDone atomic.Bool
+	startDone := make(chan struct{})
+
+	onSwitch := func(oldID, newID int64) {
+		go func() {
+			// Start は switchMu 待ちでブロックされ、bootstrap 完了後に走る
+			p.Start()
+			close(startDone)
+		}()
+		// Start が switchMu を待っている間に bootstrap を模擬
+		time.Sleep(20 * time.Millisecond)
+		bootstrapDone.Store(true)
+	}
+
+	p.SwitchSymbol(9, 1000, onSwitch)
+
+	<-startDone
+
+	if !bootstrapDone.Load() {
+		t.Error("bootstrap should have completed before Start was able to proceed")
+	}
+	if !p.Running() {
+		t.Error("pipeline should be running after Start")
+	}
+	if p.SymbolID() != 9 {
+		t.Errorf("symbolID should be 9, got %d", p.SymbolID())
+	}
+
+	p.Stop()
+}
+
+// TestSwitchSymbol_PreservesRunningState は、SwitchSymbol 単独で呼んだ場合に
+// 切替前の running 状態が正しく維持されることを検証する。
+func TestSwitchSymbol_PreservesRunningState(t *testing.T) {
+	p := newTestPipelineForConcurrency(t)
+
+	// 停止状態での切替 → 停止のまま
+	p.SwitchSymbol(10, 2000, nil)
+	if p.Running() {
+		t.Error("pipeline should remain stopped after switch from stopped state")
+	}
+	if p.SymbolID() != 10 || p.TradeAmount() != 2000 {
+		t.Errorf("fields not updated: symbolID=%d, tradeAmount=%f", p.SymbolID(), p.TradeAmount())
+	}
+
+	// 起動状態での切替 → 起動のまま
+	p.Start()
+	p.SwitchSymbol(11, 3000, nil)
+	if !p.Running() {
+		t.Error("pipeline should remain running after switch from running state")
+	}
+	if p.SymbolID() != 11 || p.TradeAmount() != 3000 {
+		t.Errorf("fields not updated: symbolID=%d, tradeAmount=%f", p.SymbolID(), p.TradeAmount())
+	}
+
+	p.Stop()
+}

--- a/backend/internal/domain/entity/symbol.go
+++ b/backend/internal/domain/entity/symbol.go
@@ -1,20 +1,23 @@
 package entity
 
+// Symbol は楽天 CFD の取引可能銘柄メタ情報。
+// 楽天 API は手数料や発注単位を string で返すため、該当フィールドは StringFloat64 で受ける。
+// MarshalJSON 時は数値で出力されるため、フロント側の TradableSymbol 型（number）と整合する。
 type Symbol struct {
-	ID                   int64   `json:"id"`
-	Authority            string  `json:"authority"`
-	TradeType            string  `json:"tradeType"`
-	CurrencyPair         string  `json:"currencyPair"`
-	BaseCurrency         string  `json:"baseCurrency"`
-	QuoteCurrency        string  `json:"quoteCurrency"`
-	BaseScale            int     `json:"baseScale"`
-	QuoteScale           int     `json:"quoteScale"`
-	BaseStepAmount       float64 `json:"baseStepAmount"`
-	MinOrderAmount       float64 `json:"minOrderAmount"`
-	MaxOrderAmount       float64 `json:"maxOrderAmount"`
-	MakerTradeFeePercent float64 `json:"makerTradeFeePercent"`
-	TakerTradeFeePercent float64 `json:"takerTradeFeePercent"`
-	CloseOnly            bool    `json:"closeOnly"`
-	ViewOnly             bool    `json:"viewOnly"`
-	Enabled              bool    `json:"enabled"`
+	ID                   int64         `json:"id"`
+	Authority            string        `json:"authority"`
+	TradeType            string        `json:"tradeType"`
+	CurrencyPair         string        `json:"currencyPair"`
+	BaseCurrency         string        `json:"baseCurrency"`
+	QuoteCurrency        string        `json:"quoteCurrency"`
+	BaseScale            int           `json:"baseScale"`
+	QuoteScale           int           `json:"quoteScale"`
+	BaseStepAmount       StringFloat64 `json:"baseStepAmount"`
+	MinOrderAmount       StringFloat64 `json:"minOrderAmount"`
+	MaxOrderAmount       StringFloat64 `json:"maxOrderAmount"`
+	MakerTradeFeePercent StringFloat64 `json:"makerTradeFeePercent"`
+	TakerTradeFeePercent StringFloat64 `json:"takerTradeFeePercent"`
+	CloseOnly            bool          `json:"closeOnly"`
+	ViewOnly             bool          `json:"viewOnly"`
+	Enabled              bool          `json:"enabled"`
 }

--- a/backend/internal/interfaces/api/handler/symbol.go
+++ b/backend/internal/interfaces/api/handler/symbol.go
@@ -1,0 +1,26 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/infrastructure/rakuten"
+)
+
+type SymbolHandler struct {
+	restClient *rakuten.RESTClient
+}
+
+func NewSymbolHandler(restClient *rakuten.RESTClient) *SymbolHandler {
+	return &SymbolHandler{restClient: restClient}
+}
+
+// GetSymbols handles GET /api/v1/symbols.
+func (h *SymbolHandler) GetSymbols(c *gin.Context) {
+	symbols, err := h.restClient.GetSymbols(c.Request.Context())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, symbols)
+}

--- a/backend/internal/interfaces/api/handler/trading_config.go
+++ b/backend/internal/interfaces/api/handler/trading_config.go
@@ -1,0 +1,109 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/infrastructure/rakuten"
+)
+
+// TradingConfigHandler は取引設定の取得・切替を行う。
+// switchSymbol は router 側で pipeline.SwitchSymbol + onSwitch をクロージャで包んだもの。
+// handler は onSwitch を知らず、「切替する」ことだけが責務。
+type TradingConfigHandler struct {
+	getSymbolID    func() int64
+	getTradeAmount func() float64
+	switchSymbol   func(symbolID int64, tradeAmount float64)
+	restClient     *rakuten.RESTClient
+}
+
+func NewTradingConfigHandler(
+	getSymbolID func() int64,
+	getTradeAmount func() float64,
+	switchSymbol func(symbolID int64, tradeAmount float64),
+	restClient *rakuten.RESTClient,
+) *TradingConfigHandler {
+	return &TradingConfigHandler{
+		getSymbolID:    getSymbolID,
+		getTradeAmount: getTradeAmount,
+		switchSymbol:   switchSymbol,
+		restClient:     restClient,
+	}
+}
+
+type tradingConfigResponse struct {
+	SymbolID    int64   `json:"symbolId"`
+	TradeAmount float64 `json:"tradeAmount"`
+}
+
+type updateTradingConfigRequest struct {
+	SymbolID    int64   `json:"symbolId"`
+	TradeAmount float64 `json:"tradeAmount"`
+}
+
+// GetTradingConfig handles GET /api/v1/trading-config.
+func (h *TradingConfigHandler) GetTradingConfig(c *gin.Context) {
+	c.JSON(http.StatusOK, tradingConfigResponse{
+		SymbolID:    h.getSymbolID(),
+		TradeAmount: h.getTradeAmount(),
+	})
+}
+
+// UpdateTradingConfig handles PUT /api/v1/trading-config.
+// interval はランタイム変更をサポートしない（リクエストで受け付けない）。
+func (h *TradingConfigHandler) UpdateTradingConfig(c *gin.Context) {
+	var req updateTradingConfigRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+		return
+	}
+
+	if req.SymbolID <= 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "symbolId must be positive"})
+		return
+	}
+
+	if req.TradeAmount <= 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "tradeAmount must be positive"})
+		return
+	}
+
+	// シンボルの存在確認と取引可否の検証
+	symbols, err := h.restClient.GetSymbols(c.Request.Context())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch symbols"})
+		return
+	}
+
+	var found bool
+	for _, s := range symbols {
+		if s.ID != req.SymbolID {
+			continue
+		}
+		if !s.Enabled {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "symbol is disabled"})
+			return
+		}
+		if s.ViewOnly {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "symbol is view-only"})
+			return
+		}
+		if s.CloseOnly {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "symbol is close-only"})
+			return
+		}
+		found = true
+		break
+	}
+	if !found {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "unknown symbolId"})
+		return
+	}
+
+	h.switchSymbol(req.SymbolID, req.TradeAmount)
+
+	c.JSON(http.StatusOK, tradingConfigResponse{
+		SymbolID:    h.getSymbolID(),
+		TradeAmount: h.getTradeAmount(),
+	})
+}

--- a/backend/internal/interfaces/api/router.go
+++ b/backend/internal/interfaces/api/router.go
@@ -9,11 +9,14 @@ import (
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase"
 )
 
-// PipelineController はTrading Pipelineの開始/停止を制御するインターフェース。
+// PipelineController はTrading Pipelineの開始/停止・銘柄切替を制御するインターフェース。
 type PipelineController interface {
 	Start()
 	Stop()
 	Running() bool
+	SymbolID() int64
+	TradeAmount() float64
+	SwitchSymbol(symbolID int64, tradeAmount float64, onSwitch func(oldID, newID int64))
 }
 
 type Dependencies struct {
@@ -27,6 +30,9 @@ type Dependencies struct {
 	Pipeline            PipelineController
 	RESTClient          *rakuten.RESTClient
 	ClientOrderRepo     repository.ClientOrderRepository
+	// OnSymbolSwitch はシンボル切替時に pipeline から呼び出されるコールバック。
+	// main 側で WebSocket 購読切替とローソク足 bootstrap を実行する。
+	OnSymbolSwitch func(oldID, newID int64)
 }
 
 func NewRouter(deps Dependencies) *gin.Engine {
@@ -87,6 +93,24 @@ func NewRouter(deps Dependencies) *gin.Engine {
 
 		symbolHandler := handler.NewSymbolHandler(deps.RESTClient)
 		v1.GET("/symbols", symbolHandler.GetSymbols)
+	}
+
+	if deps.Pipeline != nil && deps.RESTClient != nil {
+		// switchSymbol を「pipeline.SwitchSymbol + OnSymbolSwitch」のクロージャに包んで
+		// handler に渡す。handler は onSwitch を知らない。
+		pipeline := deps.Pipeline
+		onSwitch := deps.OnSymbolSwitch
+		switchSymbolFn := func(symbolID int64, tradeAmount float64) {
+			pipeline.SwitchSymbol(symbolID, tradeAmount, onSwitch)
+		}
+		tradingConfigHandler := handler.NewTradingConfigHandler(
+			deps.Pipeline.SymbolID,
+			deps.Pipeline.TradeAmount,
+			switchSymbolFn,
+			deps.RESTClient,
+		)
+		v1.GET("/trading-config", tradingConfigHandler.GetTradingConfig)
+		v1.PUT("/trading-config", tradingConfigHandler.UpdateTradingConfig)
 	}
 
 	if deps.OrderExecutor != nil && deps.ClientOrderRepo != nil {

--- a/backend/internal/interfaces/api/router.go
+++ b/backend/internal/interfaces/api/router.go
@@ -84,6 +84,9 @@ func NewRouter(deps Dependencies) *gin.Engine {
 	if deps.RESTClient != nil {
 		orderbookHandler := handler.NewOrderbookHandler(deps.RESTClient)
 		v1.GET("/orderbook", orderbookHandler.GetOrderbook)
+
+		symbolHandler := handler.NewSymbolHandler(deps.RESTClient)
+		v1.GET("/symbols", symbolHandler.GetSymbols)
 	}
 
 	if deps.OrderExecutor != nil && deps.ClientOrderRepo != nil {

--- a/frontend/src/components/AppFrame.tsx
+++ b/frontend/src/components/AppFrame.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react'
 import { Link } from '@tanstack/react-router'
+import { SymbolSelector } from './SymbolSelector'
 
 type AppFrameProps = {
   title: string
@@ -23,19 +24,22 @@ export function AppFrame({ title, subtitle, children }: AppFrameProps) {
             <h1 className="mt-2 text-3xl font-semibold tracking-tight text-white sm:text-4xl">{title}</h1>
             <p className="mt-2 max-w-2xl text-sm text-slate-300">{subtitle}</p>
           </div>
-          <nav className="flex flex-wrap gap-2">
-            {navItems.map((item) => (
-              <Link
-                key={item.to}
-                to={item.to}
-                activeProps={{ className: 'bg-white text-slate-950 shadow-lg' }}
-                inactiveProps={{ className: 'bg-white/8 text-slate-200 hover:bg-white/14' }}
-                className="rounded-full px-4 py-2 text-sm font-medium transition"
-              >
-                {item.label}
-              </Link>
-            ))}
-          </nav>
+          <div className="flex flex-col items-end gap-3">
+            <SymbolSelector />
+            <nav className="flex flex-wrap gap-2">
+              {navItems.map((item) => (
+                <Link
+                  key={item.to}
+                  to={item.to}
+                  activeProps={{ className: 'bg-white text-slate-950 shadow-lg' }}
+                  inactiveProps={{ className: 'bg-white/8 text-slate-200 hover:bg-white/14' }}
+                  className="rounded-full px-4 py-2 text-sm font-medium transition"
+                >
+                  {item.label}
+                </Link>
+              ))}
+            </nav>
+          </div>
         </div>
       </header>
       {children}

--- a/frontend/src/components/LiveTickerCard.tsx
+++ b/frontend/src/components/LiveTickerCard.tsx
@@ -3,6 +3,7 @@ import type { LiveTicker } from '../lib/api'
 type LiveTickerCardProps = {
   ticker: LiveTicker | null
   connectionState: 'connecting' | 'connected' | 'disconnected'
+  currencyPair?: string
 }
 
 function formatYen(value: number | null | undefined) {
@@ -15,16 +16,17 @@ function formatTime(timestamp: number | null | undefined) {
   return new Date(timestamp).toLocaleTimeString('ja-JP')
 }
 
-export function LiveTickerCard({ ticker, connectionState }: LiveTickerCardProps) {
+export function LiveTickerCard({ ticker, connectionState, currencyPair }: LiveTickerCardProps) {
   const delta = ticker ? ticker.last - ticker.open : null
   const deltaClass = delta !== null && delta < 0 ? 'text-accent-red' : 'text-accent-green'
+  const pairLabel = currencyPair ?? 'BTC/JPY'
 
   return (
     <section className="rounded-3xl border border-white/8 bg-bg-card/90 p-5 shadow-[0_12px_40px_rgba(0,0,0,0.22)]">
       <div className="flex items-start justify-between gap-4">
         <div>
           <p className="text-xs uppercase tracking-[0.28em] text-text-secondary">Realtime Ticker</p>
-          <h2 className="mt-2 text-xl font-semibold text-white">BTC/JPY ライブ価格</h2>
+          <h2 className="mt-2 text-xl font-semibold text-white">{pairLabel} ライブ価格</h2>
         </div>
         <span className={`rounded-full px-3 py-1 text-xs font-medium ${
           connectionState === 'connected'

--- a/frontend/src/components/SymbolSelector.tsx
+++ b/frontend/src/components/SymbolSelector.tsx
@@ -1,0 +1,38 @@
+import { useSymbolContext } from '../contexts/SymbolContext'
+
+export function SymbolSelector() {
+  const { symbolId, symbols, switchSymbol, isSwitching, isSwitchAllowed } = useSymbolContext()
+
+  const tradableSymbols = symbols.filter((s) => s.enabled && !s.viewOnly && !s.closeOnly)
+
+  if (tradableSymbols.length === 0) {
+    return null
+  }
+
+  const disabled = isSwitching || !isSwitchAllowed
+
+  return (
+    <div className="flex items-center gap-2">
+      <label
+        htmlFor="symbol-select"
+        className="text-xs uppercase tracking-[0.18em] text-text-secondary"
+      >
+        銘柄
+      </label>
+      <select
+        id="symbol-select"
+        value={symbolId}
+        onChange={(e) => switchSymbol(Number(e.target.value))}
+        disabled={disabled}
+        className="rounded-full border border-white/10 bg-white/6 px-4 py-2 text-sm font-medium text-white outline-none transition focus:border-cyan-200 disabled:opacity-50"
+      >
+        {tradableSymbols.map((s) => (
+          <option key={s.id} value={s.id} className="bg-bg-card text-white">
+            {s.currencyPair.replace('_', '/')}
+          </option>
+        ))}
+      </select>
+      {isSwitching && <span className="text-xs text-cyan-200">切替中...</span>}
+    </div>
+  )
+}

--- a/frontend/src/contexts/SymbolContext.tsx
+++ b/frontend/src/contexts/SymbolContext.tsx
@@ -1,0 +1,136 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import { useTradingConfig, useUpdateTradingConfig } from '../hooks/useTradingConfig'
+import { useSymbols } from '../hooks/useSymbols'
+import type { TradableSymbol } from '../lib/api'
+
+// 両 API が失敗した極端ケースのみ使う最終退避値
+const FALLBACK_SYMBOL_ID = 7
+
+type SymbolContextValue = {
+  symbolId: number
+  symbols: TradableSymbol[]
+  currentSymbol: TradableSymbol | undefined
+  switchSymbol: (symbolId: number) => void
+  isSwitching: boolean
+  // tradingConfig がロード完了するまで false。
+  // 未ロード時に fallback tradeAmount で PUT して誤上書きするのを防ぐため、
+  // SymbolSelector 側で disabled に反映する。
+  isSwitchAllowed: boolean
+}
+
+const SymbolContext = createContext<SymbolContextValue | null>(null)
+
+function pickFirstTradableId(symbols: TradableSymbol[] | undefined): number | null {
+  if (!symbols || symbols.length === 0) return null
+  const found = symbols.find((s) => s.enabled && !s.viewOnly && !s.closeOnly)
+  return found?.id ?? null
+}
+
+export function SymbolProvider({ children }: { children: ReactNode }) {
+  const {
+    data: tradingConfig,
+    isLoading: isConfigLoading,
+    isError: isConfigError,
+  } = useTradingConfig()
+  const { data: symbols, isLoading: isSymbolsLoading } = useSymbols()
+  const updateConfig = useUpdateTradingConfig()
+  const queryClient = useQueryClient()
+
+  const [symbolId, setSymbolId] = useState<number | null>(null)
+
+  // 初期化:
+  //   1. tradingConfig 取得成功 → その値を使う
+  //   2. tradingConfig 失敗 + symbols あり → symbols から最初の有効銘柄
+  //   3. 両方失敗 → FALLBACK_SYMBOL_ID
+  useEffect(() => {
+    if (symbolId !== null) return
+    if (tradingConfig) {
+      setSymbolId(tradingConfig.symbolId)
+      return
+    }
+    if (isConfigError) {
+      const fallbackFromSymbols = pickFirstTradableId(symbols)
+      if (fallbackFromSymbols !== null) {
+        setSymbolId(fallbackFromSymbols)
+      } else if (!isSymbolsLoading) {
+        setSymbolId(FALLBACK_SYMBOL_ID)
+      }
+    }
+  }, [tradingConfig, isConfigError, symbols, isSymbolsLoading, symbolId])
+
+  // tradingConfig がロード完了している時だけ switchSymbol を許可。
+  // 未ロード時に fallback tradeAmount で PUT して誤上書きするのを防ぐ。
+  const isSwitchAllowed = tradingConfig !== undefined
+
+  const switchSymbol = useCallback(
+    (newSymbolId: number) => {
+      if (!tradingConfig) return
+      const prevSymbolId = symbolId
+      setSymbolId(newSymbolId)
+      updateConfig.mutate(
+        { symbolId: newSymbolId, tradeAmount: tradingConfig.tradeAmount },
+        {
+          onSuccess: () => {
+            void queryClient.invalidateQueries({ queryKey: ['candles'] })
+            void queryClient.invalidateQueries({ queryKey: ['indicators'] })
+            void queryClient.invalidateQueries({ queryKey: ['positions'] })
+            void queryClient.invalidateQueries({ queryKey: ['trades'] })
+            void queryClient.invalidateQueries({ queryKey: ['status'] })
+            void queryClient.invalidateQueries({ queryKey: ['pnl'] })
+          },
+          onError: () => {
+            setSymbolId(prevSymbolId)
+          },
+        },
+      )
+    },
+    [symbolId, tradingConfig, updateConfig, queryClient],
+  )
+
+  if (symbolId === null) {
+    if (isConfigLoading || isSymbolsLoading) {
+      return (
+        <div className="flex min-h-screen items-center justify-center">
+          <p className="text-sm text-text-secondary">Loading...</p>
+        </div>
+      )
+    }
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <p className="text-sm text-text-secondary">Loading...</p>
+      </div>
+    )
+  }
+
+  const safeSymbols = symbols ?? []
+  const currentSymbol = safeSymbols.find((s) => s.id === symbolId)
+
+  return (
+    <SymbolContext.Provider
+      value={{
+        symbolId,
+        symbols: safeSymbols,
+        currentSymbol,
+        switchSymbol,
+        isSwitching: updateConfig.isPending,
+        isSwitchAllowed,
+      }}
+    >
+      {children}
+    </SymbolContext.Provider>
+  )
+}
+
+export function useSymbolContext() {
+  const ctx = useContext(SymbolContext)
+  if (!ctx) throw new Error('useSymbolContext must be used within SymbolProvider')
+  return ctx
+}

--- a/frontend/src/hooks/useMarketTickerStream.ts
+++ b/frontend/src/hooks/useMarketTickerStream.ts
@@ -11,6 +11,9 @@ export function useMarketTickerStream(symbolId: number) {
   const lastIndicatorInvalidateRef = useRef(0)
 
   useEffect(() => {
+    // symbolId 変更時に旧シンボルの価格が残らないよう、即座にリセット
+    setTicker(null)
+
     let active = true
     let socket: WebSocket | null = null
     let retryTimer: ReturnType<typeof setTimeout> | null = null

--- a/frontend/src/hooks/useSymbols.ts
+++ b/frontend/src/hooks/useSymbols.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query'
+import { fetchApi, type TradableSymbol } from '../lib/api'
+
+export function useSymbols() {
+  return useQuery({
+    queryKey: ['symbols'],
+    queryFn: () => fetchApi<TradableSymbol[]>('/symbols'),
+    staleTime: 5 * 60 * 1000,
+  })
+}

--- a/frontend/src/hooks/useTradingConfig.ts
+++ b/frontend/src/hooks/useTradingConfig.ts
@@ -1,0 +1,21 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { fetchApi, sendApi, type TradingConfig } from '../lib/api'
+
+export function useTradingConfig() {
+  return useQuery({
+    queryKey: ['trading-config'],
+    queryFn: () => fetchApi<TradingConfig>('/trading-config'),
+  })
+}
+
+export function useUpdateTradingConfig() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (config: TradingConfig) =>
+      sendApi<TradingConfig, TradingConfig>('/trading-config', 'PUT', config),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['trading-config'] })
+    },
+  })
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -65,6 +65,32 @@ export type RiskConfig = {
   initialCapital: number
 }
 
+// TradableSymbol は GET /api/v1/symbols のレスポンス要素。
+// 名前を Symbol にすると ES の組み込み Symbol と衝突するため TradableSymbol にしている。
+export type TradableSymbol = {
+  id: number
+  authority: string
+  tradeType: string
+  currencyPair: string
+  baseCurrency: string
+  quoteCurrency: string
+  baseScale: number
+  quoteScale: number
+  baseStepAmount: number
+  minOrderAmount: number
+  maxOrderAmount: number
+  makerTradeFeePercent: number
+  takerTradeFeePercent: number
+  closeOnly: boolean
+  viewOnly: boolean
+  enabled: boolean
+}
+
+export type TradingConfig = {
+  symbolId: number
+  tradeAmount: number
+}
+
 export type BotControlResponse = {
   status: 'running' | 'stopped'
   tradingHalted: boolean

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -1,5 +1,6 @@
 import { HeadContent, Outlet, Scripts, createRootRoute } from '@tanstack/react-router'
 import appCss from '../styles.css?url'
+import { SymbolProvider } from '../contexts/SymbolContext'
 
 export const Route = createRootRoute({
   head: () => ({
@@ -22,7 +23,9 @@ function RootComponent() {
         <HeadContent />
       </head>
       <body className="bg-bg-primary text-text-primary min-h-screen">
-        <Outlet />
+        <SymbolProvider>
+          <Outlet />
+        </SymbolProvider>
         <Scripts />
       </body>
     </html>

--- a/frontend/src/routes/history.tsx
+++ b/frontend/src/routes/history.tsx
@@ -3,12 +3,14 @@ import { AppFrame } from '../components/AppFrame'
 import { TradeHistoryTable } from '../components/TradeHistoryTable'
 import { useMarketTickerStream } from '../hooks/useMarketTickerStream'
 import { useTradeHistory } from '../hooks/useTradeHistory'
+import { useSymbolContext } from '../contexts/SymbolContext'
 
 export const Route = createFileRoute('/history')({ component: HistoryPage })
 
 function HistoryPage() {
-  useMarketTickerStream(7)
-  const { data: trades } = useTradeHistory(7)
+  const { symbolId } = useSymbolContext()
+  useMarketTickerStream(symbolId)
+  const { data: trades } = useTradeHistory(symbolId)
   const safeTrades = trades ?? []
   const totalProfit = safeTrades.reduce((sum, trade) => sum + trade.profit, 0)
 

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -14,19 +14,21 @@ import { useCandles } from '../hooks/useCandles'
 import { usePositions } from '../hooks/usePositions'
 import { useStartBot, useStopBot } from '../hooks/useBotControl'
 import { useMarketTickerStream } from '../hooks/useMarketTickerStream'
+import { useSymbolContext } from '../contexts/SymbolContext'
 
 export const Route = createFileRoute('/')({ component: Dashboard })
 
 function Dashboard() {
+  const { symbolId, currentSymbol } = useSymbolContext()
   const { data: status } = useStatus()
   const { data: pnl } = usePnl()
   const { data: strategy } = useStrategy()
-  const { data: indicators } = useIndicators(7)
-  const { data: candles } = useCandles(7)
-  const { data: positions } = usePositions(7)
+  const { data: indicators } = useIndicators(symbolId)
+  const { data: candles } = useCandles(symbolId)
+  const { data: positions } = usePositions(symbolId)
   const startBot = useStartBot()
   const stopBot = useStopBot()
-  const { ticker, connectionState } = useMarketTickerStream(7)
+  const { ticker, connectionState } = useMarketTickerStream(symbolId)
 
   const statusLabel = status?.tradingHalted
     ? 'リスク停止'
@@ -66,7 +68,11 @@ function Dashboard() {
 
       <div className="mt-4 grid gap-4 xl:grid-cols-[minmax(0,2fr)_minmax(320px,1fr)]">
         <section className="space-y-4">
-          <LiveTickerCard ticker={ticker} connectionState={connectionState} />
+          <LiveTickerCard
+            ticker={ticker}
+            connectionState={connectionState}
+            currencyPair={currentSymbol?.currencyPair?.replace('_', '/')}
+          />
           <CandlestickChart candles={candles ?? []} />
           <div className="rounded-3xl border border-white/8 bg-bg-card/90 p-5 shadow-[0_12px_40px_rgba(0,0,0,0.22)]">
             <div className="flex items-center justify-between">

--- a/frontend/src/routes/settings.tsx
+++ b/frontend/src/routes/settings.tsx
@@ -6,17 +6,19 @@ import { useConfig, useUpdateConfig } from '../hooks/useConfig'
 import { useStatus } from '../hooks/useStatus'
 import { useStartBot, useStopBot } from '../hooks/useBotControl'
 import { useMarketTickerStream } from '../hooks/useMarketTickerStream'
+import { useSymbolContext } from '../contexts/SymbolContext'
 import type { RiskConfig } from '../lib/api'
 
 export const Route = createFileRoute('/settings')({ component: SettingsPage })
 
 function SettingsPage() {
+  const { symbolId } = useSymbolContext()
   const { data: config } = useConfig()
   const { data: status } = useStatus()
   const updateConfig = useUpdateConfig()
   const startBot = useStartBot()
   const stopBot = useStopBot()
-  useMarketTickerStream(7)
+  useMarketTickerStream(symbolId)
   const [form, setForm] = useState<RiskConfig>({
     maxPositionAmount: 0,
     maxDailyLoss: 0,


### PR DESCRIPTION
## Summary

フロントエンド画面から取引対象銘柄（BTC/JPY, ETH/JPY 等）を切り替えられるようにする。銘柄変更時は TradingPipeline / WebSocket 購読 / ローソク足 bootstrap が動的に追従する。

**プラン:** `docs/superpowers/plans/2026-04-10-symbol-switcher.md`（レビュー反映履歴あり）

### 変更内容

**Backend**
- `GET /api/v1/symbols` — 楽天の取引可能銘柄一覧を返す
- `GET /PUT /api/v1/trading-config` — 現在の symbolId / tradeAmount を取得・更新。PUT 時は楽天側の `enabled && !viewOnly && !closeOnly` バリデーションを通す
- `TradingPipeline` を `sync.RWMutex` + `snapshot()` パターンにリファクタ（既存のデータレース修正）
- `TradingPipeline.SwitchSymbol()` を追加し、`switchMu` で `Start`/`Stop`/`SwitchSymbol` を直列化
- `startMarketRelay` を動的銘柄切替対応にし、onSwitch で新シンボルのローソク足を bootstrap してから WS を Unsubscribe→Subscribe する
- `main.go` の `ctx` 定義と `onSymbolSwitch` コールバックを `NewRouter` 呼び出しより前に移動
- `entity.Symbol` の数値フィールドを `StringFloat64` に変更（楽天 API が string で返すため、新エンドポイント追加で顕在化した既存バグ）

**Frontend**
- `TradableSymbol` / `TradingConfig` 型、`useSymbols` / `useTradingConfig` フック
- `SymbolContext` — グローバル symbolId 管理。初期化は「tradingConfig → symbols の最初の有効銘柄 → FALLBACK の3段階
- `SymbolSelector` — ヘッダーに配置する銘柄切替 dropdown
- `useMarketTickerStream` に `setTicker(null)` を追加し、symbolId 切替時に旧ペア価格が一瞬残るのを防ぐ
- `index.tsx` / `settings.tsx` / `history.tsx` のハードコード `symbolId=7` を Context 経由に置換

### レビュー対応

2人のレビュワーからの指摘を全て反映済み（詳細はプラン冒頭の履歴参照）:

- **C-NEW1**: `main.go` の ctx / NewRouter 順序問題
- **Codex #1 High**: `SwitchSymbol` と `Stop` の競合 → `switchMu` を `Start`/`Stop` にも拡張
- **Codex #2 High**: bootstrap 完了前の `Start` 割込み → 同上
- **M-NEW2**: tradingConfig 未ロード時の tradeAmount 誤上書き → `isSwitchAllowed` フラグで selector を disabled
- **Codex #3**: 無効銘柄フォールバック → symbols から最初の有効銘柄を選ぶ
- **Codex #4**: 並行性テストギャップ → `TestSwitchSymbol_*` 4件を追加（`go test -race` で検証）

### Test Plan

Automated:
- [x] `go build ./...`
- [x] `go test -race ./...`（並行性テスト4件を含む全パス）
- [x] `npx tsc --noEmit`

Docker 実環境で確認済み:
- [x] `GET /api/v1/symbols` が銘柄一覧を返す
- [x] `GET /api/v1/trading-config` で現在値を取得
- [x] `PUT /api/v1/trading-config` で有効銘柄への切替が 200 で成功し、bootstrap → WS subscription 切替がログに残る
- [x] `PUT` の無効 symbolId / tradeAmount=0 が 400 を返す
- [x] `POST /start` 直後の `PUT` + `POST /stop` 並行呼び出しで最終状態が stopped に一貫（Codex #1 対応）
- [x] サーバーログに panic / deadlock / goroutine dump なし

ブラウザでの UI 確認が残作業:
- [ ] http://localhost:33000 のヘッダーセレクタで別ペアに切替
- [ ] ティッカー / チャート / インジケーター / ポジション / 履歴が追従する
- [ ] 切替直後にティッカーが一瞬「—」状態になり、旧ペア価格が残らない

🤖 Generated with [Claude Code](https://claude.com/claude-code)