### PR TITLE
feat(backend): add POST /api/v1/positions/:id/close endpoint

### DIFF
--- a/backend/internal/interfaces/api/handler/position.go
+++ b/backend/internal/interfaces/api/handler/position.go
@@ -1,19 +1,33 @@
 package handler
 
 import (
+	"log/slog"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/repository"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase"
 )
 
 type PositionHandler struct {
-	orderClient repository.OrderClient
+	orderClient     repository.OrderClient
+	orderExecutor   *usecase.OrderExecutor
+	clientOrderRepo repository.ClientOrderRepository
 }
 
-func NewPositionHandler(orderClient repository.OrderClient) *PositionHandler {
-	return &PositionHandler{orderClient: orderClient}
+func NewPositionHandler(
+	orderClient repository.OrderClient,
+	orderExecutor *usecase.OrderExecutor,
+	clientOrderRepo repository.ClientOrderRepository,
+) *PositionHandler {
+	return &PositionHandler{
+		orderClient:     orderClient,
+		orderExecutor:   orderExecutor,
+		clientOrderRepo: clientOrderRepo,
+	}
 }
 
 // GetPositions は指定銘柄のポジション一覧を返す。
@@ -32,4 +46,102 @@ func (h *PositionHandler) GetPositions(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, positions)
+}
+
+type closePositionRequest struct {
+	SymbolID      int64  `json:"symbolId"`
+	ClientOrderID string `json:"clientOrderId"`
+}
+
+// ClosePosition handles POST /api/v1/positions/:id/close.
+// Closes the specified position by its full remaining amount via market order.
+func (h *PositionHandler) ClosePosition(c *gin.Context) {
+	if h.orderExecutor == nil || h.clientOrderRepo == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "close position is not configured"})
+		return
+	}
+
+	idStr := c.Param("id")
+	positionID, err := strconv.ParseInt(idStr, 10, 64)
+	if err != nil || positionID <= 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid position id"})
+		return
+	}
+
+	var req closePositionRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+		return
+	}
+	if req.SymbolID <= 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "symbolId is required"})
+		return
+	}
+	if req.ClientOrderID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "clientOrderId is required"})
+		return
+	}
+
+	// Idempotency: a previous close with the same clientOrderId returns the original result.
+	if existing, lookupErr := h.clientOrderRepo.Find(c.Request.Context(), req.ClientOrderID); lookupErr == nil && existing != nil {
+		c.JSON(http.StatusOK, gin.H{
+			"duplicate":     true,
+			"clientOrderId": existing.ClientOrderID,
+			"executed":      existing.Executed,
+			"orderId":       existing.OrderID,
+		})
+		return
+	}
+
+	// Find the target position by symbolId + positionId.
+	positions, err := h.orderClient.GetPositions(c.Request.Context(), req.SymbolID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	var pos *entity.Position
+	for i := range positions {
+		if positions[i].ID == positionID {
+			pos = &positions[i]
+			break
+		}
+	}
+	if pos == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "position not found"})
+		return
+	}
+
+	result, err := h.orderExecutor.ClosePosition(c.Request.Context(), *pos, pos.Price)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	record := repository.ClientOrderRecord{
+		ClientOrderID: req.ClientOrderID,
+		Executed:      result.Executed,
+		OrderID:       result.OrderID,
+		CreatedAt:     time.Now().Unix(),
+	}
+	if saveErr := h.clientOrderRepo.Save(c.Request.Context(), record); saveErr != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to save client order record"})
+		return
+	}
+
+	slog.Info("position close requested",
+		"event", "position_close",
+		"positionID", positionID,
+		"symbolID", req.SymbolID,
+		"clientOrderID", req.ClientOrderID,
+		"executed", result.Executed,
+		"orderID", result.OrderID,
+	)
+
+	c.JSON(http.StatusOK, gin.H{
+		"clientOrderId": req.ClientOrderID,
+		"executed":      result.Executed,
+		"orderId":       result.OrderID,
+		"reason":        result.Reason,
+	})
 }

--- a/backend/internal/interfaces/api/router.go
+++ b/backend/internal/interfaces/api/router.go
@@ -75,8 +75,11 @@ func NewRouter(deps Dependencies) *gin.Engine {
 	}
 
 	if deps.OrderClient != nil {
-		positionHandler := handler.NewPositionHandler(deps.OrderClient)
+		positionHandler := handler.NewPositionHandler(deps.OrderClient, deps.OrderExecutor, deps.ClientOrderRepo)
 		v1.GET("/positions", positionHandler.GetPositions)
+		if deps.OrderExecutor != nil && deps.ClientOrderRepo != nil {
+			v1.POST("/positions/:id/close", positionHandler.ClosePosition)
+		}
 
 		tradeHandler := handler.NewTradeHandler(deps.OrderClient, deps.RESTClient)
 		v1.GET("/trades", tradeHandler.GetTrades)


### PR DESCRIPTION
## Summary
- 成行クローズ用の `POST /api/v1/positions/:id/close` を追加
- `clientOrderId` による冪等性: `ClientOrderRepository.Find` で既存実行を検出し、重複時は元の結果を返す
- 実行成功時は `ClientOrderRecord` を保存し、構造化ログ (`event=position_close`) を出力
- `Dependencies.OrderExecutor` / `ClientOrderRepo` が揃っている時のみルート登録（段階導入のため）
- plan12 (order integrity hardening) の一部

## Notes
- 設計書 \`docs/design/plans/2026-04-11-plan12-order-integrity-hardening.md\` のレビュー指摘（\`submitted\` 遷移の矛盾など）はこの PR では未反映。状態遷移に関わる修正は別 PR で対応予定
- 当該銘柄でクローズ時に楽天 API が文字列数値を返すケースは #48 で対応中

## Test plan
- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test ./internal/interfaces/api/...\`
- [ ] ハンドラー単体テスト追加（冪等性パス・404・400 系）
- [ ] ステージング環境でデモ口座を使ったクローズ動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)