### PR TITLE
feat(frontend): show min order and margin in symbol selector

### DIFF
--- a/frontend/src/components/SymbolSelector.tsx
+++ b/frontend/src/components/SymbolSelector.tsx
@@ -1,7 +1,27 @@
 import { useSymbolContext } from '../contexts/SymbolContext'
+import { useStatus } from '../hooks/useStatus'
+import { useAllTickers } from '../hooks/useAllTickers'
+import type { TradableSymbol } from '../lib/api'
+
+const LEVERAGE = 2
+
+/** 最小注文に必要な証拠金を計算 */
+function requiredMargin(symbol: TradableSymbol, lastPrice: number): number {
+  return (symbol.minOrderAmount * lastPrice) / LEVERAGE
+}
+
+/** 円の表示フォーマット */
+function formatJPY(value: number): string {
+  if (value >= 10_000) {
+    return `${(value / 10_000).toFixed(1)}万`
+  }
+  return `${Math.ceil(value).toLocaleString()}`
+}
 
 export function SymbolSelector() {
   const { symbolId, symbols, switchSymbol, isSwitching, isSwitchAllowed } = useSymbolContext()
+  const { data: status } = useStatus()
+  const priceMap = useAllTickers(symbols)
 
   const tradableSymbols = symbols.filter((s) => s.enabled && !s.viewOnly && !s.closeOnly)
 
@@ -9,6 +29,7 @@ export function SymbolSelector() {
     return null
   }
 
+  const balance = status?.balance ?? 0
   const disabled = isSwitching || !isSwitchAllowed
 
   return (
@@ -26,13 +47,35 @@ export function SymbolSelector() {
         disabled={disabled}
         className="rounded-full border border-white/10 bg-white/6 px-4 py-2 text-sm font-medium text-white outline-none transition focus:border-cyan-200 disabled:opacity-50"
       >
-        {tradableSymbols.map((s) => (
-          <option key={s.id} value={s.id} className="bg-bg-card text-white">
-            {s.currencyPair.replace('_', '/')}
-          </option>
-        ))}
+        {tradableSymbols.map((s) => {
+          const price = priceMap.get(s.id)
+          const margin = price ? requiredMargin(s, price) : undefined
+          const affordable = margin !== undefined && balance > 0 ? balance >= margin : true
+
+          const label = buildLabel(s, margin)
+
+          return (
+            <option
+              key={s.id}
+              value={s.id}
+              disabled={!affordable}
+              className="bg-bg-card text-white"
+            >
+              {label}
+            </option>
+          )
+        })}
       </select>
       {isSwitching && <span className="text-xs text-cyan-200">切替中...</span>}
     </div>
   )
+}
+
+function buildLabel(s: TradableSymbol, margin: number | undefined): string {
+  const pair = s.currencyPair.replace('_', '/')
+  const min = `${s.minOrderAmount} ${s.baseCurrency}`
+  if (margin !== undefined) {
+    return `${pair}（最小 ${min} / 証拠金 ¥${formatJPY(margin)}）`
+  }
+  return `${pair}（最小 ${min}）`
 }

--- a/frontend/src/hooks/useAllTickers.ts
+++ b/frontend/src/hooks/useAllTickers.ts
@@ -1,0 +1,35 @@
+import { useQueries } from '@tanstack/react-query'
+import { fetchApi, type TradableSymbol } from '../lib/api'
+
+type TickerResponse = {
+  symbolId: number
+  last: number
+  bestAsk: number
+  bestBid: number
+}
+
+/**
+ * 全シンボルのティッカーを一括取得する。
+ * 各シンボルの現在価格を Map<symbolId, lastPrice> で返す。
+ */
+export function useAllTickers(symbols: TradableSymbol[] | undefined) {
+  const tradable = symbols?.filter((s) => s.enabled && !s.viewOnly && !s.closeOnly) ?? []
+
+  const results = useQueries({
+    queries: tradable.map((s) => ({
+      queryKey: ['ticker', s.id],
+      queryFn: () => fetchApi<TickerResponse>(`/ticker?symbolId=${s.id}`),
+      staleTime: 60_000,
+      refetchInterval: 60_000,
+    })),
+  })
+
+  const priceMap = new Map<number, number>()
+  results.forEach((r, i) => {
+    if (r.data) {
+      priceMap.set(tradable[i].id, r.data.last)
+    }
+  })
+
+  return priceMap
+}


### PR DESCRIPTION
## Summary
- 銘柄セレクトの各optionに「最小注文数量」と「必要証拠金（レバレッジ2倍）」を表示
- 現在の残高で証拠金が足りない通貨ペアを自動的にdisabledにする
- 全シンボルのティッカーを取得する `useAllTickers` hookを追加

## 表示例
```
BTC/JPY（最小 0.01 BTC / 証拠金 ¥5.7万）  ← disabled
ETH/JPY（最小 0.1 ETH / 証拠金 ¥1.8万）   ← disabled
BCH/JPY（最小 0.1 BCH / 証拠金 ¥3,417）   ← 選択可能
LTC/JPY（最小 0.1 LTC / 証拠金 ¥435）     ← 選択可能
```

## Test plan
- [ ] 銘柄セレクトを開き、各通貨に最小数量と証拠金が表示されることを確認
- [ ] 残高不足の通貨（BTC, ETH, XRP）が選択不可（disabled）になっていることを確認
- [ ] 残高十分な通貨（BCH, LTC, ADA, DOT, XLM, XTZ）が選択可能であることを確認
- [ ] 通貨切替が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)