### PR TITLE
feat(chart): add infinite scroll for candlestick chart

### DIFF
--- a/backend/internal/domain/repository/market_data.go
+++ b/backend/internal/domain/repository/market_data.go
@@ -15,7 +15,8 @@ type MarketDataRepository interface {
 	SaveCandles(ctx context.Context, symbolID int64, interval string, candles []entity.Candle) error
 
 	// GetCandles returns candlesticks for a symbol/interval, newest first, up to limit.
-	GetCandles(ctx context.Context, symbolID int64, interval string, limit int) ([]entity.Candle, error)
+	// If before > 0, only candles with time < before are returned (for pagination).
+	GetCandles(ctx context.Context, symbolID int64, interval string, limit int, before int64) ([]entity.Candle, error)
 
 	// SaveTicker saves ticker data.
 	SaveTicker(ctx context.Context, ticker entity.Ticker) error

--- a/backend/internal/infrastructure/database/market_data_repo.go
+++ b/backend/internal/infrastructure/database/market_data_repo.go
@@ -56,13 +56,24 @@ func (r *MarketDataRepo) SaveCandles(ctx context.Context, symbolID int64, interv
 	return nil
 }
 
-func (r *MarketDataRepo) GetCandles(ctx context.Context, symbolID int64, interval string, limit int) ([]entity.Candle, error) {
-	rows, err := r.db.QueryContext(ctx,
-		`SELECT open, high, low, close, volume, time FROM candles
-		 WHERE symbol_id = ? AND interval = ?
-		 ORDER BY time DESC LIMIT ?`,
-		symbolID, interval, limit,
-	)
+func (r *MarketDataRepo) GetCandles(ctx context.Context, symbolID int64, interval string, limit int, before int64) ([]entity.Candle, error) {
+	var rows *sql.Rows
+	var err error
+	if before > 0 {
+		rows, err = r.db.QueryContext(ctx,
+			`SELECT open, high, low, close, volume, time FROM candles
+			 WHERE symbol_id = ? AND interval = ? AND time < ?
+			 ORDER BY time DESC LIMIT ?`,
+			symbolID, interval, before, limit,
+		)
+	} else {
+		rows, err = r.db.QueryContext(ctx,
+			`SELECT open, high, low, close, volume, time FROM candles
+			 WHERE symbol_id = ? AND interval = ?
+			 ORDER BY time DESC LIMIT ?`,
+			symbolID, interval, limit,
+		)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("query candles: %w", err)
 	}

--- a/backend/internal/infrastructure/database/market_data_repo_test.go
+++ b/backend/internal/infrastructure/database/market_data_repo_test.go
@@ -36,7 +36,7 @@ func TestSaveAndGetCandle(t *testing.T) {
 		t.Fatalf("save failed: %v", err)
 	}
 
-	candles, err := repo.GetCandles(ctx, 7, "PT1M", 10)
+	candles, err := repo.GetCandles(ctx, 7, "PT1M", 10, 0)
 	if err != nil {
 		t.Fatalf("get failed: %v", err)
 	}
@@ -64,7 +64,7 @@ func TestSaveCandle_DuplicateIgnored(t *testing.T) {
 		t.Fatalf("duplicate save should not error: %v", err)
 	}
 
-	candles, err := repo.GetCandles(ctx, 7, "PT1M", 10)
+	candles, err := repo.GetCandles(ctx, 7, "PT1M", 10, 0)
 	if err != nil {
 		t.Fatalf("get failed: %v", err)
 	}
@@ -88,7 +88,7 @@ func TestSaveCandles_Batch(t *testing.T) {
 		t.Fatalf("batch save failed: %v", err)
 	}
 
-	result, err := repo.GetCandles(ctx, 7, "PT1M", 10)
+	result, err := repo.GetCandles(ctx, 7, "PT1M", 10, 0)
 	if err != nil {
 		t.Fatalf("get failed: %v", err)
 	}
@@ -116,12 +116,63 @@ func TestGetCandles_Limit(t *testing.T) {
 	}
 	_ = repo.SaveCandles(ctx, 7, "PT1M", candles)
 
-	result, err := repo.GetCandles(ctx, 7, "PT1M", 3)
+	result, err := repo.GetCandles(ctx, 7, "PT1M", 3, 0)
 	if err != nil {
 		t.Fatalf("get failed: %v", err)
 	}
 	if len(result) != 3 {
 		t.Fatalf("expected 3 candles (limited), got %d", len(result))
+	}
+}
+
+func TestGetCandles_BeforeCursor(t *testing.T) {
+	repo := setupTestDB(t)
+	ctx := context.Background()
+
+	candles := []entity.Candle{
+		{Open: 1, High: 2, Low: 0, Close: 1, Volume: 1, Time: 1000},
+		{Open: 2, High: 3, Low: 1, Close: 2, Volume: 2, Time: 2000},
+		{Open: 3, High: 4, Low: 2, Close: 3, Volume: 3, Time: 3000},
+		{Open: 4, High: 5, Low: 3, Close: 4, Volume: 4, Time: 4000},
+		{Open: 5, High: 6, Low: 4, Close: 5, Volume: 5, Time: 5000},
+	}
+	_ = repo.SaveCandles(ctx, 7, "PT1M", candles)
+
+	// before=3000 should return candles with time < 3000, i.e. time=2000 and time=1000
+	result, err := repo.GetCandles(ctx, 7, "PT1M", 10, 3000)
+	if err != nil {
+		t.Fatalf("get failed: %v", err)
+	}
+	if len(result) != 2 {
+		t.Fatalf("expected 2 candles before time=3000, got %d", len(result))
+	}
+	// Newest first
+	if result[0].Time != 2000 {
+		t.Fatalf("expected newest first (time=2000), got time=%d", result[0].Time)
+	}
+	if result[1].Time != 1000 {
+		t.Fatalf("expected second (time=1000), got time=%d", result[1].Time)
+	}
+
+	// before=0 should return all (no filter)
+	all, err := repo.GetCandles(ctx, 7, "PT1M", 10, 0)
+	if err != nil {
+		t.Fatalf("get failed: %v", err)
+	}
+	if len(all) != 5 {
+		t.Fatalf("expected 5 candles with before=0, got %d", len(all))
+	}
+
+	// before with limit
+	limited, err := repo.GetCandles(ctx, 7, "PT1M", 1, 5000)
+	if err != nil {
+		t.Fatalf("get failed: %v", err)
+	}
+	if len(limited) != 1 {
+		t.Fatalf("expected 1 candle with limit=1, got %d", len(limited))
+	}
+	if limited[0].Time != 4000 {
+		t.Fatalf("expected time=4000 (newest before 5000 with limit 1), got %d", limited[0].Time)
 	}
 }
 
@@ -133,7 +184,7 @@ func TestGetCandles_FilterBySymbolAndInterval(t *testing.T) {
 	_ = repo.SaveCandle(ctx, 7, "PT5M", entity.Candle{Open: 1, High: 2, Low: 0, Close: 1, Volume: 1, Time: 1000})
 	_ = repo.SaveCandle(ctx, 8, "PT1M", entity.Candle{Open: 1, High: 2, Low: 0, Close: 1, Volume: 1, Time: 1000})
 
-	result, err := repo.GetCandles(ctx, 7, "PT1M", 10)
+	result, err := repo.GetCandles(ctx, 7, "PT1M", 10, 0)
 	if err != nil {
 		t.Fatalf("get failed: %v", err)
 	}

--- a/backend/internal/interfaces/api/handler/candle.go
+++ b/backend/internal/interfaces/api/handler/candle.go
@@ -50,32 +50,54 @@ func (h *CandleHandler) GetCandles(c *gin.Context) {
 		limit = 500
 	}
 
+	var before int64
+	if beforeStr := c.Query("before"); beforeStr != "" {
+		before, _ = strconv.ParseInt(beforeStr, 10, 64)
+	}
+
 	ctx := c.Request.Context()
-	candles, err := h.marketDataSvc.GetCandles(ctx, symbolID, interval, limit)
+	candles, err := h.marketDataSvc.GetCandles(ctx, symbolID, interval, limit, before)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 
-	// DB にデータが無ければ楽天APIから取得して保存、再取得する。
-	if len(candles) == 0 && h.restClient != nil {
-		resp, fetchErr := h.restClient.GetCandlestick(ctx, symbolID, interval, nil, nil)
+	// DB のデータが不足していれば楽天APIからオンデマンド取得して補充する。
+	// - before なし: DB が空なら最新データを取得
+	// - before あり: DB が limit 未満なら dateTo=before で過去データを取得
+	needFetch := h.restClient != nil &&
+		(len(candles) == 0 || (before > 0 && len(candles) < limit))
+	if needFetch {
+		var dateFrom, dateTo *int64
+		if before > 0 {
+			dateTo = &before
+		}
+		resp, fetchErr := h.restClient.GetCandlestick(ctx, symbolID, interval, dateFrom, dateTo)
 		if fetchErr != nil {
+			// フェッチ失敗でも DB のデータがあればそれを返す
+			if len(candles) > 0 {
+				goto respond
+			}
 			c.JSON(http.StatusInternalServerError, gin.H{"error": fetchErr.Error()})
 			return
 		}
 		if len(resp.Candlesticks) > 0 {
 			if saveErr := h.marketDataSvc.SaveCandles(ctx, symbolID, interval, resp.Candlesticks); saveErr != nil {
+				if len(candles) > 0 {
+					goto respond
+				}
 				c.JSON(http.StatusInternalServerError, gin.H{"error": saveErr.Error()})
 				return
 			}
-			candles, err = h.marketDataSvc.GetCandles(ctx, symbolID, interval, limit)
+			candles, err = h.marketDataSvc.GetCandles(ctx, symbolID, interval, limit, before)
 			if err != nil {
 				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 				return
 			}
 		}
 	}
+
+respond:
 
 	// Lightweight Charts expects oldest -> newest ordering.
 	for i, j := 0, len(candles)-1; i < j; i, j = i+1, j-1 {

--- a/backend/internal/usecase/indicator.go
+++ b/backend/internal/usecase/indicator.go
@@ -25,7 +25,7 @@ func (c *IndicatorCalculator) Calculate(ctx context.Context, symbolID int64, int
 	// EMA/RSI/MACDはパス依存型指標のため、十分なウォームアップ期間が必要。
 	// EMA26は約3倍(78本)、MACD Signal(9)の追加で約90本のウォームアップ。
 	// 500本取得すれば実用上十分な精度に収束する。
-	candles, err := c.repo.GetCandles(ctx, symbolID, interval, 500)
+	candles, err := c.repo.GetCandles(ctx, symbolID, interval, 500, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/usecase/market_data.go
+++ b/backend/internal/usecase/market_data.go
@@ -78,8 +78,9 @@ func (s *MarketDataService) HandleTicker(ctx context.Context, ticker entity.Tick
 }
 
 // GetCandles retrieves candlestick data from the repository.
-func (s *MarketDataService) GetCandles(ctx context.Context, symbolID int64, interval string, limit int) ([]entity.Candle, error) {
-	return s.repo.GetCandles(ctx, symbolID, interval, limit)
+// If before > 0, only candles older than that timestamp are returned.
+func (s *MarketDataService) GetCandles(ctx context.Context, symbolID int64, interval string, limit int, before int64) ([]entity.Candle, error) {
+	return s.repo.GetCandles(ctx, symbolID, interval, limit, before)
 }
 
 // GetLatestTicker returns the most recently persisted ticker for a symbol.

--- a/backend/internal/usecase/market_data_test.go
+++ b/backend/internal/usecase/market_data_test.go
@@ -35,16 +35,28 @@ func (m *mockMarketDataRepo) SaveCandles(_ context.Context, _ int64, _ string, c
 	return nil
 }
 
-func (m *mockMarketDataRepo) GetCandles(_ context.Context, _ int64, _ string, limit int) ([]entity.Candle, error) {
+func (m *mockMarketDataRepo) GetCandles(_ context.Context, _ int64, _ string, limit int, before int64) ([]entity.Candle, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if limit > len(m.candles) {
-		limit = len(m.candles)
+
+	src := m.candles
+	if before > 0 {
+		var filtered []entity.Candle
+		for _, c := range src {
+			if c.Time < before {
+				filtered = append(filtered, c)
+			}
+		}
+		src = filtered
+	}
+
+	if limit > len(src) {
+		limit = len(src)
 	}
 	// リポジトリ契約通り新しい順で返す
 	result := make([]entity.Candle, limit)
 	for i := 0; i < limit; i++ {
-		result[i] = m.candles[len(m.candles)-1-i]
+		result[i] = src[len(src)-1-i]
 	}
 	return result, nil
 }

--- a/frontend/src/components/CandlestickChart.tsx
+++ b/frontend/src/components/CandlestickChart.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, useCallback } from 'react'
+import { useEffect, useRef, useState, useCallback, useMemo } from 'react'
 import { createChart, CandlestickSeries, LineSeries, type IChartApi, type ISeriesApi, type CandlestickData, type LineData, type Time } from 'lightweight-charts'
 import { useCandles, type CandleInterval } from '../hooks/useCandles'
 
@@ -23,6 +23,9 @@ const MA_CONFIG: Record<MALineKey, { label: string; color: string }> = {
   ema12: { label: 'EMA(12)', color: '#00bfff' },
   ema26: { label: 'EMA(26)', color: '#a78bfa' },
 }
+
+/** Threshold: fetch more data when user scrolls within N bars of the left edge. */
+const SCROLL_THRESHOLD = 20
 
 function calcSMA(closes: number[], period: number): (number | null)[] {
   const result: (number | null)[] = []
@@ -61,10 +64,26 @@ export function CandlestickChart({ symbolId }: CandlestickChartProps) {
   const chartRef = useRef<IChartApi | null>(null)
   const seriesRef = useRef<ISeriesApi<'Candlestick'> | null>(null)
   const lineSeriesRefs = useRef<Partial<Record<MALineKey, ISeriesApi<'Line'>>>>({})
+  const prevCandleCountRef = useRef(0)
 
   const [interval, setInterval] = useState<CandleInterval>('PT15M')
-  const { data: candlesData, isFetching } = useCandles(symbolId, interval)
-  const candles = candlesData ?? []
+  const { data, isFetching, hasNextPage, fetchNextPage, isFetchingNextPage } = useCandles(symbolId, interval)
+
+  // Flatten all pages into a single sorted (oldest→newest) candle array
+  const candles = useMemo(() => {
+    if (!data?.pages) return []
+    // Pages: page 0 = newest, page 1 = older, etc.
+    // Each page is already sorted oldest→newest from API.
+    // Concat older pages first, then newer.
+    const all = [...data.pages].reverse().flat()
+    // Deduplicate by time (in case of overlap from refetch)
+    const seen = new Set<number>()
+    return all.filter((c) => {
+      if (seen.has(c.time)) return false
+      seen.add(c.time)
+      return true
+    })
+  }, [data])
 
   const [visible, setVisible] = useState<Record<MALineKey, boolean>>({
     sma20: false,
@@ -115,14 +134,43 @@ export function CandlestickChart({ symbolId }: CandlestickChartProps) {
     return () => {
       window.removeEventListener('resize', handleResize)
       lineSeriesRefs.current = {}
+      prevCandleCountRef.current = 0
       chart.remove()
     }
   }, [])
 
+  // Infinite scroll: detect when user is near the left (oldest) edge
   useEffect(() => {
-    if (!seriesRef.current || candles.length === 0) return
+    const chart = chartRef.current
+    if (!chart) return
 
-    const data: CandlestickData<Time>[] = candles.map((c) => ({
+    const onVisibleRangeChange = () => {
+      const range = chart.timeScale().getVisibleLogicalRange()
+      if (!range) return
+      if (range.from <= SCROLL_THRESHOLD && hasNextPage && !isFetchingNextPage) {
+        fetchNextPage()
+      }
+    }
+
+    chart.timeScale().subscribeVisibleLogicalRangeChange(onVisibleRangeChange)
+    return () => {
+      chart.timeScale().unsubscribeVisibleLogicalRangeChange(onVisibleRangeChange)
+    }
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage])
+
+  // Update chart data — preserve scroll position when prepending older candles
+  useEffect(() => {
+    if (!seriesRef.current || !chartRef.current || candles.length === 0) return
+
+    const chart = chartRef.current
+    const prevCount = prevCandleCountRef.current
+    const prepended = candles.length > prevCount && prevCount > 0
+
+    // Save the visible time range before updating data.
+    // Time-based range is stable even when logical indices shift due to prepend.
+    const visibleTimeRange = prepended ? chart.timeScale().getVisibleRange() : null
+
+    const chartData: CandlestickData<Time>[] = candles.map((c) => ({
       time: (Math.floor(c.time / 1000)) as Time,
       open: c.open,
       high: c.high,
@@ -130,8 +178,17 @@ export function CandlestickChart({ symbolId }: CandlestickChartProps) {
       close: c.close,
     }))
 
-    seriesRef.current.setData(data)
-    chartRef.current?.timeScale().fitContent()
+    seriesRef.current.setData(chartData)
+    prevCandleCountRef.current = candles.length
+
+    if (visibleTimeRange) {
+      // Restore the same time window after prepending older candles
+      chart.timeScale().setVisibleRange(visibleTimeRange)
+    } else if (prevCount === 0) {
+      // First load — fit all content
+      chart.timeScale().fitContent()
+    }
+    // On refetch with no new candles, do nothing — keep current scroll position
   }, [candles])
 
   // Manage MA line series based on toggle state
@@ -210,7 +267,11 @@ export function CandlestickChart({ symbolId }: CandlestickChartProps) {
               )
             })}
           </div>
-          {isFetching && <span className="text-[10px] text-text-secondary">読み込み中...</span>}
+          {(isFetching || isFetchingNextPage) && (
+            <span className="text-[10px] text-text-secondary">
+              {isFetchingNextPage ? '過去データを読み込み中...' : '読み込み中...'}
+            </span>
+          )}
         </div>
         <div className="flex gap-1.5">
           {(Object.keys(MA_CONFIG) as MALineKey[]).map((key) => (

--- a/frontend/src/hooks/useCandles.ts
+++ b/frontend/src/hooks/useCandles.ts
@@ -1,12 +1,25 @@
-import { useQuery } from '@tanstack/react-query'
+import { useInfiniteQuery } from '@tanstack/react-query'
 import { fetchApi, type Candle } from '../lib/api'
 
 export type CandleInterval = 'PT1M' | 'PT5M' | 'PT15M' | 'PT1H' | 'P1D' | 'P1W'
 
+const PAGE_SIZE = 500
+
 export function useCandles(symbolId: number, interval: CandleInterval = 'PT15M') {
-  return useQuery({
+  return useInfiniteQuery({
     queryKey: ['candles', symbolId, interval],
-    queryFn: () => fetchApi<Candle[]>(`/candles/${symbolId}?interval=${interval}`),
+    queryFn: async ({ pageParam }) => {
+      const params = new URLSearchParams({ interval, limit: String(PAGE_SIZE) })
+      if (pageParam) params.set('before', String(pageParam))
+      const result = await fetchApi<Candle[] | null>(`/candles/${symbolId}?${params}`)
+      return result ?? []
+    },
+    initialPageParam: 0 as number,
+    getNextPageParam: (lastPage) => {
+      if (!lastPage || lastPage.length === 0) return undefined
+      // The oldest candle's time becomes the cursor for the next page
+      return lastPage[0].time // data comes oldest→newest from the API
+    },
     enabled: Number.isFinite(symbolId),
     refetchInterval: 60_000,
   })


### PR DESCRIPTION
## Summary

- ローソク足チャートに無限スクロール（過去データの動的読み込み）を実装
- バックエンドに `before` クエリパラメータによるカーソルベースページネーションを追加
- DBにデータがない期間は楽天APIからオンデマンドで過去データを取得・保存

## Changes

### Backend
- `GetCandles` に `before int64` パラメータを追加（repository → service → handler 全レイヤー）
- `before > 0` の場合 `WHERE time < ?` で指定時刻より前のデータのみ返す
- DBのデータが `limit` 未満の場合、楽天APIに `dateTo=before` で過去データを取得して補充
- `TestGetCandles_BeforeCursor` テストを追加

### Frontend
- `useCandles`: `useQuery` → `useInfiniteQuery` に変更、`before` カーソルでページネーション
- `CandlestickChart`: `subscribeVisibleLogicalRangeChange` で左端スクロール検知 → `fetchNextPage()`
- データprepend時のスクロール位置保持（time-based range で安定化）

## Test plan
- [x] `go test ./...` 全テストパス
- [x] `npx tsc --noEmit` 型エラーなし（既存の無関係な1件を除く）
- [x] `npx vite build` ビルド成功
- [x] Docker環境でブラウザ動作確認済み
  - 初回表示: 最新500本のローソク足が正常表示
  - 左スクロール: 過去データが自動フェッチされシームレスに表示
  - 楽天APIオンデマンド取得: DB外の期間もスクロールで自動取得（約1ヶ月分確認）
  - スクロール位置: データ追加時にジャンプしない
  - コンソールエラー: 0件

## AIエージェント利用確認
- [x] Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)