### PR TITLE
feat(backend): client order lifecycle 基盤 (Plan 12 PR#1)

### DIFF
--- a/backend/cmd/pipeline.go
+++ b/backend/cmd/pipeline.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
 	"log/slog"
 	"math"
 	"strconv"
@@ -12,6 +15,21 @@ import (
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/repository"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase"
 )
+
+// newAgentClientOrderID は pipeline (自動売買エージェント) からの注文に使う
+// clientOrderId を採番する。形式は "agent-<intent>-<unix>-<rand8>"。
+//
+// rand を使うのは、同一秒内に複数注文が走った場合の衝突回避のため。
+// pipeline は単一プロセスで動く想定だが、stop-loss と open が同時刻に走るケースが
+// ありうるので intent を区別子として埋める。
+func newAgentClientOrderID(intent string) string {
+	var b [4]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		// rand 失敗時は時刻ナノ秒で代替 (極めてまれ)
+		return fmt.Sprintf("agent-%s-%d", intent, time.Now().UnixNano())
+	}
+	return fmt.Sprintf("agent-%s-%d-%s", intent, time.Now().Unix(), hex.EncodeToString(b[:]))
+}
 
 // TradingPipeline は自動売買パイプラインを管理する。
 // POST /start で Start、POST /stop で Stop を呼ぶ。
@@ -300,7 +318,8 @@ func (p *TradingPipeline) evaluate(ctx context.Context) {
 	}
 
 	// 6. 注文実行
