### PR TITLE
feat(frontend): 取引通貨選択を URL search param で保持

### DIFF
--- a/frontend/src/components/AppFrame.tsx
+++ b/frontend/src/components/AppFrame.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react'
-import { Link } from '@tanstack/react-router'
+import { Link, useSearch } from '@tanstack/react-router'
 import { SymbolSelector } from './SymbolSelector'
 
 type AppFrameProps = {
@@ -15,6 +15,7 @@ const navItems = [
 ] as const
 
 export function AppFrame({ title, subtitle, children }: AppFrameProps) {
+  const rootSearch = useSearch({ from: '__root__' }) as { symbol?: string }
   return (
     <main className="mx-auto min-h-screen w-full max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
       <header className="mb-6 overflow-hidden rounded-3xl border border-white/8 bg-[linear-gradient(135deg,rgba(55,66,250,0.24),rgba(8,12,32,0.92)_45%,rgba(0,212,170,0.18))] p-5 sm:p-6 shadow-[0_20px_80px_rgba(0,0,0,0.35)]">
@@ -31,6 +32,7 @@ export function AppFrame({ title, subtitle, children }: AppFrameProps) {
                 <Link
                   key={item.to}
                   to={item.to}
+                  search={rootSearch}
                   activeProps={{
                     style: {
                       backgroundColor: '#00d4aa',

--- a/frontend/src/contexts/SymbolContext.tsx
+++ b/frontend/src/contexts/SymbolContext.tsx
@@ -3,10 +3,11 @@ import {
   useCallback,
   useContext,
   useEffect,
-  useState,
+  useMemo,
   type ReactNode,
 } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
+import { useNavigate, useSearch } from '@tanstack/react-router'
 import { useTradingConfig, useUpdateTradingConfig } from '../hooks/useTradingConfig'
 import { useSymbols } from '../hooks/useSymbols'
 import type { TradableSymbol } from '../lib/api'
@@ -28,10 +29,9 @@ type SymbolContextValue = {
 
 const SymbolContext = createContext<SymbolContextValue | null>(null)
 
-function pickFirstTradableId(symbols: TradableSymbol[] | undefined): number | null {
+function pickFirstTradable(symbols: TradableSymbol[] | undefined): TradableSymbol | null {
   if (!symbols || symbols.length === 0) return null
-  const found = symbols.find((s) => s.enabled && !s.viewOnly && !s.closeOnly)
-  return found?.id ?? null
+  return symbols.find((s) => s.enabled && !s.viewOnly && !s.closeOnly) ?? null
 }
 
 export function SymbolProvider({ children }: { children: ReactNode }) {
@@ -44,27 +44,47 @@ export function SymbolProvider({ children }: { children: ReactNode }) {
   const updateConfig = useUpdateTradingConfig()
   const queryClient = useQueryClient()
 
-  const [symbolId, setSymbolId] = useState<number | null>(null)
+  const search = useSearch({ from: '__root__' }) as { symbol?: string }
+  const navigate = useNavigate()
+  const urlSymbol = search.symbol
 
-  // 初期化:
-  //   1. tradingConfig 取得成功 → その値を使う
+  // URL の symbol → symbols の currencyPair と一致するエントリを探す。
+  // URL が source of truth なので、ここで導出した symbolId が全画面に流れる。
+  const resolvedFromUrl = useMemo<TradableSymbol | null>(() => {
+    if (!urlSymbol || !symbols) return null
+    return symbols.find((s) => s.currencyPair === urlSymbol) ?? null
+  }, [urlSymbol, symbols])
+
+  // URL に symbol が無い/不正な場合のデフォルト解決:
+  //   1. tradingConfig 取得成功 → その symbolId の currencyPair
   //   2. tradingConfig 失敗 + symbols あり → symbols から最初の有効銘柄
-  //   3. 両方失敗 → FALLBACK_SYMBOL_ID
-  useEffect(() => {
-    if (symbolId !== null) return
+  //   3. 両方失敗 → FALLBACK_SYMBOL_ID の currencyPair（symbols から引けなければ null）
+  const defaultSymbol = useMemo<TradableSymbol | null>(() => {
+    if (!symbols) return null
     if (tradingConfig) {
-      setSymbolId(tradingConfig.symbolId)
-      return
+      const match = symbols.find((s) => s.id === tradingConfig.symbolId)
+      if (match) return match
     }
-    if (isConfigError) {
-      const fallbackFromSymbols = pickFirstTradableId(symbols)
-      if (fallbackFromSymbols !== null) {
-        setSymbolId(fallbackFromSymbols)
-      } else if (!isSymbolsLoading) {
-        setSymbolId(FALLBACK_SYMBOL_ID)
-      }
+    if (isConfigError || tradingConfig) {
+      const first = pickFirstTradable(symbols)
+      if (first) return first
     }
-  }, [tradingConfig, isConfigError, symbols, isSymbolsLoading, symbolId])
+    return symbols.find((s) => s.id === FALLBACK_SYMBOL_ID) ?? null
+  }, [tradingConfig, isConfigError, symbols])
+
+  // URL の symbol が無い/不正な場合、デフォルトを書き戻す。
+  // replace: true で履歴に残さない。
+  useEffect(() => {
+    if (resolvedFromUrl) return
+    if (!defaultSymbol) return
+    // tradingConfig がロード中は待つ。確定したデフォルトだけを URL に書く。
+    if (isConfigLoading) return
+    void navigate({
+      to: '.',
+      search: (prev) => ({ ...prev, symbol: defaultSymbol.currencyPair }),
+      replace: true,
+    })
+  }, [resolvedFromUrl, defaultSymbol, isConfigLoading, navigate])
 
   // tradingConfig がロード完了している時だけ switchSymbol を許可。
   // 未ロード時に fallback tradeAmount で PUT して誤上書きするのを防ぐ。
@@ -73,8 +93,14 @@ export function SymbolProvider({ children }: { children: ReactNode }) {
   const switchSymbol = useCallback(
     (newSymbolId: number) => {
       if (!tradingConfig) return
-      const prevSymbolId = symbolId
-      setSymbolId(newSymbolId)
+      if (!symbols) return
+      const next = symbols.find((s) => s.id === newSymbolId)
+      if (!next) return
+      const prevSymbol = urlSymbol
+      void navigate({
+        to: '.',
+        search: (prev) => ({ ...prev, symbol: next.currencyPair }),
+      })
       updateConfig.mutate(
         { symbolId: newSymbolId, tradeAmount: tradingConfig.tradeAmount },
         {
@@ -87,22 +113,26 @@ export function SymbolProvider({ children }: { children: ReactNode }) {
             void queryClient.invalidateQueries({ queryKey: ['pnl'] })
           },
           onError: () => {
-            setSymbolId(prevSymbolId)
+            void navigate({
+              to: '.',
+              search: (prev) => ({ ...prev, symbol: prevSymbol }),
+            })
           },
         },
       )
     },
-    [symbolId, tradingConfig, updateConfig, queryClient],
+    [urlSymbol, symbols, tradingConfig, updateConfig, queryClient, navigate],
   )
 
-  if (symbolId === null) {
-    if (isConfigLoading || isSymbolsLoading) {
+  if (!resolvedFromUrl) {
+    if (isConfigLoading || isSymbolsLoading || !symbols) {
       return (
         <div className="flex min-h-screen items-center justify-center">
           <p className="text-sm text-text-secondary">Loading...</p>
         </div>
       )
     }
+    // symbols はあるがまだ URL へ書き戻し中 → 次のレンダリングで resolvedFromUrl が埋まる。
     return (
       <div className="flex min-h-screen items-center justify-center">
         <p className="text-sm text-text-secondary">Loading...</p>
@@ -110,14 +140,14 @@ export function SymbolProvider({ children }: { children: ReactNode }) {
     )
   }
 
-  const safeSymbols = symbols ?? []
-  const currentSymbol = safeSymbols.find((s) => s.id === symbolId)
+  const currentSymbol = resolvedFromUrl
+  const symbolId = resolvedFromUrl.id
 
   return (
     <SymbolContext.Provider
       value={{
         symbolId,
-        symbols: safeSymbols,
+        symbols: symbols ?? [],
         currentSymbol,
         switchSymbol,
         isSwitching: updateConfig.isPending,

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -2,7 +2,14 @@ import { HeadContent, Outlet, Scripts, createRootRoute } from '@tanstack/react-r
 import appCss from '../styles.css?url'
 import { SymbolProvider } from '../contexts/SymbolContext'
 
+type RootSearch = {
+  symbol?: string
+}
+
 export const Route = createRootRoute({
+  validateSearch: (search: Record<string, unknown>): RootSearch => ({
+    symbol: typeof search.symbol === 'string' ? search.symbol : undefined,
+  }),
   head: () => ({
     meta: [
       { charSet: 'utf-8' },

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, Link } from '@tanstack/react-router'
+import { createFileRoute, Link, useSearch } from '@tanstack/react-router'
 import { AppFrame } from '../components/AppFrame'
 import { KpiCard } from '../components/KpiCard'
 import { CandlestickChart } from '../components/CandlestickChart'
@@ -19,6 +19,7 @@ export const Route = createFileRoute('/')({ component: Dashboard })
 
 function Dashboard() {
   const { symbolId, currentSymbol } = useSymbolContext()
+  const rootSearch = useSearch({ from: '__root__' }) as { symbol?: string }
   const { data: status } = useStatus()
   const { data: pnl } = usePnl()
   const { data: strategy } = useStrategy()
@@ -92,7 +93,11 @@ function Dashboard() {
                 <p className="text-xs uppercase tracking-[0.28em] text-text-secondary">戦略インサイト</p>
                 <h2 className="mt-2 text-xl font-semibold text-white">LLM判断理由</h2>
               </div>
-              <Link to="/history" className="text-sm text-cyan-200 transition hover:text-cyan-100">
+              <Link
+                to="/history"
+                search={rootSearch}
+                className="text-sm text-cyan-200 transition hover:text-cyan-100"
+              >
                 履歴を見る
               </Link>
             </div>


### PR DESCRIPTION
## Summary
- ルート route に \`validateSearch\` を追加して \`?symbol=BTC_JPY\` を型付きで受け取り
- \`SymbolContext\` を URL を source of truth とする構造に変更（\`useState\` 廃止、\`useSearch\` + \`useNavigate\`）
- URL 未指定/不正値のときは \`tradingConfig\` → 先頭 tradable → \`FALLBACK_SYMBOL_ID\` の順で解決して \`replace: true\` で書き戻し
- \`AppFrame\` のナビリンクと index の「履歴を見る」に \`search={rootSearch}\` を渡し、ルート間遷移で symbol を保持
- 銘柄切替時は URL 更新と \`PUT /trading-config\` を並行実行、失敗時は URL を巻き戻し

## Test plan
- [x] \`tsc --noEmit\` パス
- [x] \`vite build\` 成功
- [x] \`/\` を URL なしで開く → \`?symbol=<current tradingConfig>\` に書き戻し
- [x] \`/?symbol=BTC_JPY\` で開く → BTC/JPY 表示
- [x] \`/?symbol=NOT_EXISTS\` → デフォルトに書き戻し
- [x] SymbolSelector で切替 → URL 更新 + \`PUT /trading-config\`
- [x] \`/history\`, \`/settings\` 間の遷移で \`?symbol\` 保持
- [x] ダッシュボードの「履歴を見る」リンクでも \`?symbol\` 保持

🤖 Generated with [Claude Code](https://claude.com/claude-code)