### PR TITLE
feat(frontend): add all-symbols / single-symbol tabs to trade history

### DIFF
--- a/frontend/src/components/TradeHistoryTable.tsx
+++ b/frontend/src/components/TradeHistoryTable.tsx
@@ -1,7 +1,10 @@
 import type { TradeHistoryItem } from '../lib/api'
 
+export type TradeHistoryRow = TradeHistoryItem & { currencyPair?: string }
+
 type TradeHistoryTableProps = {
-  trades: TradeHistoryItem[]
+  trades: TradeHistoryRow[]
+  showCurrencyPair?: boolean
 }
 
 function formatYen(value: number) {
@@ -12,7 +15,8 @@ function formatTimestamp(timestamp: number) {
   return new Date(timestamp).toLocaleString('ja-JP')
 }
 
-export function TradeHistoryTable({ trades }: TradeHistoryTableProps) {
+export function TradeHistoryTable({ trades, showCurrencyPair = false }: TradeHistoryTableProps) {
+  const colCount = showCurrencyPair ? 7 : 6
   return (
     <div className="overflow-hidden rounded-3xl border border-white/8 bg-bg-card/90 shadow-[0_12px_40px_rgba(0,0,0,0.22)]">
       <div className="border-b border-white/8 px-5 py-4">
@@ -24,6 +28,7 @@ export function TradeHistoryTable({ trades }: TradeHistoryTableProps) {
           <thead className="bg-white/4 text-left text-text-secondary">
             <tr>
               <th className="px-5 py-3 font-medium">日時</th>
+              {showCurrencyPair && <th className="px-5 py-3 font-medium">通貨</th>}
               <th className="px-5 py-3 font-medium">方向</th>
               <th className="px-5 py-3 font-medium">数量</th>
               <th className="px-5 py-3 font-medium">価格</th>
@@ -34,14 +39,19 @@ export function TradeHistoryTable({ trades }: TradeHistoryTableProps) {
           <tbody>
             {trades.length === 0 ? (
               <tr>
-                <td colSpan={6} className="px-5 py-10 text-center text-text-secondary">
+                <td colSpan={colCount} className="px-5 py-10 text-center text-text-secondary">
                   約定履歴はありません
                 </td>
               </tr>
             ) : (
               trades.map((trade) => (
-                <tr key={trade.id} className="border-t border-white/6 text-slate-100">
+                <tr key={`${trade.symbolId}-${trade.id}`} className="border-t border-white/6 text-slate-100">
                   <td className="px-5 py-4">{formatTimestamp(trade.createdAt)}</td>
+                  {showCurrencyPair && (
+                    <td className="px-5 py-4 font-mono text-xs text-text-secondary">
+                      {trade.currencyPair ?? '\u2014'}
+                    </td>
+                  )}
                   <td className={`px-5 py-4 font-medium ${trade.orderSide === 'BUY' ? 'text-accent-green' : 'text-accent-red'}`}>
                     {trade.orderSide}
                   </td>

--- a/frontend/src/hooks/useAllTrades.ts
+++ b/frontend/src/hooks/useAllTrades.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query'
+import { fetchApi, type AllTradesResponse } from '../lib/api'
+
+export function useAllTrades() {
+  return useQuery({
+    queryKey: ['trades', 'all'],
+    queryFn: () => fetchApi<AllTradesResponse>('/trades/all'),
+    refetchInterval: 15_000,
+  })
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -112,6 +112,17 @@ export type TradeHistoryItem = {
   createdAt: number
 }
 
+export type AllTradesEntry = {
+  symbolId: number
+  currencyPair: string
+  trades?: TradeHistoryItem[]
+  error?: string
+}
+
+export type AllTradesResponse = {
+  results: AllTradesEntry[]
+}
+
 export type LiveTicker = {
   symbolId: number
   bestAsk: number

--- a/frontend/src/routes/history.tsx
+++ b/frontend/src/routes/history.tsx
@@ -1,26 +1,65 @@
+import { useMemo, useState } from 'react'
 import { createFileRoute } from '@tanstack/react-router'
 import { AppFrame } from '../components/AppFrame'
-import { TradeHistoryTable } from '../components/TradeHistoryTable'
+import { TradeHistoryTable, type TradeHistoryRow } from '../components/TradeHistoryTable'
 import { useMarketTickerStream } from '../hooks/useMarketTickerStream'
 import { useTradeHistory } from '../hooks/useTradeHistory'
+import { useAllTrades } from '../hooks/useAllTrades'
 import { useSymbolContext } from '../contexts/SymbolContext'
 
 export const Route = createFileRoute('/history')({ component: HistoryPage })
 
+type TabKey = 'all' | 'single'
+
 function HistoryPage() {
-  const { symbolId } = useSymbolContext()
+  const { symbolId, currentSymbol } = useSymbolContext()
   useMarketTickerStream(symbolId)
-  const { data: trades } = useTradeHistory(symbolId)
-  const safeTrades = trades ?? []
-  const totalProfit = safeTrades.reduce((sum, trade) => sum + trade.profit, 0)
+
+  const [tab, setTab] = useState<TabKey>('all')
+
+  const { data: singleTrades } = useTradeHistory(symbolId)
+  const { data: allTradesData } = useAllTrades()
+
+  const rows = useMemo<TradeHistoryRow[]>(() => {
+    if (tab === 'single') {
+      const pair = currentSymbol?.currencyPair
+      return (singleTrades ?? []).map((t) => ({ ...t, currencyPair: pair }))
+    }
+    const results = allTradesData?.results ?? []
+    const flat: TradeHistoryRow[] = []
+    for (const entry of results) {
+      if (!entry.trades) continue
+      for (const t of entry.trades) {
+        flat.push({ ...t, currencyPair: entry.currencyPair })
+      }
+    }
+    flat.sort((a, b) => b.createdAt - a.createdAt)
+    return flat
+  }, [tab, singleTrades, allTradesData, currentSymbol])
+
+  const failedSymbols = useMemo(() => {
+    if (tab !== 'all') return []
+    return (allTradesData?.results ?? []).filter((e) => e.error)
+  }, [tab, allTradesData])
+
+  const totalProfit = rows.reduce((sum, trade) => sum + trade.profit, 0)
+  const subtitle =
+    tab === 'all'
+      ? '楽天 private API から全通貨の約定をまとめて REST 経由で表示します。'
+      : `現在選択中の ${currentSymbol?.currencyPair ?? ''} に絞った約定一覧です。`
 
   return (
-    <AppFrame
-      title="Trade History"
-      subtitle="楽天 private API の約定一覧を REST 経由で見せる Phase 2 画面です。最新損益の確認と異常検知を同じ導線に置きます。"
-    >
+    <AppFrame title="Trade History" subtitle={subtitle}>
+      <div className="mb-4 flex gap-2">
+        <TabButton active={tab === 'all'} onClick={() => setTab('all')}>
+          全通貨
+        </TabButton>
+        <TabButton active={tab === 'single'} onClick={() => setTab('single')}>
+          {currentSymbol?.currencyPair ?? '個別通貨'}
+        </TabButton>
+      </div>
       <div className="mb-4 grid gap-4 md:grid-cols-3">
-        <SummaryCard label="約定件数" value={safeTrades.length.toLocaleString()} />
+        <SummaryCard label="約定件数" value={rows.length.toLocaleString()} />
         <SummaryCard
           label="累計損益"
           value={`¥${totalProfit.toLocaleString('ja-JP', { maximumFractionDigits: 0 })}`}
@@ -28,11 +67,38 @@ function HistoryPage() {
         />
         <SummaryCard
           label="最新更新"
-          value={safeTrades[0] ? new Date(safeTrades[0].createdAt).toLocaleString('ja-JP') : '\u2014'}
+          value={rows[0] ? new Date(rows[0].createdAt).toLocaleString('ja-JP') : '\u2014'}
         />
       </div>
-      <TradeHistoryTable trades={safeTrades} />
+      {failedSymbols.length > 0 && (
+        <div className="mb-4 rounded-2xl border border-accent-red/40 bg-accent-red/10 px-5 py-3 text-sm text-accent-red">
+          一部通貨の取得に失敗しました: {failedSymbols.map((e) => e.currencyPair).join(', ')}
+        </div>
+      )}
+      <TradeHistoryTable trades={rows} showCurrencyPair={tab === 'all'} />
     </AppFrame>
+  )
+}
+
+type TabButtonProps = {
+  active: boolean
+  onClick: () => void
+  children: React.ReactNode
+}
+
+function TabButton({ active, onClick, children }: TabButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`rounded-full border px-4 py-2 text-sm font-medium transition ${
+        active
+          ? 'border-white/20 bg-white/10 text-white'
+          : 'border-white/8 bg-transparent text-text-secondary hover:text-white'
+      }`}
+    >
+      {children}
+    </button>
   )
 }
 


### PR DESCRIPTION
## Summary
- 取引履歴画面 (`/history`) に「全通貨」「個別通貨」タブを追加し、現状どの通貨ペアの約定かが表に表示されていなかった問題を解消します。
- 全通貨タブは既存の `/trades/all` aggregate エンドポイントを利用し、結果を createdAt 降順で flatten。行に通貨列（`currencyPair`）を表示します。
- 個別通貨タブは従来どおり `SymbolContext` の選択通貨に連動し、既存の `/trades?symbolId=` を利用。タブ切替に伴いサマリーカード（約定件数 / 累計損益 / 最新更新）も追従します。
- `/trades/all` の部分失敗（エントリに `error` が返る通貨）は通貨ペア一覧付きのインラインバナーで通知します。

## Changes
- `frontend/src/lib/api.ts`: `AllTradesEntry` / `AllTradesResponse` 型を追加。
- `frontend/src/hooks/useAllTrades.ts`: `/trades/all` を取得する新規 React Query フック（15s polling）。
- `frontend/src/components/TradeHistoryTable.tsx`: `showCurrencyPair` prop と `TradeHistoryRow` 型を追加し、通貨列を条件表示。複数通貨混在時の key 衝突を避けるため row key を `symbolId-id` に変更。
- `frontend/src/routes/history.tsx`: タブ UI とタブ連動のサマリー / エラーバナーを実装。

## Test plan
- [ ] `/history` で「全通貨」タブを開き、複数通貨の約定が時刻順に並び、通貨列が表示されることを確認
- [ ] 「個別通貨」タブで現在選択中の通貨のみが表示され、SymbolSelector で通貨切替に追従することを確認
- [ ] タブ切替でサマリーカード（件数 / 累計損益 / 最新更新）が連動することを確認
- [ ] `/trades/all` の一部通貨が失敗した場合にインラインバナーが表示されることを確認
- [x] `npx tsc --noEmit` がクリーンに通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)