### PR TITLE
feat(strategy): add MACD histogram confirmation filter

### DIFF
--- a/backend/internal/usecase/strategy.go
+++ b/backend/internal/usecase/strategy.go
@@ -39,9 +39,9 @@ func (e *StrategyEngine) Evaluate(ctx context.Context, indicators entity.Indicat
 
 	switch result.Stance {
 	case entity.MarketStanceTrendFollow:
-		return e.evaluateTrendFollow(indicators.SymbolID, sma20, sma50, rsi), nil
+		return e.evaluateTrendFollow(indicators.SymbolID, sma20, sma50, rsi, indicators.Histogram), nil
 	case entity.MarketStanceContrarian:
-		return e.evaluateContrarian(indicators.SymbolID, rsi), nil
+		return e.evaluateContrarian(indicators.SymbolID, rsi, indicators.Histogram), nil
 	default:
 		return &entity.Signal{
 			SymbolID:  indicators.SymbolID,
@@ -52,22 +52,48 @@ func (e *StrategyEngine) Evaluate(ctx context.Context, indicators entity.Indicat
 	}
 }
 
-func (e *StrategyEngine) evaluateTrendFollow(symbolID int64, sma20, sma50, rsi float64) *entity.Signal {
+func (e *StrategyEngine) evaluateTrendFollow(symbolID int64, sma20, sma50, rsi float64, histogram *float64) *entity.Signal {
 	now := time.Now().Unix()
 
 	if sma20 > sma50 && rsi < 70 {
+		// MACD histogram confirmation: skip buy if momentum is negative
+		if histogram != nil && *histogram < 0 {
+			return &entity.Signal{
+				SymbolID:  symbolID,
+				Action:    entity.SignalActionHold,
+				Reason:    "trend follow: MACD histogram negative, skipping buy",
+				Timestamp: now,
+			}
+		}
+		reason := "trend follow: SMA20 > SMA50, RSI not overbought"
+		if histogram != nil {
+			reason += ", MACD confirmed"
+		}
 		return &entity.Signal{
 			SymbolID:  symbolID,
 			Action:    entity.SignalActionBuy,
-			Reason:    "trend follow: SMA20 > SMA50, RSI not overbought",
+			Reason:    reason,
 			Timestamp: now,
 		}
 	}
 	if sma20 < sma50 && rsi > 30 {
+		// MACD histogram confirmation: skip sell if momentum is positive
+		if histogram != nil && *histogram > 0 {
+			return &entity.Signal{
+				SymbolID:  symbolID,
+				Action:    entity.SignalActionHold,
+				Reason:    "trend follow: MACD histogram positive, skipping sell",
+				Timestamp: now,
+			}
+		}
+		reason := "trend follow: SMA20 < SMA50, RSI not oversold"
+		if histogram != nil {
+			reason += ", MACD confirmed"
+		}
 		return &entity.Signal{
 			SymbolID:  symbolID,
 			Action:    entity.SignalActionSell,
-			Reason:    "trend follow: SMA20 < SMA50, RSI not oversold",
+			Reason:    reason,
 			Timestamp: now,
 		}
 	}
@@ -79,22 +105,48 @@ func (e *StrategyEngine) evaluateTrendFollow(symbolID int64, sma20, sma50, rsi f
 	}
 }
 
-func (e *StrategyEngine) evaluateContrarian(symbolID int64, rsi float64) *entity.Signal {
+func (e *StrategyEngine) evaluateContrarian(symbolID int64, rsi float64, histogram *float64) *entity.Signal {
 	now := time.Now().Unix()
 
 	if rsi < 30 {
+		// Skip contrarian buy if MACD momentum is still strongly negative
+		if histogram != nil && *histogram < -10 {
+			return &entity.Signal{
+				SymbolID:  symbolID,
+				Action:    entity.SignalActionHold,
+				Reason:    "contrarian: RSI oversold but MACD momentum still strongly negative",
+				Timestamp: now,
+			}
+		}
+		reason := "contrarian: RSI oversold, expecting bounce"
+		if histogram != nil {
+			reason += ", MACD not strongly against"
+		}
 		return &entity.Signal{
 			SymbolID:  symbolID,
 			Action:    entity.SignalActionBuy,
-			Reason:    "contrarian: RSI oversold, expecting bounce",
+			Reason:    reason,
 			Timestamp: now,
 		}
 	}
 	if rsi > 70 {
+		// Skip contrarian sell if MACD momentum is still strongly positive
+		if histogram != nil && *histogram > 10 {
+			return &entity.Signal{
+				SymbolID:  symbolID,
+				Action:    entity.SignalActionHold,
+				Reason:    "contrarian: RSI overbought but MACD momentum still strongly positive",
+				Timestamp: now,
+			}
+		}
+		reason := "contrarian: RSI overbought, expecting pullback"
+		if histogram != nil {
+			reason += ", MACD not strongly against"
+		}
 		return &entity.Signal{
 			SymbolID:  symbolID,
 			Action:    entity.SignalActionSell,
-			Reason:    "contrarian: RSI overbought, expecting pullback",
+			Reason:    reason,
 			Timestamp: now,
 		}
 	}

--- a/backend/internal/usecase/strategy_test.go
+++ b/backend/internal/usecase/strategy_test.go
@@ -221,3 +221,159 @@ func TestStrategyEngine_InsufficientIndicators_Hold(t *testing.T) {
 		t.Fatalf("expected HOLD for insufficient indicators, got %s", signal.Action)
 	}
 }
+
+func TestStrategyEngine_TrendFollow_HoldWhenMACDAgainst(t *testing.T) {
+	// SMA20 > SMA50 (uptrend) but histogram negative → HOLD
+	resolver := &mockStanceResolver{
+		result: StanceResult{
+			Stance:    entity.MarketStanceTrendFollow,
+			Reasoning: "uptrend",
+			Source:    "rule-based",
+			UpdatedAt: time.Now().Unix(),
+		},
+	}
+	engine := NewStrategyEngine(resolver)
+
+	indicators := entity.IndicatorSet{
+		SymbolID:  7,
+		SMA20:     ptr(5100000),
+		SMA50:     ptr(5000000),
+		RSI14:     ptr(55.0),
+		Histogram: ptr(-5.0),
+	}
+	signal, err := engine.Evaluate(context.Background(), indicators, 5100000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if signal.Action != entity.SignalActionHold {
+		t.Fatalf("expected HOLD when MACD histogram is against buy, got %s", signal.Action)
+	}
+	expected := "trend follow: MACD histogram negative, skipping buy"
+	if signal.Reason != expected {
+		t.Fatalf("expected reason %q, got %q", expected, signal.Reason)
+	}
+}
+
+func TestStrategyEngine_TrendFollow_SellBlockedByPositiveHistogram(t *testing.T) {
+	// SMA20 < SMA50 (downtrend) but histogram positive → HOLD
+	resolver := &mockStanceResolver{
+		result: StanceResult{
+			Stance:    entity.MarketStanceTrendFollow,
+			Reasoning: "downtrend",
+			Source:    "rule-based",
+			UpdatedAt: time.Now().Unix(),
+		},
+	}
+	engine := NewStrategyEngine(resolver)
+
+	indicators := entity.IndicatorSet{
+		SymbolID:  7,
+		SMA20:     ptr(4900000),
+		SMA50:     ptr(5000000),
+		RSI14:     ptr(45.0),
+		Histogram: ptr(5.0),
+	}
+	signal, err := engine.Evaluate(context.Background(), indicators, 4900000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if signal.Action != entity.SignalActionHold {
+		t.Fatalf("expected HOLD when MACD histogram is against sell, got %s", signal.Action)
+	}
+	expected := "trend follow: MACD histogram positive, skipping sell"
+	if signal.Reason != expected {
+		t.Fatalf("expected reason %q, got %q", expected, signal.Reason)
+	}
+}
+
+func TestStrategyEngine_TrendFollow_BuyWithMACDConfirmation(t *testing.T) {
+	// uptrend + positive histogram → BUY
+	resolver := &mockStanceResolver{
+		result: StanceResult{
+			Stance:    entity.MarketStanceTrendFollow,
+			Reasoning: "uptrend",
+			Source:    "rule-based",
+			UpdatedAt: time.Now().Unix(),
+		},
+	}
+	engine := NewStrategyEngine(resolver)
+
+	indicators := entity.IndicatorSet{
+		SymbolID:  7,
+		SMA20:     ptr(5100000),
+		SMA50:     ptr(5000000),
+		RSI14:     ptr(55.0),
+		Histogram: ptr(3.0),
+	}
+	signal, err := engine.Evaluate(context.Background(), indicators, 5100000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if signal.Action != entity.SignalActionBuy {
+		t.Fatalf("expected BUY with MACD confirmation, got %s", signal.Action)
+	}
+	expected := "trend follow: SMA20 > SMA50, RSI not overbought, MACD confirmed"
+	if signal.Reason != expected {
+		t.Fatalf("expected reason %q, got %q", expected, signal.Reason)
+	}
+}
+
+func TestStrategyEngine_Contrarian_HoldWhenMACDAgainst(t *testing.T) {
+	// RSI < 30 but histogram < -10 → HOLD
+	resolver := &mockStanceResolver{
+		result: StanceResult{
+			Stance:    entity.MarketStanceContrarian,
+			Reasoning: "oversold bounce expected",
+			Source:    "rule-based",
+			UpdatedAt: time.Now().Unix(),
+		},
+	}
+	engine := NewStrategyEngine(resolver)
+
+	indicators := entity.IndicatorSet{
+		SymbolID:  7,
+		SMA20:     ptr(4900000),
+		SMA50:     ptr(5000000),
+		RSI14:     ptr(25.0),
+		Histogram: ptr(-15.0),
+	}
+	signal, err := engine.Evaluate(context.Background(), indicators, 4900000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if signal.Action != entity.SignalActionHold {
+		t.Fatalf("expected HOLD when MACD momentum strongly negative, got %s", signal.Action)
+	}
+	expected := "contrarian: RSI oversold but MACD momentum still strongly negative"
+	if signal.Reason != expected {
+		t.Fatalf("expected reason %q, got %q", expected, signal.Reason)
+	}
+}
+
+func TestStrategyEngine_TrendFollow_NilHistogramStillTrades(t *testing.T) {
+	// histogram nil → BUY (backward compat)
+	resolver := &mockStanceResolver{
+		result: StanceResult{
+			Stance:    entity.MarketStanceTrendFollow,
+			Reasoning: "uptrend",
+			Source:    "rule-based",
+			UpdatedAt: time.Now().Unix(),
+		},
+	}
+	engine := NewStrategyEngine(resolver)
+
+	indicators := entity.IndicatorSet{
+		SymbolID:  7,
+		SMA20:     ptr(5100000),
+		SMA50:     ptr(5000000),
+		RSI14:     ptr(55.0),
+		Histogram: nil,
+	}
+	signal, err := engine.Evaluate(context.Background(), indicators, 5100000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if signal.Action != entity.SignalActionBuy {
+		t.Fatalf("expected BUY with nil histogram (backward compat), got %s", signal.Action)
+	}
+}


### PR DESCRIPTION
## Summary
- Add MACD histogram confirmation to `evaluateTrendFollow` and `evaluateContrarian` to filter out false signals where momentum disagrees with the signal direction
- Trend-follow: block buy when histogram < 0, block sell when histogram > 0
- Contrarian: block buy when histogram < -10 (strong downward momentum), block sell when histogram > 10 (strong upward momentum)
- Fully backward compatible: nil histogram preserves existing behavior

## Test plan
- [x] `TestStrategyEngine_TrendFollow_HoldWhenMACDAgainst` — uptrend but negative histogram returns HOLD
- [x] `TestStrategyEngine_TrendFollow_SellBlockedByPositiveHistogram` — downtrend but positive histogram returns HOLD
- [x] `TestStrategyEngine_TrendFollow_BuyWithMACDConfirmation` — uptrend + positive histogram returns BUY with "MACD confirmed"
- [x] `TestStrategyEngine_Contrarian_HoldWhenMACDAgainst` — RSI oversold but histogram < -10 returns HOLD
- [x] `TestStrategyEngine_TrendFollow_NilHistogramStillTrades` — nil histogram returns BUY (backward compat)
- [x] All existing tests pass (no regressions)
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)