### PR TITLE
fix(backend): 20010 を踏んで残高が 10000 のまま固まる問題を修正

### DIFF
--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -160,6 +160,10 @@ func main() {
 
 	go startMarketRelay(ctx, wsClient, marketDataSvc, realtimeHub, symbolID, symbolSwitchCh)
 	go startDailyLossReset(ctx, riskMgr)
+	// 残高・ポジションの定期同期は auto-trading の start/stop とは独立して常時回す。
+	// これにより自動売買停止中でも画面の残高が楽天の実残高に追随し、起動直後に 20010
+	// で失敗したケースも 15 秒ごとに再試行される。
+	go pipeline.runStateSyncLoop(ctx)
 
 	slog.Info("Trading pipeline ready",
 		"tradeAmount", cfg.Trading.TradeAmount,

--- a/backend/cmd/pipeline.go
+++ b/backend/cmd/pipeline.go
@@ -59,6 +59,10 @@ type TradingPipeline struct {
 	riskMgr          *usecase.RiskManager
 	tradeHistoryRepo repository.TradeHistoryRepository
 	riskStateRepo    repository.RiskStateRepository
+
+	// sleepFn は syncState のリトライバックオフで使う sleep 関数。
+	// テストで実時間を消費しないよう差し替え可能にしている。nil なら time.Sleep を使う。
+	sleepFn func(time.Duration)
 }
 
 // tradingSnapshot は evaluate / stopLoss ループで使う、ロック下にコピーしたフィールド束。
@@ -134,7 +138,9 @@ func (p *TradingPipeline) startLocked() {
 
 	go p.runTradingLoop(ctx)
 	go p.runStopLossMonitor(ctx)
-	go p.runStateSyncLoop(ctx)
+	// NOTE: runStateSyncLoop は main.go から main ctx で常時起動するため、
+	// Start()/Stop() には含めない。これにより「停止中は残高が更新されない」
+	// という silent failure を防ぐ。
 
 	slog.Info("trading pipeline started")
 }
@@ -452,18 +458,36 @@ func (p *TradingPipeline) runStateSyncLoop(ctx context.Context) {
 }
 
 // syncState は楽天APIから現在のポジション・残高を取得し、RiskManagerに反映する。
+// 楽天 Private API のレートリミット (20010) に当たった場合のみ、retryOn20010 によって
+// 最大 3 回まで再試行する。他のエラーはリトライせずに warn を吐いて抜ける。
 func (p *TradingPipeline) syncState(ctx context.Context) {
+	sleep := p.sleepFn
+	if sleep == nil {
+		sleep = time.Sleep
+	}
+
 	snap := p.snapshot()
-	positions, err := p.restClient.GetPositions(ctx, snap.symbolID)
-	if err != nil {
-		slog.Warn("pipeline: failed to sync positions", "error", err)
+
+	var positions []entity.Position
+	posErr := retryOn20010(ctx, sleep, func() error {
+		var err error
+		positions, err = p.restClient.GetPositions(ctx, snap.symbolID)
+		return err
+	})
+	if posErr != nil {
+		slog.Warn("pipeline: failed to sync positions", "error", posErr)
 	} else {
 		p.riskMgr.UpdatePositions(positions)
 	}
 
-	assets, err := p.restClient.GetAssets(ctx)
-	if err != nil {
-		slog.Warn("pipeline: failed to sync assets", "error", err)
+	var assets []entity.Asset
+	assetErr := retryOn20010(ctx, sleep, func() error {
+		var err error
+		assets, err = p.restClient.GetAssets(ctx)
+		return err
+	})
+	if assetErr != nil {
+		slog.Warn("pipeline: failed to sync assets", "error", assetErr)
 	} else {
 		for _, a := range assets {
 			if a.Currency == "JPY" {

--- a/backend/cmd/retry.go
+++ b/backend/cmd/retry.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"time"
+)
+
+// retryBackoffs は retryOn20010 が各リトライの前に挟む待ち時間。
+// 長さ = 最大リトライ回数。初回の失敗からこの長さ分までリトライする。
+//
+// 300ms スタートにしている理由:
+//   - 楽天 Private API のレートリミットは 1 req / 200ms。rest_client 側は 220ms
+//     マージンで発射しているが、サーバー側の受信時刻のジッタで 20010 を稀に踏む。
+//   - クライアント発射の 220ms 刻みに対して 300ms 以上空ければ、受信ジッタを
+//     吸収できる余地ができる。
+//   - 二重の安全マージンとして指数的に伸ばす (300→600→1200)。
+var retryBackoffs = []time.Duration{
+	300 * time.Millisecond,
+	600 * time.Millisecond,
+	1200 * time.Millisecond,
+}
+
+// isRateLimitError は楽天 API の 20010 (AUTHENTICATION_ERROR_TOO_MANY_REQUESTS) を
+// 判定する。楽天の DoRaw はエラー本文をそのまま文字列化して error に載せるので、
+// `"code":20010` が含まれていれば 20010 とみなせる。
+//
+// 将来 楽天側が整形を変えてきたら複数パターンへのマッチに広げる余地あり。
+func isRateLimitError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), `"code":20010`)
+}
+
+// retryOn20010 は fn を実行し、20010 エラーのときだけ最大 len(retryBackoffs) 回
+// リトライする。20010 以外のエラー・成功時は即座に結果を返す。
+//
+// sleep は time.Sleep をそのまま使うことを想定しているが、テストで時間を
+// 消費させないため引数で注入できるようにしている。
+//
+// ctx が死んでいたらリトライ前に中断し、最後のエラー (もしくは ctx.Err) を返す。
+func retryOn20010(ctx context.Context, sleep func(time.Duration), fn func() error) error {
+	var err error
+	for attempt := 0; attempt <= len(retryBackoffs); attempt++ {
+		err = fn()
+		if err == nil {
+			return nil
+		}
+		if !isRateLimitError(err) {
+			return err
+		}
+		if attempt == len(retryBackoffs) {
+			// 最後の試行が 20010 だった。これ以上リトライしない。
+			return err
+		}
+		if ctx.Err() != nil {
+			return err
+		}
+		delay := retryBackoffs[attempt]
+		slog.Warn("pipeline: rakuten rate limit (20010), retrying",
+			"attempt", attempt+1,
+			"next_delay_ms", delay.Milliseconds())
+		sleep(delay)
+	}
+	return err
+}

--- a/backend/cmd/retry_test.go
+++ b/backend/cmd/retry_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+)
+
+// noopSleep はテスト用に time.Sleep を置き換える no-op 関数。
+// retryOn20010 は本来バックオフ待ちに time.After を使うが、テスト時は
+// 呼び出し経路を記録するだけに差し替えたいのでスリープ関数を DI する。
+func noopSleep(d time.Duration) {}
+
+// err20010 は楽天 API の 20010 エラーレスポンスと同じ文字列を含むエラーを返す。
+// 本物は rest_client.go の do() が fmt.Errorf("API error (status 500): %s", body) を
+// さらに GetAssets 側が "GetAssets: %w" でラップした形になる。
+func err20010(label string) error {
+	return fmt.Errorf("%s: API error (status 500): {\"code\":20010}", label)
+}
+
+func TestRetryOn20010_NonRateLimitErrorDoesNotRetry(t *testing.T) {
+	calls := 0
+	err := retryOn20010(context.Background(), noopSleep, func() error {
+		calls++
+		return errors.New("some other error")
+	})
+	if err == nil || err.Error() != "some other error" {
+		t.Fatalf("expected original error to propagate, got %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected fn to be called exactly once for non-20010 error, got %d", calls)
+	}
+}
+
+func TestRetryOn20010_SuccessAfterTwoRateLimitErrors(t *testing.T) {
+	calls := 0
+	err := retryOn20010(context.Background(), noopSleep, func() error {
+		calls++
+		if calls < 3 {
+			return err20010("GetAssets")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("expected success after retries, got %v", err)
+	}
+	if calls != 3 {
+		t.Fatalf("expected fn to be called 3 times, got %d", calls)
+	}
+}
+
+func TestRetryOn20010_ExhaustsRetriesAndReturnsLastError(t *testing.T) {
+	calls := 0
+	err := retryOn20010(context.Background(), noopSleep, func() error {
+		calls++
+		return err20010("GetAssets")
+	})
+	if err == nil {
+		t.Fatalf("expected error after exhausting retries, got nil")
+	}
+	if calls != 4 {
+		t.Fatalf("expected fn to be called 4 times (1 initial + 3 retries), got %d", calls)
+	}
+}
+
+func TestRetryOn20010_ContextCancelStopsRetries(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // 事前にキャンセル済み
+
+	calls := 0
+	err := retryOn20010(ctx, noopSleep, func() error {
+		calls++
+		return err20010("GetAssets")
+	})
+	if err == nil {
+		t.Fatalf("expected non-nil error when ctx is already cancelled")
+	}
+	if calls < 1 {
+		t.Fatalf("expected fn to be called at least once before ctx check, got %d", calls)
+	}
+	// ctx が既に死んでいれば 1 回で抜けるはず（backoff 待ちで ctx.Done() を見る設計）
+	if calls > 1 {
+		t.Fatalf("expected no retries after ctx cancel, got %d calls", calls)
+	}
+}

--- a/backend/cmd/sync_state_test.go
+++ b/backend/cmd/sync_state_test.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/repository"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase"
+)
+
+// fakeRakutenClient は repository.OrderClient の最小実装。
+// GetAssets / GetPositions のみ本テストで使う。他メソッドは呼ばれないので nil で返す。
+type fakeRakutenClient struct {
+	positions []entity.Position
+
+	// getAssetsSequence は GetAssets の戻り値列。呼ばれるたびに 1 要素ずつ進む。
+	// シーケンスが尽きたら最後の要素を返す。
+	getAssetsSequence []getAssetsResult
+	getAssetsCalls    atomic.Int64
+}
+
+type getAssetsResult struct {
+	assets []entity.Asset
+	err    error
+}
+
+func (f *fakeRakutenClient) GetAssets(ctx context.Context) ([]entity.Asset, error) {
+	idx := f.getAssetsCalls.Add(1) - 1
+	if int(idx) >= len(f.getAssetsSequence) {
+		idx = int64(len(f.getAssetsSequence) - 1)
+	}
+	r := f.getAssetsSequence[idx]
+	return r.assets, r.err
+}
+
+func (f *fakeRakutenClient) GetPositions(ctx context.Context, symbolID int64) ([]entity.Position, error) {
+	return f.positions, nil
+}
+
+func (f *fakeRakutenClient) CreateOrder(ctx context.Context, req entity.OrderRequest) ([]entity.Order, error) {
+	return nil, nil
+}
+func (f *fakeRakutenClient) CreateOrderRaw(ctx context.Context, req entity.OrderRequest) (repository.CreateOrderOutcome, error) {
+	return repository.CreateOrderOutcome{}, nil
+}
+func (f *fakeRakutenClient) CancelOrder(ctx context.Context, symbolID, orderID int64) ([]entity.Order, error) {
+	return nil, nil
+}
+func (f *fakeRakutenClient) GetOrders(ctx context.Context, symbolID int64) ([]entity.Order, error) {
+	return nil, nil
+}
+func (f *fakeRakutenClient) GetMyTrades(ctx context.Context, symbolID int64) ([]entity.MyTrade, error) {
+	return nil, nil
+}
+
+// TestSyncState_RetriesOn20010 は syncState が GetAssets の 20010 エラーを
+// 最大 3 回までリトライし、最終的に成功したらその残高を riskMgr に反映することを検証する。
+func TestSyncState_RetriesOn20010(t *testing.T) {
+	err20010 := fmt.Errorf("GetAssets: API error (status 500): {\"code\":20010}")
+
+	fake := &fakeRakutenClient{
+		getAssetsSequence: []getAssetsResult{
+			{err: err20010},
+			{assets: []entity.Asset{{Currency: "JPY", OnhandAmount: "9995"}}},
+		},
+	}
+
+	riskMgr := usecase.NewRiskManager(entity.RiskConfig{InitialCapital: 10000})
+	p := &TradingPipeline{
+		symbolID:    7,
+		restClient:  fake,
+		riskMgr:     riskMgr,
+		sleepFn:     func(d time.Duration) {}, // no-op sleep: テストで実時間を消費しない
+	}
+
+	p.syncState(context.Background())
+
+	balance := riskMgr.GetStatus().Balance
+	if balance != 9995 {
+		t.Fatalf("expected balance to be updated to 9995 after 20010 retry, got %.2f", balance)
+	}
+	if fake.getAssetsCalls.Load() != 2 {
+		t.Fatalf("expected GetAssets to be called 2 times (1 failure + 1 success), got %d", fake.getAssetsCalls.Load())
+	}
+}
+
+// TestSyncState_NoRetryOnNon20010Error は 20010 以外のエラーではリトライしないことを
+// 検証する。残高は初期値のままで、GetAssets 呼び出しは 1 回のみ。
+func TestSyncState_NoRetryOnNon20010Error(t *testing.T) {
+	otherErr := fmt.Errorf("GetAssets: API error (status 500): {\"code\":99999}")
+
+	fake := &fakeRakutenClient{
+		getAssetsSequence: []getAssetsResult{
+			{err: otherErr},
+		},
+	}
+
+	riskMgr := usecase.NewRiskManager(entity.RiskConfig{InitialCapital: 10000})
+	p := &TradingPipeline{
+		symbolID:   7,
+		restClient: fake,
+		riskMgr:    riskMgr,
+		sleepFn:    func(d time.Duration) {},
+	}
+
+	p.syncState(context.Background())
+
+	if fake.getAssetsCalls.Load() != 1 {
+		t.Fatalf("expected GetAssets to be called once for non-20010 error, got %d", fake.getAssetsCalls.Load())
+	}
+	if balance := riskMgr.GetStatus().Balance; balance != 10000 {
+		t.Fatalf("expected balance to remain at initial 10000 on non-retryable error, got %.2f", balance)
+	}
+}


### PR DESCRIPTION
## Summary

- 起動直後の残高同期が楽天 Private API のレートリミット (`code 20010`) で失敗すると、`/api/v1/pnl` と `/api/v1/status` が `RISK_INITIAL_CAPITAL=10000` をそのまま `balance` として返し続けていた問題を修正する。
- `syncState` の `GetPositions` / `GetAssets` を **20010 のみ** 最大 3 回リトライ (backoff 300ms → 600ms → 1200ms)。
- `runStateSyncLoop` を `pipeline.Start()` から外し、**main ctx で常時起動** に切り替え。自動売買の on/off と独立させる。

## 背景: なぜ 10000 が表示されていたのか

Playwright で確認したところ `balance: 10000` がダッシュボードに出ていた (ユーザーの楽天口座実残高は ~9995 円)。原因を掘ると 2 つの問題が重なっていた:

1. **起動時の残高同期が 1 発勝負だった**
   `syncState` が `GetAssets` のエラーを warn だけ吐いて握りつぶしていた。楽天の 200ms レートリミットは受信時刻のジッタで稀に 20010 を返すため、初回同期で `GetPositions` → `GetAssets` を連続コールすると運が悪いと弾かれる。

2. **リトライループが動いていなかった**
   `runStateSyncLoop` (15 秒ごとの定期再同期) は `pipeline.Start()` からしか起動されない → `Start()` は `POST /api/v1/bot/start` からしか呼ばれない → **ユーザーが手動で「起動」ボタンを押すまで再同期ループが永久に動かない**。結果、起動時に 1 回踏んだ 20010 が永久に復旧しないまま `balance` が初期資本の `10000` に張り付く silent failure になっていた。

ログ証跡 (修正前):
\`\`\`
WARN pipeline: failed to sync assets error="GetAssets: API error (status 500): {\"code\":20010}"
INFO initial state sync completed
\`\`\`
→ この警告が 1 回だけ出て、以降リトライも失敗も記録されない = ループが回っていない証拠。

## 修正内容

### `backend/cmd/retry.go` (新規)
20010 のみ対象の小さなリトライヘルパー。`isRateLimitError` はエラー文字列中の `"code":20010` を部分一致で判定 (楽天の `DoRaw` がエラー本文をそのまま文字列化するので確実)。`sleep` 関数を DI できるのでテストで実時間を消費しない。

### `backend/cmd/pipeline.go`
- `syncState` の `GetPositions` / `GetAssets` をそれぞれ `retryOn20010` でラップ
- `TradingPipeline` に `sleepFn func(time.Duration)` フィールドを追加 (テスト用 DI、本番は `time.Sleep`)
- `Start()` から `go p.runStateSyncLoop(ctx)` を削除 — main ctx 側で一本化するため、二重起動を避ける

### `backend/cmd/main.go`
- `go pipeline.runStateSyncLoop(ctx)` を main ctx で常時起動。自動売買停止中でも残高は 15 秒ごとに楽天の実残高に追随する。

## Test plan

- [x] `backend/cmd/retry_test.go`: `retryOn20010` の 4 ケース (非20010 即抜け / 20010 途中で成功 / リトライ枯渇 / ctx cancel 中断)
- [x] `backend/cmd/sync_state_test.go`: fake `OrderClient` を注入し、`syncState` が 20010 を 1 回踏んでも残高 9995 に追随することを assert。20010 以外では初期値 10000 のまま。
- [x] `go test -race ./cmd/` 全 green (既存の `TestSwitchSymbol_*` 並行性テストも壊していない)
- [x] `make restart` でバックエンド再ビルド → docker compose ログで以下を確認:
  - `rakuten rate limit (20010), retrying attempt=1 next_delay_ms=300` → `initial state sync completed`
  - `/api/v1/pnl` / `/api/v1/status` が \`"balance":9994\` を返す (楽天実残高)
  - 15 秒ごとの定期 sync が main ctx で動いている

## スコープ外 (別 PR 候補)

- **`20004` エラー**: 定期 sync で散発的に出ている (nonce 系と思われる認証エラー)。今回は「リトライ対象は 20010 のみ」のスコープでユーザー合意済み。
- **UI silent failure の根治**: 現状は前回成功時の `balance` が残るので「古い値をさも最新かのように見せる」問題は残存。今回の修正で起動時にほぼ必ず成功するようになったため、silent failure の影響は大幅に小さくなったが、`stale` 表示の導入は別途検討。
- **`statusLabel` が pipeline 未起動でも "running" を返すバグ**: 別問題として残置。

🤖 Generated with [Claude Code](https://claude.com/claude-code)