### PR TITLE
fix(backend): accept string-encoded numerics in Order/Position fields

### DIFF
--- a/backend/internal/domain/entity/order.go
+++ b/backend/internal/domain/entity/order.go
@@ -1,5 +1,7 @@
 package entity
 
+import "encoding/json"
+
 type OrderSide string
 
 const (
@@ -72,4 +74,42 @@ type Order struct {
 	OrderStatus     OrderStatus   `json:"orderStatus"`
 	Leverage        float64       `json:"leverage"`
 	OrderCreatedAt  int64         `json:"orderCreatedAt"`
+}
+
+// Rakuten API may return numeric fields as JSON strings for some symbols.
+// Accept both string and number forms.
+func (o *Order) UnmarshalJSON(data []byte) error {
+	type raw struct {
+		ID              int64         `json:"id"`
+		SymbolID        int64         `json:"symbolId"`
+		OrderBehavior   OrderBehavior `json:"orderBehavior"`
+		OrderSide       OrderSide     `json:"orderSide"`
+		OrderPattern    OrderPattern  `json:"orderPattern"`
+		OrderType       OrderType     `json:"orderType"`
+		Price           flexFloat     `json:"price"`
+		Amount          flexFloat     `json:"amount"`
+		RemainingAmount flexFloat     `json:"remainingAmount"`
+		OrderStatus     OrderStatus   `json:"orderStatus"`
+		Leverage        flexFloat     `json:"leverage"`
+		OrderCreatedAt  int64         `json:"orderCreatedAt"`
+	}
+	var r raw
+	if err := json.Unmarshal(data, &r); err != nil {
+		return err
+	}
+	*o = Order{
+		ID:              r.ID,
+		SymbolID:        r.SymbolID,
+		OrderBehavior:   r.OrderBehavior,
+		OrderSide:       r.OrderSide,
+		OrderPattern:    r.OrderPattern,
+		OrderType:       r.OrderType,
+		Price:           float64(r.Price),
+		Amount:          float64(r.Amount),
+		RemainingAmount: float64(r.RemainingAmount),
+		OrderStatus:     r.OrderStatus,
+		Leverage:        float64(r.Leverage),
+		OrderCreatedAt:  r.OrderCreatedAt,
+	}
+	return nil
 }

--- a/backend/internal/domain/entity/position.go
+++ b/backend/internal/domain/entity/position.go
@@ -1,5 +1,11 @@
 package entity
 
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
 type PositionStatus string
 
 const (
@@ -21,4 +27,74 @@ type Position struct {
 	BestPrice       float64        `json:"bestPrice"`
 	OrderID         int64          `json:"orderId"`
 	CreatedAt       int64          `json:"createdAt"`
+}
+
+// Rakuten API may return numeric fields as JSON strings (e.g. "8698.2") for some symbols.
+// Accept both string and number forms.
+func (p *Position) UnmarshalJSON(data []byte) error {
+	type raw struct {
+		ID              int64          `json:"id"`
+		SymbolID        int64          `json:"symbolId"`
+		PositionStatus  PositionStatus `json:"positionStatus"`
+		OrderSide       OrderSide      `json:"orderSide"`
+		Price           flexFloat      `json:"price"`
+		Amount          flexFloat      `json:"amount"`
+		RemainingAmount flexFloat      `json:"remainingAmount"`
+		Leverage        flexFloat      `json:"leverage"`
+		FloatingProfit  flexFloat      `json:"floatingProfit"`
+		Profit          flexFloat      `json:"profit"`
+		BestPrice       flexFloat      `json:"bestPrice"`
+		OrderID         int64          `json:"orderId"`
+		CreatedAt       int64          `json:"createdAt"`
+	}
+	var r raw
+	if err := json.Unmarshal(data, &r); err != nil {
+		return err
+	}
+	*p = Position{
+		ID:              r.ID,
+		SymbolID:        r.SymbolID,
+		PositionStatus:  r.PositionStatus,
+		OrderSide:       r.OrderSide,
+		Price:           float64(r.Price),
+		Amount:          float64(r.Amount),
+		RemainingAmount: float64(r.RemainingAmount),
+		Leverage:        float64(r.Leverage),
+		FloatingProfit:  float64(r.FloatingProfit),
+		Profit:          float64(r.Profit),
+		BestPrice:       float64(r.BestPrice),
+		OrderID:         r.OrderID,
+		CreatedAt:       r.CreatedAt,
+	}
+	return nil
+}
+
+// flexFloat decodes a JSON number or numeric string into a float64.
+type flexFloat float64
+
+func (f *flexFloat) UnmarshalJSON(data []byte) error {
+	if len(data) == 0 || string(data) == "null" {
+		return nil
+	}
+	if data[0] == '"' {
+		var s string
+		if err := json.Unmarshal(data, &s); err != nil {
+			return err
+		}
+		if s == "" {
+			return nil
+		}
+		v, err := strconv.ParseFloat(s, 64)
+		if err != nil {
+			return fmt.Errorf("flexFloat parse %q: %w", s, err)
+		}
+		*f = flexFloat(v)
+		return nil
+	}
+	var v float64
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+	*f = flexFloat(v)
+	return nil
 }


### PR DESCRIPTION
## Summary
- 楽天APIが銘柄によって `Order` / `Position` の数値フィールドを JSON 文字列で返すケースに対応
- 977a677 (MyTrade) と同方針で `UnmarshalJSON` を追加し、共有の `flexFloat` 型で文字列・数値どちらも受け入れる

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [ ] 実 API レスポンス（文字列を返す銘柄）でデコードが成功することを動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)