### PR TITLE
feat: 日次損益カードを実現+未実現損益で再計算する

### DIFF
--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -123,6 +123,8 @@ func main() {
 	}
 
 	// --- REST API ---
+	dailyPnLCalc := usecase.NewDailyPnLCalculator(restClient, 10*time.Second)
+
 	router := api.NewRouter(api.Dependencies{
 		RiskManager:         riskMgr,
 		StanceResolver:      stanceResolver,
@@ -135,6 +137,7 @@ func main() {
 		RESTClient:          restClient,
 		ClientOrderRepo:     clientOrderRepo,
 		OnSymbolSwitch:      onSymbolSwitch,
+		DailyPnLCalculator:  dailyPnLCalc,
 	})
 
 	sigCh := make(chan os.Signal, 1)

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -3,10 +3,11 @@ module github.com/yui666a/rakuten-api-leverage-exchange/backend
 go 1.25.0
 
 require (
-	github.com/anthropics/anthropic-sdk-go v1.30.0
 	github.com/gin-contrib/cors v1.7.7
 	github.com/gin-gonic/gin v1.12.0
 	github.com/joho/godotenv v1.5.1
+	github.com/mark3labs/mcp-go v0.47.0
+	golang.org/x/sync v0.20.0
 	modernc.org/sqlite v1.34.5
 	nhooyr.io/websocket v1.8.11
 )
@@ -29,7 +30,6 @@ require (
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
-	github.com/mark3labs/mcp-go v0.47.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
@@ -39,10 +39,6 @@ require (
 	github.com/quic-go/quic-go v0.59.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/spf13/cast v1.7.1 // indirect
-	github.com/tidwall/gjson v1.18.0 // indirect
-	github.com/tidwall/match v1.1.1 // indirect
-	github.com/tidwall/pretty v1.2.1 // indirect
-	github.com/tidwall/sjson v1.2.5 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.3.1 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
@@ -50,7 +46,6 @@ require (
 	golang.org/x/arch v0.23.0 // indirect
 	golang.org/x/crypto v0.48.0 // indirect
 	golang.org/x/net v0.51.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/text v0.35.0 // indirect
 	google.golang.org/protobuf v1.36.10 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -1,5 +1,3 @@
-github.com/anthropics/anthropic-sdk-go v1.30.0 h1:5kGeZTNWE9UVChnM1xEbpjKEr9zka5C/W+QoZhP9BPo=
-github.com/anthropics/anthropic-sdk-go v1.30.0/go.mod h1:dSIO7kSrOI7MA4fE6RRVaw8tyWP7HNQU5/H/KS4cax8=
 github.com/bytedance/gopkg v0.1.3 h1:TPBSwH8RsouGCBcMBktLt1AymVo2TVsBVCY4b6TnZ/M=
 github.com/bytedance/gopkg v0.1.3/go.mod h1:576VvJ+eJgyCzdjS+c4+77QF3p7ubbtiKARP3TxducM=
 github.com/bytedance/sonic v1.15.0 h1:/PXeWFaR5ElNcVE84U0dOHjiMHQOwNIx3K4ymzh/uSE=
@@ -11,10 +9,10 @@ github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gE
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=
-github.com/dnaeon/go-vcr v1.2.0/go.mod h1:R4UdLID7HZT3taECzJs4YgbbH6PIGXB6W/sc5OLb6RQ=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
+github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
+github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/gabriel-vasile/mimetype v1.4.12 h1:e9hWvmLYvtp846tLHam2o++qitpguFiYCKbn0w9jyqw=
 github.com/gabriel-vasile/mimetype v1.4.12/go.mod h1:d+9Oxyo1wTzWdyVUPMmXFvp4F9tea18J8ufA774AB3s=
 github.com/gin-contrib/cors v1.7.7 h1:Oh9joP463x7Mw72vhvJ61YQm8ODh9b04YR7vsOErD0Q=
@@ -50,6 +48,10 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/klauspost/cpuid/v2 v2.3.0 h1:S4CRMLnYUhGeDFDqkGriYKdfoFlDnMtqTiI/sFzhA9Y=
 github.com/klauspost/cpuid/v2 v2.3.0/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
+github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
 github.com/mark3labs/mcp-go v0.47.0 h1:h44yeM3DduDyQgzImYWu4pt6VRkqP/0p/95AGhWngnA=
@@ -73,6 +75,8 @@ github.com/quic-go/quic-go v0.59.0 h1:OLJkp1Mlm/aS7dpKgTc6cnpynnD2Xg7C1pwL6vy/SA
 github.com/quic-go/quic-go v0.59.0/go.mod h1:upnsH4Ju1YkqpLXC305eW3yDZ4NfnNbmQRCMWS58IKU=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
+github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
+github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/spf13/cast v1.7.1 h1:cuNEagBQEHWN1FnbGEjCXL2szYEXqfJPbP2HNUaca9Y=
 github.com/spf13/cast v1.7.1/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cAdo=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -86,16 +90,6 @@ github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXl
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
-github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
-github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
-github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
-github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
-github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
-github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
-github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
-github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
-github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=
 github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS4MhqMhdFk5YI=
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/ugorji/go/codec v1.3.1 h1:waO7eEiFDwidsBN6agj1vJQ4AG7lh2yqXyOXqhgQuyY=
@@ -126,8 +120,6 @@ golang.org/x/tools v0.42.0/go.mod h1:Ma6lCIwGZvHK6XtgbswSoWroEkhugApmsXyrUmBhfr0
 google.golang.org/protobuf v1.36.10 h1:AYd7cD/uASjIL6Q9LiTjz8JLcrh/88q5UObnmY3aOOE=
 google.golang.org/protobuf v1.36.10/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
-gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/backend/internal/interfaces/api/api_test.go
+++ b/backend/internal/interfaces/api/api_test.go
@@ -230,3 +230,37 @@ func TestGetIndicators_InvalidSymbol(t *testing.T) {
 		t.Fatalf("expected 400, got %d", w.Code)
 	}
 }
+
+func TestGetPnL_PreservesLegacyFields(t *testing.T) {
+	router := setupRouter()
+	w := doRequest(router, "GET", "/api/v1/pnl", nil)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var body map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("failed to decode: %v", err)
+	}
+
+	// 既存フィールドが引き続き返ること
+	for _, key := range []string{"balance", "dailyLoss", "totalPosition", "tradingHalted"} {
+		if _, ok := body[key]; !ok {
+			t.Errorf("expected field %q in response, got keys=%v", key, mapKeys(body))
+		}
+	}
+
+	// calculator は setupRouter では nil なので dailyPnl は省略されるはず
+	if _, ok := body["dailyPnl"]; ok {
+		t.Errorf("dailyPnl should be absent when calculator is nil, got %v", body["dailyPnl"])
+	}
+}
+
+func mapKeys(m map[string]interface{}) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/backend/internal/interfaces/api/handler/risk.go
+++ b/backend/internal/interfaces/api/handler/risk.go
@@ -1,8 +1,11 @@
 package handler
 
 import (
+	"context"
 	"fmt"
+	"log/slog"
 	"net/http"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
@@ -12,10 +15,11 @@ import (
 type RiskHandler struct {
 	riskMgr     *usecase.RiskManager
 	realtimeHub *usecase.RealtimeHub
+	pnlCalc     *usecase.DailyPnLCalculator
 }
 
-func NewRiskHandler(riskMgr *usecase.RiskManager, realtimeHub *usecase.RealtimeHub) *RiskHandler {
-	return &RiskHandler{riskMgr: riskMgr, realtimeHub: realtimeHub}
+func NewRiskHandler(riskMgr *usecase.RiskManager, realtimeHub *usecase.RealtimeHub, pnlCalc *usecase.DailyPnLCalculator) *RiskHandler {
+	return &RiskHandler{riskMgr: riskMgr, realtimeHub: realtimeHub, pnlCalc: pnlCalc}
 }
 
 func (h *RiskHandler) GetConfig(c *gin.Context) {
@@ -67,10 +71,26 @@ func (h *RiskHandler) UpdateConfig(c *gin.Context) {
 
 func (h *RiskHandler) GetPnL(c *gin.Context) {
 	status := h.riskMgr.GetStatus()
-	c.JSON(http.StatusOK, gin.H{
+
+	resp := gin.H{
 		"balance":       status.Balance,
 		"dailyLoss":     status.DailyLoss,
 		"totalPosition": status.TotalPosition,
 		"tradingHalted": status.TradingHalted,
-	})
+	}
+
+	if h.pnlCalc != nil {
+		ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
+		defer cancel()
+
+		pnl, err := h.pnlCalc.Compute(ctx)
+		if err != nil {
+			slog.Warn("daily pnl compute failed", "error", err)
+			// エラー時は dailyPnl ブロック自体を省略 (フロントは undefined として handle する)
+		} else {
+			resp["dailyPnl"] = pnl
+		}
+	}
+
+	c.JSON(http.StatusOK, resp)
 }

--- a/backend/internal/interfaces/api/router.go
+++ b/backend/internal/interfaces/api/router.go
@@ -30,6 +30,7 @@ type Dependencies struct {
 	Pipeline            PipelineController
 	RESTClient          *rakuten.RESTClient
 	ClientOrderRepo     repository.ClientOrderRepository
+	DailyPnLCalculator  *usecase.DailyPnLCalculator
 	// OnSymbolSwitch はシンボル切替時に pipeline から呼び出されるコールバック。
 	// main 側で WebSocket 購読切替とローソク足 bootstrap を実行する。
 	OnSymbolSwitch func(oldID, newID int64)
@@ -53,7 +54,7 @@ func NewRouter(deps Dependencies) *gin.Engine {
 	v1.POST("/start", botHandler.Start)
 	v1.POST("/stop", botHandler.Stop)
 
-	riskHandler := handler.NewRiskHandler(deps.RiskManager, deps.RealtimeHub)
+	riskHandler := handler.NewRiskHandler(deps.RiskManager, deps.RealtimeHub, deps.DailyPnLCalculator)
 	v1.GET("/config", riskHandler.GetConfig)
 	v1.PUT("/config", riskHandler.UpdateConfig)
 	v1.GET("/pnl", riskHandler.GetPnL)

--- a/backend/internal/usecase/daily_pnl.go
+++ b/backend/internal/usecase/daily_pnl.go
@@ -1,0 +1,79 @@
+package usecase
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+	"golang.org/x/sync/singleflight"
+)
+
+// DailyPnL は画面表示用の日次損益ブレークダウン。
+// Realized: JST 当日分の決済損益 (MyTrade.CloseTradeProfit の合算)
+// Unrealized: 現在保有中ポジションの含み損益 (Position.FloatingProfit の合算)
+// Total: Realized + Unrealized
+// Stale: 個別銘柄の API 呼び出しに一部失敗した場合、または古いキャッシュを返した場合 true
+// ComputedAt: キャッシュ生成時刻 (unix seconds)
+type DailyPnL struct {
+	Realized   float64 `json:"realized"`
+	Unrealized float64 `json:"unrealized"`
+	Total      float64 `json:"total"`
+	Stale      bool    `json:"stale"`
+	ComputedAt int64   `json:"computedAt"`
+}
+
+// Clock は時刻を抽象化する。テストで固定時刻を注入するために interface にしている。
+type Clock interface {
+	Now() time.Time
+}
+
+type realClock struct{}
+
+func (realClock) Now() time.Time { return time.Now() }
+
+// rakutenClient は DailyPnLCalculator が楽天 REST から必要とするメソッドだけを切り出した interface。
+// infrastructure/rakuten.RESTClient はこれを満たす (compile-time で確認)。
+type rakutenClient interface {
+	GetSymbols(ctx context.Context) ([]entity.Symbol, error)
+	GetMyTrades(ctx context.Context, symbolID int64) ([]entity.MyTrade, error)
+	GetPositions(ctx context.Context, symbolID int64) ([]entity.Position, error)
+}
+
+// cachedPnL はキャッシュ 1 エントリ。atomic.Pointer 経由で lock-free に読み出す。
+type cachedPnL struct {
+	value     DailyPnL
+	expiresAt time.Time
+}
+
+type DailyPnLCalculator struct {
+	rest  rakutenClient
+	clock Clock
+	ttl   time.Duration
+
+	cache atomic.Pointer[cachedPnL]
+	group singleflight.Group
+
+	// mu は cache を書き換える時だけ使う。Compute 経路は atomic.Load で lock-free。
+	mu sync.Mutex
+}
+
+// NewDailyPnLCalculator は実行時構築用のコンストラクタ。
+// ttl が 0 以下の場合は 10 秒にフォールバックする。
+func NewDailyPnLCalculator(rest rakutenClient, ttl time.Duration) *DailyPnLCalculator {
+	if ttl <= 0 {
+		ttl = 10 * time.Second
+	}
+	return &DailyPnLCalculator{
+		rest:  rest,
+		clock: realClock{},
+		ttl:   ttl,
+	}
+}
+
+// Compute は最新または TTL 内キャッシュから DailyPnL を返す。
+// 実装は後続タスクで埋める。
+func (c *DailyPnLCalculator) Compute(ctx context.Context) (DailyPnL, error) {
+	return DailyPnL{}, nil
+}

--- a/backend/internal/usecase/daily_pnl.go
+++ b/backend/internal/usecase/daily_pnl.go
@@ -2,6 +2,7 @@ package usecase
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -73,7 +74,108 @@ func NewDailyPnLCalculator(rest rakutenClient, ttl time.Duration) *DailyPnLCalcu
 }
 
 // Compute は最新または TTL 内キャッシュから DailyPnL を返す。
-// 実装は後続タスクで埋める。
 func (c *DailyPnLCalculator) Compute(ctx context.Context) (DailyPnL, error) {
-	return DailyPnL{}, nil
+	now := c.clock.Now()
+
+	// 1. キャッシュが生きていれば返す
+	if cached := c.cache.Load(); cached != nil && now.Before(cached.expiresAt) {
+		return cached.value, nil
+	}
+
+	// 2. singleflight で同時リクエストを 1 コールに収束
+	key := "daily_pnl"
+	res, err, _ := c.group.Do(key, func() (any, error) {
+		return c.fetchAndCompute(ctx, now)
+	})
+	if err != nil {
+		return DailyPnL{}, err
+	}
+	return res.(DailyPnL), nil
 }
+
+// fetchAndCompute は楽天 API から trades/positions を取得し、JST 今日分の realized と全 unrealized を計算する。
+func (c *DailyPnLCalculator) fetchAndCompute(ctx context.Context, now time.Time) (DailyPnL, error) {
+	symbols, err := c.rest.GetSymbols(ctx)
+	if err != nil {
+		return DailyPnL{}, err
+	}
+
+	nowJST := now.In(jstZone)
+	todayStart := time.Date(nowJST.Year(), nowJST.Month(), nowJST.Day(), 0, 0, 0, 0, jstZone)
+	cutoffMillis := todayStart.UnixMilli()
+
+	var (
+		mu         sync.Mutex
+		realized   float64
+		unrealized float64
+		failed     int
+	)
+
+	var wg sync.WaitGroup
+	for _, sym := range symbols {
+		sym := sym
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			trades, tErr := c.rest.GetMyTrades(ctx, sym.ID)
+			if tErr != nil {
+				mu.Lock()
+				failed++
+				mu.Unlock()
+			} else {
+				var sum float64
+				for _, tr := range trades {
+					if tr.CreatedAt >= cutoffMillis {
+						sum += float64(tr.CloseTradeProfit)
+					}
+				}
+				mu.Lock()
+				realized += sum
+				mu.Unlock()
+			}
+
+			positions, pErr := c.rest.GetPositions(ctx, sym.ID)
+			if pErr != nil {
+				mu.Lock()
+				failed++
+				mu.Unlock()
+			} else {
+				var sum float64
+				for _, pos := range positions {
+					sum += pos.FloatingProfit
+				}
+				mu.Lock()
+				unrealized += sum
+				mu.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+
+	// 全呼び出し失敗 (symbols × 2 = trades + positions) ならエラーにする。
+	// 1 つでも成功していれば stale フラグを立てて結果を返す。
+	totalCalls := len(symbols) * 2
+	if totalCalls > 0 && failed == totalCalls {
+		return DailyPnL{}, errors.New("daily_pnl: all rakuten API calls failed")
+	}
+
+	result := DailyPnL{
+		Realized:   realized,
+		Unrealized: unrealized,
+		Total:      realized + unrealized,
+		Stale:      failed > 0,
+		ComputedAt: now.Unix(),
+	}
+
+	c.mu.Lock()
+	c.cache.Store(&cachedPnL{
+		value:     result,
+		expiresAt: now.Add(c.ttl),
+	})
+	c.mu.Unlock()
+
+	return result, nil
+}
+
+// jstZone は pipeline.go の restoreRiskState と同じ JST 固定ゾーン。
+var jstZone = time.FixedZone("JST", 9*60*60)

--- a/backend/internal/usecase/daily_pnl_test.go
+++ b/backend/internal/usecase/daily_pnl_test.go
@@ -1,0 +1,140 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+)
+
+// fakeRakutenClient は DailyPnLCalculator 単体テスト用のフェイク。
+// 呼び出し回数をカウントしてキャッシュ/singleflight 動作を検証できる。
+type fakeRakutenClient struct {
+	mu sync.Mutex
+
+	symbols []entity.Symbol
+
+	// trades[symbolID] = []MyTrade
+	trades map[int64][]entity.MyTrade
+	// positions[symbolID] = []Position
+	positions map[int64][]entity.Position
+
+	// 失敗設定
+	failSymbols        bool
+	failTradesSymbol   map[int64]bool
+	failPositionSymbol map[int64]bool
+
+	// call counters (atomic)
+	symbolsCalls   atomic.Int64
+	tradesCalls    atomic.Int64
+	positionsCalls atomic.Int64
+}
+
+func newFakeRakutenClient() *fakeRakutenClient {
+	return &fakeRakutenClient{
+		trades:             map[int64][]entity.MyTrade{},
+		positions:          map[int64][]entity.Position{},
+		failTradesSymbol:   map[int64]bool{},
+		failPositionSymbol: map[int64]bool{},
+	}
+}
+
+func (f *fakeRakutenClient) GetSymbols(_ context.Context) ([]entity.Symbol, error) {
+	f.symbolsCalls.Add(1)
+	if f.failSymbols {
+		return nil, errors.New("symbols failure")
+	}
+	return f.symbols, nil
+}
+
+func (f *fakeRakutenClient) GetMyTrades(_ context.Context, symbolID int64) ([]entity.MyTrade, error) {
+	f.tradesCalls.Add(1)
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.failTradesSymbol[symbolID] {
+		return nil, errors.New("trades failure")
+	}
+	return f.trades[symbolID], nil
+}
+
+func (f *fakeRakutenClient) GetPositions(_ context.Context, symbolID int64) ([]entity.Position, error) {
+	f.positionsCalls.Add(1)
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.failPositionSymbol[symbolID] {
+		return nil, errors.New("positions failure")
+	}
+	return f.positions[symbolID], nil
+}
+
+// fixedClock は固定時刻を返す Clock 実装。
+type fixedClock struct{ t time.Time }
+
+func (c *fixedClock) Now() time.Time { return c.t }
+
+// jst は JST 固定ゾーン。プロジェクトの既存コード (pipeline.go:500) と一致。
+var jst = time.FixedZone("JST", 9*60*60)
+
+// jstMillis は 指定した JST 日時の unix milliseconds を返すヘルパ。
+func jstMillis(year int, month time.Month, day, hour, minute, second, millis int) int64 {
+	return time.Date(year, month, day, hour, minute, second, millis*int(time.Millisecond), jst).UnixMilli()
+}
+
+func newCalculatorForTest(t *testing.T, fake *fakeRakutenClient, now time.Time) *DailyPnLCalculator {
+	t.Helper()
+	c := NewDailyPnLCalculator(fake, 10*time.Second)
+	c.clock = &fixedClock{t: now}
+	return c
+}
+
+func TestDailyPnLCalculator_Compute_SumsRealizedAndUnrealized(t *testing.T) {
+	fake := newFakeRakutenClient()
+	fake.symbols = []entity.Symbol{{ID: 7}, {ID: 10}}
+
+	// 今日 JST 2026-04-12 の trades
+	todayNoon := time.Date(2026, 4, 12, 12, 0, 0, 0, jst)
+
+	fake.trades[7] = []entity.MyTrade{
+		{ID: 1, SymbolID: 7, CloseTradeProfit: 100, CreatedAt: jstMillis(2026, 4, 12, 9, 0, 0, 0)},
+		{ID: 2, SymbolID: 7, CloseTradeProfit: -30, CreatedAt: jstMillis(2026, 4, 12, 10, 0, 0, 0)},
+	}
+	fake.trades[10] = []entity.MyTrade{
+		{ID: 3, SymbolID: 10, CloseTradeProfit: -6, CreatedAt: jstMillis(2026, 4, 12, 11, 0, 0, 0)},
+	}
+
+	fake.positions[7] = []entity.Position{
+		{ID: 100, SymbolID: 7, FloatingProfit: 50},
+	}
+	fake.positions[10] = []entity.Position{
+		{ID: 200, SymbolID: 10, FloatingProfit: -4},
+	}
+
+	c := newCalculatorForTest(t, fake, todayNoon)
+	got, err := c.Compute(context.Background())
+	if err != nil {
+		t.Fatalf("Compute returned error: %v", err)
+	}
+
+	// realized = 100 - 30 - 6 = 64
+	// unrealized = 50 - 4 = 46
+	// total = 110
+	if got.Realized != 64 {
+		t.Errorf("Realized = %v, want 64", got.Realized)
+	}
+	if got.Unrealized != 46 {
+		t.Errorf("Unrealized = %v, want 46", got.Unrealized)
+	}
+	if got.Total != 110 {
+		t.Errorf("Total = %v, want 110", got.Total)
+	}
+	if got.Stale {
+		t.Errorf("Stale = true, want false")
+	}
+	if got.ComputedAt != todayNoon.Unix() {
+		t.Errorf("ComputedAt = %v, want %v", got.ComputedAt, todayNoon.Unix())
+	}
+}

--- a/backend/internal/usecase/daily_pnl_test.go
+++ b/backend/internal/usecase/daily_pnl_test.go
@@ -138,3 +138,29 @@ func TestDailyPnLCalculator_Compute_SumsRealizedAndUnrealized(t *testing.T) {
 		t.Errorf("ComputedAt = %v, want %v", got.ComputedAt, todayNoon.Unix())
 	}
 }
+
+func TestDailyPnLCalculator_Compute_JSTBoundary(t *testing.T) {
+	fake := newFakeRakutenClient()
+	fake.symbols = []entity.Symbol{{ID: 7}}
+
+	// now = 2026-04-12 00:00:01 JST (今日になった直後)
+	now := time.Date(2026, 4, 12, 0, 0, 1, 0, jst)
+
+	fake.trades[7] = []entity.MyTrade{
+		// 昨日 23:59:59.999 JST の trade → 除外されるべき
+		{ID: 1, SymbolID: 7, CloseTradeProfit: 1000, CreatedAt: jstMillis(2026, 4, 11, 23, 59, 59, 999)},
+		// 今日 00:00:00.000 JST ちょうど → 含まれるべき
+		{ID: 2, SymbolID: 7, CloseTradeProfit: 7, CreatedAt: jstMillis(2026, 4, 12, 0, 0, 0, 0)},
+	}
+	fake.positions[7] = nil
+
+	c := newCalculatorForTest(t, fake, now)
+	got, err := c.Compute(context.Background())
+	if err != nil {
+		t.Fatalf("Compute returned error: %v", err)
+	}
+
+	if got.Realized != 7 {
+		t.Errorf("Realized = %v, want 7 (yesterday trade should be excluded, today 00:00 should be included)", got.Realized)
+	}
+}

--- a/backend/internal/usecase/daily_pnl_test.go
+++ b/backend/internal/usecase/daily_pnl_test.go
@@ -226,3 +226,61 @@ func TestDailyPnLCalculator_Compute_CacheExpiresAfterTTL(t *testing.T) {
 		t.Errorf("after TTL expiry, symbolsCalls = %d, want 2", fake.symbolsCalls.Load())
 	}
 }
+
+func TestDailyPnLCalculator_Compute_SingleflightCollapsesConcurrent(t *testing.T) {
+	// 100 goroutine が同時に Compute しても、楽天 API は 1 セット分 (symbols=1, trades=1, positions=1) しか呼ばれない
+	fake := newFakeRakutenClient()
+	fake.symbols = []entity.Symbol{{ID: 7}}
+	fake.positions[7] = nil
+
+	// 楽天 API に遅延を入れて singleflight の効果を観測する
+	// (fake 自体は同期的なので GetSymbols に sleep を仕込むためラッパーを使う)
+	slow := &slowFakeClient{inner: fake, delay: 50 * time.Millisecond}
+
+	c := NewDailyPnLCalculator(slow, 10*time.Second)
+	c.clock = &fixedClock{t: time.Date(2026, 4, 12, 12, 0, 0, 0, jst)}
+
+	var wg sync.WaitGroup
+	const N = 100
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := c.Compute(context.Background()); err != nil {
+				t.Errorf("Compute: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if fake.symbolsCalls.Load() != 1 {
+		t.Errorf("symbolsCalls = %d, want 1 (singleflight collapses concurrent callers)",
+			fake.symbolsCalls.Load())
+	}
+	if fake.tradesCalls.Load() != 1 {
+		t.Errorf("tradesCalls = %d, want 1", fake.tradesCalls.Load())
+	}
+	if fake.positionsCalls.Load() != 1 {
+		t.Errorf("positionsCalls = %d, want 1", fake.positionsCalls.Load())
+	}
+}
+
+// slowFakeClient は GetSymbols/GetMyTrades/GetPositions に人工的な遅延を加える。
+// singleflight 検証用に「最初の呼び出しが完了する前に後続が合流できる」状況を作る。
+type slowFakeClient struct {
+	inner *fakeRakutenClient
+	delay time.Duration
+}
+
+func (s *slowFakeClient) GetSymbols(ctx context.Context) ([]entity.Symbol, error) {
+	time.Sleep(s.delay)
+	return s.inner.GetSymbols(ctx)
+}
+func (s *slowFakeClient) GetMyTrades(ctx context.Context, symbolID int64) ([]entity.MyTrade, error) {
+	time.Sleep(s.delay)
+	return s.inner.GetMyTrades(ctx, symbolID)
+}
+func (s *slowFakeClient) GetPositions(ctx context.Context, symbolID int64) ([]entity.Position, error) {
+	time.Sleep(s.delay)
+	return s.inner.GetPositions(ctx, symbolID)
+}

--- a/backend/internal/usecase/daily_pnl_test.go
+++ b/backend/internal/usecase/daily_pnl_test.go
@@ -164,3 +164,65 @@ func TestDailyPnLCalculator_Compute_JSTBoundary(t *testing.T) {
 		t.Errorf("Realized = %v, want 7 (yesterday trade should be excluded, today 00:00 should be included)", got.Realized)
 	}
 }
+
+func TestDailyPnLCalculator_Compute_CacheHitAvoidsAPICalls(t *testing.T) {
+	fake := newFakeRakutenClient()
+	fake.symbols = []entity.Symbol{{ID: 7}}
+	fake.trades[7] = []entity.MyTrade{
+		{ID: 1, SymbolID: 7, CloseTradeProfit: 10, CreatedAt: jstMillis(2026, 4, 12, 12, 0, 0, 0)},
+	}
+	fake.positions[7] = nil
+
+	now := time.Date(2026, 4, 12, 12, 0, 0, 0, jst)
+	c := newCalculatorForTest(t, fake, now)
+
+	// 1 回目: 楽天 API を叩く
+	if _, err := c.Compute(context.Background()); err != nil {
+		t.Fatalf("first Compute: %v", err)
+	}
+	firstSymbols := fake.symbolsCalls.Load()
+	firstTrades := fake.tradesCalls.Load()
+	firstPositions := fake.positionsCalls.Load()
+
+	if firstSymbols != 1 || firstTrades != 1 || firstPositions != 1 {
+		t.Fatalf("first call counts: symbols=%d trades=%d positions=%d, want 1/1/1",
+			firstSymbols, firstTrades, firstPositions)
+	}
+
+	// 2 回目: キャッシュヒット → 呼び出しゼロ
+	if _, err := c.Compute(context.Background()); err != nil {
+		t.Fatalf("second Compute: %v", err)
+	}
+	if fake.symbolsCalls.Load() != firstSymbols ||
+		fake.tradesCalls.Load() != firstTrades ||
+		fake.positionsCalls.Load() != firstPositions {
+		t.Errorf("cached call should not invoke rakuten API; got calls symbols=%d trades=%d positions=%d",
+			fake.symbolsCalls.Load(), fake.tradesCalls.Load(), fake.positionsCalls.Load())
+	}
+}
+
+func TestDailyPnLCalculator_Compute_CacheExpiresAfterTTL(t *testing.T) {
+	fake := newFakeRakutenClient()
+	fake.symbols = []entity.Symbol{{ID: 7}}
+	fake.positions[7] = nil
+
+	clock := &fixedClock{t: time.Date(2026, 4, 12, 12, 0, 0, 0, jst)}
+	c := NewDailyPnLCalculator(fake, 10*time.Second)
+	c.clock = clock
+
+	if _, err := c.Compute(context.Background()); err != nil {
+		t.Fatalf("first Compute: %v", err)
+	}
+
+	// 10 秒ちょうどはまだ有効 (expiresAt は排他境界) ではないので、
+	// 少し進めて TTL 経過扱いにする
+	clock.t = clock.t.Add(10*time.Second + time.Millisecond)
+
+	if _, err := c.Compute(context.Background()); err != nil {
+		t.Fatalf("second Compute: %v", err)
+	}
+
+	if fake.symbolsCalls.Load() != 2 {
+		t.Errorf("after TTL expiry, symbolsCalls = %d, want 2", fake.symbolsCalls.Load())
+	}
+}

--- a/backend/internal/usecase/daily_pnl_test.go
+++ b/backend/internal/usecase/daily_pnl_test.go
@@ -284,3 +284,61 @@ func (s *slowFakeClient) GetPositions(ctx context.Context, symbolID int64) ([]en
 	time.Sleep(s.delay)
 	return s.inner.GetPositions(ctx, symbolID)
 }
+
+func TestDailyPnLCalculator_Compute_PartialFailureReturnsStale(t *testing.T) {
+	fake := newFakeRakutenClient()
+	fake.symbols = []entity.Symbol{{ID: 7}, {ID: 10}}
+
+	fake.trades[7] = []entity.MyTrade{
+		{ID: 1, SymbolID: 7, CloseTradeProfit: 20, CreatedAt: jstMillis(2026, 4, 12, 12, 0, 0, 0)},
+	}
+	// symbol 10 の positions だけ失敗させる
+	fake.failPositionSymbol[10] = true
+	fake.positions[7] = []entity.Position{{FloatingProfit: 5}}
+
+	c := newCalculatorForTest(t, fake, time.Date(2026, 4, 12, 13, 0, 0, 0, jst))
+	got, err := c.Compute(context.Background())
+	if err != nil {
+		t.Fatalf("Compute should not error on partial failure: %v", err)
+	}
+	if !got.Stale {
+		t.Errorf("Stale = false, want true on partial failure")
+	}
+	// realized は symbol 7 の 20
+	if got.Realized != 20 {
+		t.Errorf("Realized = %v, want 20", got.Realized)
+	}
+	// unrealized は symbol 7 の 5 のみ (symbol 10 は失敗で 0 扱い)
+	if got.Unrealized != 5 {
+		t.Errorf("Unrealized = %v, want 5", got.Unrealized)
+	}
+}
+
+func TestDailyPnLCalculator_Compute_AllFailureReturnsError(t *testing.T) {
+	fake := newFakeRakutenClient()
+	fake.symbols = []entity.Symbol{{ID: 7}}
+	fake.failTradesSymbol[7] = true
+	fake.failPositionSymbol[7] = true
+
+	c := newCalculatorForTest(t, fake, time.Date(2026, 4, 12, 12, 0, 0, 0, jst))
+	_, err := c.Compute(context.Background())
+	if err == nil {
+		t.Fatalf("expected error on all-failure, got nil")
+	}
+}
+
+func TestDailyPnLCalculator_Compute_Empty(t *testing.T) {
+	fake := newFakeRakutenClient()
+	fake.symbols = []entity.Symbol{{ID: 7}}
+	fake.trades[7] = nil
+	fake.positions[7] = nil
+
+	c := newCalculatorForTest(t, fake, time.Date(2026, 4, 12, 12, 0, 0, 0, jst))
+	got, err := c.Compute(context.Background())
+	if err != nil {
+		t.Fatalf("Compute: %v", err)
+	}
+	if got.Total != 0 || got.Realized != 0 || got.Unrealized != 0 || got.Stale {
+		t.Errorf("empty result got %+v, want all zero and Stale=false", got)
+	}
+}

--- a/docs/superpowers/plans/2026-04-12-daily-pnl-dashboard.md
+++ b/docs/superpowers/plans/2026-04-12-daily-pnl-dashboard.md
@@ -1,0 +1,1260 @@
+# Daily PnL Dashboard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** ダッシュボードの「日次損益」カードを、全通貨ペア合算の実現損益 (JST 当日分) + 未実現損益で計算する新しいユースケースに置き換える。
+
+**Architecture:** バックエンドに `usecase.DailyPnLCalculator` を新設し、`RiskManager` とは独立させる。`GetSymbols` + `GetMyTrades`/`GetPositions` を銘柄数ぶん並列で叩き、10 秒 TTL のキャッシュと `singleflight` で API 呼び出しを抑制する。`RiskHandler.GetPnL` から新ユースケースを呼んでレスポンスに `dailyPnl` ブロックを追加し、フロントは `dailyPnl.total` を表示する。既存 `dailyLoss` フィールドはリスク制限用に残し、後方互換を維持する。
+
+**Tech Stack:** Go (gin, `golang.org/x/sync/singleflight`, `golang.org/x/sync/errgroup`), TypeScript (React, TanStack Query), vitest.
+
+**Spec reference:** `docs/superpowers/specs/2026-04-11-daily-pnl-dashboard-design.md`
+
+---
+
+## File Structure
+
+**Backend — new:**
+- `backend/internal/usecase/daily_pnl.go` — `DailyPnLCalculator`、`DailyPnL` 型、`rakutenClient` interface、`Clock` interface、キャッシュと singleflight ロジック
+- `backend/internal/usecase/daily_pnl_test.go` — fake client + fake clock による単体テスト
+
+**Backend — modify:**
+- `backend/internal/interfaces/api/router.go` — `Dependencies` に `DailyPnLCalculator` を追加し `NewRiskHandler` に渡す
+- `backend/internal/interfaces/api/handler/risk.go` — `RiskHandler` に calculator を埋め込み、`GetPnL` でレスポンスに `dailyPnl` を追加
+- `backend/internal/interfaces/api/api_test.go` — `setupRouter` で fake calculator を注入し、`TestGetPnL` で `dailyPnl` を検証
+- `backend/cmd/main.go` — 起動時に `DailyPnLCalculator` を組み立てて `Dependencies` に渡す
+- `backend/go.mod` / `backend/go.sum` — `golang.org/x/sync` を direct 依存に昇格
+
+**Frontend — modify:**
+- `frontend/src/lib/api.ts` — `DailyPnLBreakdown` 型追加、`PnlResponse` 拡張
+- `frontend/src/routes/index.tsx` — `dailyPnl.total` を使うよう表示ロジック差し替え
+
+---
+
+## Task 1: `golang.org/x/sync` を direct 依存に昇格
+
+**Files:**
+- Modify: `backend/go.mod`
+- Modify: `backend/go.sum` (go get が自動更新)
+
+- [ ] **Step 1: Run `go get` to promote the dep**
+
+Run (in `backend/` directory):
+```bash
+cd backend && go get golang.org/x/sync@v0.20.0
+```
+Expected: `backend/go.mod` の `require` に `golang.org/x/sync v0.20.0` が `// indirect` なしで現れる。
+
+- [ ] **Step 2: Verify module graph**
+
+Run:
+```bash
+cd backend && go mod tidy && go build ./...
+```
+Expected: エラーなし。
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/go.mod backend/go.sum
+git commit -m "chore(backend): promote golang.org/x/sync to direct dependency"
+```
+
+---
+
+## Task 2: `DailyPnLCalculator` の骨組みと型定義
+
+**Files:**
+- Create: `backend/internal/usecase/daily_pnl.go`
+
+- [ ] **Step 1: Create the file with types and interfaces**
+
+Create `backend/internal/usecase/daily_pnl.go`:
+
+```go
+package usecase
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+	"golang.org/x/sync/singleflight"
+)
+
+// DailyPnL は画面表示用の日次損益ブレークダウン。
+// Realized: JST 当日分の決済損益 (MyTrade.CloseTradeProfit の合算)
+// Unrealized: 現在保有中ポジションの含み損益 (Position.FloatingProfit の合算)
+// Total: Realized + Unrealized
+// Stale: 個別銘柄の API 呼び出しに一部失敗した場合、または古いキャッシュを返した場合 true
+// ComputedAt: キャッシュ生成時刻 (unix seconds)
+type DailyPnL struct {
+	Realized   float64 `json:"realized"`
+	Unrealized float64 `json:"unrealized"`
+	Total      float64 `json:"total"`
+	Stale      bool    `json:"stale"`
+	ComputedAt int64   `json:"computedAt"`
+}
+
+// Clock は時刻を抽象化する。テストで固定時刻を注入するために interface にしている。
+type Clock interface {
+	Now() time.Time
+}
+
+type realClock struct{}
+
+func (realClock) Now() time.Time { return time.Now() }
+
+// rakutenClient は DailyPnLCalculator が楽天 REST から必要とするメソッドだけを切り出した interface。
+// infrastructure/rakuten.RESTClient はこれを満たす (compile-time で確認)。
+type rakutenClient interface {
+	GetSymbols(ctx context.Context) ([]entity.Symbol, error)
+	GetMyTrades(ctx context.Context, symbolID int64) ([]entity.MyTrade, error)
+	GetPositions(ctx context.Context, symbolID int64) ([]entity.Position, error)
+}
+
+// cachedPnL はキャッシュ 1 エントリ。atomic.Pointer 経由で lock-free に読み出す。
+type cachedPnL struct {
+	value     DailyPnL
+	expiresAt time.Time
+}
+
+type DailyPnLCalculator struct {
+	rest  rakutenClient
+	clock Clock
+	ttl   time.Duration
+
+	cache atomic.Pointer[cachedPnL]
+	group singleflight.Group
+
+	// mu は cache を書き換える時だけ使う。Compute 経路は atomic.Load で lock-free。
+	mu sync.Mutex
+}
+
+// NewDailyPnLCalculator は実行時構築用のコンストラクタ。
+// ttl が 0 以下の場合は 10 秒にフォールバックする。
+func NewDailyPnLCalculator(rest rakutenClient, ttl time.Duration) *DailyPnLCalculator {
+	if ttl <= 0 {
+		ttl = 10 * time.Second
+	}
+	return &DailyPnLCalculator{
+		rest:  rest,
+		clock: realClock{},
+		ttl:   ttl,
+	}
+}
+
+// Compute は最新または TTL 内キャッシュから DailyPnL を返す。
+// 実装は後続タスクで埋める。
+func (c *DailyPnLCalculator) Compute(ctx context.Context) (DailyPnL, error) {
+	return DailyPnL{}, nil
+}
+```
+
+- [ ] **Step 2: Verify compile**
+
+Run:
+```bash
+cd backend && go build ./internal/usecase/...
+```
+Expected: エラーなし。
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/internal/usecase/daily_pnl.go
+git commit -m "feat(backend): scaffold DailyPnLCalculator types and interfaces"
+```
+
+---
+
+## Task 3: 単純正常系テスト (実現 + 未実現集計)
+
+**Files:**
+- Create: `backend/internal/usecase/daily_pnl_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/internal/usecase/daily_pnl_test.go`:
+
+```go
+package usecase
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+)
+
+// fakeRakutenClient は DailyPnLCalculator 単体テスト用のフェイク。
+// 呼び出し回数をカウントしてキャッシュ/singleflight 動作を検証できる。
+type fakeRakutenClient struct {
+	mu sync.Mutex
+
+	symbols []entity.Symbol
+
+	// trades[symbolID] = []MyTrade
+	trades map[int64][]entity.MyTrade
+	// positions[symbolID] = []Position
+	positions map[int64][]entity.Position
+
+	// 失敗設定
+	failSymbols        bool
+	failTradesSymbol   map[int64]bool
+	failPositionSymbol map[int64]bool
+
+	// call counters (atomic)
+	symbolsCalls   atomic.Int64
+	tradesCalls    atomic.Int64
+	positionsCalls atomic.Int64
+}
+
+func newFakeRakutenClient() *fakeRakutenClient {
+	return &fakeRakutenClient{
+		trades:             map[int64][]entity.MyTrade{},
+		positions:          map[int64][]entity.Position{},
+		failTradesSymbol:   map[int64]bool{},
+		failPositionSymbol: map[int64]bool{},
+	}
+}
+
+func (f *fakeRakutenClient) GetSymbols(_ context.Context) ([]entity.Symbol, error) {
+	f.symbolsCalls.Add(1)
+	if f.failSymbols {
+		return nil, errors.New("symbols failure")
+	}
+	return f.symbols, nil
+}
+
+func (f *fakeRakutenClient) GetMyTrades(_ context.Context, symbolID int64) ([]entity.MyTrade, error) {
+	f.tradesCalls.Add(1)
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.failTradesSymbol[symbolID] {
+		return nil, errors.New("trades failure")
+	}
+	return f.trades[symbolID], nil
+}
+
+func (f *fakeRakutenClient) GetPositions(_ context.Context, symbolID int64) ([]entity.Position, error) {
+	f.positionsCalls.Add(1)
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.failPositionSymbol[symbolID] {
+		return nil, errors.New("positions failure")
+	}
+	return f.positions[symbolID], nil
+}
+
+// fixedClock は固定時刻を返す Clock 実装。
+type fixedClock struct{ t time.Time }
+
+func (c *fixedClock) Now() time.Time { return c.t }
+
+// jst は JST 固定ゾーン。プロジェクトの既存コード (pipeline.go:500) と一致。
+var jst = time.FixedZone("JST", 9*60*60)
+
+// jstMillis は 指定した JST 日時の unix milliseconds を返すヘルパ。
+func jstMillis(year int, month time.Month, day, hour, minute, second, millis int) int64 {
+	return time.Date(year, month, day, hour, minute, second, millis*int(time.Millisecond), jst).UnixMilli()
+}
+
+func newCalculatorForTest(t *testing.T, fake *fakeRakutenClient, now time.Time) *DailyPnLCalculator {
+	t.Helper()
+	c := NewDailyPnLCalculator(fake, 10*time.Second)
+	c.clock = &fixedClock{t: now}
+	return c
+}
+
+func TestDailyPnLCalculator_Compute_SumsRealizedAndUnrealized(t *testing.T) {
+	fake := newFakeRakutenClient()
+	fake.symbols = []entity.Symbol{{ID: 7}, {ID: 10}}
+
+	// 今日 JST 2026-04-12 の trades
+	todayNoon := time.Date(2026, 4, 12, 12, 0, 0, 0, jst)
+
+	fake.trades[7] = []entity.MyTrade{
+		{ID: 1, SymbolID: 7, CloseTradeProfit: 100, CreatedAt: jstMillis(2026, 4, 12, 9, 0, 0, 0)},
+		{ID: 2, SymbolID: 7, CloseTradeProfit: -30, CreatedAt: jstMillis(2026, 4, 12, 10, 0, 0, 0)},
+	}
+	fake.trades[10] = []entity.MyTrade{
+		{ID: 3, SymbolID: 10, CloseTradeProfit: -6, CreatedAt: jstMillis(2026, 4, 12, 11, 0, 0, 0)},
+	}
+
+	fake.positions[7] = []entity.Position{
+		{ID: 100, SymbolID: 7, FloatingProfit: 50},
+	}
+	fake.positions[10] = []entity.Position{
+		{ID: 200, SymbolID: 10, FloatingProfit: -4},
+	}
+
+	c := newCalculatorForTest(t, fake, todayNoon)
+	got, err := c.Compute(context.Background())
+	if err != nil {
+		t.Fatalf("Compute returned error: %v", err)
+	}
+
+	// realized = 100 - 30 - 6 = 64
+	// unrealized = 50 - 4 = 46
+	// total = 110
+	if got.Realized != 64 {
+		t.Errorf("Realized = %v, want 64", got.Realized)
+	}
+	if got.Unrealized != 46 {
+		t.Errorf("Unrealized = %v, want 46", got.Unrealized)
+	}
+	if got.Total != 110 {
+		t.Errorf("Total = %v, want 110", got.Total)
+	}
+	if got.Stale {
+		t.Errorf("Stale = true, want false")
+	}
+	if got.ComputedAt != todayNoon.Unix() {
+		t.Errorf("ComputedAt = %v, want %v", got.ComputedAt, todayNoon.Unix())
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+```bash
+cd backend && go test ./internal/usecase/ -run TestDailyPnLCalculator_Compute_SumsRealizedAndUnrealized -v
+```
+Expected: FAIL — `Compute` はまだ zero 値を返す実装なので `Realized = 0, want 64` 等で落ちる。
+
+- [ ] **Step 3: Implement Compute**
+
+Replace the `Compute` function in `backend/internal/usecase/daily_pnl.go`:
+
+```go
+func (c *DailyPnLCalculator) Compute(ctx context.Context) (DailyPnL, error) {
+	now := c.clock.Now()
+
+	// 1. キャッシュが生きていれば返す
+	if cached := c.cache.Load(); cached != nil && now.Before(cached.expiresAt) {
+		return cached.value, nil
+	}
+
+	// 2. singleflight で同時リクエストを 1 コールに収束
+	key := "daily_pnl"
+	res, err, _ := c.group.Do(key, func() (any, error) {
+		return c.fetchAndCompute(ctx, now)
+	})
+	if err != nil {
+		return DailyPnL{}, err
+	}
+	return res.(DailyPnL), nil
+}
+
+// fetchAndCompute は楽天 API から trades/positions を取得し、JST 今日分の realized と全 unrealized を計算する。
+func (c *DailyPnLCalculator) fetchAndCompute(ctx context.Context, now time.Time) (DailyPnL, error) {
+	symbols, err := c.rest.GetSymbols(ctx)
+	if err != nil {
+		return DailyPnL{}, err
+	}
+
+	nowJST := now.In(jstZone)
+	todayStart := time.Date(nowJST.Year(), nowJST.Month(), nowJST.Day(), 0, 0, 0, 0, jstZone)
+	cutoffMillis := todayStart.UnixMilli()
+
+	var (
+		mu         sync.Mutex
+		realized   float64
+		unrealized float64
+		failed     int
+	)
+
+	var wg sync.WaitGroup
+	for _, sym := range symbols {
+		sym := sym
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			trades, tErr := c.rest.GetMyTrades(ctx, sym.ID)
+			if tErr != nil {
+				mu.Lock()
+				failed++
+				mu.Unlock()
+			} else {
+				var sum float64
+				for _, tr := range trades {
+					if tr.CreatedAt >= cutoffMillis {
+						sum += float64(tr.CloseTradeProfit)
+					}
+				}
+				mu.Lock()
+				realized += sum
+				mu.Unlock()
+			}
+
+			positions, pErr := c.rest.GetPositions(ctx, sym.ID)
+			if pErr != nil {
+				mu.Lock()
+				failed++
+				mu.Unlock()
+			} else {
+				var sum float64
+				for _, pos := range positions {
+					sum += pos.FloatingProfit
+				}
+				mu.Lock()
+				unrealized += sum
+				mu.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+
+	// 全呼び出し失敗 (symbols × 2 = trades + positions) ならエラーにする。
+	// 1 つでも成功していれば stale フラグを立てて結果を返す。
+	totalCalls := len(symbols) * 2
+	if totalCalls > 0 && failed == totalCalls {
+		return DailyPnL{}, errors.New("daily_pnl: all rakuten API calls failed")
+	}
+
+	result := DailyPnL{
+		Realized:   realized,
+		Unrealized: unrealized,
+		Total:      realized + unrealized,
+		Stale:      failed > 0,
+		ComputedAt: now.Unix(),
+	}
+
+	c.mu.Lock()
+	c.cache.Store(&cachedPnL{
+		value:     result,
+		expiresAt: now.Add(c.ttl),
+	})
+	c.mu.Unlock()
+
+	return result, nil
+}
+
+// jstZone は pipeline.go の restoreRiskState と同じ JST 固定ゾーン。
+var jstZone = time.FixedZone("JST", 9*60*60)
+```
+
+Also add the import for `errors` at the top of `daily_pnl.go`:
+
+```go
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+	"golang.org/x/sync/singleflight"
+)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+```bash
+cd backend && go test ./internal/usecase/ -run TestDailyPnLCalculator_Compute_SumsRealizedAndUnrealized -v
+```
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/internal/usecase/daily_pnl.go backend/internal/usecase/daily_pnl_test.go
+git commit -m "feat(backend): DailyPnLCalculator computes realized+unrealized pnl"
+```
+
+---
+
+## Task 4: JST 境界テスト
+
+**Files:**
+- Modify: `backend/internal/usecase/daily_pnl_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `backend/internal/usecase/daily_pnl_test.go`:
+
+```go
+func TestDailyPnLCalculator_Compute_JSTBoundary(t *testing.T) {
+	fake := newFakeRakutenClient()
+	fake.symbols = []entity.Symbol{{ID: 7}}
+
+	// now = 2026-04-12 00:00:01 JST (今日になった直後)
+	now := time.Date(2026, 4, 12, 0, 0, 1, 0, jst)
+
+	fake.trades[7] = []entity.MyTrade{
+		// 昨日 23:59:59.999 JST の trade → 除外されるべき
+		{ID: 1, SymbolID: 7, CloseTradeProfit: 1000, CreatedAt: jstMillis(2026, 4, 11, 23, 59, 59, 999)},
+		// 今日 00:00:00.000 JST ちょうど → 含まれるべき
+		{ID: 2, SymbolID: 7, CloseTradeProfit: 7, CreatedAt: jstMillis(2026, 4, 12, 0, 0, 0, 0)},
+	}
+	fake.positions[7] = nil
+
+	c := newCalculatorForTest(t, fake, now)
+	got, err := c.Compute(context.Background())
+	if err != nil {
+		t.Fatalf("Compute returned error: %v", err)
+	}
+
+	if got.Realized != 7 {
+		t.Errorf("Realized = %v, want 7 (yesterday trade should be excluded, today 00:00 should be included)", got.Realized)
+	}
+}
+```
+
+- [ ] **Step 2: Run test**
+
+Run:
+```bash
+cd backend && go test ./internal/usecase/ -run TestDailyPnLCalculator_Compute_JSTBoundary -v
+```
+Expected: PASS (実装は Task 3 で既に境界ロジックを含んでいる)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/internal/usecase/daily_pnl_test.go
+git commit -m "test(backend): verify JST boundary in DailyPnLCalculator"
+```
+
+---
+
+## Task 5: キャッシュと TTL 経過テスト
+
+**Files:**
+- Modify: `backend/internal/usecase/daily_pnl_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `backend/internal/usecase/daily_pnl_test.go`:
+
+```go
+func TestDailyPnLCalculator_Compute_CacheHitAvoidsAPICalls(t *testing.T) {
+	fake := newFakeRakutenClient()
+	fake.symbols = []entity.Symbol{{ID: 7}}
+	fake.trades[7] = []entity.MyTrade{
+		{ID: 1, SymbolID: 7, CloseTradeProfit: 10, CreatedAt: jstMillis(2026, 4, 12, 12, 0, 0, 0)},
+	}
+	fake.positions[7] = nil
+
+	now := time.Date(2026, 4, 12, 12, 0, 0, 0, jst)
+	c := newCalculatorForTest(t, fake, now)
+
+	// 1 回目: 楽天 API を叩く
+	if _, err := c.Compute(context.Background()); err != nil {
+		t.Fatalf("first Compute: %v", err)
+	}
+	firstSymbols := fake.symbolsCalls.Load()
+	firstTrades := fake.tradesCalls.Load()
+	firstPositions := fake.positionsCalls.Load()
+
+	if firstSymbols != 1 || firstTrades != 1 || firstPositions != 1 {
+		t.Fatalf("first call counts: symbols=%d trades=%d positions=%d, want 1/1/1",
+			firstSymbols, firstTrades, firstPositions)
+	}
+
+	// 2 回目: キャッシュヒット → 呼び出しゼロ
+	if _, err := c.Compute(context.Background()); err != nil {
+		t.Fatalf("second Compute: %v", err)
+	}
+	if fake.symbolsCalls.Load() != firstSymbols ||
+		fake.tradesCalls.Load() != firstTrades ||
+		fake.positionsCalls.Load() != firstPositions {
+		t.Errorf("cached call should not invoke rakuten API; got calls symbols=%d trades=%d positions=%d",
+			fake.symbolsCalls.Load(), fake.tradesCalls.Load(), fake.positionsCalls.Load())
+	}
+}
+
+func TestDailyPnLCalculator_Compute_CacheExpiresAfterTTL(t *testing.T) {
+	fake := newFakeRakutenClient()
+	fake.symbols = []entity.Symbol{{ID: 7}}
+	fake.positions[7] = nil
+
+	clock := &fixedClock{t: time.Date(2026, 4, 12, 12, 0, 0, 0, jst)}
+	c := NewDailyPnLCalculator(fake, 10*time.Second)
+	c.clock = clock
+
+	if _, err := c.Compute(context.Background()); err != nil {
+		t.Fatalf("first Compute: %v", err)
+	}
+
+	// 10 秒ちょうどはまだ有効 (expiresAt は排他境界) ではないので、
+	// 少し進めて TTL 経過扱いにする
+	clock.t = clock.t.Add(10*time.Second + time.Millisecond)
+
+	if _, err := c.Compute(context.Background()); err != nil {
+		t.Fatalf("second Compute: %v", err)
+	}
+
+	if fake.symbolsCalls.Load() != 2 {
+		t.Errorf("after TTL expiry, symbolsCalls = %d, want 2", fake.symbolsCalls.Load())
+	}
+}
+```
+
+- [ ] **Step 2: Run tests**
+
+Run:
+```bash
+cd backend && go test ./internal/usecase/ -run TestDailyPnLCalculator_Compute_Cache -v
+```
+Expected: PASS (両方)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/internal/usecase/daily_pnl_test.go
+git commit -m "test(backend): verify DailyPnLCalculator cache hit and TTL expiry"
+```
+
+---
+
+## Task 6: singleflight 並行テスト
+
+**Files:**
+- Modify: `backend/internal/usecase/daily_pnl_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `backend/internal/usecase/daily_pnl_test.go`:
+
+```go
+func TestDailyPnLCalculator_Compute_SingleflightCollapsesConcurrent(t *testing.T) {
+	// 100 goroutine が同時に Compute しても、楽天 API は 1 セット分 (symbols=1, trades=1, positions=1) しか呼ばれない
+	fake := newFakeRakutenClient()
+	fake.symbols = []entity.Symbol{{ID: 7}}
+	fake.positions[7] = nil
+
+	// 楽天 API に遅延を入れて singleflight の効果を観測する
+	// (fake 自体は同期的なので GetSymbols に sleep を仕込むためラッパーを使う)
+	slow := &slowFakeClient{inner: fake, delay: 50 * time.Millisecond}
+
+	c := NewDailyPnLCalculator(slow, 10*time.Second)
+	c.clock = &fixedClock{t: time.Date(2026, 4, 12, 12, 0, 0, 0, jst)}
+
+	var wg sync.WaitGroup
+	const N = 100
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := c.Compute(context.Background()); err != nil {
+				t.Errorf("Compute: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if fake.symbolsCalls.Load() != 1 {
+		t.Errorf("symbolsCalls = %d, want 1 (singleflight collapses concurrent callers)",
+			fake.symbolsCalls.Load())
+	}
+	if fake.tradesCalls.Load() != 1 {
+		t.Errorf("tradesCalls = %d, want 1", fake.tradesCalls.Load())
+	}
+	if fake.positionsCalls.Load() != 1 {
+		t.Errorf("positionsCalls = %d, want 1", fake.positionsCalls.Load())
+	}
+}
+
+// slowFakeClient は GetSymbols/GetMyTrades/GetPositions に人工的な遅延を加える。
+// singleflight 検証用に「最初の呼び出しが完了する前に後続が合流できる」状況を作る。
+type slowFakeClient struct {
+	inner *fakeRakutenClient
+	delay time.Duration
+}
+
+func (s *slowFakeClient) GetSymbols(ctx context.Context) ([]entity.Symbol, error) {
+	time.Sleep(s.delay)
+	return s.inner.GetSymbols(ctx)
+}
+func (s *slowFakeClient) GetMyTrades(ctx context.Context, symbolID int64) ([]entity.MyTrade, error) {
+	time.Sleep(s.delay)
+	return s.inner.GetMyTrades(ctx, symbolID)
+}
+func (s *slowFakeClient) GetPositions(ctx context.Context, symbolID int64) ([]entity.Position, error) {
+	time.Sleep(s.delay)
+	return s.inner.GetPositions(ctx, symbolID)
+}
+```
+
+- [ ] **Step 2: Run test**
+
+Run:
+```bash
+cd backend && go test ./internal/usecase/ -run TestDailyPnLCalculator_Compute_Singleflight -v
+```
+Expected: PASS (singleflight が 1 コールに収束)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/internal/usecase/daily_pnl_test.go
+git commit -m "test(backend): verify DailyPnLCalculator singleflight collapses concurrent callers"
+```
+
+---
+
+## Task 7: 部分失敗 / 全失敗 / 空ケース のテスト
+
+**Files:**
+- Modify: `backend/internal/usecase/daily_pnl_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `backend/internal/usecase/daily_pnl_test.go`:
+
+```go
+func TestDailyPnLCalculator_Compute_PartialFailureReturnsStale(t *testing.T) {
+	fake := newFakeRakutenClient()
+	fake.symbols = []entity.Symbol{{ID: 7}, {ID: 10}}
+
+	fake.trades[7] = []entity.MyTrade{
+		{ID: 1, SymbolID: 7, CloseTradeProfit: 20, CreatedAt: jstMillis(2026, 4, 12, 12, 0, 0, 0)},
+	}
+	// symbol 10 の positions だけ失敗させる
+	fake.failPositionSymbol[10] = true
+	fake.positions[7] = []entity.Position{{FloatingProfit: 5}}
+
+	c := newCalculatorForTest(t, fake, time.Date(2026, 4, 12, 13, 0, 0, 0, jst))
+	got, err := c.Compute(context.Background())
+	if err != nil {
+		t.Fatalf("Compute should not error on partial failure: %v", err)
+	}
+	if !got.Stale {
+		t.Errorf("Stale = false, want true on partial failure")
+	}
+	// realized は symbol 7 の 20
+	if got.Realized != 20 {
+		t.Errorf("Realized = %v, want 20", got.Realized)
+	}
+	// unrealized は symbol 7 の 5 のみ (symbol 10 は失敗で 0 扱い)
+	if got.Unrealized != 5 {
+		t.Errorf("Unrealized = %v, want 5", got.Unrealized)
+	}
+}
+
+func TestDailyPnLCalculator_Compute_AllFailureReturnsError(t *testing.T) {
+	fake := newFakeRakutenClient()
+	fake.symbols = []entity.Symbol{{ID: 7}}
+	fake.failTradesSymbol[7] = true
+	fake.failPositionSymbol[7] = true
+
+	c := newCalculatorForTest(t, fake, time.Date(2026, 4, 12, 12, 0, 0, 0, jst))
+	_, err := c.Compute(context.Background())
+	if err == nil {
+		t.Fatalf("expected error on all-failure, got nil")
+	}
+}
+
+func TestDailyPnLCalculator_Compute_Empty(t *testing.T) {
+	fake := newFakeRakutenClient()
+	fake.symbols = []entity.Symbol{{ID: 7}}
+	fake.trades[7] = nil
+	fake.positions[7] = nil
+
+	c := newCalculatorForTest(t, fake, time.Date(2026, 4, 12, 12, 0, 0, 0, jst))
+	got, err := c.Compute(context.Background())
+	if err != nil {
+		t.Fatalf("Compute: %v", err)
+	}
+	if got.Total != 0 || got.Realized != 0 || got.Unrealized != 0 || got.Stale {
+		t.Errorf("empty result got %+v, want all zero and Stale=false", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests**
+
+Run:
+```bash
+cd backend && go test ./internal/usecase/ -run "TestDailyPnLCalculator_Compute_(PartialFailureReturnsStale|AllFailureReturnsError|Empty)" -v
+```
+Expected: PASS (全 3 ケース)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/internal/usecase/daily_pnl_test.go
+git commit -m "test(backend): cover partial/all failure and empty cases in DailyPnLCalculator"
+```
+
+---
+
+## Task 8: `rakuten.RESTClient` が interface を満たすことのコンパイル時検証
+
+**Files:**
+- Modify: `backend/internal/usecase/daily_pnl.go`
+
+- [ ] **Step 1: Add compile-time assertion**
+
+Add to the end of `backend/internal/usecase/daily_pnl.go` (before the `jstZone` declaration):
+
+```go
+// Compile-time check: *rakuten.RESTClient must implement rakutenClient.
+// 直接 import すると usecase → infrastructure 方向になり import サイクルを誘発する可能性があるため、
+// この assertion は main.go 側で行う (`var _ usecase.rakutenClient = (*rakuten.RESTClient)(nil)` も不可)。
+// 代わりに NewDailyPnLCalculator に interface 型で受け取ることで構造的にのみ担保する。
+// ここには noop の説明コメントのみを残す。
+```
+
+**Rationale:** `usecase` パッケージから `infrastructure/rakuten` を import すると既存のレイヤリングに反する。`rakutenClient` は構造的 interface なので、`main.go` で `NewDailyPnLCalculator(restClient, ...)` を書いた時点でコンパイラが自動的に型整合を検証する。そのため明示的な assertion コードは不要。
+
+- [ ] **Step 2: Verify still compiles**
+
+Run:
+```bash
+cd backend && go build ./internal/usecase/...
+```
+Expected: エラーなし。
+
+- [ ] **Step 3: (No commit)**
+
+このタスクはコードコメント追加のみで動作に変更なし。Task 9 のコミットに含める。
+
+---
+
+## Task 9: `api.Dependencies` に `DailyPnLCalculator` を追加
+
+**Files:**
+- Modify: `backend/internal/interfaces/api/router.go`
+
+- [ ] **Step 1: Add field to Dependencies struct**
+
+Edit `backend/internal/interfaces/api/router.go` (around line 22-36):
+
+```go
+type Dependencies struct {
+	RiskManager         *usecase.RiskManager
+	StanceResolver      *usecase.RuleBasedStanceResolver
+	IndicatorCalculator *usecase.IndicatorCalculator
+	MarketDataService   *usecase.MarketDataService
+	RealtimeHub         *usecase.RealtimeHub
+	OrderClient         repository.OrderClient
+	OrderExecutor       *usecase.OrderExecutor
+	Pipeline            PipelineController
+	RESTClient          *rakuten.RESTClient
+	ClientOrderRepo     repository.ClientOrderRepository
+	DailyPnLCalculator  *usecase.DailyPnLCalculator
+	// OnSymbolSwitch はシンボル切替時に pipeline から呼び出されるコールバック。
+	// main 側で WebSocket 購読切替とローソク足 bootstrap を実行する。
+	OnSymbolSwitch func(oldID, newID int64)
+}
+```
+
+- [ ] **Step 2: Pass it to NewRiskHandler**
+
+In the same file, find the `riskHandler := handler.NewRiskHandler(...)` line (around line 56) and change to:
+
+```go
+	riskHandler := handler.NewRiskHandler(deps.RiskManager, deps.RealtimeHub, deps.DailyPnLCalculator)
+```
+
+- [ ] **Step 3: Verify compile (expected to fail until Task 10)**
+
+Run:
+```bash
+cd backend && go build ./internal/interfaces/api/...
+```
+Expected: FAIL — `NewRiskHandler` の signature がまだ 3 引数を受け付けていない。次タスクで合わせる。
+
+- [ ] **Step 4: (No commit)**
+
+次タスクで一緒にコミットする。
+
+---
+
+## Task 10: `RiskHandler` に calculator を注入し `GetPnL` を拡張
+
+**Files:**
+- Modify: `backend/internal/interfaces/api/handler/risk.go`
+
+- [ ] **Step 1: Add field and constructor param**
+
+Edit `backend/internal/interfaces/api/handler/risk.go`:
+
+```go
+package handler
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase"
+)
+
+type RiskHandler struct {
+	riskMgr     *usecase.RiskManager
+	realtimeHub *usecase.RealtimeHub
+	pnlCalc     *usecase.DailyPnLCalculator
+}
+
+func NewRiskHandler(riskMgr *usecase.RiskManager, realtimeHub *usecase.RealtimeHub, pnlCalc *usecase.DailyPnLCalculator) *RiskHandler {
+	return &RiskHandler{riskMgr: riskMgr, realtimeHub: realtimeHub, pnlCalc: pnlCalc}
+}
+```
+
+Keep `GetConfig`, `UpdateConfig`, `validateRiskConfig` unchanged.
+
+- [ ] **Step 2: Extend GetPnL**
+
+Replace `GetPnL` in the same file:
+
+```go
+func (h *RiskHandler) GetPnL(c *gin.Context) {
+	status := h.riskMgr.GetStatus()
+
+	resp := gin.H{
+		"balance":       status.Balance,
+		"dailyLoss":     status.DailyLoss,
+		"totalPosition": status.TotalPosition,
+		"tradingHalted": status.TradingHalted,
+	}
+
+	if h.pnlCalc != nil {
+		ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
+		defer cancel()
+
+		pnl, err := h.pnlCalc.Compute(ctx)
+		if err != nil {
+			slog.Warn("daily pnl compute failed", "error", err)
+			// エラー時は dailyPnl ブロック自体を省略 (フロントは undefined として handle する)
+		} else {
+			resp["dailyPnl"] = pnl
+		}
+	}
+
+	c.JSON(http.StatusOK, resp)
+}
+```
+
+- [ ] **Step 3: Verify compile**
+
+Run:
+```bash
+cd backend && go build ./...
+```
+Expected: エラーなし (Task 9 の router.go と整合)。
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/internal/interfaces/api/router.go backend/internal/interfaces/api/handler/risk.go backend/internal/usecase/daily_pnl.go
+git commit -m "feat(backend): inject DailyPnLCalculator into RiskHandler and extend /api/v1/pnl"
+```
+
+---
+
+## Task 11: `api_test.go` を新 signature に合わせて修正 + `dailyPnl` 検証
+
+**Files:**
+- Modify: `backend/internal/interfaces/api/api_test.go`
+
+- [ ] **Step 1: Add fake rakutenClient for handler tests**
+
+既存の `mockOrderClient` はそのまま。ただし `DailyPnLCalculator` は nil を許容するようにしてあるので、**ハンドラテスト側では calculator を nil のまま渡しても既存テストはパスする**。ただし `TestGetPnL` で `dailyPnl` ブロックが存在しうることを検証したい。
+
+以下の方針で進める:
+1. `setupRouter` を nil calculator のままにし、既存テストの後方互換を確認
+2. `setupRouterWithPnl` を新規追加し、固定値を返す stub calculator を使う別テストを追加
+
+まず `setupRouter` は今まで通り (calculator 未設定) で動くことを確認するだけ。Dependencies の `DailyPnLCalculator` は zero value (`nil`) で OK。
+
+実際に編集が必要なのは `TestGetPnL` で**既存フィールドが維持されていること**の確認のみ。
+
+Append after `TestGetPnL`:
+
+```go
+func TestGetPnL_PreservesLegacyFields(t *testing.T) {
+	router := setupRouter()
+	w := doRequest(router, "GET", "/api/v1/pnl", nil)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var body map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("failed to decode: %v", err)
+	}
+
+	// 既存フィールドが引き続き返ること
+	for _, key := range []string{"balance", "dailyLoss", "totalPosition", "tradingHalted"} {
+		if _, ok := body[key]; !ok {
+			t.Errorf("expected field %q in response, got keys=%v", key, mapKeys(body))
+		}
+	}
+
+	// calculator は setupRouter では nil なので dailyPnl は省略されるはず
+	if _, ok := body["dailyPnl"]; ok {
+		t.Errorf("dailyPnl should be absent when calculator is nil, got %v", body["dailyPnl"])
+	}
+}
+
+func mapKeys(m map[string]interface{}) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}
+```
+
+- [ ] **Step 2: Run full api_test**
+
+Run:
+```bash
+cd backend && go test ./internal/interfaces/api/... -v
+```
+Expected: 全 PASS。特に `TestGetPnL` と `TestGetPnL_PreservesLegacyFields` が通る。
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/internal/interfaces/api/api_test.go
+git commit -m "test(backend): assert /api/v1/pnl preserves legacy fields"
+```
+
+---
+
+## Task 12: `main.go` で calculator を組み立てて注入
+
+**Files:**
+- Modify: `backend/cmd/main.go`
+
+- [ ] **Step 1: Find the deps assembly site**
+
+Run:
+```bash
+cd backend && grep -n "Dependencies{" cmd/main.go
+```
+Expected: `deps := api.Dependencies{` もしくは類似の行が見つかる。
+
+- [ ] **Step 2: Add DailyPnLCalculator construction and wire it**
+
+`backend/cmd/main.go` の `deps := api.Dependencies{...}` を組み立てている箇所の直前に以下を追加:
+
+```go
+	dailyPnLCalc := usecase.NewDailyPnLCalculator(restClient, 10*time.Second)
+```
+
+そして `deps` の初期化フィールドに追加:
+
+```go
+	DailyPnLCalculator: dailyPnLCalc,
+```
+
+(変数名 `restClient` は既存のもの。`time` パッケージは既に import 済みのはずだが、確認して必要なら追加する。)
+
+- [ ] **Step 3: Build**
+
+Run:
+```bash
+cd backend && go build ./...
+```
+Expected: エラーなし。
+
+- [ ] **Step 4: Run all backend tests**
+
+Run:
+```bash
+cd backend && go test ./...
+```
+Expected: 全 PASS。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/cmd/main.go
+git commit -m "feat(backend): wire DailyPnLCalculator in main"
+```
+
+---
+
+## Task 13: Frontend 型拡張
+
+**Files:**
+- Modify: `frontend/src/lib/api.ts`
+
+- [ ] **Step 1: Add type and extend PnlResponse**
+
+Edit `frontend/src/lib/api.ts`, after the `StatusResponse` type (around line 16), insert:
+
+```ts
+export type DailyPnLBreakdown = {
+  realized: number
+  unrealized: number
+  total: number
+  stale: boolean
+  computedAt: number
+}
+```
+
+And change `PnlResponse`:
+
+```ts
+export type PnlResponse = {
+  balance: number
+  dailyLoss: number
+  totalPosition: number
+  tradingHalted: boolean
+  dailyPnl?: DailyPnLBreakdown
+}
+```
+
+(`dailyPnl?` を optional にするのはバックエンドが失敗時省略するため。)
+
+- [ ] **Step 2: Type check**
+
+Run:
+```bash
+cd frontend && pnpm tsc --noEmit
+```
+Expected: エラーなし。
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/lib/api.ts
+git commit -m "feat(frontend): extend PnlResponse with dailyPnl breakdown"
+```
+
+---
+
+## Task 14: ダッシュボードの表示ロジック差し替え
+
+**Files:**
+- Modify: `frontend/src/routes/index.tsx`
+
+- [ ] **Step 1: Replace daily pnl derivation**
+
+Edit `frontend/src/routes/index.tsx` (around line 40-46):
+
+```tsx
+  const dailyPnlTotal = pnl?.dailyPnl?.total ?? null
+  const dailyPnlStale = pnl?.dailyPnl?.stale ?? false
+  const dailyPnlLabel =
+    dailyPnlTotal === null
+      ? '\u2014'
+      : `${dailyPnlTotal < 0 ? '-' : ''}¥${Math.abs(dailyPnlTotal).toLocaleString()}${dailyPnlStale ? '*' : ''}`
+```
+
+And update the `KpiCard` for 日次損益 (around line 65-69):
+
+```tsx
+        <KpiCard
+          label="日次損益"
+          value={dailyPnlLabel}
+          color={dailyPnlTotal !== null && dailyPnlTotal < 0 ? 'text-accent-red' : 'text-accent-green'}
+        />
+```
+
+- [ ] **Step 2: Type check**
+
+Run:
+```bash
+cd frontend && pnpm tsc --noEmit
+```
+Expected: エラーなし。
+
+- [ ] **Step 3: Run frontend tests (if any exist)**
+
+Run:
+```bash
+cd frontend && pnpm test
+```
+Expected: 既存テストが通る (もしテストが無い場合は "no tests found" でも可)。
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/routes/index.tsx
+git commit -m "feat(frontend): show dailyPnl.total (realized+unrealized) in dashboard"
+```
+
+---
+
+## Task 15: 手動 E2E 検証 (楽天本番の実残高で動作確認)
+
+**Files:** なし (検証のみ)
+
+- [ ] **Step 1: Start or verify the stack is running**
+
+Run:
+```bash
+docker ps --format '{{.Names}}\t{{.Ports}}' | grep rakuten-api-leverage-exchange
+```
+Expected: `rakuten-api-leverage-exchange-backend-1` と `...-frontend-1` が UP。  
+なければ `docker compose up -d` で起動。
+
+- [ ] **Step 2: Hit /api/v1/pnl and check dailyPnl shape**
+
+Run:
+```bash
+curl -s http://localhost:38080/api/v1/pnl | python3 -m json.tool
+```
+Expected: `dailyPnl` ブロックに `realized`, `unrealized`, `total`, `stale`, `computedAt` が含まれる。
+
+- [ ] **Step 3: Cross-check with /trades**
+
+Run:
+```bash
+curl -s 'http://localhost:38080/api/v1/trades/all' | python3 -m json.tool | head -80
+```
+Expected: 今日 JST 分の `closeTradeProfit` 合算が `/pnl` の `dailyPnl.realized` と一致する。
+
+- [ ] **Step 4: Verify frontend shows it**
+
+Playwright MCP で `http://localhost:33000/?symbol=LTC_JPY` を開いて「日次損益」カードを確認:
+
+```
+mcp__playwright-noext__browser_navigate → http://localhost:33000/?symbol=LTC_JPY
+mcp__playwright-noext__browser_snapshot
+```
+
+Expected: 日次損益カードが `¥0` ではなく実際の値 (例: `-¥6`) を赤文字で表示している。
+
+- [ ] **Step 5: Verify cache behavior**
+
+Run:
+```bash
+for i in 1 2 3 4 5; do curl -s http://localhost:38080/api/v1/pnl | python3 -c "import sys,json; d=json.load(sys.stdin); p=d.get('dailyPnl',{}); print(p.get('computedAt'), p.get('total'))"; sleep 2; done
+```
+Expected: 10 秒以内の呼び出しでは `computedAt` が変化しない (同一エポック秒)。10 秒以上経つと更新される。
+
+- [ ] **Step 6: (No commit) Report results**
+
+検証結果を会話に報告して完了。
+
+---
+
+## Self-Review
+
+Spec section → task mapping:
+- `DailyPnLCalculator` 構造と interface → Task 2 ✓
+- 実現 + 未実現集計 → Task 3 ✓
+- JST 境界 → Task 3 (実装) + Task 4 (テスト) ✓
+- エラー処理 (部分失敗 stale / 全失敗エラー) → Task 3 (実装) + Task 7 (テスト) ✓
+- キャッシュ 10 秒 TTL + singleflight → Task 3 (実装) + Task 5/6 (テスト) ✓
+- API スキーマ拡張 (`dailyPnl` ブロック) → Task 10 ✓
+- 後方互換 (`dailyLoss` 等維持) → Task 10 + Task 11 (テスト) ✓
+- Frontend 型 → Task 13 ✓
+- Frontend 表示差し替え → Task 14 ✓
+- 手動 E2E 検証 → Task 15 ✓
+- `golang.org/x/sync` direct 化 → Task 1 ✓
+
+No placeholders. Types consistent between tasks (`DailyPnL`, `rakutenClient`, `pnlCalc`).

--- a/docs/superpowers/specs/2026-04-11-daily-pnl-dashboard-design.md
+++ b/docs/superpowers/specs/2026-04-11-daily-pnl-dashboard-design.md
@@ -1,0 +1,228 @@
+# Daily PnL Dashboard — Design Spec
+
+- **Date**: 2026-04-11
+- **Status**: Draft (awaiting implementation plan)
+- **Owner**: yui666a
+
+## Problem
+
+ダッシュボードの「日次損益」カードが実態と噛み合っていない。
+
+- 現状: `GET /api/v1/pnl` が `RiskManager.dailyLoss` を返し、フロントはそれを反転して表示している (`frontend/src/routes/index.tsx:40`)。
+- `RiskManager.dailyLoss` は `MaxDailyLoss` 超過で Bot を止めるためのリスク制限用カウンタであり、**ストップロス発動時だけ**更新される (`backend/cmd/pipeline.go:379`)。
+- 結果として、手動クローズ (`POST /api/v1/positions/:id/close`) や別セッションによる約定は一切反映されず、本日 -¥6 の確定損があっても画面は `¥0` のまま表示される。
+- `dailyLoss` は片方向 (損失のみ) のカウンタでもあり、利益は意味的にも集計できない。
+
+「日次損益」を実態どおり **全通貨ペア合算の実現損益 (JST 当日分) + 未実現損益 (全保有ポジションの含み損益)** として計算し、画面に表示する。
+
+## Non-Goals
+
+- `RiskManager.dailyLoss` の廃止・削除 (リスク停止判定や設定 API と連動しているため互換性のため残す)。
+- 銘柄ごとの日次損益ブレークダウン表示。
+- ローカル `tradeHistoryRepo` と楽天 API の merge (楽天を唯一のソースとする)。
+- WebSocket push 更新 (既存の 10 秒 polling で十分)。
+- 履歴的な損益グラフや過去日比較。
+
+## Architecture
+
+新しいユースケース `usecase.DailyPnLCalculator` を追加し、既存 `RiskHandler.GetPnL` から呼び出してレスポンスに埋め込む。`RiskManager` には一切手を入れない (責務分離)。
+
+```
+GET /api/v1/pnl
+    ↓
+RiskHandler.GetPnL  (既存、拡張)
+    ├── riskMgr.GetStatus() → balance, dailyLoss, totalPosition, tradingHalted
+    └── dailyPnLCalc.Compute(ctx) → DailyPnL{realized, unrealized, total, stale, computedAt}
+    ↓
+JSON マージして返却
+```
+
+### `DailyPnLCalculator`
+
+場所: `backend/internal/usecase/daily_pnl.go`
+
+```go
+type DailyPnL struct {
+    Realized   float64 `json:"realized"`
+    Unrealized float64 `json:"unrealized"`
+    Total      float64 `json:"total"`
+    Stale      bool    `json:"stale"`
+    ComputedAt int64   `json:"computedAt"` // unix seconds
+}
+
+type Clock interface { Now() time.Time }
+
+type DailyPnLCalculator struct {
+    rest  rakutenClient   // interface for testability
+    clock Clock
+    cache atomic.Pointer[cachedPnL]
+    group singleflight.Group
+    ttl   time.Duration   // 10s
+}
+
+type rakutenClient interface {
+    GetSymbols(ctx context.Context) ([]entity.Symbol, error)
+    GetMyTrades(ctx context.Context, symbolID int64) ([]entity.MyTrade, error)
+    GetPositions(ctx context.Context, symbolID int64) ([]entity.Position, error)
+}
+
+func (c *DailyPnLCalculator) Compute(ctx context.Context) (DailyPnL, error)
+```
+
+### フロー
+
+1. キャッシュ確認: `age < ttl` ならそのまま返す。
+2. `singleflight.Do("pnl", ...)` で同時多発リクエストを 1 つに収束。
+3. `GetSymbols` で有効銘柄を取得。
+4. 各銘柄に対して `GetMyTrades` と `GetPositions` を**並列**で叩く (`errgroup` もしくは `sync.WaitGroup`)。
+5. `MyTrade.CreatedAt >= todayStartJST.UnixMilli()` のものだけ残し、`closeTradeProfit` を合算 → `realized`。
+6. 全銘柄の `Position.FloatingProfit` を合算 → `unrealized`。
+7. `total = realized + unrealized`
+8. キャッシュに書き込んで返却。
+
+### JST 境界
+
+```go
+jst := time.FixedZone("JST", 9*60*60)
+now := c.clock.Now().In(jst)
+todayStart := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, jst)
+cutoffMillis := todayStart.UnixMilli()
+```
+
+`backend/cmd/pipeline.go:500` の `restoreRiskState` と同じ JST 固定ゾーンを使うことで境界定義を一貫させる。
+
+### エラー処理
+
+- 個別銘柄の失敗 → その銘柄ぶんは 0 として扱い、`slog.Warn` でログを残し、レスポンスの `stale` を `true` にする。
+- **全銘柄失敗** → `Compute` がエラーを返す。ハンドラは 500 を返す。
+- キャッシュが生きている間に背面更新でエラーになった場合 → 古い値を `stale: true` で返す。
+
+### キャッシュ戦略
+
+- TTL: **10 秒** (フロントの `usePnl.refetchInterval` と同じ `10_000ms`、`frontend/src/hooks/usePnl.ts:8`)
+- `singleflight.Group` で同時リクエストを 1 コールに収束。
+- 1 リクエスト当たりの楽天 API コール: キャッシュミス時 `1 (GetSymbols) + N (GetMyTrades) + N (GetPositions)`、現在有効な 9 銘柄で **19 コール**。キャッシュヒット時は **0 コール**。
+- `GetSymbols` の個別長期キャッシュは YAGNI で見送り。問題が出たら個別に伸ばす。
+
+## API スキーマ (後方互換)
+
+### Before
+
+```json
+{
+  "balance": 9998,
+  "dailyLoss": 0,
+  "totalPosition": 0,
+  "tradingHalted": false
+}
+```
+
+### After
+
+```json
+{
+  "balance": 9998,
+  "dailyLoss": 0,
+  "totalPosition": 0,
+  "tradingHalted": false,
+  "dailyPnl": {
+    "realized": -6,
+    "unrealized": 0,
+    "total": -6,
+    "stale": false,
+    "computedAt": 1775916700
+  }
+}
+```
+
+- 既存フィールドは**削除しない**。`dailyLoss` は `RiskManager` のリスク制限用カウンタとして引き続き意味を持つ (Bot 停止判定に使用)。
+- フロントは `dailyLoss` 参照をやめ、`dailyPnl.total` のみを表示に使う。
+
+## Frontend 変更
+
+### `frontend/src/lib/api.ts`
+
+`PnlResponse` 型に `dailyPnl` を追加:
+
+```ts
+export type DailyPnLBreakdown = {
+  realized: number
+  unrealized: number
+  total: number
+  stale: boolean
+  computedAt: number
+}
+
+export type PnlResponse = {
+  balance: number
+  dailyLoss: number
+  totalPosition: number
+  tradingHalted: boolean
+  dailyPnl: DailyPnLBreakdown
+}
+```
+
+### `frontend/src/routes/index.tsx`
+
+```tsx
+// before
+const dailyPnl = pnl ? -pnl.dailyLoss : null
+const dailyPnlLabel =
+  dailyPnl === null
+    ? '—'
+    : dailyPnl === 0
+      ? '¥0'
+      : `¥${dailyPnl.toLocaleString()}`
+
+// after
+const dailyPnlTotal = pnl?.dailyPnl?.total ?? null
+const dailyPnlStale = pnl?.dailyPnl?.stale ?? false
+const dailyPnlLabel =
+  dailyPnlTotal === null
+    ? '—'
+    : `${dailyPnlTotal >= 0 ? '' : '-'}¥${Math.abs(dailyPnlTotal).toLocaleString()}${dailyPnlStale ? '*' : ''}`
+```
+
+色分け: `dailyPnlTotal < 0` → `text-accent-red`、それ以外 → `text-accent-green`。
+`*` (stale マーカー) は `title` 属性でホバー説明を入れる。
+
+## Test Plan
+
+### Backend (`usecase/daily_pnl_test.go`)
+
+Fake `rakutenClient` と fake `Clock` を注入してテストする。
+
+1. **正常系**: 今日の trades と positions から `realized + unrealized` を正しく計算する (複数銘柄含む)。
+2. **JST 境界**: 昨日 23:59:59.999 JST の trade は除外、今日 00:00:00.000 JST の trade は含む (`createdAt` ミリ秒)。
+3. **キャッシュ**: 10 秒以内の再呼び出しで楽天 API コール数が増えないこと (fake クライアントのコールカウントで検証)。
+4. **TTL 経過**: `clock.Now()` を TTL 超過に進めて再呼び出しすると新しくフェッチが走ること。
+5. **singleflight**: goroutine 100 本から同時に `Compute` しても楽天 API 呼び出しは 1 セット分で済むこと。
+6. **個別銘柄失敗**: 1 銘柄の `GetPositions` がエラーを返したケースで、残りの銘柄から集計した結果と `stale: true` が返ること。
+7. **全銘柄失敗**: 全銘柄でエラー → `Compute` がエラーを返すこと。
+8. **空**: trades も positions も空 → `total: 0, stale: false`。
+
+### Backend (`interfaces/api/api_test.go` への追記)
+
+9. `GET /api/v1/pnl` のレスポンス JSON に `dailyPnl` ブロックが含まれ、既存フィールド (`balance`, `dailyLoss`, `totalPosition`, `tradingHalted`) がそのまま返ること (後方互換性)。
+
+### Frontend
+
+既存の index route テストがある場合は `dailyPnl.total` を `pnl` に差し込んだモックで、表示文字列と色クラスが期待通りになることを検証する。既存テストが無い場合はスコープ外とする (既存状況に合わせる)。
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| 19 コール/リクエストで楽天 API のレート制限に当たる | 10 秒 TTL + singleflight で実質負荷を抑える。タブ複数開きでも 10 秒 1 セット |
+| `GetMyTrades` のページング未考慮 | 楽天 API は最近のトレードから返るため、「今日分」に対しては 1 ページで足りる。ただし実装時に既存 `tradeHandler.GetAllTrades` の実装を参照し、ページング仕様を確認する (実装プラン側で担保) |
+| 銘柄リストが変化した瞬間に古い銘柄の取引が取りこぼされる | `GetSymbols` を都度 (= 10 秒毎) 取得するので最長 10 秒で追随 |
+| `MyTrade.Profit` vs `MyTrade.CloseTradeProfit` の誤選択 | 「決済で発生した確定損益」は `CloseTradeProfit`。新規建ては `0` で入るため合算して問題なし (`entity/trade.go:30`) |
+| キャッシュ下で手動クローズ直後に画面が古いまま見える | TTL 10 秒の範囲内では仕様。急ぎなら TTL を短くするか無効化オプションを検討 (将来 issue) |
+
+## Out of Scope / Future Work
+
+- 銘柄別の損益ブレークダウン UI
+- 今週/今月の PnL 集計
+- `dailyLoss` (リスク制限用) の命名変更または削除
+- ローカル trade 履歴との照合
+- キャッシュ戦略の細分化 (`GetSymbols` だけ長期キャッシュ等)

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -15,11 +15,20 @@ export type StatusResponse = {
   totalPosition: number
 }
 
+export type DailyPnLBreakdown = {
+  realized: number
+  unrealized: number
+  total: number
+  stale: boolean
+  computedAt: number
+}
+
 export type PnlResponse = {
   balance: number
   dailyLoss: number
   totalPosition: number
   tradingHalted: boolean
+  dailyPnl?: DailyPnLBreakdown
 }
 
 export type StrategyResponse = {

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -37,13 +37,12 @@ function Dashboard() {
         ? '稼働中'
         : '\u2014'
 
-  const dailyPnl = pnl ? -pnl.dailyLoss : null
+  const dailyPnlTotal = pnl?.dailyPnl?.total ?? null
+  const dailyPnlStale = pnl?.dailyPnl?.stale ?? false
   const dailyPnlLabel =
-    dailyPnl === null
+    dailyPnlTotal === null
       ? '\u2014'
-      : dailyPnl === 0
-        ? '¥0'
-        : `¥${dailyPnl.toLocaleString()}`
+      : `${dailyPnlTotal < 0 ? '-' : ''}¥${Math.abs(dailyPnlTotal).toLocaleString()}${dailyPnlStale ? '*' : ''}`
 
   const reasoningLabel = strategy?.reasoning
     ? strategy.reasoning === 'insufficient indicator data'
@@ -65,7 +64,7 @@ function Dashboard() {
         <KpiCard
           label="日次損益"
           value={dailyPnlLabel}
-          color={pnl && pnl.dailyLoss > 0 ? 'text-accent-red' : 'text-accent-green'}
+          color={dailyPnlTotal !== null && dailyPnlTotal < 0 ? 'text-accent-red' : 'text-accent-green'}
         />
         <KpiCard
           label="戦略方針"


### PR DESCRIPTION
## Summary

- ダッシュボードの「日次損益」が手動クローズ等を無視して常に ¥0 を表示する問題を修正
- 新規 `DailyPnLCalculator` ユースケースで JST 当日分の**実現損益 (決済確定分)** と**未実現損益 (全保有ポジションの floatingProfit)** を全通貨ペア合算して返す
- 既存の `RiskManager.dailyLoss` はリスク制限用カウンタとして据え置き。`/api/v1/pnl` に `dailyPnl` ブロックを追加する後方互換な拡張

## Root cause

`RiskManager.dailyLoss` は `MaxDailyLoss` 超過で Bot を止めるためのリスク制限用カウンタで、`pipeline.go:379` の**ストップロス発動時にのみ** `RecordLoss` で積まれる。手動クローズ (`POST /api/v1/positions/:id/close`) やボット経由外の約定は `dailyLoss` に反映されないため、画面は ¥0 のまま。

## Design

[docs/superpowers/specs/2026-04-11-daily-pnl-dashboard-design.md](docs/superpowers/specs/2026-04-11-daily-pnl-dashboard-design.md)
[docs/superpowers/plans/2026-04-12-daily-pnl-dashboard.md](docs/superpowers/plans/2026-04-12-daily-pnl-dashboard.md)

**DailyPnLCalculator** (`backend/internal/usecase/daily_pnl.go`):
- `GetSymbols` + `GetMyTrades` + `GetPositions` を全銘柄並列で取得
- JST 0:00 cutoff で `MyTrade.CloseTradeProfit` を合算 → `realized`
- 全 `Position.FloatingProfit` を合算 → `unrealized`
- **10 秒 TTL のキャッシュ** + `singleflight` で負荷を抑制 (フロントの `refetchInterval: 10_000` と整合)
- 個別銘柄失敗は `stale: true` で degrade、全失敗のみエラー

**API スキーマ (後方互換)**:
\`\`\`json
{
  "balance": 9998,
  "dailyLoss": 0,           // 従来フィールドは維持 (リスク停止判定用)
  "totalPosition": 0,
  "tradingHalted": false,
  "dailyPnl": {             // 新規追加
    "realized": -6,
    "unrealized": 0,
    "total": -6,
    "stale": false,
    "computedAt": 1775922260
  }
}
\`\`\`

**Frontend** (`frontend/src/routes/index.tsx`):
- `pnl.dailyLoss` 参照をやめ `pnl.dailyPnl.total` を表示
- `stale: true` の時は末尾に `*` を付けて degrade 中を示す

## Test plan

- [x] `go test ./internal/usecase/...` 全 PASS (正常系、JST 境界、キャッシュ、TTL、singleflight 100 並列、部分失敗 stale、全失敗エラー、空)
- [x] `go test -race ./internal/usecase/...` レース検出ゼロ
- [x] `go test ./internal/interfaces/api/...` 後方互換アサーション PASS (`TestGetPnL_PreservesLegacyFields`)
- [x] `go test ./...` 全パッケージ PASS
- [x] `pnpm tsc --noEmit` エラーなし
- [x] E2E: `/api/v1/pnl` が `dailyPnl` を返すことを curl で確認
- [x] E2E: `/trades/all` の JST 当日分 `closeTradeProfit` 合算と `dailyPnl.realized` が一致することを確認
- [x] E2E: 12 秒連続 curl で `computedAt` が 10 秒毎に遷移することを確認 (キャッシュ TTL)
- [ ] **手動要確認**: ブラウザで http://localhost:33000/?symbol=LTC_JPY を開き、「日次損益」カードの表示が `¥0` ではなく実値になること (今日取引がある場合)

## Out of scope

- `dailyLoss` フィールドの削除・非推奨化 (Bot 停止判定と連動しているため据え置き)
- 銘柄別損益ブレークダウン UI
- ローカル tradeHistoryRepo とのマージ (楽天 API を唯一のソースとする)
- WebSocket push (既存の 10 秒 polling で十分)

🤖 Generated with [Claude Code](https://claude.com/claude-code)