### PR TITLE
feat: ローソク足チャートに足種切替UIを追加

### DIFF
--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -64,7 +64,7 @@ func main() {
 
 	symbolID := cfg.Trading.SymbolID
 
-	if err := bootstrapCandles(context.Background(), restClient, marketDataSvc, symbolID, "15min", "PT15M", 500); err != nil {
+	if err := bootstrapCandles(context.Background(), restClient, marketDataSvc, symbolID, "PT15M", 500); err != nil {
 		slog.Warn("initial candle bootstrap failed", "error", err)
 	}
 
@@ -104,7 +104,7 @@ func main() {
 
 	onSymbolSwitch := func(oldID, newID int64) {
 		// 新シンボルのローソク足を bootstrap（main の ctx を使う）
-		if err := bootstrapCandles(ctx, restClient, marketDataSvc, newID, "15min", "PT15M", 500); err != nil {
+		if err := bootstrapCandles(ctx, restClient, marketDataSvc, newID, "PT15M", 500); err != nil {
 			slog.Warn("candle bootstrap for new symbol failed", "symbolID", newID, "error", err)
 		}
 
@@ -449,15 +449,14 @@ func bootstrapCandles(
 	restClient *rakuten.RESTClient,
 	marketDataSvc *usecase.MarketDataService,
 	symbolID int64,
-	internalInterval string,
-	rakutenCandlestickType string,
+	interval string,
 	limit int,
 ) error {
 	if restClient == nil || marketDataSvc == nil {
 		return nil
 	}
 
-	resp, err := restClient.GetCandlestick(ctx, symbolID, rakutenCandlestickType, nil, nil)
+	resp, err := restClient.GetCandlestick(ctx, symbolID, interval, nil, nil)
 	if err != nil {
 		return err
 	}
@@ -468,15 +467,15 @@ func bootstrapCandles(
 	}
 
 	if len(candles) == 0 {
-		slog.Warn("candle bootstrap returned no candles", "symbolID", symbolID, "interval", internalInterval)
+		slog.Warn("candle bootstrap returned no candles", "symbolID", symbolID, "interval", interval)
 		return nil
 	}
 
 	// INSERT OR IGNORE により既存データと重複しないため、毎回全件渡して差分のみ保存される
-	if err := marketDataSvc.SaveCandles(ctx, symbolID, internalInterval, candles); err != nil {
+	if err := marketDataSvc.SaveCandles(ctx, symbolID, interval, candles); err != nil {
 		return err
 	}
 
-	slog.Info("bootstrapped candles", "count", len(candles), "symbolID", symbolID, "interval", internalInterval)
+	slog.Info("bootstrapped candles", "count", len(candles), "symbolID", symbolID, "interval", interval)
 	return nil
 }

--- a/backend/cmd/pipeline.go
+++ b/backend/cmd/pipeline.go
@@ -243,7 +243,7 @@ func (p *TradingPipeline) evaluate(ctx context.Context) {
 	}
 
 	// 2. テクニカル指標を計算
-	indicators, err := p.indicatorCalc.Calculate(ctx, snap.symbolID, "15min")
+	indicators, err := p.indicatorCalc.Calculate(ctx, snap.symbolID, "PT15M")
 	if err != nil {
 		slog.Warn("pipeline: failed to calculate indicators", "error", err)
 		return

--- a/backend/internal/interfaces/api/handler/candle.go
+++ b/backend/internal/interfaces/api/handler/candle.go
@@ -5,18 +5,31 @@ import (
 	"strconv"
 
 	"github.com/gin-gonic/gin"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/infrastructure/rakuten"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase"
 )
 
-type CandleHandler struct {
-	marketDataSvc *usecase.MarketDataService
+// allowedIntervals は楽天APIの candlestickType をそのまま interval として許容する集合。
+var allowedIntervals = map[string]struct{}{
+	"PT1M":  {},
+	"PT5M":  {},
+	"PT15M": {},
+	"PT1H":  {},
+	"P1D":   {},
+	"P1W":   {},
 }
 
-func NewCandleHandler(marketDataSvc *usecase.MarketDataService) *CandleHandler {
-	return &CandleHandler{marketDataSvc: marketDataSvc}
+type CandleHandler struct {
+	marketDataSvc *usecase.MarketDataService
+	restClient    *rakuten.RESTClient
+}
+
+func NewCandleHandler(marketDataSvc *usecase.MarketDataService, restClient *rakuten.RESTClient) *CandleHandler {
+	return &CandleHandler{marketDataSvc: marketDataSvc, restClient: restClient}
 }
 
 // GetCandles は銘柄のローソク足データを返す。
+// DB にデータが無ければ楽天APIからオンデマンド取得して保存し、改めて返す。
 func (h *CandleHandler) GetCandles(c *gin.Context) {
 	symbolStr := c.Param("symbol")
 	symbolID, err := strconv.ParseInt(symbolStr, 10, 64)
@@ -25,17 +38,43 @@ func (h *CandleHandler) GetCandles(c *gin.Context) {
 		return
 	}
 
-	interval := c.DefaultQuery("interval", "15min")
+	interval := c.DefaultQuery("interval", "PT15M")
+	if _, ok := allowedIntervals[interval]; !ok {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "unsupported interval: " + interval})
+		return
+	}
+
 	limitStr := c.DefaultQuery("limit", "500")
 	limit, err := strconv.Atoi(limitStr)
 	if err != nil || limit < 1 || limit > 500 {
 		limit = 500
 	}
 
-	candles, err := h.marketDataSvc.GetCandles(c.Request.Context(), symbolID, interval, limit)
+	ctx := c.Request.Context()
+	candles, err := h.marketDataSvc.GetCandles(ctx, symbolID, interval, limit)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
+	}
+
+	// DB にデータが無ければ楽天APIから取得して保存、再取得する。
+	if len(candles) == 0 && h.restClient != nil {
+		resp, fetchErr := h.restClient.GetCandlestick(ctx, symbolID, interval, nil, nil)
+		if fetchErr != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": fetchErr.Error()})
+			return
+		}
+		if len(resp.Candlesticks) > 0 {
+			if saveErr := h.marketDataSvc.SaveCandles(ctx, symbolID, interval, resp.Candlesticks); saveErr != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": saveErr.Error()})
+				return
+			}
+			candles, err = h.marketDataSvc.GetCandles(ctx, symbolID, interval, limit)
+			if err != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+				return
+			}
+		}
 	}
 
 	// Lightweight Charts expects oldest -> newest ordering.

--- a/backend/internal/interfaces/api/handler/indicator.go
+++ b/backend/internal/interfaces/api/handler/indicator.go
@@ -24,7 +24,7 @@ func (h *IndicatorHandler) GetIndicators(c *gin.Context) {
 		return
 	}
 
-	interval := c.DefaultQuery("interval", "15min")
+	interval := c.DefaultQuery("interval", "PT15M")
 
 	indicators, err := h.calculator.Calculate(c.Request.Context(), symbolID, interval)
 	if err != nil {

--- a/backend/internal/interfaces/api/router.go
+++ b/backend/internal/interfaces/api/router.go
@@ -67,7 +67,7 @@ func NewRouter(deps Dependencies) *gin.Engine {
 	v1.GET("/indicators/:symbol", indicatorHandler.GetIndicators)
 
 	if deps.MarketDataService != nil {
-		candleHandler := handler.NewCandleHandler(deps.MarketDataService)
+		candleHandler := handler.NewCandleHandler(deps.MarketDataService, deps.RESTClient)
 		v1.GET("/candles/:symbol", candleHandler.GetCandles)
 
 		realtimeHandler := handler.NewRealtimeHandler(deps.MarketDataService, deps.RiskManager, deps.RealtimeHub)

--- a/backend/internal/interfaces/mcp/server.go
+++ b/backend/internal/interfaces/mcp/server.go
@@ -106,7 +106,7 @@ func addIndicatorsTool(s *server.MCPServer, deps Dependencies) {
 			if err != nil {
 				return gomcp.NewToolResultError(err.Error()), nil
 			}
-			indicators, err := deps.IndicatorCalculator.Calculate(ctx, int64(symbolID), "15min")
+			indicators, err := deps.IndicatorCalculator.Calculate(ctx, int64(symbolID), "PT15M")
 			if err != nil {
 				return gomcp.NewToolResultError(fmt.Sprintf("failed to calculate indicators: %v", err)), nil
 			}

--- a/frontend/src/components/CandlestickChart.tsx
+++ b/frontend/src/components/CandlestickChart.tsx
@@ -1,12 +1,21 @@
 import { useEffect, useRef, useState, useCallback } from 'react'
 import { createChart, CandlestickSeries, LineSeries, type IChartApi, type ISeriesApi, type CandlestickData, type LineData, type Time } from 'lightweight-charts'
-import type { Candle } from '../lib/api'
+import { useCandles, type CandleInterval } from '../hooks/useCandles'
 
 type CandlestickChartProps = {
-  candles: Candle[]
+  symbolId: number
 }
 
 type MALineKey = 'sma20' | 'sma50' | 'ema12' | 'ema26'
+
+const INTERVAL_OPTIONS: { value: CandleInterval; label: string }[] = [
+  { value: 'PT1M', label: '1m' },
+  { value: 'PT5M', label: '5m' },
+  { value: 'PT15M', label: '15m' },
+  { value: 'PT1H', label: '1h' },
+  { value: 'P1D', label: '1D' },
+  { value: 'P1W', label: '1W' },
+]
 
 const MA_CONFIG: Record<MALineKey, { label: string; color: string }> = {
   sma20: { label: 'SMA(20)', color: '#f5a623' },
@@ -47,11 +56,15 @@ function calcEMA(closes: number[], period: number): (number | null)[] {
   return result
 }
 
-export function CandlestickChart({ candles }: CandlestickChartProps) {
+export function CandlestickChart({ symbolId }: CandlestickChartProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const chartRef = useRef<IChartApi | null>(null)
   const seriesRef = useRef<ISeriesApi<'Candlestick'> | null>(null)
   const lineSeriesRefs = useRef<Partial<Record<MALineKey, ISeriesApi<'Line'>>>>({})
+
+  const [interval, setInterval] = useState<CandleInterval>('PT15M')
+  const { data: candlesData, isFetching } = useCandles(symbolId, interval)
+  const candles = candlesData ?? []
 
   const [visible, setVisible] = useState<Record<MALineKey, boolean>>({
     sma20: false,
@@ -175,8 +188,30 @@ export function CandlestickChart({ candles }: CandlestickChartProps) {
 
   return (
     <div className="bg-bg-card rounded-lg p-4">
-      <div className="mb-2 flex items-center justify-between">
-        <div className="text-text-secondary text-xs">BTC/JPY</div>
+      <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <div className="flex gap-1">
+            {INTERVAL_OPTIONS.map((opt) => {
+              const active = interval === opt.value
+              return (
+                <button
+                  key={opt.value}
+                  type="button"
+                  onClick={() => setInterval(opt.value)}
+                  className="rounded-md px-2.5 py-0.5 text-[11px] font-medium transition"
+                  style={{
+                    backgroundColor: active ? 'rgba(0, 212, 170, 0.18)' : 'rgba(255,255,255,0.06)',
+                    color: active ? '#00d4aa' : '#94a3b8',
+                    border: `1px solid ${active ? 'rgba(0, 212, 170, 0.45)' : 'rgba(255,255,255,0.1)'}`,
+                  }}
+                >
+                  {opt.label}
+                </button>
+              )
+            })}
+          </div>
+          {isFetching && <span className="text-[10px] text-text-secondary">読み込み中...</span>}
+        </div>
         <div className="flex gap-1.5">
           {(Object.keys(MA_CONFIG) as MALineKey[]).map((key) => (
             <button

--- a/frontend/src/hooks/useCandles.ts
+++ b/frontend/src/hooks/useCandles.ts
@@ -1,10 +1,12 @@
 import { useQuery } from '@tanstack/react-query'
 import { fetchApi, type Candle } from '../lib/api'
 
-export function useCandles(symbolId: number) {
+export type CandleInterval = 'PT1M' | 'PT5M' | 'PT15M' | 'PT1H' | 'P1D' | 'P1W'
+
+export function useCandles(symbolId: number, interval: CandleInterval = 'PT15M') {
   return useQuery({
-    queryKey: ['candles', symbolId],
-    queryFn: () => fetchApi<Candle[]>(`/candles/${symbolId}`),
+    queryKey: ['candles', symbolId, interval],
+    queryFn: () => fetchApi<Candle[]>(`/candles/${symbolId}?interval=${interval}`),
     refetchInterval: 60_000,
   })
 }

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -10,7 +10,6 @@ import { useStatus } from '../hooks/useStatus'
 import { usePnl } from '../hooks/usePnl'
 import { useStrategy } from '../hooks/useStrategy'
 import { useIndicators } from '../hooks/useIndicators'
-import { useCandles } from '../hooks/useCandles'
 import { usePositions } from '../hooks/usePositions'
 import { useStartBot, useStopBot } from '../hooks/useBotControl'
 import { useMarketTickerStream } from '../hooks/useMarketTickerStream'
@@ -24,7 +23,6 @@ function Dashboard() {
   const { data: pnl } = usePnl()
   const { data: strategy } = useStrategy()
   const { data: indicators } = useIndicators(symbolId)
-  const { data: candles } = useCandles(symbolId)
   const { data: positions } = usePositions(symbolId)
   const startBot = useStartBot()
   const stopBot = useStopBot()
@@ -73,7 +71,7 @@ function Dashboard() {
             connectionState={connectionState}
             currencyPair={currentSymbol?.currencyPair?.replace('_', '/')}
           />
-          <CandlestickChart candles={candles ?? []} />
+          <CandlestickChart symbolId={symbolId} />
           <div className="rounded-3xl border border-white/8 bg-bg-card/90 p-5 shadow-[0_12px_40px_rgba(0,0,0,0.22)]">
             <div className="flex items-center justify-between">
               <div>


### PR DESCRIPTION
## Summary
- フロントのチャート上部に `1m / 5m / 15m / 1h / 1D / 1W` のトグルを追加し、足種をその場で切替できるようにした
- バックエンドの candle handler を楽天API の ISO 8601 形式（`PT1M/PT5M/PT15M/PT1H/P1D/P1W`）に統一し、許可リストでバリデーション
- DB 未保存の足種は楽天API からオンデマンド取得 → 保存 → 返却（次回以降はキャッシュヒット）
- 内部 interval 文字列の `"15min"` を `"PT15M"` に統一（main bootstrap、pipeline、indicator、MCP サーバー）

## 主な変更
- `backend/internal/interfaces/api/handler/candle.go`: interval 許可リスト、オンデマンド取得ロジック、`RESTClient` 依存追加
- `backend/internal/interfaces/api/router.go`: `NewCandleHandler` に `RESTClient` を渡す
- `backend/cmd/main.go` / `pipeline.go` / `handler/indicator.go` / `mcp/server.go`: 内部 interval を `PT15M` に統一。`bootstrapCandles` の冗長な2引数を1つに整理
- `frontend/src/hooks/useCandles.ts`: `CandleInterval` 型を追加、`useCandles(symbolId, interval)` シグネチャに変更
- `frontend/src/components/CandlestickChart.tsx`: props を `symbolId` に変更し、チャート内で interval state と取得を管理。足種トグル UI を追加
- `frontend/src/routes/index.tsx`: 不要になった `useCandles` 呼び出しを削除

## 注意点
- 楽天 API は日足/週足のみ `PT` の `T` を除いた `P1D`/`P1W` 形式を要求するため、その通りに実装（`PT1D`/`PT1W` は 10001 エラー）
- DB の interval カラムは古い `"15min"` 表記のデータが残る可能性があるが、起動毎の bootstrap で新形式 (`PT15M`) に再取得されるため実害なし

## Test plan
- [x] `go build ./...` / `go test ./...` パス
- [x] `tsc --noEmit` / `vite build` パス
- [x] `docker compose up --build` で再ビルド、全6足種のAPIエンドポイントで 200 を確認
- [x] 不正 interval（例: `15min`）に対して 400 を返すことを確認
- [x] Playwright で Dashboard を開き、全6足種のトグルをクリックしてチャートが切り替わること、ネットワークで `interval=PT1M/PT5M/PT15M/PT1H/P1D/P1W` が全て 200 を返すことを確認
- [x] コンソールエラー 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)