### PR TITLE
fix(backend): 残高・ポジションを定期ポーリングで同期

### DIFF
--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -74,9 +74,10 @@ func main() {
 	// --- Trading Pipeline ---
 	pipeline := NewTradingPipeline(
 		TradingPipelineConfig{
-			SymbolID:    symbolID,
-			Interval:    time.Duration(cfg.Trading.PipelineIntervalSec) * time.Second,
-			TradeAmount: cfg.Trading.TradeAmount,
+			SymbolID:          symbolID,
+			Interval:          time.Duration(cfg.Trading.PipelineIntervalSec) * time.Second,
+			StateSyncInterval: time.Duration(cfg.Trading.StateSyncIntervalSec) * time.Second,
+			TradeAmount:       cfg.Trading.TradeAmount,
 		},
 		restClient,
 		marketDataSvc,
@@ -160,6 +161,7 @@ func main() {
 	slog.Info("Trading pipeline ready",
 		"tradeAmount", cfg.Trading.TradeAmount,
 		"intervalSec", cfg.Trading.PipelineIntervalSec,
+		"stateSyncIntervalSec", cfg.Trading.StateSyncIntervalSec,
 	)
 	slog.Info("Trading pipeline ready. Use POST /api/v1/start to begin auto-trading.")
 

--- a/backend/cmd/pipeline.go
+++ b/backend/cmd/pipeline.go
@@ -46,9 +46,10 @@ type TradingPipeline struct {
 	mu       sync.RWMutex // フィールド保護（snapshot 経由で読む）
 	cancel   context.CancelFunc
 
-	symbolID    int64
-	interval    time.Duration
-	tradeAmount float64
+	symbolID          int64
+	interval          time.Duration
+	stateSyncInterval time.Duration
+	tradeAmount       float64
 
 	restClient       repository.OrderClient
 	marketDataSvc    *usecase.MarketDataService
@@ -77,9 +78,10 @@ func (p *TradingPipeline) snapshot() tradingSnapshot {
 
 // TradingPipelineConfig はパイプラインの設定。
 type TradingPipelineConfig struct {
-	SymbolID    int64
-	Interval    time.Duration
-	TradeAmount float64
+	SymbolID          int64
+	Interval          time.Duration
+	StateSyncInterval time.Duration
+	TradeAmount       float64
 }
 
 func NewTradingPipeline(
@@ -94,17 +96,18 @@ func NewTradingPipeline(
 	riskStateRepo repository.RiskStateRepository,
 ) *TradingPipeline {
 	return &TradingPipeline{
-		symbolID:         cfg.SymbolID,
-		interval:         cfg.Interval,
-		tradeAmount:      cfg.TradeAmount,
-		restClient:       restClient,
-		marketDataSvc:    marketDataSvc,
-		indicatorCalc:    indicatorCalc,
-		strategyEngine:   strategyEngine,
-		orderExecutor:    orderExecutor,
-		riskMgr:          riskMgr,
-		tradeHistoryRepo: tradeHistoryRepo,
-		riskStateRepo:    riskStateRepo,
+		symbolID:          cfg.SymbolID,
+		interval:          cfg.Interval,
+		stateSyncInterval: cfg.StateSyncInterval,
+		tradeAmount:       cfg.TradeAmount,
+		restClient:        restClient,
+		marketDataSvc:     marketDataSvc,
+		indicatorCalc:     indicatorCalc,
+		strategyEngine:    strategyEngine,
+		orderExecutor:     orderExecutor,
+		riskMgr:           riskMgr,
+		tradeHistoryRepo:  tradeHistoryRepo,
+		riskStateRepo:     riskStateRepo,
 	}
 }
 
@@ -131,6 +134,7 @@ func (p *TradingPipeline) startLocked() {
 
 	go p.runTradingLoop(ctx)
 	go p.runStopLossMonitor(ctx)
+	go p.runStateSyncLoop(ctx)
 
 	slog.Info("trading pipeline started")
 }
@@ -413,6 +417,37 @@ func (p *TradingPipeline) persistRiskState(ctx context.Context) {
 		Balance:   status.Balance,
 	}); err != nil {
 		slog.Error("pipeline: failed to persist risk state", "error", err)
+	}
+}
+
+// runStateSyncLoop は一定間隔で楽天APIからポジション・残高を取得し、RiskManagerに反映する。
+// これにより、画面の残高・損益表示がパイプライン外での約定（手動クローズ、別セッション、
+// stop-loss 経路など syncState を直接呼ばないコードパス）でも最新状態に追随する。
+// 間隔は stateSyncInterval を使い、LLM 評価ループ (interval) とは独立させている。
+func (p *TradingPipeline) runStateSyncLoop(ctx context.Context) {
+	// テスト時に依存が nil の場合はループを回さない
+	if p.restClient == nil || p.riskMgr == nil {
+		<-ctx.Done()
+		return
+	}
+
+	// stateSyncInterval 未設定時は評価間隔にフォールバック
+	syncInterval := p.stateSyncInterval
+	if syncInterval <= 0 {
+		syncInterval = p.interval
+	}
+
+	ticker := time.NewTicker(syncInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			p.syncState(ctx)
+			p.persistRiskState(ctx)
+		}
 	}
 }
 

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -18,6 +18,7 @@ type TradingConfig struct {
 	SymbolID            int64   // 取引対象シンボルID（デフォルト: 7 = BTC_JPY）
 	TradeAmount         float64 // 1回の注文金額（円）
 	PipelineIntervalSec int     // パイプライン評価間隔（秒）
+	StateSyncIntervalSec int    // ポジション・残高同期間隔（秒）
 }
 
 type LLMConfig struct {
@@ -76,9 +77,10 @@ func Load() *Config {
 			CacheTTLMin: getEnvInt("LLM_CACHE_TTL_MIN", 15),
 		},
 		Trading: TradingConfig{
-			SymbolID:            int64(getEnvInt("TRADE_SYMBOL_ID", 7)),
-			TradeAmount:         getEnvFloat("TRADE_AMOUNT", 1000),
-			PipelineIntervalSec: getEnvInt("PIPELINE_INTERVAL_SEC", 60),
+			SymbolID:             int64(getEnvInt("TRADE_SYMBOL_ID", 7)),
+			TradeAmount:          getEnvFloat("TRADE_AMOUNT", 1000),
+			PipelineIntervalSec:  getEnvInt("PIPELINE_INTERVAL_SEC", 60),
+			StateSyncIntervalSec: getEnvInt("STATE_SYNC_INTERVAL_SEC", 15),
 		},
 	}
 }


### PR DESCRIPTION
## Summary
- 画面の残高・日次損益がパイプライン外の約定（手動クローズ、stop-loss 決済、別セッション発注）で更新されない問題を修正
- `runStateSyncLoop` を追加し、`STATE_SYNC_INTERVAL_SEC`（既定 **15 秒**）ごとに楽天 API から assets / positions を取得して `RiskManager` に反映
- LLM 評価ループ (`PIPELINE_INTERVAL_SEC`, 既定 60 秒) とは独立した間隔で動くので、LLM コールを増やさずに残高表示だけ追随させられる

## Background
`GET /api/v1/pnl` が返す balance は `RiskManager.balance` のメモリ値で、これを更新していたのは 2 箇所だけだった:
1. 起動時の `syncStateInitial`
2. 自分のパイプラインが注文を約定させた直後 (`pipeline.go` の evaluate 成功時)

そのため、LLM 決済・`POST /positions/:id/close`・stop-loss 経路・別セッションでの操作では残高が一切更新されず、実口座との乖離が発生していた。

## Changes
- `backend/config/config.go`: `TradingConfig.StateSyncIntervalSec` を追加（env: `STATE_SYNC_INTERVAL_SEC`, default 15）
- `backend/cmd/pipeline.go`:
  - `TradingPipeline` / `TradingPipelineConfig` に `stateSyncInterval` を追加
  - `Start()` で `runStateSyncLoop` goroutine を追加起動（`Stop()` 時の ctx キャンセルで自然終了）
  - ループ内で `syncState` → `persistRiskState` を呼ぶ
  - 依存 nil 時は既存パターン通り ctx 待ちで no-op
- `backend/cmd/main.go`: config から pipeline への受け渡し、起動ログに `stateSyncIntervalSec` を追加

## Out of scope
日次損益 (`dailyLoss`) が stop-loss 経路でしか積まれていない問題は別 PR で対応予定。LLM 決済や手動クローズの損益も `dailyLoss` に反映するには `RiskManager.dailyLoss` の責務を「その日の実現損益」に再設計し、close 系 3 経路（OrderExecutor.ClosePosition / POST /positions/:id/close / stop-loss）で統一して積む必要があるため。

## Test plan
- [x] `go build ./...`
- [x] `go test -race ./cmd/... ./internal/usecase/... ./config/...`
- [ ] ローカルで起動してログに `stateSyncIntervalSec=15` が出ることを確認
- [ ] パイプライン稼働中に楽天画面から手動クローズし、15 秒以内に `GET /api/v1/pnl` の `balance` が追随することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)