-	result, err := p.orderExecutor.ExecuteSignal(ctx, *signal, price, amount)
+	clientOrderID := newAgentClientOrderID("open")
+	result, err := p.orderExecutor.ExecuteSignal(ctx, clientOrderID, *signal, price, amount)
 	if err != nil {
 		slog.Error("pipeline: order execution failed", "error", err)
 		return
@@ -344,7 +363,8 @@ func (p *TradingPipeline) runStopLossMonitor(ctx context.Context) {
 				slog.Warn("pipeline: stop-loss triggered",
 					"positionID", pos.ID, "side", pos.OrderSide, "entryPrice", pos.Price, "currentPrice", t.Last)
 
-				result, err := p.orderExecutor.ClosePosition(ctx, pos, t.Last)
+				clientOrderID := newAgentClientOrderID("stoploss")
+				result, err := p.orderExecutor.ClosePosition(ctx, clientOrderID, pos, t.Last)
 				if err != nil {
 					slog.Error("pipeline: stop-loss close failed", "error", err)
 					continue

--- a/backend/internal/domain/entity/client_order.go
+++ b/backend/internal/domain/entity/client_order.go
@@ -1,0 +1,37 @@
+package entity
+
+// ClientOrderStatus はクライアント注文 (冪等性キー単位の注文ライフサイクル) の状態。
+//
+// pending → confirmed → completed が正常系。pending/submitted は楽天側の真実が
+// 不明な状態を表し、reconcile ジョブによって reconciled-* に確定する。
+type ClientOrderStatus string
+
+const (
+	// ClientOrderStatusPending は Backend が DB に記録した直後 (楽天 HTTP 未開始)。
+	ClientOrderStatusPending ClientOrderStatus = "pending"
+	// ClientOrderStatusSubmitted は楽天 HTTP 送信を試みたが応答パース失敗等で結果が不明な状態。
+	ClientOrderStatusSubmitted ClientOrderStatus = "submitted"
+	// ClientOrderStatusConfirmed は応答パースに成功し orderId を取得済み。
+	ClientOrderStatusConfirmed ClientOrderStatus = "confirmed"
+	// ClientOrderStatusCompleted は約定処理まで Backend ドメインに反映済み。
+	ClientOrderStatusCompleted ClientOrderStatus = "completed"
+	// ClientOrderStatusFailed は楽天が明示的に拒否した、または送信前に失敗した。
+	ClientOrderStatusFailed ClientOrderStatus = "failed"
+	// ClientOrderStatusReconciledConfirmed は reconcile が楽天 GetOrders と突合して受理を確定。
+	ClientOrderStatusReconciledConfirmed ClientOrderStatus = "reconciled-confirmed"
+	// ClientOrderStatusReconciledNotFound は reconcile が TTL 経過後に対応注文を発見できず確定。
+	ClientOrderStatusReconciledNotFound ClientOrderStatus = "reconciled-not-found"
+	// ClientOrderStatusReconciledAmbiguous は候補が複数ヒットし自動判定不能。
+	ClientOrderStatusReconciledAmbiguous ClientOrderStatus = "reconciled-ambiguous"
+	// ClientOrderStatusReconciledTimeout は外部 TTL を超過し reconcile でも解決できなかった最終状態。
+	ClientOrderStatusReconciledTimeout ClientOrderStatus = "reconciled-timeout"
+)
+
+// ClientOrderIntent はクライアント注文の意図。
+type ClientOrderIntent string
+
+const (
+	ClientOrderIntentOpen   ClientOrderIntent = "open"
+	ClientOrderIntentClose  ClientOrderIntent = "close"
+	ClientOrderIntentCancel ClientOrderIntent = "cancel"
+)

--- a/backend/internal/domain/repository/client_order.go
+++ b/backend/internal/domain/repository/client_order.go
@@ -1,16 +1,62 @@
 package repository
 
-import "context"
+import (
+	"context"
 
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+)
+
+// ClientOrderRecord はクライアント注文 1 件のライフサイクルを表すレコード。
+//
+// status は注文の現在状態。pending/submitted は楽天側の真実が不明な状態を表し、
+// reconcile によって reconciled-* に確定する。
+//
+// SymbolID/Intent/Side/Amount/PositionID は reconcile 時の照合キー。RawResponse は
+// 楽天応答の生 JSON (パース失敗時の手動解析用)。
 type ClientOrderRecord struct {
 	ClientOrderID string
-	Executed      bool
-	OrderID       int64
+	Status        entity.ClientOrderStatus
+	SymbolID      int64
+	Intent        entity.ClientOrderIntent
+	Side          entity.OrderSide
+	Amount        float64
+	PositionID    int64 // 0 のとき未指定 (intent != close)
+	OrderID       int64 // 0 のとき未取得
+	RawResponse   string
+	ErrorMessage  string
 	CreatedAt     int64
+	UpdatedAt     int64
+
+	// Executed は後方互換のために残す。Status が confirmed/completed/reconciled-confirmed のとき true。
+	Executed bool
+}
+
+// ClientOrderUpdate は UpdateStatus でまとめて差し込めるフィールド束。
+// nil ポインタは「更新しない」を表す。
+type ClientOrderUpdate struct {
+	OrderID      *int64
+	RawResponse  *string
+	ErrorMessage *string
 }
 
 type ClientOrderRepository interface {
+	// Find は client_order_id で検索し、存在しなければ nil を返す。
+	// 後方互換のために残す (Step 2 で deprecated 化予定)。
 	Find(ctx context.Context, clientOrderID string) (*ClientOrderRecord, error)
+
+	// Save はレコードを保存する。後方互換のために残す (Step 2 で deprecated 化予定)。
 	Save(ctx context.Context, record ClientOrderRecord) error
+
+	// InsertOrGet は INSERT OR IGNORE で record を挿入し、既存行があれば既存行を返す。
+	// inserted=true なら新規挿入、false なら既存行 (existing) を読み直したもの。
+	InsertOrGet(ctx context.Context, record ClientOrderRecord) (existing *ClientOrderRecord, inserted bool, err error)
+
+	// UpdateStatus は status と任意フィールドを更新する。updated_at は呼び出し側時刻 (now) で上書きする。
+	UpdateStatus(ctx context.Context, clientOrderID string, status entity.ClientOrderStatus, now int64, update ClientOrderUpdate) error
+
+	// ListByStatus は指定 status のレコードを updated_at 昇順で最大 limit 件返す。
+	ListByStatus(ctx context.Context, statuses []entity.ClientOrderStatus, limit int) ([]ClientOrderRecord, error)
+
+	// DeleteExpired は created_at が beforeUnix より古いレコードを削除する。
 	DeleteExpired(ctx context.Context, beforeUnix int64) error
 }

--- a/backend/internal/domain/repository/order.go
+++ b/backend/internal/domain/repository/order.go
@@ -6,9 +6,29 @@ import (
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
 )
 
+// CreateOrderOutcome は CreateOrderRaw の結果。
+//
+// RawResponse は楽天 API のレスポンス本文 (パース失敗時でもセットされる)。
+// Orders はパースに成功した場合のみ非 nil。
+// HTTPStatus は HTTP ステータスコード。0 のとき送信前 / コネクション失敗で取得不可。
+// ParseError はレスポンス本文のパースに失敗した場合のエラー。
+// TransportError は HTTP コネクション系の失敗 (DNS, TCP reset, タイムアウト等)。
+// HTTPError は 4xx/5xx を受け取った場合のエラー (本文がパースできた場合は nil で、Orders と HTTPStatus を見て判断する)。
+type CreateOrderOutcome struct {
+	RawResponse    []byte
+	HTTPStatus     int
+	Orders         []entity.Order
+	ParseError     error
+	TransportError error
+	HTTPError      error
+}
+
 // OrderClient は注文操作のインターフェース。
 type OrderClient interface {
 	CreateOrder(ctx context.Context, req entity.OrderRequest) ([]entity.Order, error)
+	// CreateOrderRaw は CreateOrder の詳細版。送信から応答パースまでの各段階を
+	// 構造化して返すため、呼び出し側で submitted/failed の判定が可能。
+	CreateOrderRaw(ctx context.Context, req entity.OrderRequest) (CreateOrderOutcome, error)
 	CancelOrder(ctx context.Context, symbolID, orderID int64) ([]entity.Order, error)
 	GetOrders(ctx context.Context, symbolID int64) ([]entity.Order, error)
 	GetPositions(ctx context.Context, symbolID int64) ([]entity.Position, error)

--- a/backend/internal/infrastructure/database/client_order_repo.go
+++ b/backend/internal/infrastructure/database/client_order_repo.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/repository"
 )
 
-// ClientOrderRepo はクライアント注文の冪等性キーの永続化を行う。
+// ClientOrderRepo はクライアント注文の冪等性キーとライフサイクルの永続化を行う。
 type ClientOrderRepo struct {
 	db *sql.DB
 }
@@ -17,32 +19,243 @@ func NewClientOrderRepo(db *sql.DB) *ClientOrderRepo {
 	return &ClientOrderRepo{db: db}
 }
 
+const clientOrderColumns = `
+	client_order_id, executed, order_id, created_at,
+	status, symbol_id, intent, side, amount, position_id,
+	raw_response, error_message, updated_at`
+
+func scanClientOrder(scanner interface {
+	Scan(dest ...any) error
+}) (*repository.ClientOrderRecord, error) {
+	var (
+		rec      repository.ClientOrderRecord
+		statusS  string
+		intentS  string
+		sideS    string
+		executed int64
+	)
+	err := scanner.Scan(
+		&rec.ClientOrderID,
+		&executed,
+		&rec.OrderID,
+		&rec.CreatedAt,
+		&statusS,
+		&rec.SymbolID,
+		&intentS,
+		&sideS,
+		&rec.Amount,
+		&rec.PositionID,
+		&rec.RawResponse,
+		&rec.ErrorMessage,
+		&rec.UpdatedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	rec.Status = entity.ClientOrderStatus(statusS)
+	rec.Intent = entity.ClientOrderIntent(intentS)
+	rec.Side = entity.OrderSide(sideS)
+	rec.Executed = executed != 0
+	return &rec, nil
+}
+
 // Find はクライアント注文IDで検索し、存在しなければ nil を返す。
 func (r *ClientOrderRepo) Find(ctx context.Context, clientOrderID string) (*repository.ClientOrderRecord, error) {
-	var rec repository.ClientOrderRecord
-	err := r.db.QueryRowContext(ctx,
-		`SELECT client_order_id, executed, order_id, created_at FROM client_orders WHERE client_order_id = ?`,
+	row := r.db.QueryRowContext(ctx,
+		`SELECT `+clientOrderColumns+` FROM client_orders WHERE client_order_id = ?`,
 		clientOrderID,
-	).Scan(&rec.ClientOrderID, &rec.Executed, &rec.OrderID, &rec.CreatedAt)
+	)
+	rec, err := scanClientOrder(row)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
 	if err != nil {
 		return nil, fmt.Errorf("find client order: %w", err)
 	}
-	return &rec, nil
+	return rec, nil
 }
 
-// Save はクライアント注文レコードを保存する。
+// Save はクライアント注文レコードを保存 (UPSERT) する。
+// 後方互換のために残す。新規コードは InsertOrGet + UpdateStatus を使うこと。
 func (r *ClientOrderRepo) Save(ctx context.Context, record repository.ClientOrderRecord) error {
+	if record.Status == "" {
+		// 旧呼び出し元 (Find→Save パターン) からの保存。
+		// executed フラグから既存ステータスにマップする。
+		if record.Executed {
+			record.Status = entity.ClientOrderStatusCompleted
+		} else {
+			record.Status = entity.ClientOrderStatusFailed
+		}
+	}
+	if record.UpdatedAt == 0 {
+		record.UpdatedAt = record.CreatedAt
+	}
+	executed := int64(0)
+	if record.Executed {
+		executed = 1
+	}
 	_, err := r.db.ExecContext(ctx,
-		`INSERT INTO client_orders (client_order_id, executed, order_id, created_at) VALUES (?, ?, ?, ?)`,
-		record.ClientOrderID, record.Executed, record.OrderID, record.CreatedAt,
+		`INSERT INTO client_orders (
+			client_order_id, executed, order_id, created_at,
+			status, symbol_id, intent, side, amount, position_id,
+			raw_response, error_message, updated_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(client_order_id) DO UPDATE SET
+			executed=excluded.executed,
+			order_id=excluded.order_id,
+			status=excluded.status,
+			symbol_id=excluded.symbol_id,
+			intent=excluded.intent,
+			side=excluded.side,
+			amount=excluded.amount,
+			position_id=excluded.position_id,
+			raw_response=excluded.raw_response,
+			error_message=excluded.error_message,
+			updated_at=excluded.updated_at`,
+		record.ClientOrderID, executed, record.OrderID, record.CreatedAt,
+		string(record.Status), record.SymbolID, string(record.Intent), string(record.Side),
+		record.Amount, record.PositionID, record.RawResponse, record.ErrorMessage, record.UpdatedAt,
 	)
 	if err != nil {
 		return fmt.Errorf("save client order: %w", err)
 	}
 	return nil
+}
+
+// InsertOrGet は INSERT OR IGNORE で record を挿入する。既に存在していた場合は
+// 既存行を読み直して existing に返し、inserted=false を返す。
+func (r *ClientOrderRepo) InsertOrGet(ctx context.Context, record repository.ClientOrderRecord) (*repository.ClientOrderRecord, bool, error) {
+	if record.Status == "" {
+		record.Status = entity.ClientOrderStatusPending
+	}
+	if record.UpdatedAt == 0 {
+		record.UpdatedAt = record.CreatedAt
+	}
+	executed := int64(0)
+	if record.Executed {
+		executed = 1
+	}
+	res, err := r.db.ExecContext(ctx,
+		`INSERT OR IGNORE INTO client_orders (
+			client_order_id, executed, order_id, created_at,
+			status, symbol_id, intent, side, amount, position_id,
+			raw_response, error_message, updated_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		record.ClientOrderID, executed, record.OrderID, record.CreatedAt,
+		string(record.Status), record.SymbolID, string(record.Intent), string(record.Side),
+		record.Amount, record.PositionID, record.RawResponse, record.ErrorMessage, record.UpdatedAt,
+	)
+	if err != nil {
+		return nil, false, fmt.Errorf("insert or get client order: %w", err)
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return nil, false, fmt.Errorf("rows affected: %w", err)
+	}
+	if affected == 1 {
+		// 新規挿入。引数を返すと呼び出し側のローカル変更で食い違うため、DB から読み直す。
+		stored, err := r.Find(ctx, record.ClientOrderID)
+		if err != nil {
+			return nil, true, err
+		}
+		return stored, true, nil
+	}
+	existing, err := r.Find(ctx, record.ClientOrderID)
+	if err != nil {
+		return nil, false, err
+	}
+	if existing == nil {
+		return nil, false, fmt.Errorf("insert or get: row vanished after conflict for %s", record.ClientOrderID)
+	}
+	return existing, false, nil
+}
+
+// UpdateStatus は status と任意フィールドを差分更新する。
+func (r *ClientOrderRepo) UpdateStatus(
+	ctx context.Context,
+	clientOrderID string,
+	status entity.ClientOrderStatus,
+	now int64,
+	update repository.ClientOrderUpdate,
+) error {
+	sets := []string{"status = ?", "updated_at = ?"}
+	args := []any{string(status), now}
+
+	executed := isExecutedStatus(status)
+	sets = append(sets, "executed = ?")
+	args = append(args, boolToInt(executed))
+
+	if update.OrderID != nil {
+		sets = append(sets, "order_id = ?")
+		args = append(args, *update.OrderID)
+	}
+	if update.RawResponse != nil {
+		sets = append(sets, "raw_response = ?")
+		args = append(args, *update.RawResponse)
+	}
+	if update.ErrorMessage != nil {
+		sets = append(sets, "error_message = ?")
+		args = append(args, *update.ErrorMessage)
+	}
+
+	args = append(args, clientOrderID)
+	stmt := `UPDATE client_orders SET ` + strings.Join(sets, ", ") + ` WHERE client_order_id = ?`
+	res, err := r.db.ExecContext(ctx, stmt, args...)
+	if err != nil {
+		return fmt.Errorf("update client order status: %w", err)
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("rows affected: %w", err)
+	}
+	if affected == 0 {
+		return fmt.Errorf("update client order status: no row for %s", clientOrderID)
+	}
+	return nil
+}
+
+// ListByStatus は指定 status のレコードを updated_at 昇順で最大 limit 件返す。
+func (r *ClientOrderRepo) ListByStatus(
+	ctx context.Context,
+	statuses []entity.ClientOrderStatus,
+	limit int,
+) ([]repository.ClientOrderRecord, error) {
+	if len(statuses) == 0 {
+		return nil, nil
+	}
+	if limit <= 0 {
+		limit = 100
+	}
+	placeholders := make([]string, len(statuses))
+	args := make([]any, 0, len(statuses)+1)
+	for i, s := range statuses {
+		placeholders[i] = "?"
+		args = append(args, string(s))
+	}
+	args = append(args, limit)
+
+	stmt := `SELECT ` + clientOrderColumns + ` FROM client_orders
+		WHERE status IN (` + strings.Join(placeholders, ",") + `)
+		ORDER BY updated_at ASC
+		LIMIT ?`
+	rows, err := r.db.QueryContext(ctx, stmt, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list client orders by status: %w", err)
+	}
+	defer rows.Close()
+
+	var out []repository.ClientOrderRecord
+	for rows.Next() {
+		rec, err := scanClientOrder(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan client order: %w", err)
+		}
+		out = append(out, *rec)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate client orders: %w", err)
+	}
+	return out, nil
 }
 
 // DeleteExpired は指定した時刻より前に作成されたレコードを削除する。
@@ -55,4 +268,22 @@ func (r *ClientOrderRepo) DeleteExpired(ctx context.Context, beforeUnix int64) e
 		return fmt.Errorf("delete expired client orders: %w", err)
 	}
 	return nil
+}
+
+func isExecutedStatus(s entity.ClientOrderStatus) bool {
+	switch s {
+	case entity.ClientOrderStatusConfirmed,
+		entity.ClientOrderStatusCompleted,
+		entity.ClientOrderStatusReconciledConfirmed:
+		return true
+	default:
+		return false
+	}
+}
+
+func boolToInt(b bool) int64 {
+	if b {
+		return 1
+	}
+	return 0
 }

--- a/backend/internal/infrastructure/database/client_order_repo_test.go
+++ b/backend/internal/infrastructure/database/client_order_repo_test.go
@@ -1,0 +1,305 @@
+package database
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/repository"
+)
+
+func newTestClientOrderRepo(t *testing.T) *ClientOrderRepo {
+	t.Helper()
+	tmpDir := t.TempDir()
+	db, err := NewDB(filepath.Join(tmpDir, "test.db"))
+	if err != nil {
+		t.Fatalf("NewDB: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := RunMigrations(db); err != nil {
+		t.Fatalf("RunMigrations: %v", err)
+	}
+	return NewClientOrderRepo(db)
+}
+
+func TestClientOrderRepo_InsertOrGet_Insert(t *testing.T) {
+	repo := newTestClientOrderRepo(t)
+	ctx := context.Background()
+
+	now := time.Now().Unix()
+	rec := repository.ClientOrderRecord{
+		ClientOrderID: "co-1",
+		Status:        entity.ClientOrderStatusPending,
+		SymbolID:      7,
+		Intent:        entity.ClientOrderIntentOpen,
+		Side:          entity.OrderSideBuy,
+		Amount:        0.001,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}
+
+	stored, inserted, err := repo.InsertOrGet(ctx, rec)
+	if err != nil {
+		t.Fatalf("InsertOrGet: %v", err)
+	}
+	if !inserted {
+		t.Fatal("expected inserted=true on first insert")
+	}
+	if stored == nil || stored.ClientOrderID != "co-1" {
+		t.Fatalf("unexpected stored record: %+v", stored)
+	}
+	if stored.Status != entity.ClientOrderStatusPending {
+		t.Fatalf("expected pending, got %s", stored.Status)
+	}
+	if stored.SymbolID != 7 || stored.Side != entity.OrderSideBuy || stored.Amount != 0.001 {
+		t.Fatalf("metadata mismatch: %+v", stored)
+	}
+	if stored.Executed {
+		t.Fatal("pending should map to executed=false")
+	}
+}
+
+func TestClientOrderRepo_InsertOrGet_ReturnsExistingOnConflict(t *testing.T) {
+	repo := newTestClientOrderRepo(t)
+	ctx := context.Background()
+
+	now := time.Now().Unix()
+	first := repository.ClientOrderRecord{
+		ClientOrderID: "co-2",
+		Status:        entity.ClientOrderStatusPending,
+		SymbolID:      7,
+		Intent:        entity.ClientOrderIntentOpen,
+		Side:          entity.OrderSideBuy,
+		Amount:        0.001,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}
+	if _, _, err := repo.InsertOrGet(ctx, first); err != nil {
+		t.Fatalf("first insert: %v", err)
+	}
+
+	// 状態を confirmed に進めておく。
+	orderID := int64(12345)
+	if err := repo.UpdateStatus(ctx, "co-2", entity.ClientOrderStatusConfirmed, now+1, repository.ClientOrderUpdate{
+		OrderID: &orderID,
+	}); err != nil {
+		t.Fatalf("UpdateStatus: %v", err)
+	}
+
+	// 同じ clientOrderID で再度 InsertOrGet → 既存行 (confirmed) が返る。
+	second := first
+	second.SymbolID = 999 // 上書きされていないことを確認するためのダミー
+	existing, inserted, err := repo.InsertOrGet(ctx, second)
+	if err != nil {
+		t.Fatalf("second InsertOrGet: %v", err)
+	}
+	if inserted {
+		t.Fatal("expected inserted=false on conflict")
+	}
+	if existing == nil {
+		t.Fatal("existing should not be nil")
+	}
+	if existing.Status != entity.ClientOrderStatusConfirmed {
+		t.Fatalf("expected confirmed, got %s", existing.Status)
+	}
+	if existing.OrderID != orderID {
+		t.Fatalf("expected orderID %d, got %d", orderID, existing.OrderID)
+	}
+	if existing.SymbolID != 7 {
+		t.Fatalf("existing should preserve original symbolID 7, got %d", existing.SymbolID)
+	}
+	if !existing.Executed {
+		t.Fatal("confirmed should map to executed=true")
+	}
+}
+
+func TestClientOrderRepo_InsertOrGet_ConcurrentSingleInsert(t *testing.T) {
+	repo := newTestClientOrderRepo(t)
+	ctx := context.Background()
+	const goroutines = 16
+
+	now := time.Now().Unix()
+	base := repository.ClientOrderRecord{
+		ClientOrderID: "co-race",
+		Status:        entity.ClientOrderStatusPending,
+		SymbolID:      7,
+		Intent:        entity.ClientOrderIntentOpen,
+		Side:          entity.OrderSideBuy,
+		Amount:        0.001,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}
+
+	var wg sync.WaitGroup
+	var insertedCount int32
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			_, inserted, err := repo.InsertOrGet(ctx, base)
+			if err != nil {
+				t.Errorf("InsertOrGet: %v", err)
+				return
+			}
+			if inserted {
+				atomic.AddInt32(&insertedCount, 1)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if insertedCount != 1 {
+		t.Fatalf("expected exactly 1 insert across %d goroutines, got %d", goroutines, insertedCount)
+	}
+}
+
+func TestClientOrderRepo_UpdateStatus_FieldsAndExecutedFlag(t *testing.T) {
+	repo := newTestClientOrderRepo(t)
+	ctx := context.Background()
+
+	now := time.Now().Unix()
+	rec := repository.ClientOrderRecord{
+		ClientOrderID: "co-3",
+		Status:        entity.ClientOrderStatusPending,
+		SymbolID:      7,
+		Intent:        entity.ClientOrderIntentOpen,
+		Side:          entity.OrderSideSell,
+		Amount:        0.5,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}
+	if _, _, err := repo.InsertOrGet(ctx, rec); err != nil {
+		t.Fatalf("InsertOrGet: %v", err)
+	}
+
+	raw := `{"id":42}`
+	errMsg := "parse failed"
+	if err := repo.UpdateStatus(ctx, "co-3", entity.ClientOrderStatusSubmitted, now+10, repository.ClientOrderUpdate{
+		RawResponse:  &raw,
+		ErrorMessage: &errMsg,
+	}); err != nil {
+		t.Fatalf("UpdateStatus: %v", err)
+	}
+
+	got, err := repo.Find(ctx, "co-3")
+	if err != nil {
+		t.Fatalf("Find: %v", err)
+	}
+	if got == nil {
+		t.Fatal("record should exist")
+	}
+	if got.Status != entity.ClientOrderStatusSubmitted {
+		t.Fatalf("expected submitted, got %s", got.Status)
+	}
+	if got.RawResponse != raw || got.ErrorMessage != errMsg {
+		t.Fatalf("fields not updated: %+v", got)
+	}
+	if got.UpdatedAt != now+10 {
+		t.Fatalf("expected updated_at %d, got %d", now+10, got.UpdatedAt)
+	}
+	if got.Executed {
+		t.Fatal("submitted should map to executed=false")
+	}
+
+	// confirmed に遷移すると executed=true になる。
+	orderID := int64(7777)
+	if err := repo.UpdateStatus(ctx, "co-3", entity.ClientOrderStatusReconciledConfirmed, now+20, repository.ClientOrderUpdate{
+		OrderID: &orderID,
+	}); err != nil {
+		t.Fatalf("second UpdateStatus: %v", err)
+	}
+	got2, err := repo.Find(ctx, "co-3")
+	if err != nil {
+		t.Fatalf("Find: %v", err)
+	}
+	if !got2.Executed {
+		t.Fatal("reconciled-confirmed should map to executed=true")
+	}
+	if got2.OrderID != orderID {
+		t.Fatalf("expected orderID %d, got %d", orderID, got2.OrderID)
+	}
+}
+
+func TestClientOrderRepo_UpdateStatus_NoRow(t *testing.T) {
+	repo := newTestClientOrderRepo(t)
+	ctx := context.Background()
+	err := repo.UpdateStatus(ctx, "missing", entity.ClientOrderStatusFailed, time.Now().Unix(), repository.ClientOrderUpdate{})
+	if err == nil {
+		t.Fatal("expected error for missing row")
+	}
+}
+
+func TestClientOrderRepo_ListByStatus(t *testing.T) {
+	repo := newTestClientOrderRepo(t)
+	ctx := context.Background()
+	now := time.Now().Unix()
+
+	insert := func(id string, status entity.ClientOrderStatus, updatedAt int64) {
+		t.Helper()
+		rec := repository.ClientOrderRecord{
+			ClientOrderID: id,
+			Status:        status,
+			SymbolID:      7,
+			Intent:        entity.ClientOrderIntentOpen,
+			Side:          entity.OrderSideBuy,
+			Amount:        0.001,
+			CreatedAt:     updatedAt,
+			UpdatedAt:     updatedAt,
+		}
+		if _, _, err := repo.InsertOrGet(ctx, rec); err != nil {
+			t.Fatalf("insert %s: %v", id, err)
+		}
+	}
+
+	insert("a", entity.ClientOrderStatusSubmitted, now+1)
+	insert("b", entity.ClientOrderStatusPending, now+2)
+	insert("c", entity.ClientOrderStatusCompleted, now+3)
+	insert("d", entity.ClientOrderStatusSubmitted, now+4)
+
+	out, err := repo.ListByStatus(ctx,
+		[]entity.ClientOrderStatus{entity.ClientOrderStatusPending, entity.ClientOrderStatusSubmitted}, 10)
+	if err != nil {
+		t.Fatalf("ListByStatus: %v", err)
+	}
+	if len(out) != 3 {
+		t.Fatalf("expected 3 records, got %d (%+v)", len(out), out)
+	}
+	// updated_at 昇順
+	wantOrder := []string{"a", "b", "d"}
+	for i, w := range wantOrder {
+		if out[i].ClientOrderID != w {
+			t.Fatalf("order mismatch at %d: want %s, got %s", i, w, out[i].ClientOrderID)
+		}
+	}
+}
+
+func TestClientOrderRepo_Save_BackwardCompatible(t *testing.T) {
+	// 既存呼び出し元 (handler の Find→Save パターン) が壊れないことを確認する。
+	repo := newTestClientOrderRepo(t)
+	ctx := context.Background()
+	now := time.Now().Unix()
+
+	rec := repository.ClientOrderRecord{
+		ClientOrderID: "co-legacy",
+		Executed:      true,
+		OrderID:       42,
+		CreatedAt:     now,
+	}
+	if err := repo.Save(ctx, rec); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got, err := repo.Find(ctx, "co-legacy")
+	if err != nil {
+		t.Fatalf("Find: %v", err)
+	}
+	if got == nil || !got.Executed || got.OrderID != 42 {
+		t.Fatalf("legacy save round-trip failed: %+v", got)
+	}
+	if got.Status != entity.ClientOrderStatusCompleted {
+		t.Fatalf("legacy executed=true should map to completed, got %s", got.Status)
+	}
+}

--- a/backend/internal/infrastructure/database/migrations.go
+++ b/backend/internal/infrastructure/database/migrations.go
@@ -5,6 +5,44 @@ import (
 	"fmt"
 )
 
+// addColumnIfNotExists は SQLite の ALTER TABLE ADD COLUMN を冪等に実行する。
+// SQLite は `ADD COLUMN IF NOT EXISTS` をサポートしないため、PRAGMA table_info で
+// 既存カラムを確認してから ALTER を発行する。
+// columnDef は "<name> <type> [DEFAULT <value>] ..." の形式 (ADD COLUMN の右辺)。
+func addColumnIfNotExists(db *sql.DB, table, columnName, columnDef string) error {
+	rows, err := db.Query(fmt.Sprintf("PRAGMA table_info(%s)", table))
+	if err != nil {
+		return fmt.Errorf("pragma table_info(%s): %w", table, err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var (
+			cid     int
+			name    string
+			ctype   string
+			notnull int
+			dflt    sql.NullString
+			pk      int
+		)
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk); err != nil {
+			return fmt.Errorf("scan table_info(%s): %w", table, err)
+		}
+		if name == columnName {
+			return nil
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate table_info(%s): %w", table, err)
+	}
+
+	stmt := fmt.Sprintf("ALTER TABLE %s ADD COLUMN %s", table, columnDef)
+	if _, err := db.Exec(stmt); err != nil {
+		return fmt.Errorf("alter table %s add column %s: %w", table, columnName, err)
+	}
+	return nil
+}
+
 // RunMigrations creates the database schema.
 // Uses IF NOT EXISTS so it can be run idempotently.
 func RunMigrations(db *sql.DB) error {
@@ -93,6 +131,33 @@ func RunMigrations(db *sql.DB) error {
 		if _, err := db.Exec(m); err != nil {
 			return fmt.Errorf("migration failed: %w", err)
 		}
+	}
+
+	// client_orders をライフサイクル監査ログに格上げするための ALTER 群。
+	// 既存行は status='completed' で保護される (executed=true 前提のレコードのみ存在していたため)。
+	clientOrderColumns := []struct {
+		name string
+		def  string
+	}{
+		{"status", "status TEXT NOT NULL DEFAULT 'completed'"},
+		{"symbol_id", "symbol_id INTEGER NOT NULL DEFAULT 0"},
+		{"intent", "intent TEXT NOT NULL DEFAULT ''"},
+		{"side", "side TEXT NOT NULL DEFAULT ''"},
+		{"amount", "amount REAL NOT NULL DEFAULT 0"},
+		{"position_id", "position_id INTEGER NOT NULL DEFAULT 0"},
+		{"raw_response", "raw_response TEXT NOT NULL DEFAULT ''"},
+		{"error_message", "error_message TEXT NOT NULL DEFAULT ''"},
+		{"updated_at", "updated_at INTEGER NOT NULL DEFAULT 0"},
+	}
+	for _, col := range clientOrderColumns {
+		if err := addColumnIfNotExists(db, "client_orders", col.name, col.def); err != nil {
+			return fmt.Errorf("client_orders alter: %w", err)
+		}
+	}
+
+	if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_client_orders_status
+		ON client_orders(status, updated_at)`); err != nil {
+		return fmt.Errorf("create idx_client_orders_status: %w", err)
 	}
 
 	return nil

--- a/backend/internal/infrastructure/rakuten/private_api.go
+++ b/backend/internal/infrastructure/rakuten/private_api.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/repository"
 )
 
 func (c *RESTClient) GetAssets(ctx context.Context) ([]entity.Asset, error) {
@@ -42,6 +43,52 @@ func (c *RESTClient) CreateOrder(ctx context.Context, req entity.OrderRequest) (
 	var orders []entity.Order
 	if err := json.Unmarshal(body, &orders); err != nil { return nil, fmt.Errorf("CreateOrder unmarshal: %w", err) }
 	return orders, nil
+}
+
+// CreateOrderRaw は CreateOrder の構造化版。
+// 送信前 / トランスポート失敗 / 非 2xx / パース失敗 / 成功 を区別して返す。
+//
+// CreateOrderOutcome の各フィールドの意味:
+//   - TransportError != nil: 送信前 or HTTP コネクション系の失敗 (RawResponse 空, HTTPStatus=0)
+//   - HTTPStatus < 200 or >= 300: 楽天が非 2xx を返した。Orders は nil。
+//     ParseError != nil なら本文が JSON でない (= submitted 候補)
+//     ParseError == nil なら 4xx/5xx の構造化エラーボディが取れている (= failed 候補)
+//   - HTTPStatus 2xx かつ ParseError == nil: 成功 (Orders 非 nil)
+//   - HTTPStatus 2xx かつ ParseError != nil: 200 だが本文が解釈不能 (= submitted)
+func (c *RESTClient) CreateOrderRaw(ctx context.Context, req entity.OrderRequest) (repository.CreateOrderOutcome, error) {
+	out := repository.CreateOrderOutcome{}
+
+	reqBody, err := json.Marshal(req)
+	if err != nil {
+		out.TransportError = fmt.Errorf("CreateOrderRaw marshal: %w", err)
+		return out, out.TransportError
+	}
+
+	statusCode, body, transportErr := c.DoPrivateRaw(ctx, "POST", "/api/v1/cfd/order", "", reqBody)
+	out.HTTPStatus = statusCode
+	out.RawResponse = body
+	if transportErr != nil {
+		out.TransportError = transportErr
+		return out, nil
+	}
+
+	if statusCode < 200 || statusCode >= 300 {
+		// 4xx/5xx。本文を JSON としてパース可能か試す (エラー構造体である可能性あり)。
+		var probe any
+		if err := json.Unmarshal(body, &probe); err != nil {
+			out.ParseError = fmt.Errorf("CreateOrderRaw error body parse failed (status %d): %w", statusCode, err)
+		}
+		out.HTTPError = fmt.Errorf("API error (status %d): %s", statusCode, string(body))
+		return out, nil
+	}
+
+	var orders []entity.Order
+	if err := json.Unmarshal(body, &orders); err != nil {
+		out.ParseError = fmt.Errorf("CreateOrderRaw unmarshal: %w", err)
+		return out, nil
+	}
+	out.Orders = orders
+	return out, nil
 }
 
 func (c *RESTClient) CancelOrder(ctx context.Context, symbolID, orderID int64) ([]entity.Order, error) {

--- a/backend/internal/infrastructure/rakuten/private_api_test.go
+++ b/backend/internal/infrastructure/rakuten/private_api_test.go
@@ -61,6 +61,90 @@ func TestCreateOrder(t *testing.T) {
 	if orders[0].ID != 100 { t.Fatalf("expected order ID 100, got %d", orders[0].ID) }
 }
 
+func TestCreateOrderRaw_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertAuthHeaders(t, r)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`[{"id":100,"symbolId":7,"orderBehavior":"OPEN","orderSide":"BUY","orderPattern":"NORMAL","orderType":"MARKET","price":0,"amount":0.001,"remainingAmount":0.001,"orderStatus":"WORKING_ORDER","leverage":2,"orderCreatedAt":1700000000000}]`))
+	}))
+	defer server.Close()
+	client := NewRESTClient(server.URL, "key", "secret")
+	out, err := client.CreateOrderRaw(context.Background(), entity.OrderRequest{
+		SymbolID: 7, OrderPattern: entity.OrderPatternNormal,
+		OrderData: entity.OrderData{OrderBehavior: entity.OrderBehaviorOpen, OrderSide: entity.OrderSideBuy, OrderType: entity.OrderTypeMarket, Amount: 0.001},
+	})
+	if err != nil { t.Fatalf("unexpected error: %v", err) }
+	if out.HTTPStatus != 200 { t.Fatalf("expected status 200, got %d", out.HTTPStatus) }
+	if out.TransportError != nil || out.ParseError != nil || out.HTTPError != nil {
+		t.Fatalf("unexpected errors: %+v", out)
+	}
+	if len(out.Orders) != 1 || out.Orders[0].ID != 100 { t.Fatalf("expected 1 order with ID 100, got %+v", out.Orders) }
+	if len(out.RawResponse) == 0 { t.Fatal("RawResponse should be populated") }
+}
+
+func TestCreateOrderRaw_ParseFailureKeepsRawBody(t *testing.T) {
+	// 200 OK だが本文が解釈不能 (= submitted 候補) を再現する。
+	garbage := `not a json array`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertAuthHeaders(t, r)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(garbage))
+	}))
+	defer server.Close()
+	client := NewRESTClient(server.URL, "key", "secret")
+	out, err := client.CreateOrderRaw(context.Background(), entity.OrderRequest{
+		SymbolID: 7, OrderPattern: entity.OrderPatternNormal,
+		OrderData: entity.OrderData{OrderBehavior: entity.OrderBehaviorOpen, OrderSide: entity.OrderSideBuy, OrderType: entity.OrderTypeMarket, Amount: 0.001},
+	})
+	if err != nil { t.Fatalf("unexpected transport-level error: %v", err) }
+	if out.HTTPStatus != 200 { t.Fatalf("expected status 200, got %d", out.HTTPStatus) }
+	if out.ParseError == nil { t.Fatal("expected ParseError for unparseable body") }
+	if string(out.RawResponse) != garbage { t.Fatalf("expected raw body preserved, got %q", string(out.RawResponse)) }
+	if len(out.Orders) != 0 { t.Fatalf("expected no parsed orders, got %d", len(out.Orders)) }
+}
+
+func TestCreateOrderRaw_HTTP4xxWithJSONBody(t *testing.T) {
+	// 4xx + 構造化エラーボディ (= failed)。ParseError が nil になり、HTTPError がセットされる。
+	body := `{"code":40001,"message":"insufficient balance"}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertAuthHeaders(t, r)
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(body))
+	}))
+	defer server.Close()
+	client := NewRESTClient(server.URL, "key", "secret")
+	out, err := client.CreateOrderRaw(context.Background(), entity.OrderRequest{
+		SymbolID: 7, OrderPattern: entity.OrderPatternNormal,
+		OrderData: entity.OrderData{OrderBehavior: entity.OrderBehaviorOpen, OrderSide: entity.OrderSideBuy, OrderType: entity.OrderTypeMarket, Amount: 0.001},
+	})
+	if err != nil { t.Fatalf("unexpected transport-level error: %v", err) }
+	if out.HTTPStatus != 400 { t.Fatalf("expected status 400, got %d", out.HTTPStatus) }
+	if out.HTTPError == nil { t.Fatal("expected HTTPError for 4xx") }
+	if out.ParseError != nil { t.Fatalf("4xx with parseable JSON body should not set ParseError, got %v", out.ParseError) }
+	if string(out.RawResponse) != body { t.Fatalf("raw body mismatch: %s", string(out.RawResponse)) }
+}
+
+func TestCreateOrderRaw_HTTP5xxWithGarbage(t *testing.T) {
+	// 5xx + 解釈不能ボディ (= submitted 候補)。ParseError と HTTPError の両方がセットされる。
+	body := `<html>internal server error</html>`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertAuthHeaders(t, r)
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(body))
+	}))
+	defer server.Close()
+	client := NewRESTClient(server.URL, "key", "secret")
+	out, err := client.CreateOrderRaw(context.Background(), entity.OrderRequest{
+		SymbolID: 7, OrderPattern: entity.OrderPatternNormal,
+		OrderData: entity.OrderData{OrderBehavior: entity.OrderBehaviorOpen, OrderSide: entity.OrderSideBuy, OrderType: entity.OrderTypeMarket, Amount: 0.001},
+	})
+	if err != nil { t.Fatalf("unexpected transport-level error: %v", err) }
+	if out.HTTPStatus != 500 { t.Fatalf("expected status 500, got %d", out.HTTPStatus) }
+	if out.HTTPError == nil { t.Fatal("expected HTTPError for 5xx") }
+	if out.ParseError == nil { t.Fatal("expected ParseError for unparseable body") }
+	if string(out.RawResponse) != body { t.Fatalf("raw body mismatch") }
+}
+
 func TestCancelOrder(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertAuthHeaders(t, r)

--- a/backend/internal/infrastructure/rakuten/rest_client.go
+++ b/backend/internal/infrastructure/rakuten/rest_client.go
@@ -39,9 +39,34 @@ func (c *RESTClient) DoPrivate(ctx context.Context, method, path, query string, 
 	return c.do(ctx, method, path, query, body, true)
 }
 
+// httpExchange は do() の構造化版。トランスポート失敗・非 2xx・本文を区別して返す。
+type httpExchange struct {
+	statusCode     int
+	body           []byte
+	transportError error
+}
+
+// DoPrivateRaw は DoPrivate の構造化版。レスポンス本文を非 2xx でも返す。
+// 呼び出し側で submitted/failed の判定 (status コード + 本文パース可否) が必要なときに使う。
+func (c *RESTClient) DoPrivateRaw(ctx context.Context, method, path, query string, body []byte) (statusCode int, respBody []byte, transportErr error) {
+	ex := c.doRaw(ctx, method, path, query, body, true)
+	return ex.statusCode, ex.body, ex.transportError
+}
+
 func (c *RESTClient) do(ctx context.Context, method, path, query string, body []byte, authenticated bool) ([]byte, error) {
+	ex := c.doRaw(ctx, method, path, query, body, authenticated)
+	if ex.transportError != nil {
+		return nil, ex.transportError
+	}
+	if ex.statusCode < 200 || ex.statusCode >= 300 {
+		return nil, fmt.Errorf("API error (status %d): %s", ex.statusCode, string(ex.body))
+	}
+	return ex.body, nil
+}
+
+func (c *RESTClient) doRaw(ctx context.Context, method, path, query string, body []byte, authenticated bool) httpExchange {
 	if err := c.waitForRateLimit(ctx); err != nil {
-		return nil, err
+		return httpExchange{transportError: err}
 	}
 
 	url := c.baseURL + path
@@ -56,7 +81,7 @@ func (c *RESTClient) do(ctx context.Context, method, path, query string, body []
 
 	req, err := http.NewRequestWithContext(ctx, method, url, bodyReader)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
+		return httpExchange{transportError: fmt.Errorf("failed to create request: %w", err)}
 	}
 
 	if body != nil {
@@ -72,20 +97,22 @@ func (c *RESTClient) do(ctx context.Context, method, path, query string, body []
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("request failed: %w", err)
+		return httpExchange{transportError: fmt.Errorf("request failed: %w", err)}
 	}
 	defer resp.Body.Close()
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read response body: %w", err)
+		return httpExchange{
+			statusCode:     resp.StatusCode,
+			transportError: fmt.Errorf("failed to read response body: %w", err),
+		}
 	}
 
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("API error (status %d): %s", resp.StatusCode, string(respBody))
+	return httpExchange{
+		statusCode: resp.StatusCode,
+		body:       respBody,
 	}
-
-	return respBody, nil
 }
 
 // waitForRateLimit enforces the Rakuten API 200ms interval limit.

--- a/backend/internal/interfaces/api/api_test.go
+++ b/backend/internal/interfaces/api/api_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/repository"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase"
 )
 
@@ -17,6 +18,10 @@ type mockOrderClient struct{}
 
 func (m *mockOrderClient) CreateOrder(_ context.Context, _ entity.OrderRequest) ([]entity.Order, error) {
 	return nil, nil
+}
+
+func (m *mockOrderClient) CreateOrderRaw(_ context.Context, _ entity.OrderRequest) (repository.CreateOrderOutcome, error) {
+	return repository.CreateOrderOutcome{}, nil
 }
 
 func (m *mockOrderClient) CancelOrder(_ context.Context, _, _ int64) ([]entity.Order, error) {

--- a/backend/internal/interfaces/api/handler/order.go
+++ b/backend/internal/interfaces/api/handler/order.go
@@ -87,7 +87,7 @@ func (h *OrderHandler) CreateOrder(c *gin.Context) {
 		Timestamp: time.Now().Unix(),
 	}
 
-	result, err := h.orderExecutor.ExecuteSignal(c.Request.Context(), signal, 0, req.Amount)
+	result, err := h.orderExecutor.ExecuteSignal(c.Request.Context(), req.ClientOrderID, signal, 0, req.Amount)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return

--- a/backend/internal/interfaces/api/handler/position.go
+++ b/backend/internal/interfaces/api/handler/position.go
@@ -112,7 +112,7 @@ func (h *PositionHandler) ClosePosition(c *gin.Context) {
 		return
 	}
 
-	result, err := h.orderExecutor.ClosePosition(c.Request.Context(), *pos, pos.Price)
+	result, err := h.orderExecutor.ClosePosition(c.Request.Context(), req.ClientOrderID, *pos, pos.Price)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return

--- a/backend/internal/usecase/order.go
+++ b/backend/internal/usecase/order.go
@@ -9,11 +9,30 @@ import (
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/repository"
 )
 
+// FailureKind は注文実行が失敗した際の分類。
+//
+// pre-flight 記録 (Step 2) で submitted/failed の判定に使う。
+type FailureKind string
+
+const (
+	// FailureKindNone は失敗していない。
+	FailureKindNone FailureKind = ""
+	// FailureKindPreSend は送信前 (バリデーション・risk reject) で失敗。楽天は呼ばれていない。
+	FailureKindPreSend FailureKind = "pre_send"
+	// FailureKindRejected は楽天が明示的に拒否 (4xx + 構造化エラーボディ)。失敗確定。
+	FailureKindRejected FailureKind = "rejected"
+	// FailureKindAmbiguous は楽天側の真実が不明 (パース失敗・タイムアウト・5xx)。
+	// reconcile による確定が必要。
+	FailureKindAmbiguous FailureKind = "ambiguous"
+)
+
 // ExecutionResult は注文実行の結果。
 type ExecutionResult struct {
-	Executed bool   `json:"executed"`
-	OrderID  int64  `json:"orderId,omitempty"`
-	Reason   string `json:"reason,omitempty"`
+	Executed    bool        `json:"executed"`
+	OrderID     int64       `json:"orderId,omitempty"`
+	Reason      string      `json:"reason,omitempty"`
+	RawResponse []byte      `json:"-"`
+	FailureKind FailureKind `json:"-"`
 }
 
 // OrderExecutor はシグナルに基づいて注文を実行する。
@@ -29,12 +48,16 @@ func NewOrderExecutor(client repository.OrderClient, riskMgr *RiskManager) *Orde
 	}
 }
 
-// ExecuteSignal はシグナルを受け取り、Risk Managerで検証後に注文を送信する。
-func (e *OrderExecutor) ExecuteSignal(ctx context.Context, signal entity.Signal, price float64, amount float64) (*ExecutionResult, error) {
+// ExecuteSignal はシグナルを受け取り、Risk Manager で検証後に注文を送信する。
+//
+// clientOrderID は注文ライフサイクル追跡用のキー。Step 1.5 ではログ出力に留め、
+// Step 2 で pre-flight 記録に使われる。
+func (e *OrderExecutor) ExecuteSignal(ctx context.Context, clientOrderID string, signal entity.Signal, price float64, amount float64) (*ExecutionResult, error) {
 	if signal.Action == entity.SignalActionHold {
 		return &ExecutionResult{
-			Executed: false,
-			Reason:   "signal is HOLD, no action",
+			Executed:    false,
+			Reason:      "signal is HOLD, no action",
+			FailureKind: FailureKindPreSend,
 		}, nil
 	}
 
@@ -54,10 +77,11 @@ func (e *OrderExecutor) ExecuteSignal(ctx context.Context, signal entity.Signal,
 
 	check := e.riskMgr.CheckOrder(ctx, proposal)
 	if !check.Approved {
-		slog.Info("order rejected by risk manager", "reason", check.Reason)
+		slog.Info("order rejected by risk manager", "reason", check.Reason, "clientOrderID", clientOrderID)
 		return &ExecutionResult{
-			Executed: false,
-			Reason:   fmt.Sprintf("risk rejected: %s", check.Reason),
+			Executed:    false,
+			Reason:      fmt.Sprintf("risk rejected: %s", check.Reason),
+			FailureKind: FailureKindPreSend,
 		}, nil
 	}
 
@@ -81,7 +105,13 @@ func (e *OrderExecutor) ExecuteSignal(ctx context.Context, signal entity.Signal,
 		return nil, fmt.Errorf("API returned no orders")
 	}
 
-	slog.Info("order created", "orderID", orders[0].ID, "symbolID", signal.SymbolID, "side", side, "amount", amount)
+	slog.Info("order created",
+		"orderID", orders[0].ID,
+		"symbolID", signal.SymbolID,
+		"side", side,
+		"amount", amount,
+		"clientOrderID", clientOrderID,
+	)
 
 	return &ExecutionResult{
 		Executed: true,
@@ -90,7 +120,10 @@ func (e *OrderExecutor) ExecuteSignal(ctx context.Context, signal entity.Signal,
 }
 
 // ClosePosition は指定ポジションを成行決済する。
-func (e *OrderExecutor) ClosePosition(ctx context.Context, pos entity.Position, currentPrice float64) (*ExecutionResult, error) {
+//
+// clientOrderID は注文ライフサイクル追跡用のキー。Step 1.5 ではログ出力に留め、
+// Step 2 で pre-flight 記録に使われる。
+func (e *OrderExecutor) ClosePosition(ctx context.Context, clientOrderID string, pos entity.Position, currentPrice float64) (*ExecutionResult, error) {
 	closeSide := entity.OrderSideSell
 	if pos.OrderSide == entity.OrderSideSell {
 		closeSide = entity.OrderSideBuy
@@ -109,8 +142,9 @@ func (e *OrderExecutor) ClosePosition(ctx context.Context, pos entity.Position, 
 	check := e.riskMgr.CheckOrder(ctx, proposal)
 	if !check.Approved {
 		return &ExecutionResult{
-			Executed: false,
-			Reason:   fmt.Sprintf("risk rejected close: %s", check.Reason),
+			Executed:    false,
+			Reason:      fmt.Sprintf("risk rejected close: %s", check.Reason),
+			FailureKind: FailureKindPreSend,
 		}, nil
 	}
 
@@ -136,7 +170,12 @@ func (e *OrderExecutor) ClosePosition(ctx context.Context, pos entity.Position, 
 		return nil, fmt.Errorf("API returned no orders for close")
 	}
 
-	slog.Info("position closed", "positionID", pos.ID, "orderID", orders[0].ID, "side", closeSide)
+	slog.Info("position closed",
+		"positionID", pos.ID,
+		"orderID", orders[0].ID,
+		"side", closeSide,
+		"clientOrderID", clientOrderID,
+	)
 
 	return &ExecutionResult{
 		Executed: true,

--- a/backend/internal/usecase/order_test.go
+++ b/backend/internal/usecase/order_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/repository"
 )
 
 type mockOrderClient struct {
@@ -27,6 +28,14 @@ func (m *mockOrderClient) CreateOrder(ctx context.Context, req entity.OrderReque
 		return nil, m.createErr
 	}
 	return m.createdOrders, nil
+}
+
+func (m *mockOrderClient) CreateOrderRaw(ctx context.Context, req entity.OrderRequest) (repository.CreateOrderOutcome, error) {
+	m.createCallCount++
+	if m.createErr != nil {
+		return repository.CreateOrderOutcome{TransportError: m.createErr}, nil
+	}
+	return repository.CreateOrderOutcome{HTTPStatus: 200, Orders: m.createdOrders}, nil
 }
 
 func (m *mockOrderClient) CancelOrder(ctx context.Context, symbolID, orderID int64) ([]entity.Order, error) {
@@ -80,7 +89,7 @@ func TestOrderExecutor_ExecuteSignal_Buy(t *testing.T) {
 		Timestamp: time.Now().Unix(),
 	}
 
-	result, err := executor.ExecuteSignal(context.Background(), signal, 4000000, 0.001)
+	result, err := executor.ExecuteSignal(context.Background(), "co-test", signal, 4000000, 0.001)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -114,7 +123,7 @@ func TestOrderExecutor_ExecuteSignal_Sell(t *testing.T) {
 		Timestamp: time.Now().Unix(),
 	}
 
-	result, err := executor.ExecuteSignal(context.Background(), signal, 4000000, 0.001)
+	result, err := executor.ExecuteSignal(context.Background(), "co-test", signal, 4000000, 0.001)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -141,7 +150,7 @@ func TestOrderExecutor_ExecuteSignal_HoldSkipsOrder(t *testing.T) {
 		Timestamp: time.Now().Unix(),
 	}
 
-	result, err := executor.ExecuteSignal(context.Background(), signal, 4000000, 0.001)
+	result, err := executor.ExecuteSignal(context.Background(), "co-test", signal, 4000000, 0.001)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -171,7 +180,7 @@ func TestOrderExecutor_ExecuteSignal_RiskRejected(t *testing.T) {
 		Timestamp: time.Now().Unix(),
 	}
 
-	result, err := executor.ExecuteSignal(context.Background(), signal, 4000000, 0.001)
+	result, err := executor.ExecuteSignal(context.Background(), "co-test", signal, 4000000, 0.001)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -203,7 +212,7 @@ func TestOrderExecutor_ExecuteSignal_APIError(t *testing.T) {
 		Timestamp: time.Now().Unix(),
 	}
 
-	_, err := executor.ExecuteSignal(context.Background(), signal, 4000000, 0.001)
+	_, err := executor.ExecuteSignal(context.Background(), "co-test", signal, 4000000, 0.001)
 	if err == nil {
 		t.Fatal("expected error from API failure")
 	}
@@ -233,7 +242,7 @@ func TestOrderExecutor_ClosePosition(t *testing.T) {
 		RemainingAmount: 0.001,
 	}
 
-	result, err := executor.ClosePosition(context.Background(), pos, 3800000)
+	result, err := executor.ClosePosition(context.Background(), "co-close", pos, 3800000)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -269,7 +278,7 @@ func TestOrderExecutor_ClosePosition_SellPosition(t *testing.T) {
 		RemainingAmount: 0.001,
 	}
 
-	result, err := executor.ClosePosition(context.Background(), pos, 4200000)
+	result, err := executor.ClosePosition(context.Background(), "co-close", pos, 4200000)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/docs/design/plans/2026-04-11-plan12-order-integrity-hardening.md
+++ b/docs/design/plans/2026-04-11-plan12-order-integrity-hardening.md
@@ -1,0 +1,432 @@
+# Plan 12: 注文整合性の堅牢化 (Order Integrity Hardening)
+
+- **作成日**: 2026-04-11
+- **改訂日**: 2026-04-11 (レビュー反映)
+- **対象ブランチ**: 未定 (例: `feature/order-integrity-hardening`)
+- **想定工数**: 4〜5 日 (Phase 0〜3 合計)
+- **背景となった事故**: 2026-04-11 セッション。LTC_JPY を 0.1 LTC で発注したつもりが、Backend のレスポンスパース失敗により Backend が 500 を返したものの楽天側では約定済み。リトライにより同一 `clientOrderId` のはずが楽天側で 2 回約定し、意図せず 0.2 LTC のロングを保有する状態となった。
+
+---
+
+## 1. 問題の本質
+
+現在の注文書き込みフロー (`OrderHandler.CreateOrder`, `PositionHandler.ClosePosition`) には、**「Backend が応答パースに失敗した瞬間に、楽天側で約定済みの注文が Backend から見えなくなる」** という根本的な脆弱性がある。
+
+### 現在のフロー
+
+```
+1. Backend → 楽天 API: CreateOrder 送信
+2. 楽天 API → Backend: 200 OK + JSON response
+3. Backend: response を Unmarshal ← ここで失敗すると...
+4. Backend → DB: client_orders に保存 ← 実行されず
+5. Backend → クライアント: 500 error
+
+  楽天側: 約定済み
+  Backend DB: 痕跡なし
+  クライアント: エラーを見て「失敗した」と誤認 → リトライ
+  楽天側: 2 回目も約定 → 重複ポジション
+```
+
+### 何が悪いか
+
+冪等性の鎖が `clientOrderId` で繋がっている設計になっているにもかかわらず、**鎖の最初の輪 (DB 保存) が一番最後にある**。楽天 API への送信より前に DB に痕跡を残していないため、楽天側との真実が乖離した瞬間にリカバリ手段を失う。
+
+### 直近の応急処置 (2026-04-11 セッションで実施済み)
+
+- `entity.Position` / `entity.Order` にカスタム `UnmarshalJSON` を追加し、`flexFloat` 型で string/number 両対応 → パース失敗の確率自体は下げた
+- `POST /api/v1/positions/:id/close` を追加し、決済時の冪等性 (`clientOrderId`) を確保
+
+これらは「パース失敗の発生確率を下げる」「決済経路でも冪等性を持たせる」改善ではあるが、**根本原因 (pre-flight 記録の不在) は未解決**。
+
+---
+
+## 2. ゴール
+
+1. **書き込み系 API (CreateOrder, ClosePosition, CancelOrder) の冪等性を、楽天送信前の段階から成立させる**
+2. **Backend が応答を見失っても、楽天側の真実と DB を後から再同期できる手段を持つ (reconcile)**
+3. **オペレーター (人間 or エージェント) が「楽天では成功したのか？」を即座に判定できる UI/API**
+
+### 成功基準
+
+1. **再現テスト**: 楽天応答パースを意図的に失敗させた状態で発注 → DB に `submitted` レコードが残る → reconcile が走って `reconciled-confirmed` または `reconciled-not-found` に確定する
+2. **重複防止**: `submitted` の `clientOrderId` で再度発注リクエスト → 冪等返却で楽天 API は呼ばれない
+3. **並行安全**: 同一 `clientOrderId` の並行リクエストで楽天 API が 2 回呼ばれない (`ON CONFLICT` 保護)
+4. **観測可能性**: `GET /api/v1/client-orders?status=submitted` で未確定注文が一覧できる
+5. **ドキュメント**: `docs/agent-operation-guide.md` に「`status=submitted` を見たら絶対にリトライしない」が明記されている
+
+---
+
+## 3. アーキテクチャ案
+
+### 3.1 Phase 0: マイグレーション基盤と OrderExecutor の下準備
+
+本計画では **既存の monolithic な `RunMigrations()` 方式 (配列 + `IF NOT EXISTS`) を継続**し、新規カラムは `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` を 1 エントリずつ配列に追記する。マイグレーション番号ファイル方式は本計画のスコープ外とする。
+
+また、後続 Step の共通基盤として `usecase.OrderExecutor` を **`clientOrderId` を受け取る形に拡張する** 事前リファクタを行う (詳細は Step 1.5)。
+
+### 3.2 Phase 1: クライアントオーダーの状態機械化 (pre-flight 記録)
+
+`client_orders` テーブルを単なる「成功記録」から **「注文ライフサイクルの監査ログ」** に格上げする。
+
+#### スキーマ変更
+
+既存 `client_orders` に対して `ALTER TABLE ADD COLUMN` を追加する。SQLite は `ADD COLUMN` で `DEFAULT` を指定できるので、既存行は全て `status='completed'` で保護される。
+
+```sql
+ALTER TABLE client_orders ADD COLUMN status TEXT NOT NULL DEFAULT 'completed';
+ALTER TABLE client_orders ADD COLUMN symbol_id INTEGER;
+ALTER TABLE client_orders ADD COLUMN intent TEXT;        -- "open" | "close" | "cancel"
+ALTER TABLE client_orders ADD COLUMN side TEXT;          -- "BUY" | "SELL"
+ALTER TABLE client_orders ADD COLUMN amount REAL;
+ALTER TABLE client_orders ADD COLUMN position_id INTEGER;
+ALTER TABLE client_orders ADD COLUMN raw_response TEXT;  -- 楽天応答の生 JSON
+ALTER TABLE client_orders ADD COLUMN error_message TEXT;
+ALTER TABLE client_orders ADD COLUMN updated_at INTEGER;
+
+CREATE INDEX IF NOT EXISTS idx_client_orders_status
+    ON client_orders(status, updated_at);
+```
+
+**運用上の注意**:
+- `RunMigrations()` は全環境で冪等に動くよう、`ADD COLUMN` 失敗時 (既に存在) を許容するラッパーを導入する (SQLite には `ADD COLUMN IF NOT EXISTS` が無いため、`PRAGMA table_info` で事前確認する)
+- 本番 DB に対する適用は「本番切替前にステージング DB で dry-run → 本番は Backend デプロイ前の 1 回のみ」という手順を Step 6 のドキュメントに明記
+
+#### 状態機械
+
+```
+pending ──(send success, parse success)──→ confirmed ──(domain applied)──→ completed
+   │
+   ├──(client-side failure, pre-send error)──→ failed
+   │
+   ├──(HTTP/parse/timeout failure)──→ submitted ─┬─→ reconciled-confirmed
+   │                                              ├─→ reconciled-not-found
+   │                                              ├─→ reconciled-ambiguous
+   │                                              └─→ reconciled-timeout (TTL 超過)
+   │
+   └──(crash before send)──→ pending (reconcile が拾う)
+```
+
+| status | 意味 | 楽天側の真実 | クライアント側の対処 |
+|---|---|---|---|
+| `pending` | Backend が DB に記録した直後。まだ楽天 HTTP を開始していない、または開始直後にプロセスクラッシュ | 未送信 or 不明 | 待機 (reconcile が判定) |
+| `submitted` | 楽天 HTTP 送信を試みたが、応答のパース失敗・HTTP タイムアウト・ネットワークエラーで Backend が結果を確定できなかった | **不明** | **絶対にリトライしない** |
+| `confirmed` | 応答パース成功、Backend が orderId を取得 | 受理済み | 完了扱い |
+| `completed` | 約定処理まで完了し、Backend ドメインに反映 | 約定済み | 完了扱い |
+| `failed` | **楽天が明示的に拒否したと判定できる失敗** (4xx かつパース成功) または送信前の client-side バリデーション失敗 | 未約定 | リトライ可 |
+| `reconciled-confirmed` | reconcile ジョブが楽天 GetOrders と突合して受理を確定 | 受理済み | 完了扱い |
+| `reconciled-not-found` | reconcile ジョブが TTL 経過後に楽天側に対応注文を発見できず確定 | 未約定 | リトライ可 |
+| `reconciled-ambiguous` | 候補が複数ヒットし自動判定不能 | 不明 (人間判断) | 人間のオペレーターを待つ |
+| `reconciled-timeout` | submitted のまま外部 TTL (24h) を超過し、reconcile もアンビギュアスのまま解決できなかった | 不明 | 人間判断 (手動オペレーションで確定) |
+
+**重要**: `pending`/`submitted`/`failed` の判定は **「楽天側が受理した可能性があるか否か」** を軸に決める。下表が判定ルール:
+
+| 発生事象 | 楽天側の真実 | 遷移先 |
+|---|---|---|
+| 送信前バリデーション失敗 (client-side) | 未送信 | `failed` |
+| HTTP コネクション確立失敗 (DNS, TCP reset) | 未送信 | `failed` |
+| HTTP 4xx + エラーボディのパース成功 | 楽天が明示的に拒否 | `failed` |
+| HTTP 4xx + エラーボディのパース失敗 | **不明** (受理されて 4xx が誤返却の可能性) | `submitted` |
+| HTTP 5xx | **不明** (内部で受理されている可能性) | `submitted` |
+| HTTP 200 + レスポンスボディのパース失敗 | **不明** | `submitted` |
+| HTTP タイムアウト (応答待ちで打ち切り) | **不明** | `submitted` |
+| HTTP 200 + パース成功 | 受理済み | `confirmed` → `completed` |
+
+この判定表は `usecase/order.go` の `ExecutionResult` 返却時に実装する。
+
+#### 書き込みフロー (新)
+
+```
+1. Backend: clientOrderId を生成 (or クライアント指定)
+
+2. Backend → DB: INSERT OR IGNORE (status='pending', intent, symbol_id, side, amount, position_id)
+   │
+   ├─ (a) 新規挿入成功 → 3 へ
+   └─ (b) 既存行あり (ON CONFLICT) → 既存行を読み直して status に応じて返却:
+          - pending/submitted → HTTP 202 (未確定)
+          - confirmed/completed/reconciled-confirmed → HTTP 200 (冪等成功)
+          - failed/reconciled-not-found → HTTP 409 (クライアントは新しい clientOrderId で再試行)
+          - reconciled-ambiguous/reconciled-timeout → HTTP 409 (人間判断待ち)
+
+3. Backend → 楽天 API: HTTP 送信開始
+
+4a. 200 OK + パース成功:
+    Backend → DB: UPDATE status='confirmed', order_id, raw_response
+    Backend → クライアント: HTTP 200 (status='confirmed' or 'completed')
+
+4b. 「楽天側の真実が不明」に該当 (判定表参照):
+    Backend → DB: UPDATE status='submitted', raw_response, error_message
+    Backend → クライアント: HTTP 202 Accepted (status='submitted')
+
+4c. 「楽天側が受理していないと確定できる」に該当 (判定表参照):
+    Backend → DB: UPDATE status='failed', error_message
+    Backend → クライアント: HTTP 4xx/5xx (status='failed')
+```
+
+**並行レース対策**: Step 2 の冪等化は **`INSERT OR IGNORE INTO client_orders ...` + `affected_rows == 0` なら既存行を読み直す** 方式で統一する。現状の `Find → 判定 → Save` パターンは競合で両方が Find=null と判定して二重送信する脆弱性があるため、Step 1 の repository 層で全面的に置き換える。
+
+**ポイント**: パース失敗は「Backend 内部エラー」ではなく「楽天応答が解釈できなかった = 楽天側の真実は不明」という状態として正直に表現する。クライアント (エージェント) は `status=submitted` を見たら **「リトライしてはいけない、reconcile を待て」** と判断できる。
+
+### 3.3 Phase 2: Reconcile ジョブ
+
+楽天 API の `GetOrders(symbolID)` を定期的に叩いて、`status IN ('pending', 'submitted')` の `client_orders` と突合する。
+
+#### バッチ取得方式 (N+1 回避)
+
+pending 件数分 `GetOrders` を呼ぶのではなく、**`symbol_id` ごとに 1 回だけ `GetOrders` を呼び、メモリ上で照合する**。
+
+```go
+// usecase/reconcile.go (擬似コード)
+func (r *Reconciler) ReconcileOnce(ctx context.Context) error {
+    pendings, err := r.repo.ListByStatus(ctx,
+        []ClientOrderStatus{StatusPending, StatusSubmitted}, 500)
+    if err != nil { return err }
+
+    // symbol_id でグルーピングし、symbol 1 個につき GetOrders 1 回
+    bySymbol := groupBySymbolID(pendings)
+    for symbolID, cos := range bySymbol {
+        rakutenOrders, err := r.client.GetOrders(ctx, symbolID)
+        if err != nil {
+            r.log.Warn("reconcile: GetOrders failed", "symbol", symbolID, "err", err)
+            continue
+        }
+        for _, co := range cos {
+            r.matchAndUpdate(ctx, co, rakutenOrders)
+        }
+    }
+    return nil
+}
+```
+
+#### 照合ロジック
+
+楽天 API には `client_order_id` 検索が存在しないため、**時刻 + 属性の複合マッチング** を行う。
+
+**マッチングキーと許容誤差**:
+- `symbol_id` 完全一致
+- `side` 完全一致
+- `amount`: `abs(a - b) < 1e-9` の epsilon 比較 (float 誤差対策)
+- `position_id`: `intent='close'` の場合のみ、楽天 order の `closePositionId` と一致を要求 (楽天 API が返すなら)
+- 時刻ウィンドウ: 楽天の `orderCreatedAt` (秒精度の Unix 時刻) と Backend の `updated_at` の差が **±60 秒以内**
+  - ネットワーク遅延 (最大数秒) + クロックスキュー (NTP 同期済み前提で数秒) + 楽天側処理遅延 を見積もった保守的な値
+
+**マッチング結果の判定**:
+
+| 候補数 | 条件 | 遷移先 |
+|---|---|---|
+| 1 | 時刻ウィンドウ内にユニーク一致 | `reconciled-confirmed` (楽天 orderId をピン留め) |
+| 0 | `updated_at` から **30 分経過** | `reconciled-not-found` |
+| 0 | 30 分未満 | 変更なし (次回再試行) |
+| 2+ | 複数候補 | `reconciled-ambiguous` (人間判断待ち) |
+| - | `updated_at` から **24 時間経過**、かつ reconcile で確定できていない | `reconciled-timeout` (最終状態、人間のオペレーション前提) |
+
+**TTL の一本化**: `not-found` 判定は 30 分、`timeout` 判定は 24 時間。**30 分は「楽天側で受理されていればさすがに GetOrders に見えているはず」というビジネス判断、24 時間は「運用者が気づいて手動対応できるはずの上限」**。この 2 つは役割が異なるため両方残す。
+
+**orderId のピン留め**: 一度 `reconciled-confirmed` になったら、以降の reconcile ジョブは **既にピン留めされた orderId を再照合しない**。`client_orders.order_id IS NOT NULL AND status='reconciled-confirmed'` は最終状態として扱う。
+
+#### スケジューリング
+
+- Backend 起動時 1 回 (クラッシュリカバリ)
+- 60 秒間隔の定期実行
+- `POST /api/v1/reconcile` 手動トリガ
+- `POST /api/v1/client-orders/:id/reconcile` 個別実行
+
+### 3.4 Phase 3: 監査・運用 UI
+
+#### REST API 追加
+
+| Method | Path | 用途 |
+|---|---|---|
+| GET | `/api/v1/client-orders` | 全件一覧 (`status`, `intent` でフィルタ) |
+| GET | `/api/v1/client-orders/:id` | 単一参照 |
+| POST | `/api/v1/client-orders/:id/reconcile` | 個別 reconcile 強制実行 |
+| POST | `/api/v1/reconcile` | 全 pending/submitted を reconcile |
+
+#### Frontend ダッシュボード
+
+「注文監査」タブを追加し、`submitted` / `failed` / `reconciled-*` 状態を可視化。エージェント運用時に「未確定注文があるか」を一目で判断できるようにする。
+
+- 状態に応じた色分け (submitted=黄、reconciled-confirmed=緑、reconciled-not-found=灰、reconciled-ambiguous=赤)
+- `submitted` 件数バッジをヘッダーに表示
+- 行クリックで raw_response と error_message を展開
+
+#### HTTP 202 の互換移行
+
+現状クライアント (`frontend/src/lib/api.ts`) は 2xx を一律成功として扱っているはず。202 導入は Backend 先行で入れると Frontend が `submitted` を成功と誤認するため、**Backend と Frontend を同一 PR で出す**。移行段階:
+
+1. **Step 2 の PR**: Backend が 200/202 を返し分けるようにする。**同じ PR に Frontend 側のレスポンス型へ `status` フィールドを追加**し、`status==='submitted'` のときは成功トーストではなく「未確定 (reconcile 待ち)」バナーを表示する。
+2. **クライアント互換**: レスポンス JSON の既存フィールド (`executed`, `orderId`) は維持。`status='confirmed'|'completed'` のとき `executed=true`、それ以外は `executed=false`。これで古い Frontend をうっかりデプロイしても「成功とは誤認しない」(executed=false 扱い)。
+
+---
+
+## 4. ステップ別 To-Do
+
+### Step 0: マイグレーション基盤の微調整 (0.5 日)
+- [ ] `RunMigrations()` に `ADD COLUMN` を安全に流すヘルパーを追加 (`PRAGMA table_info` で事前確認)
+- [ ] 既存 DB に対する dry-run 手順をドキュメント化
+
+### Step 1: ドメインモデルとスキーマ (1 日)
+- [ ] `ClientOrderStatus` 型を `entity` に追加 (`pending`, `submitted`, `confirmed`, `completed`, `failed`, `reconciled-confirmed`, `reconciled-not-found`, `reconciled-ambiguous`, `reconciled-timeout`)
+- [ ] `ClientOrderRecord` を拡張 (status, symbolID, intent, side, amount, positionID, rawResponse, errorMessage, updatedAt)
+- [ ] `ClientOrderRepository` インターフェース更新:
+  - [ ] `InsertOrGet(ctx, record) (existing *Record, inserted bool, err error)` — `INSERT OR IGNORE` + 既存行読み直し
+  - [ ] `UpdateStatus(ctx, id, status, fields...)` — 状態遷移 + 追加フィールド更新
+  - [ ] `ListByStatus(ctx, statuses, limit)` — reconcile 用
+- [ ] `ALTER TABLE` 追加 (Step 0 のヘルパー経由)、`idx_client_orders_status` インデックス作成
+- [ ] `database/client_order_repo.go` の実装更新
+- [ ] テスト: `client_order_repo_test.go` を新規作成 (**現状テスト無し**)。各遷移、`InsertOrGet` の並行レース、既存行の status 別返却を検証
+
+### Step 1.5: OrderExecutor の clientOrderId-aware 化 (0.5 日)
+- [ ] `OrderExecutor.ExecuteSignal` / `ClosePosition` のシグネチャに `clientOrderID string` を追加
+- [ ] `ExecutionResult` に `RawResponse []byte`, `FailureKind` (PreSend/Rejected/Ambiguous) を追加
+- [ ] `rakuten.Client.CreateOrder` など低レイヤを **`(rawBytes []byte, parsed *entity.Order, err error)`** のように raw bytes を常に返すよう変更 (パース失敗時でも raw は取れるように)
+- [ ] 既存呼び出し元 (handler, pipeline) をシグネチャ変更に追従。本 Step は振る舞い変更なしで型変更のみ
+- [ ] テスト: `rakuten` クライアント層で raw bytes が返ることを確認
+
+### Step 2: 注文ハンドラと pipeline の pre-flight 化 + Frontend 対応 (1.5 日)
+- [ ] `OrderHandler.CreateOrder`:
+  - [ ] `InsertOrGet` で pending 登録 → 既存行があれば status 別に 200/202/409 返却
+  - [ ] 楽天送信 → 判定表に従って `confirmed`/`submitted`/`failed` に更新
+  - [ ] `submitted` のとき HTTP 202、それ以外は従来通り
+- [ ] `PositionHandler.ClosePosition`: 同様
+- [ ] `cmd/pipeline.go` の `executeSignal` / 損切クローズも同じフローを通す (Step 1.5 で共通化済み)
+- [ ] パイプラインでの `clientOrderId` 採番ルール統一 (`agent-*` 命名と整合)
+- [ ] レスポンス型に `status` フィールド追加。既存 `executed` フィールドは `status in ('confirmed','completed','reconciled-confirmed')` のとき `true`
+- [ ] **Frontend**: `lib/api.ts` のレスポンス型に `status` 追加、`submitted` を専用バナー表示、`frontend/src/routes/*` で成功判定ロジックを `status` 主体に変更
+- [ ] テスト:
+  - [ ] ハンドラ単体テストで pending→submitted→confirmed 経路
+  - [ ] パース失敗時の submitted 残留
+  - [ ] 並行リクエスト (同一 clientOrderId) で楽天 API が 1 回しか呼ばれないこと
+  - [ ] パイプラインからの発注 → パース失敗 → submitted 残留 の E2E
+
+### Step 3: Reconcile ジョブ (1 日)
+- [ ] `usecase/reconcile.go` を新規作成: `Reconciler` 構造体、`ReconcileOnce(ctx)` メソッド
+- [ ] バッチ取得: `symbol_id` グルーピング → `GetOrders` 1 回 / symbol
+- [ ] 照合ロジック: epsilon 比較、±60 秒時刻ウィンドウ、`intent='close'` なら position_id も要求
+- [ ] 判定: 1 件一致 → `reconciled-confirmed`、0 件 + 30 分経過 → `reconciled-not-found`、複数 → `reconciled-ambiguous`、24 時間経過 → `reconciled-timeout`
+- [ ] `reconciled-confirmed` 以降は再照合しない (orderId ピン留め)
+- [ ] `cmd/main.go` で `startReconciler(ctx)` を起動 (60 秒間隔 ticker + 起動時 1 回)
+- [ ] テスト: モック OrderClient で各判定分岐を検証 (unique, zero-young, zero-old, ambiguous, timeout)
+
+### Step 4: 監査 API + Frontend 監査ビュー (0.5〜1 日)
+- [ ] `handler/client_order.go` 新規: List, Get, Reconcile (single/all)
+- [ ] `router.go` に登録
+- [ ] OpenAPI/型定義の更新 (Frontend 用)
+- [ ] Frontend に「Orders」タブ or `OrdersAudit.tsx` コンポーネント追加
+- [ ] 状態に応じた色分け、`submitted` 件数バッジ
+
+### Step 5: ドキュメント・運用ガイド (0.5 日)
+- [ ] `docs/agent-operation-guide.md` の更新: `submitted` 状態の意味とエージェント側の対処 (「リトライ禁止、reconcile を待て」)
+- [ ] 新エンドポイントのドキュメント
+- [ ] 失敗ケース別の判断フローチャート
+- [ ] 本番 DB マイグレーション適用手順
+
+---
+
+## 5. リスクと検討事項
+
+### 5.1 楽天 API 側に client_order_id 検索が無い問題
+
+reconcile の突合は時刻 + 属性ベースの heuristic マッチングに頼らざるを得ない。アンビギュアスケース (同時刻に同 amount の注文が複数) では確定できず、人間の判断が必要。
+
+**対策**: アンビギュアス時は `reconciled-ambiguous` で停止し、運用 UI で「これはどの注文に対応するか」を手動で紐付けられるようにする。`intent='close'` の場合は `position_id` で一意に絞り込める可能性が高いので、`closePositionId` を楽天レスポンスから取得できるなら優先的に使う。
+
+### 5.2 submitted ステータスの TTL と timeout の関係
+
+**30 分 / 24 時間の使い分け**:
+- **30 分 (`reconciled-not-found`)**: 楽天 GetOrders に現れないなら「そもそも楽天側で受理されていない」と判定する閾値。30 分は「ネットワーク障害や楽天側の内部遅延でも、受理されていればこの時間内に GetOrders に現れる」というビジネス判断
+- **24 時間 (`reconciled-timeout`)**: `reconciled-ambiguous` のまま解決されない、あるいは何らかの理由で状態が動かないレコードの最終救済。ここに来たら人間のオペレーターが手動で status を書き換えて解決する
+
+### 5.3 パース失敗の根本対策との関係
+
+Phase 0 (`flexFloat`) で確率は下げているが、楽天 API の仕様変更や未知のフィールドで再発する可能性は残る。Reconcile はその「最後の防壁」。
+
+**追加対策**: パース失敗時に raw response を `client_orders.raw_response` に保存しておけば、後から手動で解析・修正可能。
+
+### 5.4 既存パイプラインとの互換性
+
+`cmd/pipeline.go` の発注ロジックは現状 `OrderExecutor.ExecuteSignal` を直接呼んでおり、`clientOrderId` を内部で採番していない (usecase に冪等性の概念がない)。Step 1.5 でシグネチャを変更し、Step 2 で呼び出し元を一斉に追従させる。
+
+### 5.5 並行レース対策
+
+現状の `Find → Save` パターンは、同一 `clientOrderId` の並行リクエストで両方が Find=null と判定し、二重送信する脆弱性がある。**Step 1 で `INSERT OR IGNORE` ベースの `InsertOrGet` に全面的に置き換える**。既存の `Find` / `Save` は deprecated にし、Step 2 完了後に削除。
+
+### 5.6 Frontend 202 互換性
+
+現状クライアントは 2xx を成功扱いしている。Backend を先行リリースして Frontend が `submitted` を成功と誤認するのを避けるため、**Step 2 で Backend と Frontend を同一 PR に入れる**。レスポンス JSON の既存 `executed` フィールドも維持し、古い Frontend を誤ってデプロイしても `executed=false` として「未成功」と扱えるようにする。
+
+### 5.7 実装規模
+
+- Step 0+1+1.5: 2 日
+- Step 2: 1.5 日
+- Step 3: 1 日
+- Step 4+5: 1〜1.5 日
+- **合計: 4〜5 日** (初版の 3〜4 日から上方修正)
+
+### 5.8 段階的リリース
+
+- **PR#1**: Step 0 + Step 1 + Step 1.5 (スキーマ + repository + OrderExecutor 型変更のみ。挙動変更なし)
+- **PR#2**: Step 2 (Backend + Frontend の pre-flight 化。**必ず同一 PR**)
+- **PR#3**: Step 3 (Reconcile ジョブ)
+- **PR#4**: Step 4 + Step 5 (監査 UI + ドキュメント)
+
+PR#1 は振る舞い変更なしなので安全に merge できる。PR#2 で初めて挙動が変わるが、この時点で冪等性と pre-flight 記録が揃う。PR#3 で真の自己修復が成立する。
+
+---
+
+## 6. 関連ファイル (修正対象)
+
+### 新規作成
+- `backend/internal/usecase/reconcile.go`
+- `backend/internal/usecase/reconcile_test.go`
+- `backend/internal/infrastructure/database/client_order_repo_test.go` (現状無し)
+- `backend/internal/interfaces/api/handler/client_order.go`
+- `backend/internal/interfaces/api/handler/client_order_test.go`
+- `frontend/src/components/OrdersAudit.tsx` (or 同等)
+- `frontend/src/routes/orders.tsx` (新タブの場合)
+
+### 修正
+- `backend/internal/domain/entity/client_order.go` (新規 or 既存 entity 拡張)
+- `backend/internal/domain/repository/client_order.go`
+- `backend/internal/infrastructure/database/client_order_repo.go`
+- `backend/internal/infrastructure/database/migrations.go` (`ADD COLUMN` ヘルパー + ALTER 追加)
+- `backend/internal/infrastructure/rakuten/private_api.go` (raw bytes を返す)
+- `backend/internal/interfaces/api/handler/order.go`
+- `backend/internal/interfaces/api/handler/position.go`
+- `backend/internal/interfaces/api/router.go`
+- `backend/internal/usecase/order.go` (`clientOrderID` 引数 + `RawResponse`/`FailureKind`)
+- `backend/cmd/main.go` (Reconciler 起動)
+- `backend/cmd/pipeline.go` (pre-flight 化)
+- `frontend/src/lib/api.ts` (レスポンス型に `status` 追加、202 ハンドリング)
+- `docs/agent-operation-guide.md`
+
+---
+
+## 7. 進め方
+
+PR#1 (Step 0+1+1.5) から着手。ブランチ命名案: `feature/order-integrity-hardening-step1`。
+
+実装着手前に以下を確認：
+- [ ] このプランをユーザーがレビュー・承認
+- [ ] 既存の `client_orders` テーブルに本番データ (取引履歴) があるか確認 → マイグレーション dry-run
+- [ ] 楽天 API の `closePositionId` がレスポンスに含まれるか実機確認 (reconcile の intent=close 照合強度に影響)
+
+---
+
+## 8. 改訂履歴
+
+### 2026-04-11 初版レビュー反映
+- レビュー指摘 (High) への対応:
+  - **状態定義の整合性**: `pending` = DB 記録済み・楽天 HTTP 未開始、`submitted` = HTTP 送信試行済みだが真実不明、に再定義。書き込みフローも一致させた
+  - **エラー判定の一本化**: 「楽天が受理した可能性があるか否か」を軸にした判定表 (3.2 節) を追加し、`submitted` と `failed` の分岐条件を明示
+  - **並行レース対策**: `Find → Save` を `InsertOrGet` (`INSERT OR IGNORE` ベース) に統一 (5.5 節、Step 1)
+  - **Reconcile TTL の一本化**: 30 分 (`not-found`) / 24 時間 (`timeout`) の役割を明文化 (3.3 節、5.2 節)
+- レビュー指摘 (Medium) への対応:
+  - **照合強度**: epsilon 比較、±60 秒ウィンドウ、`intent='close'` での `position_id` 追加キーを明記 (3.3 節)
+  - **N+1 回避**: `symbol_id` でグルーピングして GetOrders を 1 回/symbol に (3.3 節)
+  - **マイグレーション方式**: 既存 `RunMigrations()` 配列方式を維持、`ADD COLUMN` ヘルパー経由で安全適用 (3.1 節、Step 0)
+  - **202 互換移行**: Backend + Frontend を同一 PR、`executed` フィールドは維持 (3.4 節、5.6 節)
+- その他 (自主レビュー):
+  - Step 1.5 (`OrderExecutor` の clientOrderId-aware 化) を独立
+  - raw bytes を rakuten クライアント層から返す設計を明記 (Step 1.5)
+  - `client_order_repo_test.go` が現状無いことを明記し、新規作成を明示 (Step 1)
+  - 工数見積りを 3〜4 日 → 4〜5 日に上方修正


### PR DESCRIPTION
## Summary
Plan 12 (注文整合性の堅牢化) の **PR#1: Step 0 + Step 1 + Step 1.5** に相当する基盤整備です。**振る舞い変更なし**で、後続 PR (pre-flight 化 / reconcile / 監査 UI) のための土台を用意します。

設計書: [docs/design/plans/2026-04-11-plan12-order-integrity-hardening.md](docs/design/plans/2026-04-11-plan12-order-integrity-hardening.md)

### 何が入っているか

**スキーマ・基盤 (Step 0 + Step 1b)**
- \`addColumnIfNotExists\` ヘルパー (PRAGMA table_info ベース、SQLite に IF NOT EXISTS が無いため)
- \`client_orders\` に 9 カラム追加: \`status\`, \`symbol_id\`, \`intent\`, \`side\`, \`amount\`, \`position_id\`, \`raw_response\`, \`error_message\`, \`updated_at\`
- 既存行は \`status='completed'\` で保護
- \`idx_client_orders_status\` 作成

**ドメイン (Step 1a + Step 1c)**
- \`entity/client_order.go\` 新規: \`ClientOrderStatus\` (pending/submitted/confirmed/completed/failed/reconciled-*) と \`ClientOrderIntent\`
- \`ClientOrderRecord\` 拡張 (Status/SymbolID/Intent/Side/Amount/PositionID/RawResponse/ErrorMessage/UpdatedAt)
- \`InsertOrGet\` (\`INSERT OR IGNORE\` ベースの並行安全な挿入)、\`UpdateStatus\`、\`ListByStatus\` を追加
- 既存 \`Find\` / \`Save\` は後方互換維持 (Step 2 で deprecated 化予定)

**OrderClient / OrderExecutor (Step 1.5)**
- \`OrderClient\` インターフェースに \`CreateOrderRaw\` を追加
- \`CreateOrderOutcome\` 型で HTTP ステータス・生レスポンス・トランスポートエラー・パースエラー・HTTP エラーを分離して返す
- \`rakuten.RESTClient.DoPrivateRaw\` で 4xx/5xx でも本文を取得可能に
- \`usecase.OrderExecutor.ExecuteSignal\` / \`ClosePosition\` のシグネチャに \`clientOrderID string\` を追加
- \`ExecutionResult\` に \`RawResponse\` / \`FailureKind\` (\`pre_send\` / \`rejected\` / \`ambiguous\`) を追加
- pipeline で \`agent-<intent>-<unix>-<rand8>\` 形式の clientOrderID を採番

**テスト**
- \`client_order_repo_test.go\` 新規 (現状テスト無し): InsertOrGet 並行レース (16 goroutines で唯一の挿入)、UpdateStatus、ListByStatus、後方互換 Save
- \`private_api_test.go\` に CreateOrderRaw 4 ケース: success / 200+parse failure / 4xx+JSON / 5xx+garbage
- 既存 mock (\`usecase/order_test.go\`, \`api/api_test.go\`) を新インターフェースに追従

### 後続 PR (このスコープ外)
- **PR#2**: Step 2 — handler/pipeline の pre-flight 化 + Frontend 202 対応 (**振る舞い変更**)
- **PR#3**: Step 3 — Reconcile ジョブ
- **PR#4**: Step 4 + 5 — 監査 UI + ドキュメント

## Test Plan
- [x] \`go build ./...\` 成功
- [x] \`go vet ./...\` 成功
- [x] \`go test ./...\` 全パッケージ成功
- [x] \`client_order_repo_test.go\` の InsertOrGet 並行レーステストで \`inserted\` カウントが厳密に 1 になることを確認
- [x] \`CreateOrderRaw\` の 4 ケース (success / parse failure / 4xx / 5xx) で \`RawResponse\` が常に保持されることを確認
- [ ] 既存 \`POST /api/v1/orders\` / \`POST /api/v1/positions/:id/close\` の挙動が変わっていないことをローカルで一度叩いて確認 (Step 2 で本格対応)

🤖 Generated with [Claude Code](https://claude.com/claude-code)