### PR TITLE
feat(backend): add /trades/all aggregate endpoint and widen rate-limit margin

### DIFF
--- a/backend/internal/infrastructure/rakuten/rest_client.go
+++ b/backend/internal/infrastructure/rakuten/rest_client.go
@@ -89,13 +89,15 @@ func (c *RESTClient) do(ctx context.Context, method, path, query string, body []
 }
 
 // waitForRateLimit enforces the Rakuten API 200ms interval limit.
+// Uses a 220ms margin to absorb clock skew between client and Rakuten server,
+// since requests pacing exactly at 200ms occasionally trip AUTHENTICATION_ERROR_TOO_MANY_REQUESTS (code 20010).
 // Returns an error if the context is cancelled during the wait.
 func (c *RESTClient) waitForRateLimit(ctx context.Context) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	elapsed := time.Since(c.lastCall)
-	if wait := 200*time.Millisecond - elapsed; wait > 0 {
+	if wait := 220*time.Millisecond - elapsed; wait > 0 {
 		select {
 		case <-time.After(wait):
 		case <-ctx.Done():

--- a/backend/internal/interfaces/api/handler/trade.go
+++ b/backend/internal/interfaces/api/handler/trade.go
@@ -5,15 +5,18 @@ import (
 	"strconv"
 
 	"github.com/gin-gonic/gin"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/repository"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/infrastructure/rakuten"
 )
 
 type TradeHandler struct {
 	orderClient repository.OrderClient
+	restClient  *rakuten.RESTClient
 }
 
-func NewTradeHandler(orderClient repository.OrderClient) *TradeHandler {
-	return &TradeHandler{orderClient: orderClient}
+func NewTradeHandler(orderClient repository.OrderClient, restClient *rakuten.RESTClient) *TradeHandler {
+	return &TradeHandler{orderClient: orderClient, restClient: restClient}
 }
 
 func (h *TradeHandler) GetTrades(c *gin.Context) {
@@ -31,4 +34,44 @@ func (h *TradeHandler) GetTrades(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, trades)
+}
+
+// allTradesEntry はシンボル単位の約定取得結果。
+// 部分失敗を許容するため、取得成功と失敗を 1 シンボル単位で返す。
+type allTradesEntry struct {
+	SymbolID     int64             `json:"symbolId"`
+	CurrencyPair string            `json:"currencyPair"`
+	Trades       []entity.MyTrade  `json:"trades,omitempty"`
+	Error        string            `json:"error,omitempty"`
+}
+
+// GetAllTrades は楽天の取引可能な全シンボルについて約定履歴をまとめて返す。
+// 楽天 API 側に bulk エンドポイントが無いため内部でシンボルごとに直列ループするが、
+// RESTClient 側の 220ms スロットラーが直列化を保証するため code 20010 は構造的に発生しない。
+func (h *TradeHandler) GetAllTrades(c *gin.Context) {
+	if h.restClient == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "rest client not configured"})
+		return
+	}
+
+	ctx := c.Request.Context()
+	symbols, err := h.restClient.GetSymbols(ctx)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	results := make([]allTradesEntry, 0, len(symbols))
+	for _, sym := range symbols {
+		entry := allTradesEntry{SymbolID: sym.ID, CurrencyPair: sym.CurrencyPair}
+		trades, err := h.orderClient.GetMyTrades(ctx, sym.ID)
+		if err != nil {
+			entry.Error = err.Error()
+		} else {
+			entry.Trades = trades
+		}
+		results = append(results, entry)
+	}
+
+	c.JSON(http.StatusOK, gin.H{"results": results})
 }

--- a/backend/internal/interfaces/api/router.go
+++ b/backend/internal/interfaces/api/router.go
@@ -78,8 +78,9 @@ func NewRouter(deps Dependencies) *gin.Engine {
 		positionHandler := handler.NewPositionHandler(deps.OrderClient)
 		v1.GET("/positions", positionHandler.GetPositions)
 
-		tradeHandler := handler.NewTradeHandler(deps.OrderClient)
+		tradeHandler := handler.NewTradeHandler(deps.OrderClient, deps.RESTClient)
 		v1.GET("/trades", tradeHandler.GetTrades)
+		v1.GET("/trades/all", tradeHandler.GetAllTrades)
 	}
 
 	if deps.MarketDataService != nil {


### PR DESCRIPTION
## Summary
- 楽天 CFD `/api/v1/cfd/trade` は `symbolId` が必須・単数のため、フロントで全シンボルの約定をまとめて取りたい用途に集約口が無かった。`GET /api/v1/trades/all` を追加し、サーバ側で全シンボルを直列ループして1レスポンスで返すようにした
- `RESTClient.waitForRateLimit` の最低間隔を 200ms → 220ms に拡張。200ms ぴったりだと楽天サーバ側時計とのズレで `AUTHENTICATION_ERROR_TOO_MANY_REQUESTS` (`code 20010`) がたまに返ってきていたため、マージンを乗せて構造的に潰した
- 集約レスポンスは部分失敗を許容（`results: [{ symbolId, currencyPair, trades?, error? }]`）。1 シンボルが死んでも他は返る

## Background
9シンボルを `for` で連続リクエストすると 3 シンボルだけ `code 20010` (`AUTHENTICATION_ERROR_TOO_MANY_REQUESTS`) を返していた。楽天ウォレットの仕様で 1 ユーザあたり 200ms 間隔のレート制限がある（[ドキュメント](https://www.rakuten-wallet.co.jp/service/api-leverage-exchange/) §4.2 / §7）。`RESTClient` 側の直列化はあるものの 200ms ジャストでは時計ズレで弾かれることがあったので、マージンを上乗せした。

## Changes
- `backend/internal/infrastructure/rakuten/rest_client.go` — スロットラーのインターバルを 220ms に。理由をコメント追記
- `backend/internal/interfaces/api/handler/trade.go` — `GetAllTrades` ハンドラ追加。`NewTradeHandler` の引数に `*rakuten.RESTClient` を追加してシンボル一覧を取得
- `backend/internal/interfaces/api/router.go` — `GET /api/v1/trades/all` を登録、`NewTradeHandler` 呼び出しを更新

## Test plan
- [x] `go build ./...` 通過
- [x] `go vet ./...` 通過
- [x] `go test ./internal/interfaces/api/... ./internal/infrastructure/rakuten/...` 通過
- [x] Docker でリビルドし `curl http://localhost:38080/api/v1/trades/all` 実行 → 9 シンボル全部返り、`code 20010` ゼロ
- [ ] フロントから新エンドポイントを叩く実装は別 PR

## Out of scope / follow-up
- LTC_JPY (id=10) のレスポンスで `MyTrade.price` が string で返ってくるケースがあり、現状 unmarshal エラーになる。`entity.MyTrade` を `StringFloat64` 対応にする修正は別 PR で対応予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)