### PR TITLE
feat(risk): add take-profit exit logic

### DIFF
--- a/backend/cmd/pipeline.go
+++ b/backend/cmd/pipeline.go
@@ -429,6 +429,29 @@ func (p *TradingPipeline) runStopLossMonitor(ctx context.Context) {
 					p.persistRiskState(ctx)
 				}
 			}
+
+			// Take-profit チェック
+			tpTargets := p.riskMgr.CheckTakeProfit(t.SymbolID, t.Last)
+			for _, pos := range tpTargets {
+				slog.Info("pipeline: take-profit triggered",
+					"positionID", pos.ID, "side", pos.OrderSide, "entryPrice", pos.Price, "currentPrice", t.Last)
+
+				clientOrderID := newAgentClientOrderID("takeprofit")
+				result, err := p.orderExecutor.ClosePosition(ctx, clientOrderID, pos, t.Last)
+				if err != nil {
+					slog.Error("pipeline: take-profit close failed", "error", err)
+					continue
+				}
+				if result.Executed {
+					slog.Info("pipeline: take-profit closed", "orderID", result.OrderID)
+					closeSide := string(entity.OrderSideSell)
+					if pos.OrderSide == entity.OrderSideSell {
+						closeSide = string(entity.OrderSideBuy)
+					}
+					p.recordTrade(ctx, pos.SymbolID, result.OrderID, closeSide, "close", t.Last, pos.RemainingAmount, "take-profit", false)
+					p.persistRiskState(ctx)
+				}
+			}
 		}
 	}
 }

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -40,6 +40,7 @@ type RiskConfig struct {
 	MaxPositionAmount float64
 	MaxDailyLoss      float64
 	StopLossPercent   float64
+	TakeProfitPercent float64
 	InitialCapital    float64
 }
 
@@ -62,6 +63,7 @@ func Load() *Config {
 			MaxPositionAmount: getEnvFloat("RISK_MAX_POSITION_AMOUNT", 5000),
 			MaxDailyLoss:      getEnvFloat("RISK_MAX_DAILY_LOSS", 5000),
 			StopLossPercent:   getEnvFloat("RISK_STOP_LOSS_PERCENT", 5),
+			TakeProfitPercent: getEnvFloat("RISK_TAKE_PROFIT_PERCENT", 10),
 			InitialCapital:    getEnvFloat("RISK_INITIAL_CAPITAL", 10000),
 		},
 		Rakuten: RakutenConfig{

--- a/backend/internal/domain/entity/risk.go
+++ b/backend/internal/domain/entity/risk.go
@@ -5,6 +5,7 @@ type RiskConfig struct {
 	MaxPositionAmount float64 `json:"maxPositionAmount"` // 同時ポジション上限（円）
 	MaxDailyLoss      float64 `json:"maxDailyLoss"`      // 日次損失上限（円）
 	StopLossPercent   float64 `json:"stopLossPercent"`    // 損切りライン（%）
+	TakeProfitPercent float64 `json:"takeProfitPercent"`  // 利確ライン（%）
 	InitialCapital    float64 `json:"initialCapital"`     // 軍資金（円）
 }
 

--- a/backend/internal/usecase/risk.go
+++ b/backend/internal/usecase/risk.go
@@ -97,6 +97,31 @@ func (rm *RiskManager) CheckStopLoss(symbolID int64, currentPrice float64) []ent
 	return result
 }
 
+func (rm *RiskManager) CheckTakeProfit(symbolID int64, currentPrice float64) []entity.Position {
+	if rm.config.TakeProfitPercent <= 0 {
+		return nil
+	}
+	rm.mu.RLock()
+	defer rm.mu.RUnlock()
+
+	var result []entity.Position
+	for _, pos := range rm.positions {
+		if pos.SymbolID != symbolID {
+			continue
+		}
+		var profitPercent float64
+		if pos.OrderSide == entity.OrderSideBuy {
+			profitPercent = (currentPrice - pos.Price) / pos.Price * 100
+		} else {
+			profitPercent = (pos.Price - currentPrice) / pos.Price * 100
+		}
+		if profitPercent >= rm.config.TakeProfitPercent {
+			result = append(result, pos)
+		}
+	}
+	return result
+}
+
 func (rm *RiskManager) RecordLoss(loss float64) {
 	rm.mu.Lock()
 	defer rm.mu.Unlock()

--- a/backend/internal/usecase/risk_test.go
+++ b/backend/internal/usecase/risk_test.go
@@ -12,6 +12,7 @@ func defaultRiskConfig() entity.RiskConfig {
 		MaxPositionAmount: 5000,
 		MaxDailyLoss:      5000,
 		StopLossPercent:   5,
+		TakeProfitPercent: 10,
 		InitialCapital:    10000,
 	}
 }
