### PR TITLE
feat(strategy): add signal confidence scoring and amount scaling

### DIFF
--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -78,6 +78,7 @@ func main() {
 			Interval:          time.Duration(cfg.Trading.PipelineIntervalSec) * time.Second,
 			StateSyncInterval: time.Duration(cfg.Trading.StateSyncIntervalSec) * time.Second,
 			TradeAmount:       cfg.Trading.TradeAmount,
+			MinConfidence:     cfg.Trading.MinConfidence,
 		},
 		restClient,
 		restClient, // SymbolFetcher

--- a/backend/cmd/pipeline.go
+++ b/backend/cmd/pipeline.go
@@ -52,6 +52,7 @@ type TradingPipeline struct {
 	tradeAmount    float64
 	baseStepAmount float64 // シンボルごとの最小注文刻み幅（例: BTC=0.01, LTC=0.1）
 	minOrderAmount float64 // シンボルごとの最小注文数量
+	minConfidence  float64 // シグナル最小信頼度（これ未満はHOLD扱い）
 
 	restClient       repository.OrderClient
 	symbolFetcher    repository.SymbolFetcher
@@ -74,6 +75,7 @@ type tradingSnapshot struct {
 	tradeAmount    float64
 	baseStepAmount float64
 	minOrderAmount float64
+	minConfidence  float64
 }
 
 func (p *TradingPipeline) snapshot() tradingSnapshot {
@@ -84,6 +86,7 @@ func (p *TradingPipeline) snapshot() tradingSnapshot {
 		tradeAmount:    p.tradeAmount,
 		baseStepAmount: p.baseStepAmount,
 		minOrderAmount: p.minOrderAmount,
+		minConfidence:  p.minConfidence,
 	}
 }
 
@@ -93,6 +96,7 @@ type TradingPipelineConfig struct {
 	Interval          time.Duration
 	StateSyncInterval time.Duration
 	TradeAmount       float64
+	MinConfidence     float64
 }
 
 func NewTradingPipeline(
@@ -112,6 +116,7 @@ func NewTradingPipeline(
 		interval:          cfg.Interval,
 		stateSyncInterval: cfg.StateSyncInterval,
 		tradeAmount:       cfg.TradeAmount,
+		minConfidence:     cfg.MinConfidence,
 		restClient:        restClient,
 		symbolFetcher:     symbolFetcher,
 		marketDataSvc:     marketDataSvc,
@@ -320,9 +325,15 @@ func (p *TradingPipeline) evaluate(ctx context.Context) {
 		return
 	}
 
-	slog.Info("pipeline: signal evaluated", "action", signal.Action, "reason", signal.Reason, "price", latestTicker.Last)
+	slog.Info("pipeline: signal evaluated", "action", signal.Action, "confidence", signal.Confidence, "reason", signal.Reason, "price", latestTicker.Last)
 
 	if signal.Action == entity.SignalActionHold {
+		return
+	}
+
+	// Skip low-confidence signals
+	if snap.minConfidence > 0 && signal.Confidence < snap.minConfidence {
+		slog.Info("pipeline: signal below min confidence, skipping", "confidence", signal.Confidence, "minConfidence", snap.minConfidence)
 		return
 	}
 
@@ -355,7 +366,8 @@ func (p *TradingPipeline) evaluate(ctx context.Context) {
 		return
 	}
 
-	amount := snap.tradeAmount / price
+	scaledTradeAmount := snap.tradeAmount * scaleByConfidence(signal.Confidence, snap.minConfidence)
+	amount := scaledTradeAmount / price
 	// シンボルの baseStepAmount に合わせて切り捨て丸め
 	amount = roundDownToStep(amount, snap.baseStepAmount)
 	if amount <= 0 || amount < snap.minOrderAmount {
@@ -630,6 +642,18 @@ func restoreRiskState(ctx context.Context, repo repository.RiskStateRepository, 
 		riskMgr.RecordLoss(state.DailyLoss)
 	}
 	slog.Info("risk state restored", "balance", state.Balance, "dailyLoss", state.DailyLoss)
+}
+
+// scaleByConfidence は信頼度に基づいて注文金額のスケール係数を返す。
+// [minConfidence, 1.0] → [0.5, 1.0] の線形マッピング。
+func scaleByConfidence(confidence, minConfidence float64) float64 {
+	if confidence >= 1.0 {
+		return 1.0
+	}
+	if minConfidence >= 1.0 {
+		return 1.0
+	}
+	return 0.5 + 0.5*(confidence-minConfidence)/(1.0-minConfidence)
 }
 
 // roundDownToStep は amount を step の整数倍に切り捨てる。

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -15,10 +15,11 @@ type Config struct {
 }
 
 type TradingConfig struct {
-	SymbolID            int64   // 取引対象シンボルID（デフォルト: 7 = BTC_JPY）
-	TradeAmount         float64 // 1回の注文金額（円）
-	PipelineIntervalSec int     // パイプライン評価間隔（秒）
-	StateSyncIntervalSec int    // ポジション・残高同期間隔（秒）
+	SymbolID             int64   // 取引対象シンボルID（デフォルト: 7 = BTC_JPY）
+	TradeAmount          float64 // 1回の注文金額（円）
+	PipelineIntervalSec  int     // パイプライン評価間隔（秒）
+	StateSyncIntervalSec int     // ポジション・残高同期間隔（秒）
+	MinConfidence        float64 // シグナル最小信頼度（0.0–1.0, デフォルト 0.3）
 }
 
 type LLMConfig struct {
@@ -87,6 +88,7 @@ func Load() *Config {
 			TradeAmount:          getEnvFloat("TRADE_AMOUNT", 1000),
 			PipelineIntervalSec:  getEnvInt("PIPELINE_INTERVAL_SEC", 60),
 			StateSyncIntervalSec: getEnvInt("STATE_SYNC_INTERVAL_SEC", 15),
+			MinConfidence:        getEnvFloat("TRADE_MIN_CONFIDENCE", 0.3),
 		},
 	}
 }

--- a/backend/internal/domain/entity/signal.go
+++ b/backend/internal/domain/entity/signal.go
@@ -11,8 +11,9 @@ const (
 
 // Signal はStrategy Engineが生成する売買シグナル。
 type Signal struct {
-	SymbolID  int64        `json:"symbolId"`
-	Action    SignalAction `json:"action"`
-	Reason    string       `json:"reason"`
-	Timestamp int64        `json:"timestamp"`
+	SymbolID   int64        `json:"symbolId"`
+	Action     SignalAction `json:"action"`
+	Confidence float64      `json:"confidence"` // 0.0–1.0: indicator agreement score
+	Reason     string       `json:"reason"`
+	Timestamp  int64        `json:"timestamp"`
 }

--- a/backend/internal/usecase/strategy.go
+++ b/backend/internal/usecase/strategy.go
@@ -2,6 +2,7 @@ package usecase
 
 import (
 	"context"
+	"math"
 	"time"
 
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
@@ -70,10 +71,11 @@ func (e *StrategyEngine) evaluateTrendFollow(symbolID int64, sma20, sma50, rsi f
 			reason += ", MACD confirmed"
 		}
 		return &entity.Signal{
-			SymbolID:  symbolID,
-			Action:    entity.SignalActionBuy,
-			Reason:    reason,
-			Timestamp: now,
+			SymbolID:   symbolID,
+			Action:     entity.SignalActionBuy,
+			Confidence: trendFollowConfidence(sma20, sma50, rsi, histogram, true),
+			Reason:     reason,
+			Timestamp:  now,
 		}
 	}
 	if sma20 < sma50 && rsi > 30 {
@@ -91,10 +93,11 @@ func (e *StrategyEngine) evaluateTrendFollow(symbolID int64, sma20, sma50, rsi f
 			reason += ", MACD confirmed"
 		}
 		return &entity.Signal{
-			SymbolID:  symbolID,
-			Action:    entity.SignalActionSell,
-			Reason:    reason,
-			Timestamp: now,
+			SymbolID:   symbolID,
+			Action:     entity.SignalActionSell,
+			Confidence: trendFollowConfidence(sma20, sma50, rsi, histogram, false),
+			Reason:     reason,
+			Timestamp:  now,
 		}
 	}
 	return &entity.Signal{
@@ -103,6 +106,30 @@ func (e *StrategyEngine) evaluateTrendFollow(symbolID int64, sma20, sma50, rsi f
 		Reason:    "trend follow: no clear signal",
 		Timestamp: now,
 	}
+}
+
+// trendFollowConfidence computes a 0.0–1.0 confidence score for trend-follow signals.
+// Factors: SMA divergence strength (40%), RSI headroom (30%), MACD histogram agreement (30%).
+func trendFollowConfidence(sma20, sma50, rsi float64, histogram *float64, isBuy bool) float64 {
+	// SMA divergence: how strongly the cross is established (capped at 2%)
+	smaDivergence := math.Min(math.Abs(sma20-sma50)/sma50*100, 2.0) / 2.0
+
+	// RSI headroom: distance from the overbought/oversold boundary
+	var rsiRoom float64
+	if isBuy {
+		rsiRoom = (70 - rsi) / 40 // 30→1.0, 70→0.0
+	} else {
+		rsiRoom = (rsi - 30) / 40 // 70→1.0, 30→0.0
+	}
+	rsiRoom = math.Max(0, math.Min(1, rsiRoom))
+
+	// MACD histogram confirmation
+	macdConfirm := 0.5 // neutral when histogram unavailable
+	if histogram != nil {
+		macdConfirm = math.Min(math.Abs(*histogram)/10, 1.0)
+	}
+
+	return smaDivergence*0.4 + rsiRoom*0.3 + macdConfirm*0.3
 }
 
 func (e *StrategyEngine) evaluateContrarian(symbolID int64, rsi float64, histogram *float64) *entity.Signal {
@@ -123,10 +150,11 @@ func (e *StrategyEngine) evaluateContrarian(symbolID int64, rsi float64, histogr
 			reason += ", MACD not strongly against"
 		}
 		return &entity.Signal{
-			SymbolID:  symbolID,
-			Action:    entity.SignalActionBuy,
-			Reason:    reason,
-			Timestamp: now,
+			SymbolID:   symbolID,
+			Action:     entity.SignalActionBuy,
+			Confidence: contrarianConfidence(rsi, histogram, true),
+			Reason:     reason,
+			Timestamp:  now,
 		}
 	}
 	if rsi > 70 {
@@ -144,10 +172,11 @@ func (e *StrategyEngine) evaluateContrarian(symbolID int64, rsi float64, histogr
 			reason += ", MACD not strongly against"
 		}
 		return &entity.Signal{
-			SymbolID:  symbolID,
-			Action:    entity.SignalActionSell,
-			Reason:    reason,
-			Timestamp: now,
+			SymbolID:   symbolID,
+			Action:     entity.SignalActionSell,
+			Confidence: contrarianConfidence(rsi, histogram, false),
+			Reason:     reason,
+			Timestamp:  now,
 		}
 	}
 	return &entity.Signal{
@@ -156,4 +185,25 @@ func (e *StrategyEngine) evaluateContrarian(symbolID int64, rsi float64, histogr
 		Reason:    "contrarian: RSI in neutral zone",
 		Timestamp: now,
 	}
+}
+
+// contrarianConfidence computes a 0.0–1.0 confidence score for contrarian signals.
+// Factors: RSI extremity (60%), MACD not-against (40%).
+func contrarianConfidence(rsi float64, histogram *float64, isBuy bool) float64 {
+	// RSI extremity: how deep into oversold/overbought territory
+	var rsiExtreme float64
+	if isBuy {
+		rsiExtreme = (30 - rsi) / 30 // 0→1.0, 30→0.0
+	} else {
+		rsiExtreme = (rsi - 70) / 30 // 100→1.0, 70→0.0
+	}
+	rsiExtreme = math.Max(0, math.Min(1, rsiExtreme))
+
+	// MACD not-against: lower opposing momentum = higher confidence
+	macdNotAgainst := 0.5 // neutral when histogram unavailable
+	if histogram != nil {
+		macdNotAgainst = 1.0 - math.Min(math.Abs(*histogram)/20, 1.0)
+	}
+
+	return rsiExtreme*0.6 + macdNotAgainst*0.4
 }

--- a/backend/internal/usecase/strategy_test.go
+++ b/backend/internal/usecase/strategy_test.go
@@ -377,3 +377,117 @@ func TestStrategyEngine_TrendFollow_NilHistogramStillTrades(t *testing.T) {
 		t.Fatalf("expected BUY with nil histogram (backward compat), got %s", signal.Action)
 	}
 }
+
+func TestStrategyEngine_Confidence_TrendFollowStrong(t *testing.T) {
+	// Strong uptrend: SMA divergence 2%, RSI 55, histogram +5 → high confidence
+	resolver := &mockStanceResolver{
+		result: StanceResult{Stance: entity.MarketStanceTrendFollow, Reasoning: "uptrend", Source: "rule-based", UpdatedAt: time.Now().Unix()},
+	}
+	engine := NewStrategyEngine(resolver)
+
+	indicators := entity.IndicatorSet{
+		SymbolID:  7,
+		SMA20:     ptr(5100000.0), // 2% above SMA50
+		SMA50:     ptr(5000000.0),
+		RSI14:     ptr(55.0),
+		Histogram: ptr(5.0),
+	}
+	signal, err := engine.Evaluate(context.Background(), indicators, 5100000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if signal.Action != entity.SignalActionBuy {
+		t.Fatalf("expected BUY, got %s", signal.Action)
+	}
+	// SMA divergence: min(2.0, 2.0)/2.0 = 1.0 * 0.4 = 0.4
+	// RSI room: (70-55)/40 = 0.375 * 0.3 = 0.1125
+	// MACD confirm: min(5/10, 1.0) = 0.5 * 0.3 = 0.15
+	// Total: 0.6625
+	if signal.Confidence < 0.6 || signal.Confidence > 0.75 {
+		t.Fatalf("expected confidence ~0.66, got %.4f", signal.Confidence)
+	}
+}
+
+func TestStrategyEngine_Confidence_TrendFollowWeak(t *testing.T) {
+	// Weak uptrend: SMA barely crossing (0.1% divergence), RSI 68, no histogram
+	resolver := &mockStanceResolver{
+		result: StanceResult{Stance: entity.MarketStanceTrendFollow, Reasoning: "uptrend", Source: "rule-based", UpdatedAt: time.Now().Unix()},
+	}
+	engine := NewStrategyEngine(resolver)
+
+	indicators := entity.IndicatorSet{
+		SymbolID:  7,
+		SMA20:     ptr(5005000.0), // 0.1% above SMA50
+		SMA50:     ptr(5000000.0),
+		RSI14:     ptr(68.0),
+		Histogram: nil,
+	}
+	signal, err := engine.Evaluate(context.Background(), indicators, 5005000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if signal.Action != entity.SignalActionBuy {
+		t.Fatalf("expected BUY, got %s", signal.Action)
+	}
+	// SMA divergence: min(0.1, 2.0)/2.0 = 0.05 * 0.4 = 0.02
+	// RSI room: (70-68)/40 = 0.05 * 0.3 = 0.015
+	// MACD confirm: nil → 0.5 * 0.3 = 0.15
+	// Total: 0.185
+	if signal.Confidence > 0.25 {
+		t.Fatalf("expected low confidence (<0.25), got %.4f", signal.Confidence)
+	}
+}
+
+func TestStrategyEngine_Confidence_ContrarianStrong(t *testing.T) {
+	// Deep oversold: RSI 15, histogram mildly negative (-3)
+	resolver := &mockStanceResolver{
+		result: StanceResult{Stance: entity.MarketStanceContrarian, Reasoning: "oversold", Source: "rule-based", UpdatedAt: time.Now().Unix()},
+	}
+	engine := NewStrategyEngine(resolver)
+
+	indicators := entity.IndicatorSet{
+		SymbolID:  7,
+		SMA20:     ptr(4900000.0),
+		SMA50:     ptr(5000000.0),
+		RSI14:     ptr(15.0),
+		Histogram: ptr(-3.0),
+	}
+	signal, err := engine.Evaluate(context.Background(), indicators, 4900000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if signal.Action != entity.SignalActionBuy {
+		t.Fatalf("expected BUY, got %s", signal.Action)
+	}
+	// RSI extreme: (30-15)/30 = 0.5 * 0.6 = 0.3
+	// MACD not against: 1.0 - min(3/20, 1.0) = 0.85 * 0.4 = 0.34
+	// Total: 0.64
+	if signal.Confidence < 0.55 || signal.Confidence > 0.75 {
+		t.Fatalf("expected confidence ~0.64, got %.4f", signal.Confidence)
+	}
+}
+
+func TestStrategyEngine_Confidence_HoldIsZero(t *testing.T) {
+	// HOLD signals should have 0.0 confidence
+	resolver := &mockStanceResolver{
+		result: StanceResult{Stance: entity.MarketStanceHold, Reasoning: "uncertain", Source: "rule-based", UpdatedAt: time.Now().Unix()},
+	}
+	engine := NewStrategyEngine(resolver)
+
+	indicators := entity.IndicatorSet{
+		SymbolID: 7,
+		SMA20:    ptr(5100000.0),
+		SMA50:    ptr(5000000.0),
+		RSI14:    ptr(55.0),
+	}
+	signal, err := engine.Evaluate(context.Background(), indicators, 5100000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if signal.Action != entity.SignalActionHold {
+		t.Fatalf("expected HOLD, got %s", signal.Action)
+	}
+	if signal.Confidence != 0.0 {
+		t.Fatalf("expected confidence 0.0 for HOLD, got %.4f", signal.Confidence)
+	}
+}


### PR DESCRIPTION
## Summary
- Signal entity に `Confidence` フィールド (0.0–1.0) を追加
- Trend Follow: SMA乖離率(40%) + RSIヘッドルーム(30%) + MACDヒストグラム確認(30%) でスコアリング
- Contrarian: RSI極端度(60%) + MACD非反対(40%) でスコアリング
- Pipeline が `TRADE_MIN_CONFIDENCE` (デフォルト0.3) 未満のシグナルをフィルタリング
- 信頼度に応じて注文金額を50%–100%でスケーリング

## Test plan
- [x] 強いTrend Followシグナル（SMA 2%乖離, RSI 55, MACD +5）で高confidence (~0.66)
- [x] 弱いTrend Followシグナル（SMA 0.1%乖離, RSI 68）で低confidence (<0.25)
- [x] 強いContrarianシグナル（RSI 15, MACD -3）で高confidence (~0.64)
- [x] HOLDシグナルはconfidence 0.0
- [x] 既存テスト全件PASS（後方互換性）

🤖 Generated with [Claude Code](https://claude.com/claude-code)