### PR TITLE
fix: sync RiskConfig type and settings UI with new backend fields

### DIFF
--- a/backend/internal/interfaces/api/handler/risk.go
+++ b/backend/internal/interfaces/api/handler/risk.go
@@ -37,8 +37,17 @@ func validateRiskConfig(cfg entity.RiskConfig) error {
 	if cfg.StopLossPercent <= 0 {
 		return fmt.Errorf("stopLossPercent must be positive")
 	}
+	if cfg.TakeProfitPercent < 0 {
+		return fmt.Errorf("takeProfitPercent must be non-negative")
+	}
 	if cfg.InitialCapital <= 0 {
 		return fmt.Errorf("initialCapital must be positive")
+	}
+	if cfg.MaxConsecutiveLosses < 0 {
+		return fmt.Errorf("maxConsecutiveLosses must be non-negative")
+	}
+	if cfg.CooldownMinutes < 0 {
+		return fmt.Errorf("cooldownMinutes must be non-negative")
 	}
 	return nil
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -71,7 +71,10 @@ export type RiskConfig = {
   maxPositionAmount: number
   maxDailyLoss: number
   stopLossPercent: number
+  takeProfitPercent: number
   initialCapital: number
+  maxConsecutiveLosses: number
+  cooldownMinutes: number
 }
 
 // TradableSymbol は GET /api/v1/symbols のレスポンス要素。

--- a/frontend/src/routes/settings.tsx
+++ b/frontend/src/routes/settings.tsx
@@ -23,7 +23,10 @@ function SettingsPage() {
     maxPositionAmount: 0,
     maxDailyLoss: 0,
     stopLossPercent: 0,
+    takeProfitPercent: 0,
     initialCapital: 0,
+    maxConsecutiveLosses: 0,
+    cooldownMinutes: 0,
   })
 
   useEffect(() => {
@@ -66,9 +69,24 @@ function SettingsPage() {
               onChange={(value) => handleNumberChange('stopLossPercent', value)}
             />
             <Field
+              label="利確率 (%)"
+              value={form.takeProfitPercent}
+              onChange={(value) => handleNumberChange('takeProfitPercent', value)}
+            />
+            <Field
               label="初期資金"
               value={form.initialCapital}
               onChange={(value) => handleNumberChange('initialCapital', value)}
+            />
+            <Field
+              label="連敗上限 (0=無効)"
+              value={form.maxConsecutiveLosses}
+              onChange={(value) => handleNumberChange('maxConsecutiveLosses', value)}
+            />
+            <Field
+              label="冷却期間 (分)"
+              value={form.cooldownMinutes}
+              onChange={(value) => handleNumberChange('cooldownMinutes', value)}
             />
           </div>
 


### PR DESCRIPTION
## Summary
- `frontend/src/lib/api.ts`: `RiskConfig` 型に `takeProfitPercent`, `maxConsecutiveLosses`, `cooldownMinutes` を追加
- `frontend/src/routes/settings.tsx`: 設定画面に「利確率」「連敗上限」「冷却期間」のフォームフィールドを追加
- `backend/internal/interfaces/api/handler/risk.go`: 新フィールドのバリデーション追加（0は「無効」として許可）

## Why
PR #58〜#60 で `RiskConfig` に新フィールドを追加したが、フロントエンドの型定義と設定画面が未同期だった。

## Test plan
- [ ] `npx tsc --noEmit` — TypeScript 型チェック PASS
- [ ] `npx vite build` — フロントエンドビルド PASS
- [ ] `go test ./...` — バックエンド全テスト PASS
- [ ] 設定画面で新しい3項目が表示・編集・保存できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)