@@ -177,5 +178,55 @@ func TestRiskManager_TradingHalted(t *testing.T) {
 	status := rm.GetStatus()
 	if !status.TradingHalted {
 		t.Fatal("trading should be halted after max daily loss")
+	}
+}
+
+func TestRiskManager_CheckTakeProfit_BuyPosition(t *testing.T) {
+	rm := NewRiskManager(defaultRiskConfig())
+	rm.UpdatePositions([]entity.Position{
+		{ID: 1, SymbolID: 7, OrderSide: entity.OrderSideBuy, Price: 5000000, Amount: 0.001, RemainingAmount: 0.001},
+	})
+	// 5,500,000 is 10% above 5,000,000 → should trigger take-profit
+	tpPositions := rm.CheckTakeProfit(7, 5500000)
+	if len(tpPositions) != 1 {
+		t.Fatalf("expected 1 take-profit position, got %d", len(tpPositions))
+	}
+}
+
+func TestRiskManager_CheckTakeProfit_NoTrigger(t *testing.T) {
+	rm := NewRiskManager(defaultRiskConfig())
+	rm.UpdatePositions([]entity.Position{
+		{ID: 1, SymbolID: 7, OrderSide: entity.OrderSideBuy, Price: 5000000, Amount: 0.001, RemainingAmount: 0.001},
+	})
+	// 5,250,000 is 5% above 5,000,000 → should NOT trigger (threshold is 10%)
+	tpPositions := rm.CheckTakeProfit(7, 5250000)
+	if len(tpPositions) != 0 {
+		t.Fatalf("expected 0 take-profit positions, got %d", len(tpPositions))
+	}
+}
+
+func TestRiskManager_CheckTakeProfit_SellPosition(t *testing.T) {
+	rm := NewRiskManager(defaultRiskConfig())
+	rm.UpdatePositions([]entity.Position{
+		{ID: 1, SymbolID: 7, OrderSide: entity.OrderSideSell, Price: 5000000, Amount: 0.001, RemainingAmount: 0.001},
+	})
+	// 4,500,000 is 10% below 5,000,000 → should trigger take-profit for sell
+	tpPositions := rm.CheckTakeProfit(7, 4500000)
+	if len(tpPositions) != 1 {
+		t.Fatalf("expected 1 take-profit position, got %d", len(tpPositions))
+	}
+}
+
+func TestRiskManager_CheckTakeProfit_ZeroConfig_NeverTriggers(t *testing.T) {
+	cfg := defaultRiskConfig()
+	cfg.TakeProfitPercent = 0
+	rm := NewRiskManager(cfg)
+	rm.UpdatePositions([]entity.Position{
+		{ID: 1, SymbolID: 7, OrderSide: entity.OrderSideBuy, Price: 5000000, Amount: 0.001, RemainingAmount: 0.001},
+	})
+	// Even with 20% profit, should return nil when TakeProfitPercent is 0
+	tpPositions := rm.CheckTakeProfit(7, 6000000)
+	if len(tpPositions) != 0 {
+		t.Fatalf("expected 0 take-profit positions when disabled, got %d", len(tpPositions))
 	}
 }


### PR DESCRIPTION
## Summary

- Add configurable take-profit percentage (default 10%) that automatically closes positions when the profit target is reached
- Combined with the existing 5% stop-loss, this creates a **1:2 risk:reward ratio** — the bot now captures profits at 10% while cutting losses at 5%
- Previously, positions only closed on loss (stop-loss), never on profit, creating an asymmetric profile where the bot always lost money

## Changes

- **`entity/risk.go`** — Added `TakeProfitPercent float64` field with `json:"takeProfitPercent"` tag
- **`config/config.go`** — Added `RISK_TAKE_PROFIT_PERCENT` env var (default 10)
- **`usecase/risk.go`** — New `CheckTakeProfit()` method that mirrors `CheckStopLoss()` but checks for profit threshold
- **`usecase/risk_test.go`** — 4 new test cases + updated `defaultRiskConfig()` to include `TakeProfitPercent: 10`
- **`cmd/pipeline.go`** — Integrated take-profit check into `runStopLossMonitor`, executing after the stop-loss loop on each ticker update

## Test plan

- [x] `TestRiskManager_CheckTakeProfit_BuyPosition` — buy at 5M, price rises to 5.5M (10%) → triggers
- [x] `TestRiskManager_CheckTakeProfit_NoTrigger` — buy at 5M, price rises to 5.25M (5%) → does not trigger
- [x] `TestRiskManager_CheckTakeProfit_SellPosition` — sell at 5M, price drops to 4.5M (10%) → triggers
- [x] `TestRiskManager_CheckTakeProfit_ZeroConfig_NeverTriggers` — TakeProfitPercent=0 → feature disabled
- [x] All existing tests pass (`go test ./...` — 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)