### PR TITLE
fix(backend): round order amount by symbol's baseStepAmount

### DIFF
--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -80,6 +80,7 @@ func main() {
 			TradeAmount:       cfg.Trading.TradeAmount,
 		},
 		restClient,
+		restClient, // SymbolFetcher
 		marketDataSvc,
 		indicatorCalc,
 		strategyEngine,
@@ -88,6 +89,11 @@ func main() {
 		tradeHistoryRepo,
 		riskStateRepo,
 	)
+
+	// 初期シンボルの baseStepAmount / minOrderAmount をロード
+	pipeline.mu.Lock()
+	pipeline.loadSymbolMeta(context.Background(), symbolID)
+	pipeline.mu.Unlock()
 
 	// 起動時にポジション・残高を同期
 	pipeline.syncStateInitial(context.Background())

--- a/backend/cmd/pipeline.go
+++ b/backend/cmd/pipeline.go
@@ -46,12 +46,15 @@ type TradingPipeline struct {
 	mu       sync.RWMutex // フィールド保護（snapshot 経由で読む）
 	cancel   context.CancelFunc
 
-	symbolID          int64
-	interval          time.Duration
+	symbolID       int64
+	interval       time.Duration
 	stateSyncInterval time.Duration
-	tradeAmount       float64
+	tradeAmount    float64
+	baseStepAmount float64 // シンボルごとの最小注文刻み幅（例: BTC=0.01, LTC=0.1）
+	minOrderAmount float64 // シンボルごとの最小注文数量
 
 	restClient       repository.OrderClient
+	symbolFetcher    repository.SymbolFetcher
 	marketDataSvc    *usecase.MarketDataService
 	indicatorCalc    *usecase.IndicatorCalculator
 	strategyEngine   *usecase.StrategyEngine
@@ -67,16 +70,20 @@ type TradingPipeline struct {
 
 // tradingSnapshot は evaluate / stopLoss ループで使う、ロック下にコピーしたフィールド束。
 type tradingSnapshot struct {
-	symbolID    int64
-	tradeAmount float64
+	symbolID       int64
+	tradeAmount    float64
+	baseStepAmount float64
+	minOrderAmount float64
 }
 
 func (p *TradingPipeline) snapshot() tradingSnapshot {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 	return tradingSnapshot{
-		symbolID:    p.symbolID,
-		tradeAmount: p.tradeAmount,
+		symbolID:       p.symbolID,
+		tradeAmount:    p.tradeAmount,
+		baseStepAmount: p.baseStepAmount,
+		minOrderAmount: p.minOrderAmount,
 	}
 }
 
@@ -91,6 +98,7 @@ type TradingPipelineConfig struct {
 func NewTradingPipeline(
 	cfg TradingPipelineConfig,
 	restClient repository.OrderClient,
+	symbolFetcher repository.SymbolFetcher,
 	marketDataSvc *usecase.MarketDataService,
 	indicatorCalc *usecase.IndicatorCalculator,
 	strategyEngine *usecase.StrategyEngine,
@@ -105,6 +113,7 @@ func NewTradingPipeline(
 		stateSyncInterval: cfg.StateSyncInterval,
 		tradeAmount:       cfg.TradeAmount,
 		restClient:        restClient,
+		symbolFetcher:     symbolFetcher,
 		marketDataSvc:     marketDataSvc,
 		indicatorCalc:     indicatorCalc,
 		strategyEngine:    strategyEngine,
@@ -189,6 +198,32 @@ func (p *TradingPipeline) TradeAmount() float64 {
 	return p.tradeAmount
 }
 
+// loadSymbolMeta は指定シンボルの baseStepAmount / minOrderAmount を楽天 API から取得し、
+// パイプラインのフィールドを更新する。mu ロック下で呼ぶこと。
+func (p *TradingPipeline) loadSymbolMeta(ctx context.Context, symbolID int64) {
+	if p.symbolFetcher == nil {
+		return
+	}
+	symbols, err := p.symbolFetcher.GetSymbols(ctx)
+	if err != nil {
+		slog.Warn("pipeline: failed to fetch symbols for step amount", "error", err)
+		return
+	}
+	for _, s := range symbols {
+		if s.ID == symbolID {
+			p.baseStepAmount = s.BaseStepAmount.Float64()
+			p.minOrderAmount = s.MinOrderAmount.Float64()
+			slog.Info("pipeline: loaded symbol meta",
+				"symbolID", symbolID,
+				"baseStepAmount", p.baseStepAmount,
+				"minOrderAmount", p.minOrderAmount,
+			)
+			return
+		}
+	}
+	slog.Warn("pipeline: symbol not found in API response", "symbolID", symbolID)
+}
+
 // SwitchSymbol は取引対象シンボルを切り替える。
 // switchMu でシリアライズすることで:
 //   - 連続切替の順序保証（逆順適用を防ぐ）
@@ -219,6 +254,7 @@ func (p *TradingPipeline) SwitchSymbol(symbolID int64, tradeAmount float64, onSw
 	if tradeAmount > 0 {
 		p.tradeAmount = tradeAmount
 	}
+	p.loadSymbolMeta(context.Background(), symbolID)
 	p.mu.Unlock()
 
 	// onSwitch（bootstrapCandles + WS切替）を同期実行
@@ -320,10 +356,12 @@ func (p *TradingPipeline) evaluate(ctx context.Context) {
 	}
 
 	amount := snap.tradeAmount / price
-	// 楽天の最小注文単位に丸める（BTC_JPY は 0.0001 BTC）
-	amount = math.Floor(amount*10000) / 10000
-	if amount <= 0 {
-		slog.Warn("pipeline: calculated amount is 0, skip", "tradeAmount", snap.tradeAmount, "price", price)
+	// シンボルの baseStepAmount に合わせて切り捨て丸め
+	amount = roundDownToStep(amount, snap.baseStepAmount)
+	if amount <= 0 || amount < snap.minOrderAmount {
+		slog.Warn("pipeline: amount below minimum, skip",
+			"amount", amount, "minOrderAmount", snap.minOrderAmount,
+			"tradeAmount", snap.tradeAmount, "price", price)
 		return
 	}
 
@@ -535,6 +573,17 @@ func restoreRiskState(ctx context.Context, repo repository.RiskStateRepository, 
 		riskMgr.RecordLoss(state.DailyLoss)
 	}
 	slog.Info("risk state restored", "balance", state.Balance, "dailyLoss", state.DailyLoss)
+}
+
+// roundDownToStep は amount を step の整数倍に切り捨てる。
+// step が 0 以下の場合はフォールバックとして小数4位で切り捨てる。
+// 浮動小数点の丸め誤差を避けるため、除算結果を 1e9 スケールで round してから floor する。
+func roundDownToStep(amount, step float64) float64 {
+	if step <= 0 {
+		return math.Floor(amount*10000) / 10000
+	}
+	n := math.Round(amount/step*1e9) / 1e9
+	return math.Floor(n) * step
 }
 
 // startDailyLossReset は毎日0時(JST)に日次損失をリセットするgoroutineを起動する。

--- a/backend/cmd/pipeline_test.go
+++ b/backend/cmd/pipeline_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"math"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -169,4 +170,32 @@ func TestSwitchSymbol_PreservesRunningState(t *testing.T) {
 	}
 
 	p.Stop()
+}
+
+func TestRoundDownToStep(t *testing.T) {
+	tests := []struct {
+		name   string
+		amount float64
+		step   float64
+		want   float64
+	}{
+		{"LTC step=0.1, amount=0.1166", 0.1166, 0.1, 0.1},
+		{"LTC step=0.1, amount=0.9999", 0.9999, 0.1, 0.9},
+		{"BTC step=0.01, amount=0.0156", 0.0156, 0.01, 0.01},
+		{"XRP step=100, amount=250", 250.0, 100.0, 200.0},
+		{"ADA step=10, amount=24.8", 24.8, 10.0, 20.0},
+		{"DOT step=1, amount=4.76", 4.76, 1.0, 4.0},
+		{"exact match", 0.3, 0.1, 0.3},
+		{"step=0 fallback to 4 decimals", 0.11667, 0, 0.1166},
+		{"step negative fallback", 0.11667, -1, 0.1166},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := roundDownToStep(tt.amount, tt.step)
+			if math.Abs(got-tt.want) > 1e-9 {
+				t.Errorf("roundDownToStep(%v, %v) = %v, want %v", tt.amount, tt.step, got, tt.want)
+			}
+		})
+	}
 }

--- a/backend/internal/domain/repository/order.go
+++ b/backend/internal/domain/repository/order.go
@@ -35,3 +35,8 @@ type OrderClient interface {
 	GetMyTrades(ctx context.Context, symbolID int64) ([]entity.MyTrade, error)
 	GetAssets(ctx context.Context) ([]entity.Asset, error)
 }
+
+// SymbolFetcher はシンボル情報取得のインターフェース。
+type SymbolFetcher interface {
+	GetSymbols(ctx context.Context) ([]entity.Symbol, error)
+}


### PR DESCRIPTION
## Summary
- パイプラインの注文数量丸めが小数4位（BTC専用）にハードコードされていたため、LTC等の他通貨で楽天API エラー 50023 (`ORDER_ERROR_INVALID_AMOUNT`) が発生していた
- `SymbolFetcher` インターフェースを追加し、シンボル起動時・切替時に `baseStepAmount` / `minOrderAmount` を楽天APIから取得するように修正
- `roundDownToStep()` 関数で通貨ごとの刻み幅に応じた正しい丸めを実装

## Changes
| ファイル | 変更内容 |
|---------|---------|
| `repository/order.go` | `SymbolFetcher` インターフェース追加 |
| `pipeline.go` | `baseStepAmount`/`minOrderAmount` フィールド追加、`loadSymbolMeta()`、`roundDownToStep()` 実装 |
| `main.go` | パイプライン初期化時に `SymbolFetcher` を渡し、起動時にメタ情報ロード |
| `pipeline_test.go` | `roundDownToStep` のテーブルドリブンテスト（全通貨パターン） |

## Test plan
- [x] `go test ./...` 全パス
- [x] LTC_JPY (symbolId=10) で `baseStepAmount=0.1` がロードされることを確認
- [x] 実際に LTC_JPY で成行BUY注文が `amount=0.1` で約定することを確認（修正前は 0.1166 でエラー 50023）

🤖 Generated with [Claude Code](https://claude.com/claude-code)