### PR TITLE
fix/feat(frontend): polish dashboard UI and guard useCandles

### DIFF
--- a/frontend/src/components/AppFrame.tsx
+++ b/frontend/src/components/AppFrame.tsx
@@ -9,31 +9,44 @@ type AppFrameProps = {
 }
 
 const navItems = [
-  { to: '/', label: 'Dashboard' },
-  { to: '/settings', label: 'Settings' },
-  { to: '/history', label: 'History' },
+  { to: '/', label: 'ダッシュボード' },
+  { to: '/settings', label: '設定' },
+  { to: '/history', label: '履歴' },
 ] as const
 
 export function AppFrame({ title, subtitle, children }: AppFrameProps) {
   return (
     <main className="mx-auto min-h-screen w-full max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
-      <header className="mb-6 overflow-hidden rounded-3xl border border-white/8 bg-[linear-gradient(135deg,rgba(55,66,250,0.24),rgba(8,12,32,0.92)_45%,rgba(0,212,170,0.18))] p-6 shadow-[0_20px_80px_rgba(0,0,0,0.35)]">
+      <header className="mb-6 overflow-hidden rounded-3xl border border-white/8 bg-[linear-gradient(135deg,rgba(55,66,250,0.24),rgba(8,12,32,0.92)_45%,rgba(0,212,170,0.18))] p-5 sm:p-6 shadow-[0_20px_80px_rgba(0,0,0,0.35)]">
         <div className="flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
           <div>
             <p className="text-[0.7rem] uppercase tracking-[0.35em] text-cyan-200/70">Rakuten CFD Bot</p>
-            <h1 className="mt-2 text-3xl font-semibold tracking-tight text-white sm:text-4xl">{title}</h1>
+            <h1 className="mt-2 text-2xl font-semibold tracking-tight text-white sm:text-3xl lg:text-4xl">{title}</h1>
             <p className="mt-2 max-w-2xl text-sm text-slate-300">{subtitle}</p>
           </div>
-          <div className="flex flex-col items-end gap-3">
+          <div className="flex flex-col gap-3 lg:items-end">
             <SymbolSelector />
-            <nav className="flex flex-wrap gap-2">
+            <nav className="-mx-1 flex gap-2 overflow-x-auto px-1 pb-1 lg:overflow-visible">
               {navItems.map((item) => (
                 <Link
                   key={item.to}
                   to={item.to}
-                  activeProps={{ className: 'bg-white text-slate-950 shadow-lg' }}
-                  inactiveProps={{ className: 'bg-white/8 text-slate-200 hover:bg-white/14' }}
-                  className="rounded-full px-4 py-2 text-sm font-medium transition"
+                  activeProps={{
+                    style: {
+                      backgroundColor: '#00d4aa',
+                      color: '#0f172a',
+                      boxShadow: '0 8px 24px rgba(0,212,170,0.35)',
+                      borderColor: 'rgba(0,212,170,0.6)',
+                    },
+                  }}
+                  inactiveProps={{
+                    style: {
+                      backgroundColor: 'rgba(255,255,255,0.08)',
+                      color: '#e2e8f0',
+                      borderColor: 'rgba(255,255,255,0.12)',
+                    },
+                  }}
+                  className="whitespace-nowrap rounded-full border px-4 py-2 text-sm font-semibold transition hover:brightness-110"
                 >
                   {item.label}
                 </Link>

--- a/frontend/src/components/BotControlCard.tsx
+++ b/frontend/src/components/BotControlCard.tsx
@@ -8,26 +8,33 @@ type BotControlCardProps = {
 }
 
 function getStatusLabel(status: StatusResponse | undefined): string {
-  if (!status) return 'loading'
-  if (status.manuallyStopped) return 'manual stop'
-  if (status.tradingHalted) return 'risk halted'
-  return 'running'
+  if (!status) return '読込中'
+  if (status.manuallyStopped) return '手動停止'
+  if (status.tradingHalted) return 'リスク停止'
+  if (status.status === 'running') return '稼働中'
+  return status.status ?? '不明'
 }
 
 export function BotControlCard({ status, onStart, onStop, isPending }: BotControlCardProps) {
   const current = getStatusLabel(status)
   const disabled = isPending
+  const isRunning = status?.status === 'running' && !status?.manuallyStopped && !status?.tradingHalted
+  const badgeClass = !status
+    ? 'bg-white/6 text-slate-300'
+    : isRunning
+      ? 'bg-accent-green/18 text-accent-green'
+      : 'bg-accent-red/18 text-accent-red'
 
   return (
     <section className="rounded-3xl border border-white/8 bg-bg-card/90 p-5 shadow-[0_12px_40px_rgba(0,0,0,0.22)]">
       <div className="flex items-start justify-between gap-4">
         <div>
-          <p className="text-xs uppercase tracking-[0.28em] text-text-secondary">Bot Control</p>
+          <p className="text-xs uppercase tracking-[0.28em] text-text-secondary">ボット制御</p>
           <h2 className="mt-2 text-xl font-semibold text-white">起動 / 停止</h2>
           <p className="mt-2 text-sm text-slate-300">現在状態: <span className="font-medium text-white">{current}</span></p>
         </div>
-        <div className="rounded-full border border-white/10 bg-white/6 px-3 py-1 text-xs text-slate-300">
-          {status?.status ?? 'unknown'}
+        <div className={`rounded-full border border-white/10 px-3 py-1 text-xs ${badgeClass}`}>
+          {current}
         </div>
       </div>
 
@@ -38,7 +45,7 @@ export function BotControlCard({ status, onStart, onStop, isPending }: BotContro
           disabled={disabled}
           className="rounded-full bg-accent-green px-4 py-2 text-sm font-semibold text-slate-950 transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-50"
         >
-          Start
+          起動
         </button>
         <button
           type="button"
@@ -46,7 +53,7 @@ export function BotControlCard({ status, onStart, onStop, isPending }: BotContro
           disabled={disabled}
           className="rounded-full bg-accent-red px-4 py-2 text-sm font-semibold text-white transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-50"
         >
-          Stop
+          停止
         </button>
       </div>
     </section>

--- a/frontend/src/components/LiveTickerCard.tsx
+++ b/frontend/src/components/LiveTickerCard.tsx
@@ -16,6 +16,12 @@ function formatTime(timestamp: number | null | undefined) {
   return new Date(timestamp).toLocaleTimeString('ja-JP')
 }
 
+const CONNECTION_LABEL: Record<'connecting' | 'connected' | 'disconnected', string> = {
+  connecting: '接続中…',
+  connected: '接続済み',
+  disconnected: '切断',
+}
+
 export function LiveTickerCard({ ticker, connectionState, currencyPair }: LiveTickerCardProps) {
   const delta = ticker ? ticker.last - ticker.open : null
   const deltaClass = delta !== null && delta < 0 ? 'text-accent-red' : 'text-accent-green'
@@ -25,7 +31,7 @@ export function LiveTickerCard({ ticker, connectionState, currencyPair }: LiveTi
     <section className="rounded-3xl border border-white/8 bg-bg-card/90 p-5 shadow-[0_12px_40px_rgba(0,0,0,0.22)]">
       <div className="flex items-start justify-between gap-4">
         <div>
-          <p className="text-xs uppercase tracking-[0.28em] text-text-secondary">Realtime Ticker</p>
+          <p className="text-xs uppercase tracking-[0.28em] text-text-secondary">リアルタイムティッカー</p>
           <h2 className="mt-2 text-xl font-semibold text-white">{pairLabel} ライブ価格</h2>
         </div>
         <span className={`rounded-full px-3 py-1 text-xs font-medium ${
@@ -35,7 +41,7 @@ export function LiveTickerCard({ ticker, connectionState, currencyPair }: LiveTi
               ? 'bg-cyan-200/16 text-cyan-200'
               : 'bg-accent-red/18 text-accent-red'
         }`}>
-          {connectionState}
+          {CONNECTION_LABEL[connectionState]}
         </span>
       </div>
 
@@ -47,10 +53,10 @@ export function LiveTickerCard({ ticker, connectionState, currencyPair }: LiveTi
           </p>
         </div>
         <div className="grid grid-cols-2 gap-3 text-sm">
-          <Metric label="Best Ask" value={formatYen(ticker?.bestAsk)} />
-          <Metric label="Best Bid" value={formatYen(ticker?.bestBid)} />
-          <Metric label="Volume" value={ticker?.volume?.toLocaleString('ja-JP') ?? '\u2014'} />
-          <Metric label="Updated" value={formatTime(ticker?.timestamp)} />
+          <Metric label="売気配" value={formatYen(ticker?.bestAsk)} />
+          <Metric label="買気配" value={formatYen(ticker?.bestBid)} />
+          <Metric label="出来高" value={ticker?.volume?.toLocaleString('ja-JP') ?? '\u2014'} />
+          <Metric label="更新時刻" value={formatTime(ticker?.timestamp)} />
         </div>
       </div>
     </section>

--- a/frontend/src/hooks/useCandles.ts
+++ b/frontend/src/hooks/useCandles.ts
@@ -7,6 +7,7 @@ export function useCandles(symbolId: number, interval: CandleInterval = 'PT15M')
   return useQuery({
     queryKey: ['candles', symbolId, interval],
     queryFn: () => fetchApi<Candle[]>(`/candles/${symbolId}?interval=${interval}`),
+    enabled: Number.isFinite(symbolId),
     refetchInterval: 60_000,
   })
 }

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -36,12 +36,26 @@ function Dashboard() {
         ? '稼働中'
         : '\u2014'
 
+  const dailyPnl = pnl ? -pnl.dailyLoss : null
+  const dailyPnlLabel =
+    dailyPnl === null
+      ? '\u2014'
+      : dailyPnl === 0
+        ? '¥0'
+        : `¥${dailyPnl.toLocaleString()}`
+
+  const reasoningLabel = strategy?.reasoning
+    ? strategy.reasoning === 'insufficient indicator data'
+      ? '指標データが不足しています'
+      : strategy.reasoning
+    : '戦略コメントはまだ生成されていません。'
+
   return (
     <AppFrame
-      title="Trading Dashboard"
-      subtitle="KPI・戦略・ポジションを集約しつつ、Phase 2 の操作系を同じ導線に載せた監視画面です。"
+      title="トレーディングダッシュボード"
+      subtitle="KPI・戦略・ポジション・操作系を集約した監視画面です。"
     >
-      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+      <div className="grid grid-cols-2 gap-3 sm:gap-4 xl:grid-cols-4">
         <KpiCard
           label="残高"
           value={pnl ? `¥${pnl.balance.toLocaleString()}` : '\u2014'}
@@ -49,7 +63,7 @@ function Dashboard() {
         />
         <KpiCard
           label="日次損益"
-          value={pnl ? `¥${(-pnl.dailyLoss).toLocaleString()}` : '\u2014'}
+          value={dailyPnlLabel}
           color={pnl && pnl.dailyLoss > 0 ? 'text-accent-red' : 'text-accent-green'}
         />
         <KpiCard
@@ -75,15 +89,15 @@ function Dashboard() {
           <div className="rounded-3xl border border-white/8 bg-bg-card/90 p-5 shadow-[0_12px_40px_rgba(0,0,0,0.22)]">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-xs uppercase tracking-[0.28em] text-text-secondary">Strategy Insight</p>
-                <h2 className="mt-2 text-xl font-semibold text-white">LLM reasoning</h2>
+                <p className="text-xs uppercase tracking-[0.28em] text-text-secondary">戦略インサイト</p>
+                <h2 className="mt-2 text-xl font-semibold text-white">LLM判断理由</h2>
               </div>
               <Link to="/history" className="text-sm text-cyan-200 transition hover:text-cyan-100">
                 履歴を見る
               </Link>
             </div>
             <p className="mt-4 text-sm leading-7 text-slate-300">
-              {strategy?.reasoning ?? '戦略コメントはまだ生成されていません。'}
+              {reasoningLabel}
             </p>
           </div>
         </section>


### PR DESCRIPTION
## Summary
- `/api/v1/candles/undefined` への 400 を `useCandles` の `Number.isFinite` ガードで抑制
- ダッシュボードの和英混在ラベル・社内向け文言（Phase 2 等）を整理し日本語へ統一
- KPI カードをモバイルでも 2×2 に、ヘッダをレスポンシブに調整。`¥-0` → `¥0` にフォールバック
- ナビのアクティブ状態をアクセントカラーで強調し、非アクティブとのコントラストを改善

## Test plan
- [x] `npx tsc --noEmit` 通過
- [x] Playwright で 1440 / 768 / 375 の各ビューポートで console errors: 0 を確認
- [x] `/` ⇔ `/settings` 遷移でナビのアクティブ表示が切り替わることを目視確認
- [x] KPI が 375px で 2×2 グリッドになることを確認
- [x] `insufficient indicator data` が「指標データが不足しています」と表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)