### PR TITLE
feat(risk): add trailing stop-loss

### DIFF
--- a/backend/cmd/pipeline.go
+++ b/backend/cmd/pipeline.go
@@ -406,6 +406,37 @@ func (p *TradingPipeline) runStopLossMonitor(ctx context.Context) {
 				continue
 			}
 
+			// High water mark を更新
+			positions, posErr := p.restClient.GetPositions(ctx, snap.symbolID)
+			if posErr == nil {
+				for _, pos := range positions {
+					p.riskMgr.UpdateHighWaterMark(pos.ID, t.Last)
+				}
+			}
+
+			// Trailing stop チェック
+			trailTargets := p.riskMgr.CheckTrailingStop(t.SymbolID, t.Last)
+			for _, pos := range trailTargets {
+				slog.Info("pipeline: trailing stop triggered",
+					"positionID", pos.ID, "side", pos.OrderSide, "entryPrice", pos.Price, "currentPrice", t.Last)
+
+				clientOrderID := newAgentClientOrderID("trailstop")
+				result, err := p.orderExecutor.ClosePosition(ctx, clientOrderID, pos, t.Last)
+				if err != nil {
+					slog.Error("pipeline: trailing stop close failed", "error", err)
+					continue
+				}
+				if result.Executed {
+					slog.Info("pipeline: trailing stop closed", "orderID", result.OrderID)
+					closeSide := string(entity.OrderSideSell)
+					if pos.OrderSide == entity.OrderSideSell {
+						closeSide = string(entity.OrderSideBuy)
+					}
+					p.recordTrade(ctx, pos.SymbolID, result.OrderID, closeSide, "close", t.Last, pos.RemainingAmount, "trailing-stop", false)
+					p.persistRiskState(ctx)
+				}
+			}
+
 			targets := p.riskMgr.CheckStopLoss(t.SymbolID, t.Last)
 			for _, pos := range targets {
 				slog.Warn("pipeline: stop-loss triggered",

--- a/backend/internal/usecase/risk.go
+++ b/backend/internal/usecase/risk.go
@@ -18,18 +18,20 @@ type RiskStatus struct {
 }
 
 type RiskManager struct {
-	config    entity.RiskConfig
-	mu        sync.RWMutex
-	balance   float64
-	dailyLoss float64
-	positions []entity.Position
-	manualStop bool
+	config         entity.RiskConfig
+	mu             sync.RWMutex
+	balance        float64
+	dailyLoss      float64
+	positions      []entity.Position
+	manualStop     bool
+	highWaterMarks map[int64]float64 // positionID → best price
 }
 
 func NewRiskManager(config entity.RiskConfig) *RiskManager {
 	return &RiskManager{
-		config:  config,
-		balance: config.InitialCapital,
+		config:         config,
+		balance:        config.InitialCapital,
+		highWaterMarks: make(map[int64]float64),
 	}
 }
 
@@ -134,10 +136,88 @@ func (rm *RiskManager) ResetDailyLoss() {
 	rm.dailyLoss = 0
 }
 
+// UpdateHighWaterMark updates the best price for a position.
+// For BUY positions: tracks highest price. For SELL positions: tracks lowest price.
+func (rm *RiskManager) UpdateHighWaterMark(positionID int64, currentPrice float64) {
+	rm.mu.Lock()
+	defer rm.mu.Unlock()
+
+	existing, ok := rm.highWaterMarks[positionID]
+	if !ok {
+		rm.highWaterMarks[positionID] = currentPrice
+		return
+	}
+
+	// Find position direction
+	var isBuy bool
+	for _, pos := range rm.positions {
+		if pos.ID == positionID {
+			isBuy = pos.OrderSide == entity.OrderSideBuy
+			break
+		}
+	}
+
+	if isBuy && currentPrice > existing {
+		rm.highWaterMarks[positionID] = currentPrice
+	} else if !isBuy && currentPrice < existing {
+		rm.highWaterMarks[positionID] = currentPrice
+	}
+}
+
+// CheckTrailingStop returns positions where price has reversed by StopLossPercent
+// from the high water mark. Only activates when the position is in profit.
+func (rm *RiskManager) CheckTrailingStop(symbolID int64, currentPrice float64) []entity.Position {
+	rm.mu.RLock()
+	defer rm.mu.RUnlock()
+
+	var result []entity.Position
+	for _, pos := range rm.positions {
+		if pos.SymbolID != symbolID {
+			continue
+		}
+		hwm, ok := rm.highWaterMarks[pos.ID]
+		if !ok {
+			continue
+		}
+
+		if pos.OrderSide == entity.OrderSideBuy {
+			// Only activate if position has been in profit
+			if hwm <= pos.Price {
+				continue
+			}
+			trailLine := hwm * (1 - rm.config.StopLossPercent/100)
+			if currentPrice <= trailLine {
+				result = append(result, pos)
+			}
+		} else {
+			// Sell position: low water mark
+			if hwm >= pos.Price {
+				continue
+			}
+			trailLine := hwm * (1 + rm.config.StopLossPercent/100)
+			if currentPrice >= trailLine {
+				result = append(result, pos)
+			}
+		}
+	}
+	return result
+}
+
 func (rm *RiskManager) UpdatePositions(positions []entity.Position) {
 	rm.mu.Lock()
 	defer rm.mu.Unlock()
 	rm.positions = positions
+
+	// Clean up high water marks for closed positions
+	active := make(map[int64]bool, len(positions))
+	for _, pos := range positions {
+		active[pos.ID] = true
+	}
+	for id := range rm.highWaterMarks {
+		if !active[id] {
+			delete(rm.highWaterMarks, id)
+		}
+	}
 }
 
 func (rm *RiskManager) UpdateBalance(balance float64) {

--- a/backend/internal/usecase/risk_test.go
+++ b/backend/internal/usecase/risk_test.go
@@ -230,3 +230,56 @@ func TestRiskManager_CheckTakeProfit_ZeroConfig_NeverTriggers(t *testing.T) {
 		t.Fatalf("expected 0 take-profit positions when disabled, got %d", len(tpPositions))
 	}
 }
+
+func TestRiskManager_TrailingStop_BuyPosition(t *testing.T) {
+	rm := NewRiskManager(defaultRiskConfig())
+	rm.UpdatePositions([]entity.Position{
+		{ID: 1, SymbolID: 7, OrderSide: entity.OrderSideBuy, Price: 5000000, Amount: 0.001, RemainingAmount: 0.001},
+	})
+	// Price went up to 5500000 then drops
+	rm.UpdateHighWaterMark(1, 5500000)
+	// Trail = 5500000 * 0.95 = 5225000. Price 5200000 < 5225000 → trigger
+	targets := rm.CheckTrailingStop(7, 5200000)
+	if len(targets) != 1 {
+		t.Fatalf("expected 1 trailing stop position, got %d", len(targets))
+	}
+}
+
+func TestRiskManager_TrailingStop_NoTriggerAboveTrail(t *testing.T) {
+	rm := NewRiskManager(defaultRiskConfig())
+	rm.UpdatePositions([]entity.Position{
+		{ID: 1, SymbolID: 7, OrderSide: entity.OrderSideBuy, Price: 5000000, Amount: 0.001, RemainingAmount: 0.001},
+	})
+	rm.UpdateHighWaterMark(1, 5500000)
+	// Trail = 5225000. Price 5300000 > 5225000 → no trigger
+	targets := rm.CheckTrailingStop(7, 5300000)
+	if len(targets) != 0 {
+		t.Fatalf("expected 0 trailing stop positions, got %d", len(targets))
+	}
+}
+
+func TestRiskManager_TrailingStop_OnlyActivatesAfterProfit(t *testing.T) {
+	rm := NewRiskManager(defaultRiskConfig())
+	rm.UpdatePositions([]entity.Position{
+		{ID: 1, SymbolID: 7, OrderSide: entity.OrderSideBuy, Price: 5000000, Amount: 0.001, RemainingAmount: 0.001},
+	})
+	// No high water mark above entry → trailing stop should not activate
+	targets := rm.CheckTrailingStop(7, 4800000)
+	if len(targets) != 0 {
+		t.Fatalf("expected 0 — trailing stop should not activate before profit, got %d", len(targets))
+	}
+}
+
+func TestRiskManager_TrailingStop_SellPosition(t *testing.T) {
+	rm := NewRiskManager(defaultRiskConfig())
+	rm.UpdatePositions([]entity.Position{
+		{ID: 1, SymbolID: 7, OrderSide: entity.OrderSideSell, Price: 5000000, Amount: 0.001, RemainingAmount: 0.001},
+	})
+	// Sell: low water mark = 4500000
+	rm.UpdateHighWaterMark(1, 4500000)
+	// Trail = 4500000 * 1.05 = 4725000. Price 4750000 > 4725000 → trigger
+	targets := rm.CheckTrailingStop(7, 4750000)
+	if len(targets) != 1 {
+		t.Fatalf("expected 1 trailing stop for sell position, got %d", len(targets))
+	}
+}


### PR DESCRIPTION
## Summary
- Add trailing stop-loss that tracks the high water mark (best price) for each open position
- When price reverses by `StopLossPercent` from the high water mark, the position is closed to protect unrealized profits
- Only activates once a position has been in profit — positions that never reach profit fall through to the regular fixed stop-loss
- High water marks are automatically cleaned up when positions are closed via `UpdatePositions`

## Changes
- **`backend/internal/usecase/risk.go`**: Added `highWaterMarks` field to `RiskManager`, `UpdateHighWaterMark` method, `CheckTrailingStop` method, updated `NewRiskManager` and `UpdatePositions`
- **`backend/internal/usecase/risk_test.go`**: Added 4 test cases covering buy/sell positions, no-trigger, and profit-only activation
- **`backend/cmd/pipeline.go`**: Integrated HWM updates and trailing stop check into `runStopLossMonitor` (before existing stop-loss check)

## Test plan
- [x] `TestRiskManager_TrailingStop_BuyPosition` — triggers when price drops below trail line
- [x] `TestRiskManager_TrailingStop_NoTriggerAboveTrail` — no trigger when price stays above trail line
- [x] `TestRiskManager_TrailingStop_OnlyActivatesAfterProfit` — does not activate before position is in profit
- [x] `TestRiskManager_TrailingStop_SellPosition` — triggers for sell position when price rises above trail line
- [x] All existing tests continue to pass (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)