### PR TITLE
feat(risk): add consecutive loss breaker with cooldown

### DIFF
--- a/backend/cmd/pipeline.go
+++ b/backend/cmd/pipeline.go
@@ -433,6 +433,7 @@ func (p *TradingPipeline) runStopLossMonitor(ctx context.Context) {
 						closeSide = string(entity.OrderSideBuy)
 					}
 					p.recordTrade(ctx, pos.SymbolID, result.OrderID, closeSide, "close", t.Last, pos.RemainingAmount, "trailing-stop", false)
+					p.riskMgr.RecordConsecutiveLoss()
 					p.persistRiskState(ctx)
 				}
 			}
@@ -452,6 +453,7 @@ func (p *TradingPipeline) runStopLossMonitor(ctx context.Context) {
 					slog.Info("pipeline: stop-loss closed", "orderID", result.OrderID)
 					loss := math.Abs(pos.FloatingProfit)
 					p.riskMgr.RecordLoss(loss)
+					p.riskMgr.RecordConsecutiveLoss()
 					closeSide := string(entity.OrderSideSell)
 					if pos.OrderSide == entity.OrderSideSell {
 						closeSide = string(entity.OrderSideBuy)
@@ -475,6 +477,7 @@ func (p *TradingPipeline) runStopLossMonitor(ctx context.Context) {
 				}
 				if result.Executed {
 					slog.Info("pipeline: take-profit closed", "orderID", result.OrderID)
+					p.riskMgr.ResetConsecutiveLosses()
 					closeSide := string(entity.OrderSideSell)
 					if pos.OrderSide == entity.OrderSideSell {
 						closeSide = string(entity.OrderSideBuy)

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -37,11 +37,13 @@ type DatabaseConfig struct {
 }
 
 type RiskConfig struct {
-	MaxPositionAmount float64
-	MaxDailyLoss      float64
-	StopLossPercent   float64
-	TakeProfitPercent float64
-	InitialCapital    float64
+	MaxPositionAmount    float64
+	MaxDailyLoss         float64
+	StopLossPercent      float64
+	TakeProfitPercent    float64
+	InitialCapital       float64
+	MaxConsecutiveLosses int
+	CooldownMinutes      int
 }
 
 type RakutenConfig struct {
@@ -60,11 +62,13 @@ func Load() *Config {
 			Path: getEnv("DATABASE_PATH", "data/trading.db"),
 		},
 		Risk: RiskConfig{
-			MaxPositionAmount: getEnvFloat("RISK_MAX_POSITION_AMOUNT", 5000),
-			MaxDailyLoss:      getEnvFloat("RISK_MAX_DAILY_LOSS", 5000),
-			StopLossPercent:   getEnvFloat("RISK_STOP_LOSS_PERCENT", 5),
-			TakeProfitPercent: getEnvFloat("RISK_TAKE_PROFIT_PERCENT", 10),
-			InitialCapital:    getEnvFloat("RISK_INITIAL_CAPITAL", 10000),
+			MaxPositionAmount:    getEnvFloat("RISK_MAX_POSITION_AMOUNT", 5000),
+			MaxDailyLoss:         getEnvFloat("RISK_MAX_DAILY_LOSS", 5000),
+			StopLossPercent:      getEnvFloat("RISK_STOP_LOSS_PERCENT", 5),
+			TakeProfitPercent:    getEnvFloat("RISK_TAKE_PROFIT_PERCENT", 10),
+			InitialCapital:       getEnvFloat("RISK_INITIAL_CAPITAL", 10000),
+			MaxConsecutiveLosses: getEnvInt("RISK_MAX_CONSECUTIVE_LOSSES", 3),
+			CooldownMinutes:      getEnvInt("RISK_COOLDOWN_MINUTES", 30),
 		},
 		Rakuten: RakutenConfig{
 			BaseURL:   getEnv("RAKUTEN_API_BASE_URL", "https://exchange.rakuten-wallet.co.jp"),

--- a/backend/internal/domain/entity/risk.go
+++ b/backend/internal/domain/entity/risk.go
@@ -2,11 +2,13 @@ package entity
 
 // RiskConfig はリスク管理のパラメータ。
 type RiskConfig struct {
-	MaxPositionAmount float64 `json:"maxPositionAmount"` // 同時ポジション上限（円）
-	MaxDailyLoss      float64 `json:"maxDailyLoss"`      // 日次損失上限（円）
-	StopLossPercent   float64 `json:"stopLossPercent"`    // 損切りライン（%）
-	TakeProfitPercent float64 `json:"takeProfitPercent"`  // 利確ライン（%）
-	InitialCapital    float64 `json:"initialCapital"`     // 軍資金（円）
+	MaxPositionAmount    float64 `json:"maxPositionAmount"`    // 同時ポジション上限（円）
+	MaxDailyLoss         float64 `json:"maxDailyLoss"`         // 日次損失上限（円）
+	StopLossPercent      float64 `json:"stopLossPercent"`      // 損切りライン（%）
+	TakeProfitPercent    float64 `json:"takeProfitPercent"`    // 利確ライン（%）
+	InitialCapital       float64 `json:"initialCapital"`       // 軍資金（円）
+	MaxConsecutiveLosses int     `json:"maxConsecutiveLosses"` // 連敗上限（0=無効）
+	CooldownMinutes      int     `json:"cooldownMinutes"`      // 冷却期間（分）
 }
 
 // OrderProposal はRisk Managerに承認を求める注文提案。

--- a/backend/internal/usecase/risk.go
+++ b/backend/internal/usecase/risk.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
 )
@@ -18,13 +19,15 @@ type RiskStatus struct {
 }
 
 type RiskManager struct {
-	config         entity.RiskConfig
-	mu             sync.RWMutex
-	balance        float64
-	dailyLoss      float64
-	positions      []entity.Position
-	manualStop     bool
-	highWaterMarks map[int64]float64 // positionID → best price
+	config            entity.RiskConfig
+	mu                sync.RWMutex
+	balance           float64
+	dailyLoss         float64
+	positions         []entity.Position
+	manualStop        bool
+	highWaterMarks    map[int64]float64 // positionID → best price
+	consecutiveLosses int
+	cooldownUntil     time.Time
 }
 
 func NewRiskManager(config entity.RiskConfig) *RiskManager {
@@ -49,6 +52,13 @@ func (rm *RiskManager) CheckOrder(ctx context.Context, proposal entity.OrderProp
 		return entity.RiskCheckResult{
 			Approved: false,
 			Reason:   "trading is manually stopped",
+		}
+	}
+
+	if rm.config.MaxConsecutiveLosses > 0 && !rm.cooldownUntil.IsZero() && time.Now().Before(rm.cooldownUntil) {
+		return entity.RiskCheckResult{
+			Approved: false,
+			Reason:   fmt.Sprintf("cooldown: %d consecutive losses, trading paused until %s", rm.consecutiveLosses, rm.cooldownUntil.Format("15:04")),
 		}
 	}
 
@@ -134,6 +144,25 @@ func (rm *RiskManager) ResetDailyLoss() {
 	rm.mu.Lock()
 	defer rm.mu.Unlock()
 	rm.dailyLoss = 0
+}
+
+// RecordConsecutiveLoss increments the consecutive loss counter.
+// If the counter reaches MaxConsecutiveLosses, a cooldown period is activated.
+func (rm *RiskManager) RecordConsecutiveLoss() {
+	rm.mu.Lock()
+	defer rm.mu.Unlock()
+	rm.consecutiveLosses++
+	if rm.config.MaxConsecutiveLosses > 0 && rm.consecutiveLosses >= rm.config.MaxConsecutiveLosses {
+		rm.cooldownUntil = time.Now().Add(time.Duration(rm.config.CooldownMinutes) * time.Minute)
+	}
+}
+
+// ResetConsecutiveLosses resets the consecutive loss counter and clears cooldown.
+func (rm *RiskManager) ResetConsecutiveLosses() {
+	rm.mu.Lock()
+	defer rm.mu.Unlock()
+	rm.consecutiveLosses = 0
+	rm.cooldownUntil = time.Time{}
 }
 
 // UpdateHighWaterMark updates the best price for a position.

--- a/backend/internal/usecase/risk_test.go
+++ b/backend/internal/usecase/risk_test.go
@@ -9,11 +9,13 @@ import (
 
 func defaultRiskConfig() entity.RiskConfig {
 	return entity.RiskConfig{
-		MaxPositionAmount: 5000,
-		MaxDailyLoss:      5000,
-		StopLossPercent:   5,
-		TakeProfitPercent: 10,
-		InitialCapital:    10000,
+		MaxPositionAmount:    5000,
+		MaxDailyLoss:         5000,
+		StopLossPercent:      5,
+		TakeProfitPercent:    10,
+		InitialCapital:       10000,
+		MaxConsecutiveLosses: 3,
+		CooldownMinutes:      30,
 	}
 }
 
@@ -281,5 +283,80 @@ func TestRiskManager_TrailingStop_SellPosition(t *testing.T) {
 	targets := rm.CheckTrailingStop(7, 4750000)
 	if len(targets) != 1 {
 		t.Fatalf("expected 1 trailing stop for sell position, got %d", len(targets))
+	}
+}
+
+func TestRiskManager_ConsecutiveLossBreaker_BlocksAfterNLosses(t *testing.T) {
+	rm := NewRiskManager(defaultRiskConfig())
+	// Record 3 consecutive losses (MaxConsecutiveLosses=3)
+	rm.RecordConsecutiveLoss()
+	rm.RecordConsecutiveLoss()
+	rm.RecordConsecutiveLoss()
+
+	proposal := entity.OrderProposal{
+		SymbolID: 7, Side: entity.OrderSideBuy, OrderType: entity.OrderTypeMarket,
+		Amount: 0.001, Price: 1000000,
+	}
+	result := rm.CheckOrder(context.Background(), proposal)
+	if result.Approved {
+		t.Fatal("order should be rejected after 3 consecutive losses")
+	}
+	if result.Reason == "" {
+		t.Fatal("rejection reason should not be empty")
+	}
+}
+
+func TestRiskManager_ConsecutiveLossBreaker_ResetOnWin(t *testing.T) {
+	rm := NewRiskManager(defaultRiskConfig())
+	// Record 2 losses then reset (simulating a take-profit win)
+	rm.RecordConsecutiveLoss()
+	rm.RecordConsecutiveLoss()
+	rm.ResetConsecutiveLosses()
+
+	proposal := entity.OrderProposal{
+		SymbolID: 7, Side: entity.OrderSideBuy, OrderType: entity.OrderTypeMarket,
+		Amount: 0.001, Price: 1000000,
+	}
+	result := rm.CheckOrder(context.Background(), proposal)
+	if !result.Approved {
+		t.Fatalf("order should be approved after reset: %s", result.Reason)
+	}
+}
+
+func TestRiskManager_ConsecutiveLossBreaker_DisabledWhenZero(t *testing.T) {
+	cfg := defaultRiskConfig()
+	cfg.MaxConsecutiveLosses = 0
+	rm := NewRiskManager(cfg)
+
+	// Record many losses — should never trigger cooldown when disabled
+	for i := 0; i < 10; i++ {
+		rm.RecordConsecutiveLoss()
+	}
+
+	proposal := entity.OrderProposal{
+		SymbolID: 7, Side: entity.OrderSideBuy, OrderType: entity.OrderTypeMarket,
+		Amount: 0.001, Price: 1000000,
+	}
+	result := rm.CheckOrder(context.Background(), proposal)
+	if !result.Approved {
+		t.Fatalf("order should be approved when MaxConsecutiveLosses=0: %s", result.Reason)
+	}
+}
+
+func TestRiskManager_ConsecutiveLossBreaker_CloseOrdersAllowed(t *testing.T) {
+	rm := NewRiskManager(defaultRiskConfig())
+	// Trigger cooldown
+	rm.RecordConsecutiveLoss()
+	rm.RecordConsecutiveLoss()
+	rm.RecordConsecutiveLoss()
+
+	posID := int64(1)
+	proposal := entity.OrderProposal{
+		SymbolID: 7, Side: entity.OrderSideSell, OrderType: entity.OrderTypeMarket,
+		Amount: 0.001, Price: 1000000, IsClose: true, PositionID: &posID,
+	}
+	result := rm.CheckOrder(context.Background(), proposal)
+	if !result.Approved {
+		t.Fatalf("close order should always be approved during cooldown: %s", result.Reason)
 	}
 }


### PR DESCRIPTION
## Summary
- Add a consecutive loss counter and cooldown timer to RiskManager that pauses trading for N minutes (default 30) after M consecutive stop-losses (default 3)
- Take-profit wins reset the counter; close orders are always allowed during cooldown
- Configurable via `RISK_MAX_CONSECUTIVE_LOSSES` and `RISK_COOLDOWN_MINUTES` env vars (set to 0 to disable)

## Changed files
- `backend/internal/domain/entity/risk.go` — Added `MaxConsecutiveLosses` and `CooldownMinutes` fields to `RiskConfig`
- `backend/config/config.go` — Added new config fields with env var support
- `backend/internal/usecase/risk.go` — Added `consecutiveLosses`/`cooldownUntil` state, `RecordConsecutiveLoss()`/`ResetConsecutiveLosses()` methods, and cooldown check in `CheckOrder`
- `backend/internal/usecase/risk_test.go` — Updated `defaultRiskConfig()`, added 4 test cases
- `backend/cmd/pipeline.go` — Wired `RecordConsecutiveLoss` on stop-loss/trailing-stop and `ResetConsecutiveLosses` on take-profit

## Test plan
- [x] `TestRiskManager_ConsecutiveLossBreaker_BlocksAfterNLosses` — 3 losses then order rejected
- [x] `TestRiskManager_ConsecutiveLossBreaker_ResetOnWin` — 2 losses + reset → order approved
- [x] `TestRiskManager_ConsecutiveLossBreaker_DisabledWhenZero` — MaxConsecutiveLosses=0 → never blocks
- [x] `TestRiskManager_ConsecutiveLossBreaker_CloseOrdersAllowed` — IsClose=true orders always allowed during cooldown
- [x] All existing tests pass (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)