### PR TITLE
feat(strategy): add Bollinger Bands and volatility squeeze filter

### DIFF
--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -78,6 +78,7 @@ func main() {
 			Interval:          time.Duration(cfg.Trading.PipelineIntervalSec) * time.Second,
 			StateSyncInterval: time.Duration(cfg.Trading.StateSyncIntervalSec) * time.Second,
 			TradeAmount:       cfg.Trading.TradeAmount,
+			MinConfidence:     cfg.Trading.MinConfidence,
 		},
 		restClient,
 		restClient, // SymbolFetcher

--- a/backend/cmd/pipeline.go
+++ b/backend/cmd/pipeline.go
@@ -311,15 +311,21 @@ func (p *TradingPipeline) evaluate(ctx context.Context) {
 		return
 	}
 
-	// 2. テクニカル指標を計算
+	// 2. テクニカル指標を計算（主: PT15M、上位: PT1H）
 	indicators, err := p.indicatorCalc.Calculate(ctx, snap.symbolID, "PT15M")
 	if err != nil {
 		slog.Warn("pipeline: failed to calculate indicators", "error", err)
 		return
 	}
 
-	// 3. 戦略判定
-	signal, err := p.strategyEngine.Evaluate(ctx, *indicators, latestTicker.Last)
+	higherTF, err := p.indicatorCalc.Calculate(ctx, snap.symbolID, "PT1H")
+	if err != nil {
+		slog.Warn("pipeline: failed to calculate higher TF indicators, proceeding without", "error", err)
+		higherTF = nil
+	}
+
+	// 3. 戦略判定（マルチタイムフレーム分析付き）
+	signal, err := p.strategyEngine.EvaluateWithHigherTF(ctx, *indicators, higherTF, latestTicker.Last)
 	if err != nil {
 		slog.Warn("pipeline: failed to evaluate strategy", "error", err)
 		return

--- a/backend/cmd/pipeline.go
+++ b/backend/cmd/pipeline.go
@@ -52,6 +52,7 @@ type TradingPipeline struct {
 	tradeAmount    float64
 	baseStepAmount float64 // シンボルごとの最小注文刻み幅（例: BTC=0.01, LTC=0.1）
 	minOrderAmount float64 // シンボルごとの最小注文数量
+	minConfidence  float64 // シグナル最小信頼度（これ未満はHOLD扱い）
 
 	restClient       repository.OrderClient
 	symbolFetcher    repository.SymbolFetcher
@@ -74,6 +75,7 @@ type tradingSnapshot struct {
 	tradeAmount    float64
 	baseStepAmount float64
 	minOrderAmount float64
+	minConfidence  float64
 }
 
 func (p *TradingPipeline) snapshot() tradingSnapshot {
@@ -84,6 +86,7 @@ func (p *TradingPipeline) snapshot() tradingSnapshot {
 		tradeAmount:    p.tradeAmount,
 		baseStepAmount: p.baseStepAmount,
 		minOrderAmount: p.minOrderAmount,
+		minConfidence:  p.minConfidence,
 	}
 }
 
@@ -93,6 +96,7 @@ type TradingPipelineConfig struct {
 	Interval          time.Duration
 	StateSyncInterval time.Duration
 	TradeAmount       float64
+	MinConfidence     float64
 }
 
 func NewTradingPipeline(
@@ -112,6 +116,7 @@ func NewTradingPipeline(
 		interval:          cfg.Interval,
 		stateSyncInterval: cfg.StateSyncInterval,
 		tradeAmount:       cfg.TradeAmount,
+		minConfidence:     cfg.MinConfidence,
 		restClient:        restClient,
 		symbolFetcher:     symbolFetcher,
 		marketDataSvc:     marketDataSvc,
@@ -320,9 +325,15 @@ func (p *TradingPipeline) evaluate(ctx context.Context) {
 		return
 	}
 
-	slog.Info("pipeline: signal evaluated", "action", signal.Action, "reason", signal.Reason, "price", latestTicker.Last)
+	slog.Info("pipeline: signal evaluated", "action", signal.Action, "confidence", signal.Confidence, "reason", signal.Reason, "price", latestTicker.Last)
 
 	if signal.Action == entity.SignalActionHold {
+		return
+	}
+
+	// Skip low-confidence signals
+	if snap.minConfidence > 0 && signal.Confidence < snap.minConfidence {
+		slog.Info("pipeline: signal below min confidence, skipping", "confidence", signal.Confidence, "minConfidence", snap.minConfidence)
 		return
 	}
 
@@ -355,7 +366,8 @@ func (p *TradingPipeline) evaluate(ctx context.Context) {
 		return
 	}
 
-	amount := snap.tradeAmount / price
+	scaledTradeAmount := snap.tradeAmount * scaleByConfidence(signal.Confidence, snap.minConfidence)
+	amount := scaledTradeAmount / price
 	// シンボルの baseStepAmount に合わせて切り捨て丸め
 	amount = roundDownToStep(amount, snap.baseStepAmount)
 	if amount <= 0 || amount < snap.minOrderAmount {
@@ -630,6 +642,18 @@ func restoreRiskState(ctx context.Context, repo repository.RiskStateRepository, 
 		riskMgr.RecordLoss(state.DailyLoss)
 	}
 	slog.Info("risk state restored", "balance", state.Balance, "dailyLoss", state.DailyLoss)
+}
+
+// scaleByConfidence は信頼度に基づいて注文金額のスケール係数を返す。
+// [minConfidence, 1.0] → [0.5, 1.0] の線形マッピング。
+func scaleByConfidence(confidence, minConfidence float64) float64 {
+	if confidence >= 1.0 {
+		return 1.0
+	}
+	if minConfidence >= 1.0 {
+		return 1.0
+	}
+	return 0.5 + 0.5*(confidence-minConfidence)/(1.0-minConfidence)
 }
 
 // roundDownToStep は amount を step の整数倍に切り捨てる。

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -15,10 +15,11 @@ type Config struct {
 }
 
 type TradingConfig struct {
-	SymbolID            int64   // 取引対象シンボルID（デフォルト: 7 = BTC_JPY）
-	TradeAmount         float64 // 1回の注文金額（円）
-	PipelineIntervalSec int     // パイプライン評価間隔（秒）
-	StateSyncIntervalSec int    // ポジション・残高同期間隔（秒）
+	SymbolID             int64   // 取引対象シンボルID（デフォルト: 7 = BTC_JPY）
+	TradeAmount          float64 // 1回の注文金額（円）
+	PipelineIntervalSec  int     // パイプライン評価間隔（秒）
+	StateSyncIntervalSec int     // ポジション・残高同期間隔（秒）
+	MinConfidence        float64 // シグナル最小信頼度（0.0–1.0, デフォルト 0.3）
 }
 
 type LLMConfig struct {
@@ -87,6 +88,7 @@ func Load() *Config {
 			TradeAmount:          getEnvFloat("TRADE_AMOUNT", 1000),
 			PipelineIntervalSec:  getEnvInt("PIPELINE_INTERVAL_SEC", 60),
 			StateSyncIntervalSec: getEnvInt("STATE_SYNC_INTERVAL_SEC", 15),
+			MinConfidence:        getEnvFloat("TRADE_MIN_CONFIDENCE", 0.3),
 		},
 	}
 }

--- a/backend/internal/domain/entity/indicator.go
+++ b/backend/internal/domain/entity/indicator.go
@@ -3,14 +3,18 @@ package entity
 // IndicatorSet はある時点の全テクニカル指標をまとめた構造体。
 // データ不足で計算できない指標はnilになる。
 type IndicatorSet struct {
-	SymbolID   int64    `json:"symbolId"`
-	SMA20      *float64 `json:"sma20"`
-	SMA50      *float64 `json:"sma50"`
-	EMA12      *float64 `json:"ema12"`
-	EMA26      *float64 `json:"ema26"`
-	RSI14      *float64 `json:"rsi14"`
-	MACDLine   *float64 `json:"macdLine"`
-	SignalLine *float64 `json:"signalLine"`
-	Histogram  *float64 `json:"histogram"`
-	Timestamp  int64    `json:"timestamp"`
+	SymbolID       int64    `json:"symbolId"`
+	SMA20          *float64 `json:"sma20"`
+	SMA50          *float64 `json:"sma50"`
+	EMA12          *float64 `json:"ema12"`
+	EMA26          *float64 `json:"ema26"`
+	RSI14          *float64 `json:"rsi14"`
+	MACDLine       *float64 `json:"macdLine"`
+	SignalLine     *float64 `json:"signalLine"`
+	Histogram      *float64 `json:"histogram"`
+	BBUpper        *float64 `json:"bbUpper"`
+	BBMiddle       *float64 `json:"bbMiddle"`
+	BBLower        *float64 `json:"bbLower"`
+	BBBandwidth    *float64 `json:"bbBandwidth"`
+	Timestamp      int64    `json:"timestamp"`
 }

--- a/backend/internal/domain/entity/signal.go
+++ b/backend/internal/domain/entity/signal.go
@@ -11,8 +11,9 @@ const (
 
 // Signal はStrategy Engineが生成する売買シグナル。
 type Signal struct {
-	SymbolID  int64        `json:"symbolId"`
-	Action    SignalAction `json:"action"`
-	Reason    string       `json:"reason"`
-	Timestamp int64        `json:"timestamp"`
+	SymbolID   int64        `json:"symbolId"`
+	Action     SignalAction `json:"action"`
+	Confidence float64      `json:"confidence"` // 0.0–1.0: indicator agreement score
+	Reason     string       `json:"reason"`
+	Timestamp  int64        `json:"timestamp"`
 }

--- a/backend/internal/infrastructure/indicator/bollinger.go
+++ b/backend/internal/infrastructure/indicator/bollinger.go
@@ -1,0 +1,31 @@
+package indicator
+
+import "math"
+
+// BollingerBands computes upper, middle (SMA), lower bands and bandwidth.
+// period is typically 20, multiplier is typically 2.0.
+// Returns NaN values if insufficient data.
+func BollingerBands(prices []float64, period int, multiplier float64) (upper, middle, lower, bandwidth float64) {
+	if len(prices) < period {
+		return math.NaN(), math.NaN(), math.NaN(), math.NaN()
+	}
+
+	middle = SMA(prices, period)
+
+	// Standard deviation of the last `period` prices
+	window := prices[len(prices)-period:]
+	sumSqDiff := 0.0
+	for _, p := range window {
+		diff := p - middle
+		sumSqDiff += diff * diff
+	}
+	stdDev := math.Sqrt(sumSqDiff / float64(period))
+
+	upper = middle + multiplier*stdDev
+	lower = middle - multiplier*stdDev
+
+	if middle > 0 {
+		bandwidth = (upper - lower) / middle
+	}
+	return upper, middle, lower, bandwidth
+}

--- a/backend/internal/infrastructure/indicator/bollinger_test.go
+++ b/backend/internal/infrastructure/indicator/bollinger_test.go
@@ -1,0 +1,58 @@
+package indicator
+
+import (
+	"math"
+	"testing"
+)
+
+func TestBollingerBands_InsufficientData(t *testing.T) {
+	upper, middle, lower, bw := BollingerBands([]float64{1, 2, 3}, 20, 2.0)
+	if !math.IsNaN(upper) || !math.IsNaN(middle) || !math.IsNaN(lower) || !math.IsNaN(bw) {
+		t.Fatal("expected NaN for insufficient data")
+	}
+}
+
+func TestBollingerBands_ConstantPrices(t *testing.T) {
+	prices := make([]float64, 20)
+	for i := range prices {
+		prices[i] = 100.0
+	}
+	upper, middle, lower, bw := BollingerBands(prices, 20, 2.0)
+	if middle != 100.0 {
+		t.Fatalf("expected middle=100, got %f", middle)
+	}
+	if upper != 100.0 || lower != 100.0 {
+		t.Fatalf("expected upper=lower=100 for constant prices, got upper=%f lower=%f", upper, lower)
+	}
+	if bw != 0.0 {
+		t.Fatalf("expected bandwidth=0 for constant prices, got %f", bw)
+	}
+}
+
+func TestBollingerBands_KnownValues(t *testing.T) {
+	// 5-period BB with multiplier 2.0, simple dataset
+	prices := []float64{10, 11, 12, 11, 10}
+	upper, middle, lower, bw := BollingerBands(prices, 5, 2.0)
+
+	// SMA = 10.8
+	expectedMiddle := 10.8
+	if math.Abs(middle-expectedMiddle) > 0.01 {
+		t.Fatalf("expected middle=%.2f, got %.4f", expectedMiddle, middle)
+	}
+
+	// stddev = sqrt(((10-10.8)^2 + (11-10.8)^2 + (12-10.8)^2 + (11-10.8)^2 + (10-10.8)^2) / 5)
+	// = sqrt((0.64 + 0.04 + 1.44 + 0.04 + 0.64) / 5) = sqrt(0.56) ≈ 0.7483
+	expectedStdDev := 0.7483
+	expectedUpper := expectedMiddle + 2*expectedStdDev
+	expectedLower := expectedMiddle - 2*expectedStdDev
+
+	if math.Abs(upper-expectedUpper) > 0.01 {
+		t.Fatalf("expected upper=%.4f, got %.4f", expectedUpper, upper)
+	}
+	if math.Abs(lower-expectedLower) > 0.01 {
+		t.Fatalf("expected lower=%.4f, got %.4f", expectedLower, lower)
+	}
+	if bw <= 0 {
+		t.Fatalf("expected positive bandwidth, got %f", bw)
+	}
+}

--- a/backend/internal/usecase/indicator.go
+++ b/backend/internal/usecase/indicator.go
@@ -56,6 +56,12 @@ func (c *IndicatorCalculator) Calculate(ctx context.Context, symbolID int64, int
 	result.SignalLine = toPtr(signalLine)
 	result.Histogram = toPtr(histogram)
 
+	bbUpper, bbMiddle, bbLower, bbBandwidth := indicator.BollingerBands(prices, 20, 2.0)
+	result.BBUpper = toPtr(bbUpper)
+	result.BBMiddle = toPtr(bbMiddle)
+	result.BBLower = toPtr(bbLower)
+	result.BBBandwidth = toPtr(bbBandwidth)
+
 	return result, nil
 }
 

--- a/backend/internal/usecase/strategy.go
+++ b/backend/internal/usecase/strategy.go
@@ -19,6 +19,54 @@ func NewStrategyEngine(stanceResolver StanceResolver) *StrategyEngine {
 	}
 }
 
+// EvaluateWithHigherTF はマルチタイムフレーム分析付きでシグナルを生成する。
+// higherTFがnon-nilの場合、Trend Followシグナルが上位トレンドに逆行していればHOLDにフィルタする。
+// 上位トレンドと一致している場合はconfidenceを10%ブーストする。
+// Contrarianシグナルは意図的に逆張りなのでフィルタしない。
+func (e *StrategyEngine) EvaluateWithHigherTF(ctx context.Context, indicators entity.IndicatorSet, higherTF *entity.IndicatorSet, lastPrice float64) (*entity.Signal, error) {
+	signal, err := e.Evaluate(ctx, indicators, lastPrice)
+	if err != nil || signal.Action == entity.SignalActionHold {
+		return signal, err
+	}
+
+	if higherTF == nil || higherTF.SMA20 == nil || higherTF.SMA50 == nil {
+		return signal, nil
+	}
+
+	// Contrarian signals are intentionally counter-trend; don't filter them
+	result := e.stanceResolver.Resolve(ctx, indicators)
+	if result.Stance == entity.MarketStanceContrarian {
+		return signal, nil
+	}
+
+	higherUptrend := *higherTF.SMA20 > *higherTF.SMA50
+
+	if signal.Action == entity.SignalActionBuy && !higherUptrend {
+		return &entity.Signal{
+			SymbolID:  indicators.SymbolID,
+			Action:    entity.SignalActionHold,
+			Reason:    "MTF filter: higher timeframe downtrend blocks buy",
+			Timestamp: signal.Timestamp,
+		}, nil
+	}
+	if signal.Action == entity.SignalActionSell && higherUptrend {
+		return &entity.Signal{
+			SymbolID:  indicators.SymbolID,
+			Action:    entity.SignalActionHold,
+			Reason:    "MTF filter: higher timeframe uptrend blocks sell",
+			Timestamp: signal.Timestamp,
+		}, nil
+	}
+
+	// Signal aligns with higher TF: boost confidence by 10% (capped at 1.0)
+	boosted := signal.Confidence + 0.1
+	if boosted > 1.0 {
+		boosted = 1.0
+	}
+	signal.Confidence = boosted
+	return signal, nil
+}
+
 // Evaluate はテクニカル指標と現在価格から売買シグナルを生成する。
 // 指標データが不足している場合はHOLDを返す。
 func (e *StrategyEngine) Evaluate(ctx context.Context, indicators entity.IndicatorSet, lastPrice float64) (*entity.Signal, error) {

--- a/backend/internal/usecase/strategy.go
+++ b/backend/internal/usecase/strategy.go
@@ -2,6 +2,7 @@ package usecase
 
 import (
 	"context"
+	"math"
 	"time"
 
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
@@ -70,10 +71,11 @@ func (e *StrategyEngine) evaluateTrendFollow(symbolID int64, sma20, sma50, rsi f
 			reason += ", MACD confirmed"
 		}
 		return &entity.Signal{
-			SymbolID:  symbolID,
-			Action:    entity.SignalActionBuy,
-			Reason:    reason,
-			Timestamp: now,
+			SymbolID:   symbolID,
+			Action:     entity.SignalActionBuy,
+			Confidence: trendFollowConfidence(sma20, sma50, rsi, histogram, true),
+			Reason:     reason,
+			Timestamp:  now,
 		}
 	}
 	if sma20 < sma50 && rsi > 30 {
@@ -91,10 +93,11 @@ func (e *StrategyEngine) evaluateTrendFollow(symbolID int64, sma20, sma50, rsi f
 			reason += ", MACD confirmed"
 		}
 		return &entity.Signal{
-			SymbolID:  symbolID,
-			Action:    entity.SignalActionSell,
-			Reason:    reason,
-			Timestamp: now,
+			SymbolID:   symbolID,
+			Action:     entity.SignalActionSell,
+			Confidence: trendFollowConfidence(sma20, sma50, rsi, histogram, false),
+			Reason:     reason,
+			Timestamp:  now,
 		}
 	}
 	return &entity.Signal{
@@ -103,6 +106,30 @@ func (e *StrategyEngine) evaluateTrendFollow(symbolID int64, sma20, sma50, rsi f
 		Reason:    "trend follow: no clear signal",
 		Timestamp: now,
 	}
+}
+
+// trendFollowConfidence computes a 0.0–1.0 confidence score for trend-follow signals.
+// Factors: SMA divergence strength (40%), RSI headroom (30%), MACD histogram agreement (30%).
+func trendFollowConfidence(sma20, sma50, rsi float64, histogram *float64, isBuy bool) float64 {
+	// SMA divergence: how strongly the cross is established (capped at 2%)
+	smaDivergence := math.Min(math.Abs(sma20-sma50)/sma50*100, 2.0) / 2.0
+
+	// RSI headroom: distance from the overbought/oversold boundary
+	var rsiRoom float64
+	if isBuy {
+		rsiRoom = (70 - rsi) / 40 // 30→1.0, 70→0.0
+	} else {
+		rsiRoom = (rsi - 30) / 40 // 70→1.0, 30→0.0
+	}
+	rsiRoom = math.Max(0, math.Min(1, rsiRoom))
+
+	// MACD histogram confirmation
+	macdConfirm := 0.5 // neutral when histogram unavailable
+	if histogram != nil {
+		macdConfirm = math.Min(math.Abs(*histogram)/10, 1.0)
+	}
+
+	return smaDivergence*0.4 + rsiRoom*0.3 + macdConfirm*0.3
 }
 
 func (e *StrategyEngine) evaluateContrarian(symbolID int64, rsi float64, histogram *float64) *entity.Signal {
@@ -123,10 +150,11 @@ func (e *StrategyEngine) evaluateContrarian(symbolID int64, rsi float64, histogr
 			reason += ", MACD not strongly against"
 		}
 		return &entity.Signal{
-			SymbolID:  symbolID,
-			Action:    entity.SignalActionBuy,
-			Reason:    reason,
-			Timestamp: now,
+			SymbolID:   symbolID,
+			Action:     entity.SignalActionBuy,
+			Confidence: contrarianConfidence(rsi, histogram, true),
+			Reason:     reason,
+			Timestamp:  now,
 		}
 	}
 	if rsi > 70 {
@@ -144,10 +172,11 @@ func (e *StrategyEngine) evaluateContrarian(symbolID int64, rsi float64, histogr
 			reason += ", MACD not strongly against"
 		}
 		return &entity.Signal{
-			SymbolID:  symbolID,
-			Action:    entity.SignalActionSell,
-			Reason:    reason,
-			Timestamp: now,
+			SymbolID:   symbolID,
+			Action:     entity.SignalActionSell,
+			Confidence: contrarianConfidence(rsi, histogram, false),
+			Reason:     reason,
+			Timestamp:  now,
 		}
 	}
 	return &entity.Signal{
@@ -156,4 +185,25 @@ func (e *StrategyEngine) evaluateContrarian(symbolID int64, rsi float64, histogr
 		Reason:    "contrarian: RSI in neutral zone",
 		Timestamp: now,
 	}
+}
+
+// contrarianConfidence computes a 0.0–1.0 confidence score for contrarian signals.
+// Factors: RSI extremity (60%), MACD not-against (40%).
+func contrarianConfidence(rsi float64, histogram *float64, isBuy bool) float64 {
+	// RSI extremity: how deep into oversold/overbought territory
+	var rsiExtreme float64
+	if isBuy {
+		rsiExtreme = (30 - rsi) / 30 // 0→1.0, 30→0.0
+	} else {
+		rsiExtreme = (rsi - 70) / 30 // 100→1.0, 70→0.0
+	}
+	rsiExtreme = math.Max(0, math.Min(1, rsiExtreme))
+
+	// MACD not-against: lower opposing momentum = higher confidence
+	macdNotAgainst := 0.5 // neutral when histogram unavailable
+	if histogram != nil {
+		macdNotAgainst = 1.0 - math.Min(math.Abs(*histogram)/20, 1.0)
+	}
+
+	return rsiExtreme*0.6 + macdNotAgainst*0.4
 }

--- a/backend/internal/usecase/strategy.go
+++ b/backend/internal/usecase/strategy.go
@@ -23,18 +23,42 @@ func NewStrategyEngine(stanceResolver StanceResolver) *StrategyEngine {
 // higherTFがnon-nilの場合、Trend Followシグナルが上位トレンドに逆行していればHOLDにフィルタする。
 // 上位トレンドと一致している場合はconfidenceを10%ブーストする。
 // Contrarianシグナルは意図的に逆張りなのでフィルタしない。
+// ボラティリティフィルター: BBバンド幅が非常に狭い(squeeze)場合、Trend Followシグナルを抑制する。
 func (e *StrategyEngine) EvaluateWithHigherTF(ctx context.Context, indicators entity.IndicatorSet, higherTF *entity.IndicatorSet, lastPrice float64) (*entity.Signal, error) {
 	signal, err := e.Evaluate(ctx, indicators, lastPrice)
 	if err != nil || signal.Action == entity.SignalActionHold {
 		return signal, err
 	}
 
+	result := e.stanceResolver.Resolve(ctx, indicators)
+
+	// Volatility filter: squeeze detection for trend-follow signals
+	// BBBandwidth < 0.02 (2%) indicates very low volatility / consolidation
+	if result.Stance == entity.MarketStanceTrendFollow && indicators.BBBandwidth != nil && *indicators.BBBandwidth < 0.02 {
+		return &entity.Signal{
+			SymbolID:  indicators.SymbolID,
+			Action:    entity.SignalActionHold,
+			Reason:    "volatility filter: Bollinger squeeze, trend signal unreliable",
+			Timestamp: signal.Timestamp,
+		}, nil
+	}
+
+	// BB position can boost/penalize confidence for contrarian
+	if result.Stance == entity.MarketStanceContrarian && indicators.BBLower != nil && indicators.BBUpper != nil {
+		if signal.Action == entity.SignalActionBuy && lastPrice <= *indicators.BBLower {
+			// Price at/below lower band: extra confidence for buy
+			signal.Confidence = math.Min(signal.Confidence+0.1, 1.0)
+		} else if signal.Action == entity.SignalActionSell && lastPrice >= *indicators.BBUpper {
+			// Price at/above upper band: extra confidence for sell
+			signal.Confidence = math.Min(signal.Confidence+0.1, 1.0)
+		}
+	}
+
 	if higherTF == nil || higherTF.SMA20 == nil || higherTF.SMA50 == nil {
 		return signal, nil
 	}
 
-	// Contrarian signals are intentionally counter-trend; don't filter them
-	result := e.stanceResolver.Resolve(ctx, indicators)
+	// Contrarian signals are intentionally counter-trend; don't filter by higher TF
 	if result.Stance == entity.MarketStanceContrarian {
 		return signal, nil
 	}
@@ -59,11 +83,7 @@ func (e *StrategyEngine) EvaluateWithHigherTF(ctx context.Context, indicators en
 	}
 
 	// Signal aligns with higher TF: boost confidence by 10% (capped at 1.0)
-	boosted := signal.Confidence + 0.1
-	if boosted > 1.0 {
-		boosted = 1.0
-	}
-	signal.Confidence = boosted
+	signal.Confidence = math.Min(signal.Confidence+0.1, 1.0)
 	return signal, nil
 }
 

--- a/backend/internal/usecase/strategy_test.go
+++ b/backend/internal/usecase/strategy_test.go
@@ -609,6 +609,92 @@ func TestStrategyEngine_MTF_ContrarianNotFiltered(t *testing.T) {
 	}
 }
 
+func TestStrategyEngine_VolatilityFilter_SqueezeBlocksTrendFollow(t *testing.T) {
+	// BB bandwidth < 0.02 during trend follow → HOLD
+	resolver := &mockStanceResolver{
+		result: StanceResult{Stance: entity.MarketStanceTrendFollow, Reasoning: "uptrend", Source: "rule-based", UpdatedAt: time.Now().Unix()},
+	}
+	engine := NewStrategyEngine(resolver)
+
+	indicators := entity.IndicatorSet{
+		SymbolID:    7,
+		SMA20:       ptr(5100000.0),
+		SMA50:       ptr(5000000.0),
+		RSI14:       ptr(55.0),
+		Histogram:   ptr(3.0),
+		BBBandwidth: ptr(0.015), // squeeze
+	}
+	signal, err := engine.EvaluateWithHigherTF(context.Background(), indicators, nil, 5100000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if signal.Action != entity.SignalActionHold {
+		t.Fatalf("expected HOLD during BB squeeze, got %s", signal.Action)
+	}
+	if signal.Reason != "volatility filter: Bollinger squeeze, trend signal unreliable" {
+		t.Fatalf("unexpected reason: %s", signal.Reason)
+	}
+}
+
+func TestStrategyEngine_VolatilityFilter_NormalBandwidthAllowsTrade(t *testing.T) {
+	// BB bandwidth >= 0.02 → normal trading
+	resolver := &mockStanceResolver{
+		result: StanceResult{Stance: entity.MarketStanceTrendFollow, Reasoning: "uptrend", Source: "rule-based", UpdatedAt: time.Now().Unix()},
+	}
+	engine := NewStrategyEngine(resolver)
+
+	indicators := entity.IndicatorSet{
+		SymbolID:    7,
+		SMA20:       ptr(5100000.0),
+		SMA50:       ptr(5000000.0),
+		RSI14:       ptr(55.0),
+		Histogram:   ptr(3.0),
+		BBBandwidth: ptr(0.05), // normal volatility
+	}
+	signal, err := engine.EvaluateWithHigherTF(context.Background(), indicators, nil, 5100000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if signal.Action != entity.SignalActionBuy {
+		t.Fatalf("expected BUY with normal bandwidth, got %s", signal.Action)
+	}
+}
+
+func TestStrategyEngine_BB_ContrarianBuyAtLowerBandBoost(t *testing.T) {
+	// Contrarian BUY with price at lower BB → confidence boosted
+	resolver := &mockStanceResolver{
+		result: StanceResult{Stance: entity.MarketStanceContrarian, Reasoning: "oversold", Source: "rule-based", UpdatedAt: time.Now().Unix()},
+	}
+	engine := NewStrategyEngine(resolver)
+
+	indicators := entity.IndicatorSet{
+		SymbolID:  7,
+		SMA20:     ptr(4900000.0),
+		SMA50:     ptr(5000000.0),
+		RSI14:     ptr(25.0),
+		Histogram: ptr(-3.0),
+		BBUpper:   ptr(5200000.0),
+		BBLower:   ptr(4850000.0),
+	}
+	// Price at lower band
+	signal, err := engine.EvaluateWithHigherTF(context.Background(), indicators, nil, 4850000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if signal.Action != entity.SignalActionBuy {
+		t.Fatalf("expected BUY, got %s", signal.Action)
+	}
+
+	// Compare with same signal without BB
+	indicatorsNoBB := indicators
+	indicatorsNoBB.BBLower = nil
+	indicatorsNoBB.BBUpper = nil
+	signalNoBB, _ := engine.EvaluateWithHigherTF(context.Background(), indicatorsNoBB, nil, 4850000)
+	if signal.Confidence <= signalNoBB.Confidence {
+		t.Fatalf("expected BB-boosted confidence (%.4f) > base (%.4f)", signal.Confidence, signalNoBB.Confidence)
+	}
+}
+
 func TestStrategyEngine_Confidence_HoldIsZero(t *testing.T) {
 	// HOLD signals should have 0.0 confidence
 	resolver := &mockStanceResolver{

--- a/backend/internal/usecase/strategy_test.go
+++ b/backend/internal/usecase/strategy_test.go
@@ -377,3 +377,117 @@ func TestStrategyEngine_TrendFollow_NilHistogramStillTrades(t *testing.T) {
 		t.Fatalf("expected BUY with nil histogram (backward compat), got %s", signal.Action)
 	}
 }
+
+func TestStrategyEngine_Confidence_TrendFollowStrong(t *testing.T) {
+	// Strong uptrend: SMA divergence 2%, RSI 55, histogram +5 → high confidence
+	resolver := &mockStanceResolver{
+		result: StanceResult{Stance: entity.MarketStanceTrendFollow, Reasoning: "uptrend", Source: "rule-based", UpdatedAt: time.Now().Unix()},
+	}
+	engine := NewStrategyEngine(resolver)
+
+	indicators := entity.IndicatorSet{
+		SymbolID:  7,
+		SMA20:     ptr(5100000.0), // 2% above SMA50
+		SMA50:     ptr(5000000.0),
+		RSI14:     ptr(55.0),
+		Histogram: ptr(5.0),
+	}
+	signal, err := engine.Evaluate(context.Background(), indicators, 5100000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if signal.Action != entity.SignalActionBuy {
+		t.Fatalf("expected BUY, got %s", signal.Action)
+	}
+	// SMA divergence: min(2.0, 2.0)/2.0 = 1.0 * 0.4 = 0.4
+	// RSI room: (70-55)/40 = 0.375 * 0.3 = 0.1125
+	// MACD confirm: min(5/10, 1.0) = 0.5 * 0.3 = 0.15
+	// Total: 0.6625
+	if signal.Confidence < 0.6 || signal.Confidence > 0.75 {
+		t.Fatalf("expected confidence ~0.66, got %.4f", signal.Confidence)
+	}
+}
+
+func TestStrategyEngine_Confidence_TrendFollowWeak(t *testing.T) {
+	// Weak uptrend: SMA barely crossing (0.1% divergence), RSI 68, no histogram
+	resolver := &mockStanceResolver{
+		result: StanceResult{Stance: entity.MarketStanceTrendFollow, Reasoning: "uptrend", Source: "rule-based", UpdatedAt: time.Now().Unix()},
+	}
+	engine := NewStrategyEngine(resolver)
+
+	indicators := entity.IndicatorSet{
+		SymbolID:  7,
+		SMA20:     ptr(5005000.0), // 0.1% above SMA50
+		SMA50:     ptr(5000000.0),
+		RSI14:     ptr(68.0),
+		Histogram: nil,
+	}
+	signal, err := engine.Evaluate(context.Background(), indicators, 5005000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if signal.Action != entity.SignalActionBuy {
+		t.Fatalf("expected BUY, got %s", signal.Action)
+	}
+	// SMA divergence: min(0.1, 2.0)/2.0 = 0.05 * 0.4 = 0.02
+	// RSI room: (70-68)/40 = 0.05 * 0.3 = 0.015
+	// MACD confirm: nil → 0.5 * 0.3 = 0.15
+	// Total: 0.185
+	if signal.Confidence > 0.25 {
+		t.Fatalf("expected low confidence (<0.25), got %.4f", signal.Confidence)
+	}
+}
+
+func TestStrategyEngine_Confidence_ContrarianStrong(t *testing.T) {
+	// Deep oversold: RSI 15, histogram mildly negative (-3)
+	resolver := &mockStanceResolver{
+		result: StanceResult{Stance: entity.MarketStanceContrarian, Reasoning: "oversold", Source: "rule-based", UpdatedAt: time.Now().Unix()},
+	}
+	engine := NewStrategyEngine(resolver)
+
+	indicators := entity.IndicatorSet{
+		SymbolID:  7,
+		SMA20:     ptr(4900000.0),
+		SMA50:     ptr(5000000.0),
+		RSI14:     ptr(15.0),
+		Histogram: ptr(-3.0),
+	}
+	signal, err := engine.Evaluate(context.Background(), indicators, 4900000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if signal.Action != entity.SignalActionBuy {
+		t.Fatalf("expected BUY, got %s", signal.Action)
+	}
+	// RSI extreme: (30-15)/30 = 0.5 * 0.6 = 0.3
+	// MACD not against: 1.0 - min(3/20, 1.0) = 0.85 * 0.4 = 0.34
+	// Total: 0.64
+	if signal.Confidence < 0.55 || signal.Confidence > 0.75 {
+		t.Fatalf("expected confidence ~0.64, got %.4f", signal.Confidence)
+	}
+}
+
+func TestStrategyEngine_Confidence_HoldIsZero(t *testing.T) {
+	// HOLD signals should have 0.0 confidence
+	resolver := &mockStanceResolver{
+		result: StanceResult{Stance: entity.MarketStanceHold, Reasoning: "uncertain", Source: "rule-based", UpdatedAt: time.Now().Unix()},
+	}
+	engine := NewStrategyEngine(resolver)
+
+	indicators := entity.IndicatorSet{
+		SymbolID: 7,
+		SMA20:    ptr(5100000.0),
+		SMA50:    ptr(5000000.0),
+		RSI14:    ptr(55.0),
+	}
+	signal, err := engine.Evaluate(context.Background(), indicators, 5100000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if signal.Action != entity.SignalActionHold {
+		t.Fatalf("expected HOLD, got %s", signal.Action)
+	}
+	if signal.Confidence != 0.0 {
+		t.Fatalf("expected confidence 0.0 for HOLD, got %.4f", signal.Confidence)
+	}
+}

--- a/backend/internal/usecase/strategy_test.go
+++ b/backend/internal/usecase/strategy_test.go
@@ -467,6 +467,148 @@ func TestStrategyEngine_Confidence_ContrarianStrong(t *testing.T) {
 	}
 }
 
+func TestStrategyEngine_MTF_BuyBlockedByHigherDowntrend(t *testing.T) {
+	// PT15M says BUY, but PT1H SMA20 < SMA50 (higher timeframe downtrend) → HOLD
+	resolver := &mockStanceResolver{
+		result: StanceResult{Stance: entity.MarketStanceTrendFollow, Reasoning: "uptrend", Source: "rule-based", UpdatedAt: time.Now().Unix()},
+	}
+	engine := NewStrategyEngine(resolver)
+
+	indicators := entity.IndicatorSet{
+		SymbolID:  7,
+		SMA20:     ptr(5100000.0),
+		SMA50:     ptr(5000000.0),
+		RSI14:     ptr(55.0),
+		Histogram: ptr(3.0),
+	}
+	higherTF := &entity.IndicatorSet{
+		SymbolID: 7,
+		SMA20:    ptr(4900000.0), // downtrend on higher TF
+		SMA50:    ptr(5000000.0),
+	}
+	signal, err := engine.EvaluateWithHigherTF(context.Background(), indicators, higherTF, 5100000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if signal.Action != entity.SignalActionHold {
+		t.Fatalf("expected HOLD when higher TF is downtrend but signal is BUY, got %s (reason: %s)", signal.Action, signal.Reason)
+	}
+}
+
+func TestStrategyEngine_MTF_SellBlockedByHigherUptrend(t *testing.T) {
+	// PT15M says SELL, but PT1H SMA20 > SMA50 (higher timeframe uptrend) → HOLD
+	resolver := &mockStanceResolver{
+		result: StanceResult{Stance: entity.MarketStanceTrendFollow, Reasoning: "downtrend", Source: "rule-based", UpdatedAt: time.Now().Unix()},
+	}
+	engine := NewStrategyEngine(resolver)
+
+	indicators := entity.IndicatorSet{
+		SymbolID:  7,
+		SMA20:     ptr(4900000.0),
+		SMA50:     ptr(5000000.0),
+		RSI14:     ptr(45.0),
+		Histogram: ptr(-3.0),
+	}
+	higherTF := &entity.IndicatorSet{
+		SymbolID: 7,
+		SMA20:    ptr(5100000.0), // uptrend on higher TF
+		SMA50:    ptr(5000000.0),
+	}
+	signal, err := engine.EvaluateWithHigherTF(context.Background(), indicators, higherTF, 4900000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if signal.Action != entity.SignalActionHold {
+		t.Fatalf("expected HOLD when higher TF is uptrend but signal is SELL, got %s (reason: %s)", signal.Action, signal.Reason)
+	}
+}
+
+func TestStrategyEngine_MTF_BuyAlignedWithHigherUptrend(t *testing.T) {
+	// PT15M says BUY, PT1H also uptrend → BUY with boosted confidence
+	resolver := &mockStanceResolver{
+		result: StanceResult{Stance: entity.MarketStanceTrendFollow, Reasoning: "uptrend", Source: "rule-based", UpdatedAt: time.Now().Unix()},
+	}
+	engine := NewStrategyEngine(resolver)
+
+	indicators := entity.IndicatorSet{
+		SymbolID:  7,
+		SMA20:     ptr(5100000.0),
+		SMA50:     ptr(5000000.0),
+		RSI14:     ptr(55.0),
+		Histogram: ptr(5.0),
+	}
+	higherTF := &entity.IndicatorSet{
+		SymbolID: 7,
+		SMA20:    ptr(5200000.0), // uptrend on higher TF too
+		SMA50:    ptr(5000000.0),
+	}
+
+	signalWithMTF, err := engine.EvaluateWithHigherTF(context.Background(), indicators, higherTF, 5100000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if signalWithMTF.Action != entity.SignalActionBuy {
+		t.Fatalf("expected BUY, got %s", signalWithMTF.Action)
+	}
+
+	// Compare: without higher TF
+	signalBase, _ := engine.Evaluate(context.Background(), indicators, 5100000)
+	if signalWithMTF.Confidence <= signalBase.Confidence {
+		t.Fatalf("expected MTF-aligned confidence (%.4f) > base confidence (%.4f)", signalWithMTF.Confidence, signalBase.Confidence)
+	}
+}
+
+func TestStrategyEngine_MTF_NilHigherTFFallsBack(t *testing.T) {
+	// nil higherTF → behaves same as Evaluate()
+	resolver := &mockStanceResolver{
+		result: StanceResult{Stance: entity.MarketStanceTrendFollow, Reasoning: "uptrend", Source: "rule-based", UpdatedAt: time.Now().Unix()},
+	}
+	engine := NewStrategyEngine(resolver)
+
+	indicators := entity.IndicatorSet{
+		SymbolID:  7,
+		SMA20:     ptr(5100000.0),
+		SMA50:     ptr(5000000.0),
+		RSI14:     ptr(55.0),
+		Histogram: ptr(3.0),
+	}
+	signal, err := engine.EvaluateWithHigherTF(context.Background(), indicators, nil, 5100000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if signal.Action != entity.SignalActionBuy {
+		t.Fatalf("expected BUY with nil higherTF, got %s", signal.Action)
+	}
+}
+
+func TestStrategyEngine_MTF_ContrarianNotFiltered(t *testing.T) {
+	// Contrarian signals are NOT filtered by higher TF (they're intentionally counter-trend)
+	resolver := &mockStanceResolver{
+		result: StanceResult{Stance: entity.MarketStanceContrarian, Reasoning: "oversold", Source: "rule-based", UpdatedAt: time.Now().Unix()},
+	}
+	engine := NewStrategyEngine(resolver)
+
+	indicators := entity.IndicatorSet{
+		SymbolID:  7,
+		SMA20:     ptr(4900000.0),
+		SMA50:     ptr(5000000.0),
+		RSI14:     ptr(25.0),
+		Histogram: ptr(-3.0),
+	}
+	higherTF := &entity.IndicatorSet{
+		SymbolID: 7,
+		SMA20:    ptr(4800000.0), // downtrend on higher TF
+		SMA50:    ptr(5000000.0),
+	}
+	signal, err := engine.EvaluateWithHigherTF(context.Background(), indicators, higherTF, 4900000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if signal.Action != entity.SignalActionBuy {
+		t.Fatalf("expected contrarian BUY even with higher TF downtrend, got %s", signal.Action)
+	}
+}
+
 func TestStrategyEngine_Confidence_HoldIsZero(t *testing.T) {
 	// HOLD signals should have 0.0 confidence
 	resolver := &mockStanceResolver{


### PR DESCRIPTION
## Summary
- ボリンジャーバンド (20期間, 2σ) インジケーターを追加
- IndicatorSet に BBUpper/BBMiddle/BBLower/BBBandwidth フィールドを追加
- **ボラティリティフィルター**: BB Bandwidth < 2% (Bollinger squeeze) でTrend Followシグナルをブロック
- **Contrarian BB ブースト**: 価格がBB下限/上限に接触時にconfidence +10%

## Test plan
- [x] Bollinger Bands: 不十分データでNaN
- [x] Bollinger Bands: 定数価格でband=0
- [x] Bollinger Bands: 既知の値で正確な計算
- [x] BB squeeze (bandwidth < 2%) でTrend Followがブロック
- [x] 通常bandwidth (>= 2%) で正常にトレード
- [x] Contrarian BUY + 下限バンド接触でconfidenceブースト
- [x] 既存テスト全件PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)