### PR TITLE
fix(backend): accept string-encoded numerics in MyTrade fields

### DIFF
--- a/backend/internal/domain/entity/trade.go
+++ b/backend/internal/domain/entity/trade.go
@@ -15,17 +15,20 @@ type MarketTradesResponse struct {
 	Timestamp int64         `json:"timestamp"`
 }
 
+// MyTrade の数値フィールドは楽天 API がシンボルによって number と string の
+// どちらでも返してくる（例: LTC_JPY は price を string で返すケースが観測されている）。
+// Symbol 型と同様に StringFloat64 で受け、Marshal 時は number に正規化する。
 type MyTrade struct {
-	ID               int64     `json:"id"`
-	SymbolID         int64     `json:"symbolId"`
-	OrderSide        OrderSide `json:"orderSide"`
-	Price            float64   `json:"price"`
-	Amount           float64   `json:"amount"`
-	Profit           float64   `json:"profit"`
-	Fee              float64   `json:"fee"`
-	PositionFee      float64   `json:"positionFee"`
-	CloseTradeProfit float64   `json:"closeTradeProfit"`
-	OrderID          int64     `json:"orderId"`
-	PositionID       int64     `json:"positionId"`
-	CreatedAt        int64     `json:"createdAt"`
+	ID               int64         `json:"id"`
+	SymbolID         int64         `json:"symbolId"`
+	OrderSide        OrderSide     `json:"orderSide"`
+	Price            StringFloat64 `json:"price"`
+	Amount           StringFloat64 `json:"amount"`
+	Profit           StringFloat64 `json:"profit"`
+	Fee              StringFloat64 `json:"fee"`
+	PositionFee      StringFloat64 `json:"positionFee"`
+	CloseTradeProfit StringFloat64 `json:"closeTradeProfit"`
+	OrderID          int64         `json:"orderId"`
+	PositionID       int64         `json:"positionId"`
+	CreatedAt        int64         `json:"createdAt"`
 }

--- a/backend/internal/infrastructure/rakuten/private_api_test.go
+++ b/backend/internal/infrastructure/rakuten/private_api_test.go
@@ -86,6 +86,26 @@ func TestGetMyTrades(t *testing.T) {
 	trades, err := client.GetMyTrades(context.Background(), 7)
 	if err != nil { t.Fatalf("unexpected error: %v", err) }
 	if len(trades) != 1 { t.Fatalf("expected 1 trade, got %d", len(trades)) }
+	if trades[0].Price.Float64() != 5000000 { t.Fatalf("expected price 5000000, got %v", trades[0].Price.Float64()) }
+}
+
+// TestGetMyTrades_StringNumericFields は楽天 LTC_JPY 等で観測されている
+// 数値フィールドが string で返ってくるケースで unmarshal が通ることを保証する。
+func TestGetMyTrades_StringNumericFields(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertAuthHeaders(t, r)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`[{"id":2,"symbolId":10,"orderSide":"BUY","price":"12345.6","amount":"0.5","profit":"10.5","fee":"1.2","positionFee":"0","closeTradeProfit":"0","orderId":200,"positionId":2,"createdAt":1700000000000}]`))
+	}))
+	defer server.Close()
+	client := NewRESTClient(server.URL, "key", "secret")
+	trades, err := client.GetMyTrades(context.Background(), 10)
+	if err != nil { t.Fatalf("unexpected error: %v", err) }
+	if len(trades) != 1 { t.Fatalf("expected 1 trade, got %d", len(trades)) }
+	if trades[0].Price.Float64() != 12345.6 { t.Fatalf("expected price 12345.6, got %v", trades[0].Price.Float64()) }
+	if trades[0].Amount.Float64() != 0.5 { t.Fatalf("expected amount 0.5, got %v", trades[0].Amount.Float64()) }
+	if trades[0].Profit.Float64() != 10.5 { t.Fatalf("expected profit 10.5, got %v", trades[0].Profit.Float64()) }
+	if trades[0].Fee.Float64() != 1.2 { t.Fatalf("expected fee 1.2, got %v", trades[0].Fee.Float64()) }
 }
 
 func assertAuthHeaders(t *testing.T, r *http.Request) {


### PR DESCRIPTION
## Summary
- 楽天 CFD API の `GET /api/v1/cfd/trade` レスポンスで `price` / `amount` / `profit` / `fee` 等の数値フィールドが、シンボルによって **number と string のどちらでも返ってくる**ことが判明した（LTC_JPY symbolId=10 で string が観測された）
- `entity.MyTrade` の該当6フィールドを `float64` → `StringFloat64` に変更。Symbol 型で既に使われている既存の正規化型を再利用
- `StringFloat64.MarshalJSON` は number を返すので、フロントへのレスポンス JSON 形式は変更なし

## Background
PR #45 で追加した `/api/v1/trades/all` を叩いたところ、LTC_JPY だけ次のエラーになっていた：

```
GetMyTrades unmarshal: json: cannot unmarshal string into Go struct field MyTrade.price of type float64
```

楽天側の仕様揺れ。Symbol 型では既に `StringFloat64` で同じ問題に対処済み（commit `ff1d359`）だったので、同じパターンを `MyTrade` にも適用する。

## Changes
- `backend/internal/domain/entity/trade.go` — `MyTrade.{Price,Amount,Profit,Fee,PositionFee,CloseTradeProfit}` を `StringFloat64` に変更。理由をコメント追記
- `backend/internal/infrastructure/rakuten/private_api_test.go` — string 形式のレスポンスを返すモックサーバで `GetMyTrades` を呼び、各数値フィールドが正しく float に復元されることを検証する `TestGetMyTrades_StringNumericFields` を追加。既存テストは number 形式のリグレッション保護として残す

## Test plan
- [x] `go build ./...` 通過
- [x] `go test ./...` 全パッケージ通過（新テスト含む）
- [x] Docker でリビルドし `curl http://localhost:38080/api/v1/trades?symbolId=10` 実行 → LTC の実約定 1 件が `price: 8720.1` (number) として正しく返る
- [x] `/api/v1/trades/all` でも LTC_JPY が `trades` 配列付きで返ることを確認

## Out of scope
- `/api/v1/trades/all` を連続実行すると稀に別シンボルで `code 20010` が出る挙動が残っている。原因はバックエンド内の他ポーリング（candles/indicators）が `RESTClient` を共有していることによる 220ms スロットラーへの割り込みと推測される。これは別 issue / 別 PR で扱う

## Stack
- base: `feature/trades-aggregate-endpoint` (PR #45)
- PR #45 がマージされたら GitHub が自動で base を `main` に切り替える

🤖 Generated with [Claude Code](https://claude.com/claude-code)