### PR TITLE
feat(risk): add ATR-based dynamic stop-loss and trailing stop

### DIFF
--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -78,6 +78,7 @@ func main() {
 			Interval:          time.Duration(cfg.Trading.PipelineIntervalSec) * time.Second,
 			StateSyncInterval: time.Duration(cfg.Trading.StateSyncIntervalSec) * time.Second,
 			TradeAmount:       cfg.Trading.TradeAmount,
+			MinConfidence:     cfg.Trading.MinConfidence,
 		},
 		restClient,
 		restClient, // SymbolFetcher

--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -55,10 +55,14 @@ func main() {
 	stanceResolver := usecase.NewRuleBasedStanceResolver(stanceOverrideRepo)
 	strategyEngine := usecase.NewStrategyEngine(stanceResolver)
 	riskMgr := usecase.NewRiskManager(entity.RiskConfig{
-		MaxPositionAmount: cfg.Risk.MaxPositionAmount,
-		MaxDailyLoss:      cfg.Risk.MaxDailyLoss,
-		StopLossPercent:   cfg.Risk.StopLossPercent,
-		InitialCapital:    cfg.Risk.InitialCapital,
+		MaxPositionAmount:     cfg.Risk.MaxPositionAmount,
+		MaxDailyLoss:          cfg.Risk.MaxDailyLoss,
+		StopLossPercent:       cfg.Risk.StopLossPercent,
+		StopLossATRMultiplier: cfg.Risk.StopLossATRMultiplier,
+		TakeProfitPercent:     cfg.Risk.TakeProfitPercent,
+		InitialCapital:        cfg.Risk.InitialCapital,
+		MaxConsecutiveLosses:  cfg.Risk.MaxConsecutiveLosses,
+		CooldownMinutes:       cfg.Risk.CooldownMinutes,
 	})
 	orderExecutor := usecase.NewOrderExecutor(restClient, riskMgr)
 

--- a/backend/cmd/pipeline.go
+++ b/backend/cmd/pipeline.go
@@ -318,6 +318,11 @@ func (p *TradingPipeline) evaluate(ctx context.Context) {
 		return
 	}
 
+	// Update ATR for dynamic stop-loss
+	if indicators.ATR14 != nil {
+		p.riskMgr.UpdateATR(*indicators.ATR14)
+	}
+
 	higherTF, err := p.indicatorCalc.Calculate(ctx, snap.symbolID, "PT1H")
 	if err != nil {
 		slog.Warn("pipeline: failed to calculate higher TF indicators, proceeding without", "error", err)

--- a/backend/cmd/pipeline.go
+++ b/backend/cmd/pipeline.go
@@ -311,15 +311,21 @@ func (p *TradingPipeline) evaluate(ctx context.Context) {
 		return
 	}
 
-	// 2. テクニカル指標を計算
+	// 2. テクニカル指標を計算（主: PT15M、上位: PT1H）
 	indicators, err := p.indicatorCalc.Calculate(ctx, snap.symbolID, "PT15M")
 	if err != nil {
 		slog.Warn("pipeline: failed to calculate indicators", "error", err)
 		return
 	}
 
-	// 3. 戦略判定
-	signal, err := p.strategyEngine.Evaluate(ctx, *indicators, latestTicker.Last)
+	higherTF, err := p.indicatorCalc.Calculate(ctx, snap.symbolID, "PT1H")
+	if err != nil {
+		slog.Warn("pipeline: failed to calculate higher TF indicators, proceeding without", "error", err)
+		higherTF = nil
+	}
+
+	// 3. 戦略判定（マルチタイムフレーム分析付き）
+	signal, err := p.strategyEngine.EvaluateWithHigherTF(ctx, *indicators, higherTF, latestTicker.Last)
 	if err != nil {
 		slog.Warn("pipeline: failed to evaluate strategy", "error", err)
 		return

--- a/backend/cmd/pipeline.go
+++ b/backend/cmd/pipeline.go
@@ -52,6 +52,7 @@ type TradingPipeline struct {
 	tradeAmount    float64
 	baseStepAmount float64 // シンボルごとの最小注文刻み幅（例: BTC=0.01, LTC=0.1）
 	minOrderAmount float64 // シンボルごとの最小注文数量
+	minConfidence  float64 // シグナル最小信頼度（これ未満はHOLD扱い）
 
 	restClient       repository.OrderClient
 	symbolFetcher    repository.SymbolFetcher
@@ -74,6 +75,7 @@ type tradingSnapshot struct {
 	tradeAmount    float64
 	baseStepAmount float64
 	minOrderAmount float64
+	minConfidence  float64
 }
 
 func (p *TradingPipeline) snapshot() tradingSnapshot {
@@ -84,6 +86,7 @@ func (p *TradingPipeline) snapshot() tradingSnapshot {
 		tradeAmount:    p.tradeAmount,
 		baseStepAmount: p.baseStepAmount,
 		minOrderAmount: p.minOrderAmount,
+		minConfidence:  p.minConfidence,
 	}
 }
 
@@ -93,6 +96,7 @@ type TradingPipelineConfig struct {
 	Interval          time.Duration
 	StateSyncInterval time.Duration
 	TradeAmount       float64
+	MinConfidence     float64
 }
 
 func NewTradingPipeline(
@@ -112,6 +116,7 @@ func NewTradingPipeline(
 		interval:          cfg.Interval,
 		stateSyncInterval: cfg.StateSyncInterval,
 		tradeAmount:       cfg.TradeAmount,
+		minConfidence:     cfg.MinConfidence,
 		restClient:        restClient,
 		symbolFetcher:     symbolFetcher,
 		marketDataSvc:     marketDataSvc,
@@ -320,9 +325,15 @@ func (p *TradingPipeline) evaluate(ctx context.Context) {
 		return
 	}
 
-	slog.Info("pipeline: signal evaluated", "action", signal.Action, "reason", signal.Reason, "price", latestTicker.Last)
+	slog.Info("pipeline: signal evaluated", "action", signal.Action, "confidence", signal.Confidence, "reason", signal.Reason, "price", latestTicker.Last)
 
 	if signal.Action == entity.SignalActionHold {
+		return
+	}
+
+	// Skip low-confidence signals
+	if snap.minConfidence > 0 && signal.Confidence < snap.minConfidence {
+		slog.Info("pipeline: signal below min confidence, skipping", "confidence", signal.Confidence, "minConfidence", snap.minConfidence)
 		return
 	}
 
@@ -355,7 +366,8 @@ func (p *TradingPipeline) evaluate(ctx context.Context) {
 		return
 	}
 
-	amount := snap.tradeAmount / price
+	scaledTradeAmount := snap.tradeAmount * scaleByConfidence(signal.Confidence, snap.minConfidence)
+	amount := scaledTradeAmount / price
 	// シンボルの baseStepAmount に合わせて切り捨て丸め
 	amount = roundDownToStep(amount, snap.baseStepAmount)
 	if amount <= 0 || amount < snap.minOrderAmount {
@@ -630,6 +642,18 @@ func restoreRiskState(ctx context.Context, repo repository.RiskStateRepository, 
 		riskMgr.RecordLoss(state.DailyLoss)
 	}
 	slog.Info("risk state restored", "balance", state.Balance, "dailyLoss", state.DailyLoss)
+}
+
+// scaleByConfidence は信頼度に基づいて注文金額のスケール係数を返す。
+// [minConfidence, 1.0] → [0.5, 1.0] の線形マッピング。
+func scaleByConfidence(confidence, minConfidence float64) float64 {
+	if confidence >= 1.0 {
+		return 1.0
+	}
+	if minConfidence >= 1.0 {
+		return 1.0
+	}
+	return 0.5 + 0.5*(confidence-minConfidence)/(1.0-minConfidence)
 }
 
 // roundDownToStep は amount を step の整数倍に切り捨てる。

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -15,10 +15,11 @@ type Config struct {
 }
 
 type TradingConfig struct {
-	SymbolID            int64   // 取引対象シンボルID（デフォルト: 7 = BTC_JPY）
-	TradeAmount         float64 // 1回の注文金額（円）
-	PipelineIntervalSec int     // パイプライン評価間隔（秒）
-	StateSyncIntervalSec int    // ポジション・残高同期間隔（秒）
+	SymbolID             int64   // 取引対象シンボルID（デフォルト: 7 = BTC_JPY）
+	TradeAmount          float64 // 1回の注文金額（円）
+	PipelineIntervalSec  int     // パイプライン評価間隔（秒）
+	StateSyncIntervalSec int     // ポジション・残高同期間隔（秒）
+	MinConfidence        float64 // シグナル最小信頼度（0.0–1.0, デフォルト 0.3）
 }
 
 type LLMConfig struct {
@@ -87,6 +88,7 @@ func Load() *Config {
 			TradeAmount:          getEnvFloat("TRADE_AMOUNT", 1000),
 			PipelineIntervalSec:  getEnvInt("PIPELINE_INTERVAL_SEC", 60),
 			StateSyncIntervalSec: getEnvInt("STATE_SYNC_INTERVAL_SEC", 15),
+			MinConfidence:        getEnvFloat("TRADE_MIN_CONFIDENCE", 0.3),
 		},
 	}
 }

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -38,13 +38,14 @@ type DatabaseConfig struct {
 }
 
 type RiskConfig struct {
-	MaxPositionAmount    float64
-	MaxDailyLoss         float64
-	StopLossPercent      float64
-	TakeProfitPercent    float64
-	InitialCapital       float64
-	MaxConsecutiveLosses int
-	CooldownMinutes      int
+	MaxPositionAmount     float64
+	MaxDailyLoss          float64
+	StopLossPercent       float64
+	StopLossATRMultiplier float64
+	TakeProfitPercent     float64
+	InitialCapital        float64
+	MaxConsecutiveLosses  int
+	CooldownMinutes       int
 }
 
 type RakutenConfig struct {
@@ -63,13 +64,14 @@ func Load() *Config {
 			Path: getEnv("DATABASE_PATH", "data/trading.db"),
 		},
 		Risk: RiskConfig{
-			MaxPositionAmount:    getEnvFloat("RISK_MAX_POSITION_AMOUNT", 5000),
-			MaxDailyLoss:         getEnvFloat("RISK_MAX_DAILY_LOSS", 5000),
-			StopLossPercent:      getEnvFloat("RISK_STOP_LOSS_PERCENT", 5),
-			TakeProfitPercent:    getEnvFloat("RISK_TAKE_PROFIT_PERCENT", 10),
-			InitialCapital:       getEnvFloat("RISK_INITIAL_CAPITAL", 10000),
-			MaxConsecutiveLosses: getEnvInt("RISK_MAX_CONSECUTIVE_LOSSES", 3),
-			CooldownMinutes:      getEnvInt("RISK_COOLDOWN_MINUTES", 30),
+			MaxPositionAmount:     getEnvFloat("RISK_MAX_POSITION_AMOUNT", 5000),
+			MaxDailyLoss:          getEnvFloat("RISK_MAX_DAILY_LOSS", 5000),
+			StopLossPercent:       getEnvFloat("RISK_STOP_LOSS_PERCENT", 5),
+			StopLossATRMultiplier: getEnvFloat("RISK_STOP_LOSS_ATR_MULTIPLIER", 2.0),
+			TakeProfitPercent:     getEnvFloat("RISK_TAKE_PROFIT_PERCENT", 10),
+			InitialCapital:        getEnvFloat("RISK_INITIAL_CAPITAL", 10000),
+			MaxConsecutiveLosses:  getEnvInt("RISK_MAX_CONSECUTIVE_LOSSES", 3),
+			CooldownMinutes:       getEnvInt("RISK_COOLDOWN_MINUTES", 30),
 		},
 		Rakuten: RakutenConfig{
 			BaseURL:   getEnv("RAKUTEN_API_BASE_URL", "https://exchange.rakuten-wallet.co.jp"),

--- a/backend/internal/domain/entity/indicator.go
+++ b/backend/internal/domain/entity/indicator.go
@@ -16,5 +16,6 @@ type IndicatorSet struct {
 	BBMiddle       *float64 `json:"bbMiddle"`
 	BBLower        *float64 `json:"bbLower"`
 	BBBandwidth    *float64 `json:"bbBandwidth"`
+	ATR14          *float64 `json:"atr14"`
 	Timestamp      int64    `json:"timestamp"`
 }

--- a/backend/internal/domain/entity/indicator.go
+++ b/backend/internal/domain/entity/indicator.go
@@ -3,14 +3,18 @@ package entity
 // IndicatorSet はある時点の全テクニカル指標をまとめた構造体。
 // データ不足で計算できない指標はnilになる。
 type IndicatorSet struct {
-	SymbolID   int64    `json:"symbolId"`
-	SMA20      *float64 `json:"sma20"`
-	SMA50      *float64 `json:"sma50"`
-	EMA12      *float64 `json:"ema12"`
-	EMA26      *float64 `json:"ema26"`
-	RSI14      *float64 `json:"rsi14"`
-	MACDLine   *float64 `json:"macdLine"`
-	SignalLine *float64 `json:"signalLine"`
-	Histogram  *float64 `json:"histogram"`
-	Timestamp  int64    `json:"timestamp"`
+	SymbolID       int64    `json:"symbolId"`
+	SMA20          *float64 `json:"sma20"`
+	SMA50          *float64 `json:"sma50"`
+	EMA12          *float64 `json:"ema12"`
+	EMA26          *float64 `json:"ema26"`
+	RSI14          *float64 `json:"rsi14"`
+	MACDLine       *float64 `json:"macdLine"`
+	SignalLine     *float64 `json:"signalLine"`
+	Histogram      *float64 `json:"histogram"`
+	BBUpper        *float64 `json:"bbUpper"`
+	BBMiddle       *float64 `json:"bbMiddle"`
+	BBLower        *float64 `json:"bbLower"`
+	BBBandwidth    *float64 `json:"bbBandwidth"`
+	Timestamp      int64    `json:"timestamp"`
 }

--- a/backend/internal/domain/entity/risk.go
+++ b/backend/internal/domain/entity/risk.go
@@ -4,7 +4,8 @@ package entity
 type RiskConfig struct {
 	MaxPositionAmount    float64 `json:"maxPositionAmount"`    // 同時ポジション上限（円）
 	MaxDailyLoss         float64 `json:"maxDailyLoss"`         // 日次損失上限（円）
-	StopLossPercent      float64 `json:"stopLossPercent"`      // 損切りライン（%）
+	StopLossPercent      float64 `json:"stopLossPercent"`      // 損切りライン（%）— ATR未使用時のフォールバック
+	StopLossATRMultiplier float64 `json:"stopLossAtrMultiplier"` // ATR基準の損切り倍率（0=固定%を使用）
 	TakeProfitPercent    float64 `json:"takeProfitPercent"`    // 利確ライン（%）
 	InitialCapital       float64 `json:"initialCapital"`       // 軍資金（円）
 	MaxConsecutiveLosses int     `json:"maxConsecutiveLosses"` // 連敗上限（0=無効）

--- a/backend/internal/domain/entity/signal.go
+++ b/backend/internal/domain/entity/signal.go
@@ -11,8 +11,9 @@ const (
 
 // Signal はStrategy Engineが生成する売買シグナル。
 type Signal struct {
-	SymbolID  int64        `json:"symbolId"`
-	Action    SignalAction `json:"action"`
-	Reason    string       `json:"reason"`
-	Timestamp int64        `json:"timestamp"`
+	SymbolID   int64        `json:"symbolId"`
+	Action     SignalAction `json:"action"`
+	Confidence float64      `json:"confidence"` // 0.0–1.0: indicator agreement score
+	Reason     string       `json:"reason"`
+	Timestamp  int64        `json:"timestamp"`
 }

--- a/backend/internal/infrastructure/indicator/atr.go
+++ b/backend/internal/infrastructure/indicator/atr.go
@@ -1,0 +1,37 @@
+package indicator
+
+import "math"
+
+// ATR computes the Average True Range using Wilder's smoothing.
+// candles must be in chronological order (oldest first).
+// Each candle is [high, low, close].
+// Returns NaN if insufficient data.
+func ATR(highs, lows, closes []float64, period int) float64 {
+	n := len(highs)
+	if n < period+1 || len(lows) != n || len(closes) != n {
+		return math.NaN()
+	}
+
+	// Compute True Range series
+	trs := make([]float64, n-1)
+	for i := 1; i < n; i++ {
+		tr1 := highs[i] - lows[i]
+		tr2 := math.Abs(highs[i] - closes[i-1])
+		tr3 := math.Abs(lows[i] - closes[i-1])
+		trs[i-1] = math.Max(tr1, math.Max(tr2, tr3))
+	}
+
+	// Initial ATR: simple average of first `period` true ranges
+	sum := 0.0
+	for i := 0; i < period; i++ {
+		sum += trs[i]
+	}
+	atr := sum / float64(period)
+
+	// Wilder's smoothing for remaining
+	for i := period; i < len(trs); i++ {
+		atr = (atr*float64(period-1) + trs[i]) / float64(period)
+	}
+
+	return atr
+}

--- a/backend/internal/infrastructure/indicator/atr_test.go
+++ b/backend/internal/infrastructure/indicator/atr_test.go
@@ -1,0 +1,70 @@
+package indicator
+
+import (
+	"math"
+	"testing"
+)
+
+func TestATR_InsufficientData(t *testing.T) {
+	result := ATR([]float64{1, 2}, []float64{0.5, 1}, []float64{0.8, 1.5}, 14)
+	if !math.IsNaN(result) {
+		t.Fatalf("expected NaN for insufficient data, got %f", result)
+	}
+}
+
+func TestATR_MismatchedLengths(t *testing.T) {
+	result := ATR([]float64{1, 2, 3}, []float64{0.5, 1}, []float64{0.8, 1.5, 2.5}, 2)
+	if !math.IsNaN(result) {
+		t.Fatalf("expected NaN for mismatched lengths, got %f", result)
+	}
+}
+
+func TestATR_KnownValues(t *testing.T) {
+	// Simple 3-period ATR with known data
+	highs := []float64{10, 12, 11, 13}
+	lows := []float64{8, 9, 9, 10}
+	closes := []float64{9, 11, 10, 12}
+
+	result := ATR(highs, lows, closes, 3)
+	if math.IsNaN(result) {
+		t.Fatal("expected valid ATR, got NaN")
+	}
+
+	// TR[0] = max(12-9, |12-9|, |9-9|) = 3
+	// TR[1] = max(11-9, |11-11|, |9-11|) = 2
+	// TR[2] = max(13-10, |13-10|, |10-10|) = 3
+	// Initial ATR (3-period): (3+2+3)/3 = 2.6667 (but only 3 TRs with period=3, no smoothing step)
+	// Actually: first `period` TRs are 0..2 → (3+2)/2... let me recalculate
+	// n=4, period=3. Need period+1=4 candles. trs has 3 entries.
+	// trs[0]: max(12-9, |12-9|, |9-9|) = 3
+	// trs[1]: max(11-9, |11-11|, |9-11|) = 2
+	// trs[2]: max(13-10, |13-10|, |10-10|) = 3
+	// Initial ATR = (3+2+3)/3 = 2.6667
+	// No remaining TRs to smooth → ATR = 2.6667
+	expected := (3.0 + 2.0 + 3.0) / 3.0
+	if math.Abs(result-expected) > 0.01 {
+		t.Fatalf("expected ATR=%.4f, got %.4f", expected, result)
+	}
+}
+
+func TestATR_WithSmoothing(t *testing.T) {
+	// 2-period ATR with 4 candles (3 TRs, smoothing applied once)
+	highs := []float64{10, 12, 11, 14}
+	lows := []float64{8, 9, 9, 11}
+	closes := []float64{9, 11, 10, 13}
+
+	result := ATR(highs, lows, closes, 2)
+	if math.IsNaN(result) {
+		t.Fatal("expected valid ATR, got NaN")
+	}
+
+	// trs[0]: max(12-9, |12-9|, |9-9|) = 3
+	// trs[1]: max(11-9, |11-11|, |9-11|) = 2
+	// trs[2]: max(14-11, |14-10|, |11-10|) = 4
+	// Initial ATR (2-period): (3+2)/2 = 2.5
+	// Smoothed: (2.5*1 + 4)/2 = 3.25
+	expected := 3.25
+	if math.Abs(result-expected) > 0.01 {
+		t.Fatalf("expected ATR=%.4f, got %.4f", expected, result)
+	}
+}

--- a/backend/internal/infrastructure/indicator/bollinger.go
+++ b/backend/internal/infrastructure/indicator/bollinger.go
@@ -1,0 +1,31 @@
+package indicator
+
+import "math"
+
+// BollingerBands computes upper, middle (SMA), lower bands and bandwidth.
+// period is typically 20, multiplier is typically 2.0.
+// Returns NaN values if insufficient data.
+func BollingerBands(prices []float64, period int, multiplier float64) (upper, middle, lower, bandwidth float64) {
+	if len(prices) < period {
+		return math.NaN(), math.NaN(), math.NaN(), math.NaN()
+	}
+
+	middle = SMA(prices, period)
+
+	// Standard deviation of the last `period` prices
+	window := prices[len(prices)-period:]
+	sumSqDiff := 0.0
+	for _, p := range window {
+		diff := p - middle
+		sumSqDiff += diff * diff
+	}
+	stdDev := math.Sqrt(sumSqDiff / float64(period))
+
+	upper = middle + multiplier*stdDev
+	lower = middle - multiplier*stdDev
+
+	if middle > 0 {
+		bandwidth = (upper - lower) / middle
+	}
+	return upper, middle, lower, bandwidth
+}

--- a/backend/internal/infrastructure/indicator/bollinger_test.go
+++ b/backend/internal/infrastructure/indicator/bollinger_test.go
@@ -1,0 +1,58 @@
+package indicator
+
+import (
+	"math"
+	"testing"
+)
+
+func TestBollingerBands_InsufficientData(t *testing.T) {
+	upper, middle, lower, bw := BollingerBands([]float64{1, 2, 3}, 20, 2.0)
+	if !math.IsNaN(upper) || !math.IsNaN(middle) || !math.IsNaN(lower) || !math.IsNaN(bw) {
+		t.Fatal("expected NaN for insufficient data")
+	}
+}
+
+func TestBollingerBands_ConstantPrices(t *testing.T) {
+	prices := make([]float64, 20)
+	for i := range prices {
+		prices[i] = 100.0
+	}
+	upper, middle, lower, bw := BollingerBands(prices, 20, 2.0)
+	if middle != 100.0 {
+		t.Fatalf("expected middle=100, got %f", middle)
+	}
+	if upper != 100.0 || lower != 100.0 {
+		t.Fatalf("expected upper=lower=100 for constant prices, got upper=%f lower=%f", upper, lower)
+	}
+	if bw != 0.0 {
+		t.Fatalf("expected bandwidth=0 for constant prices, got %f", bw)
+	}
+}
+
+func TestBollingerBands_KnownValues(t *testing.T) {
+	// 5-period BB with multiplier 2.0, simple dataset
+	prices := []float64{10, 11, 12, 11, 10}
+	upper, middle, lower, bw := BollingerBands(prices, 5, 2.0)
+
+	// SMA = 10.8
+	expectedMiddle := 10.8
+	if math.Abs(middle-expectedMiddle) > 0.01 {
+		t.Fatalf("expected middle=%.2f, got %.4f", expectedMiddle, middle)
+	}
+
+	// stddev = sqrt(((10-10.8)^2 + (11-10.8)^2 + (12-10.8)^2 + (11-10.8)^2 + (10-10.8)^2) / 5)
+	// = sqrt((0.64 + 0.04 + 1.44 + 0.04 + 0.64) / 5) = sqrt(0.56) ≈ 0.7483
+	expectedStdDev := 0.7483
+	expectedUpper := expectedMiddle + 2*expectedStdDev
+	expectedLower := expectedMiddle - 2*expectedStdDev
+
+	if math.Abs(upper-expectedUpper) > 0.01 {
+		t.Fatalf("expected upper=%.4f, got %.4f", expectedUpper, upper)
+	}
+	if math.Abs(lower-expectedLower) > 0.01 {
+		t.Fatalf("expected lower=%.4f, got %.4f", expectedLower, lower)
+	}
+	if bw <= 0 {
+		t.Fatalf("expected positive bandwidth, got %f", bw)
+	}
+}

--- a/backend/internal/usecase/indicator.go
+++ b/backend/internal/usecase/indicator.go
@@ -31,9 +31,14 @@ func (c *IndicatorCalculator) Calculate(ctx context.Context, symbolID int64, int
 	}
 
 	// GetCandles returns newest-first, reverse to oldest-first for calculations
-	prices := make([]float64, len(candles))
+	n := len(candles)
+	prices := make([]float64, n)
+	highs := make([]float64, n)
+	lows := make([]float64, n)
 	for i, cd := range candles {
-		prices[len(candles)-1-i] = cd.Close
+		prices[n-1-i] = cd.Close
+		highs[n-1-i] = cd.High
+		lows[n-1-i] = cd.Low
 	}
 
 	var timestamp int64
@@ -61,6 +66,8 @@ func (c *IndicatorCalculator) Calculate(ctx context.Context, symbolID int64, int
 	result.BBMiddle = toPtr(bbMiddle)
 	result.BBLower = toPtr(bbLower)
 	result.BBBandwidth = toPtr(bbBandwidth)
+
+	result.ATR14 = toPtr(indicator.ATR(highs, lows, prices, 14))
 
 	return result, nil
 }

--- a/backend/internal/usecase/indicator.go
+++ b/backend/internal/usecase/indicator.go
@@ -56,6 +56,12 @@ func (c *IndicatorCalculator) Calculate(ctx context.Context, symbolID int64, int
 	result.SignalLine = toPtr(signalLine)
 	result.Histogram = toPtr(histogram)
 
+	bbUpper, bbMiddle, bbLower, bbBandwidth := indicator.BollingerBands(prices, 20, 2.0)
+	result.BBUpper = toPtr(bbUpper)
+	result.BBMiddle = toPtr(bbMiddle)
+	result.BBLower = toPtr(bbLower)
+	result.BBBandwidth = toPtr(bbBandwidth)
+
 	return result, nil
 }
 

--- a/backend/internal/usecase/risk.go
+++ b/backend/internal/usecase/risk.go
@@ -15,6 +15,7 @@ type RiskStatus struct {
 	TotalPosition float64           `json:"totalPosition"`
 	TradingHalted bool              `json:"tradingHalted"`
 	ManuallyStopped bool            `json:"manuallyStopped"`
+	CurrentATR    float64           `json:"currentAtr"`
 	Config        entity.RiskConfig `json:"config"`
 }
 
@@ -28,6 +29,7 @@ type RiskManager struct {
 	highWaterMarks    map[int64]float64 // positionID → best price
 	consecutiveLosses int
 	cooldownUntil     time.Time
+	currentATR        float64 // latest ATR value for dynamic stop-loss
 }
 
 func NewRiskManager(config entity.RiskConfig) *RiskManager {
@@ -96,13 +98,14 @@ func (rm *RiskManager) CheckStopLoss(symbolID int64, currentPrice float64) []ent
 		if pos.SymbolID != symbolID {
 			continue
 		}
-		var lossPercent float64
+		slDistance := rm.stopLossDistance(pos.Price)
+		var loss float64
 		if pos.OrderSide == entity.OrderSideBuy {
-			lossPercent = (pos.Price - currentPrice) / pos.Price * 100
+			loss = pos.Price - currentPrice
 		} else {
-			lossPercent = (currentPrice - pos.Price) / pos.Price * 100
+			loss = currentPrice - pos.Price
 		}
-		if lossPercent >= rm.config.StopLossPercent {
+		if loss >= slDistance {
 			result = append(result, pos)
 		}
 	}
@@ -193,8 +196,9 @@ func (rm *RiskManager) UpdateHighWaterMark(positionID int64, currentPrice float6
 	}
 }
 
-// CheckTrailingStop returns positions where price has reversed by StopLossPercent
-// from the high water mark. Only activates when the position is in profit.
+// CheckTrailingStop returns positions where price has reversed by the stop-loss
+// distance from the high water mark. Only activates when the position is in profit.
+// Uses ATR-based distance when available, otherwise falls back to fixed percentage.
 func (rm *RiskManager) CheckTrailingStop(symbolID int64, currentPrice float64) []entity.Position {
 	rm.mu.RLock()
 	defer rm.mu.RUnlock()
@@ -209,13 +213,14 @@ func (rm *RiskManager) CheckTrailingStop(symbolID int64, currentPrice float64) [
 			continue
 		}
 
+		slDistance := rm.stopLossDistance(pos.Price)
+
 		if pos.OrderSide == entity.OrderSideBuy {
 			// Only activate if position has been in profit
 			if hwm <= pos.Price {
 				continue
 			}
-			trailLine := hwm * (1 - rm.config.StopLossPercent/100)
-			if currentPrice <= trailLine {
+			if hwm-currentPrice >= slDistance {
 				result = append(result, pos)
 			}
 		} else {
@@ -223,8 +228,7 @@ func (rm *RiskManager) CheckTrailingStop(symbolID int64, currentPrice float64) [
 			if hwm >= pos.Price {
 				continue
 			}
-			trailLine := hwm * (1 + rm.config.StopLossPercent/100)
-			if currentPrice >= trailLine {
+			if currentPrice-hwm >= slDistance {
 				result = append(result, pos)
 			}
 		}
@@ -261,6 +265,23 @@ func (rm *RiskManager) UpdateConfig(config entity.RiskConfig) {
 	rm.config = config
 }
 
+// UpdateATR updates the current ATR value used for dynamic stop-loss calculation.
+func (rm *RiskManager) UpdateATR(atr float64) {
+	rm.mu.Lock()
+	defer rm.mu.Unlock()
+	rm.currentATR = atr
+}
+
+// stopLossDistance returns the stop-loss distance in price units for a given entry price.
+// If ATR-based stop-loss is configured and ATR is available, uses ATR * multiplier.
+// Otherwise falls back to entry price * StopLossPercent / 100.
+func (rm *RiskManager) stopLossDistance(entryPrice float64) float64 {
+	if rm.config.StopLossATRMultiplier > 0 && rm.currentATR > 0 {
+		return rm.currentATR * rm.config.StopLossATRMultiplier
+	}
+	return entryPrice * rm.config.StopLossPercent / 100
+}
+
 func (rm *RiskManager) StartTrading() {
 	rm.mu.Lock()
 	defer rm.mu.Unlock()
@@ -282,6 +303,7 @@ func (rm *RiskManager) GetStatus() RiskStatus {
 		TotalPosition:   rm.calcTotalPositionValue(),
 		TradingHalted:   rm.dailyLoss >= rm.config.MaxDailyLoss,
 		ManuallyStopped: rm.manualStop,
+		CurrentATR:      rm.currentATR,
 		Config:          rm.config,
 	}
 }

--- a/backend/internal/usecase/risk_test.go
+++ b/backend/internal/usecase/risk_test.go
@@ -360,3 +360,100 @@ func TestRiskManager_ConsecutiveLossBreaker_CloseOrdersAllowed(t *testing.T) {
 		t.Fatalf("close order should always be approved during cooldown: %s", result.Reason)
 	}
 }
+
+func TestRiskManager_ATR_StopLoss(t *testing.T) {
+	cfg := defaultRiskConfig()
+	cfg.StopLossATRMultiplier = 2.0
+	cfg.StopLossPercent = 5 // fallback
+	rm := NewRiskManager(cfg)
+
+	rm.UpdateATR(50000) // ATR = 50,000 → stop distance = 100,000
+	rm.UpdatePositions([]entity.Position{
+		{ID: 1, SymbolID: 7, OrderSide: entity.OrderSideBuy, Price: 5000000, Amount: 0.01, RemainingAmount: 0.01},
+	})
+
+	// Price dropped 90,000 → within ATR stop (100,000), no trigger
+	targets := rm.CheckStopLoss(7, 4910000)
+	if len(targets) != 0 {
+		t.Fatalf("expected no stop-loss at 90k drop (ATR stop = 100k), got %d targets", len(targets))
+	}
+
+	// Price dropped 100,000 → exactly at ATR stop, trigger
+	targets = rm.CheckStopLoss(7, 4900000)
+	if len(targets) != 1 {
+		t.Fatalf("expected stop-loss trigger at 100k drop, got %d targets", len(targets))
+	}
+}
+
+func TestRiskManager_ATR_FallbackToPercent(t *testing.T) {
+	cfg := defaultRiskConfig()
+	cfg.StopLossATRMultiplier = 2.0
+	cfg.StopLossPercent = 5
+	rm := NewRiskManager(cfg)
+
+	// ATR not set (0) → fallback to 5% = 250,000 at price 5,000,000
+	rm.UpdatePositions([]entity.Position{
+		{ID: 1, SymbolID: 7, OrderSide: entity.OrderSideBuy, Price: 5000000, Amount: 0.01, RemainingAmount: 0.01},
+	})
+
+	// 4% drop → no trigger
+	targets := rm.CheckStopLoss(7, 4800000)
+	if len(targets) != 0 {
+		t.Fatalf("expected no trigger at 4%% drop, got %d", len(targets))
+	}
+
+	// 5% drop → trigger
+	targets = rm.CheckStopLoss(7, 4750000)
+	if len(targets) != 1 {
+		t.Fatalf("expected trigger at 5%% drop, got %d", len(targets))
+	}
+}
+
+func TestRiskManager_ATR_TrailingStop(t *testing.T) {
+	cfg := defaultRiskConfig()
+	cfg.StopLossATRMultiplier = 1.5
+	rm := NewRiskManager(cfg)
+
+	rm.UpdateATR(40000) // trailing distance = 60,000
+	rm.UpdatePositions([]entity.Position{
+		{ID: 1, SymbolID: 7, OrderSide: entity.OrderSideBuy, Price: 5000000, Amount: 0.01, RemainingAmount: 0.01},
+	})
+
+	// Price went up to 5,100,000 (in profit)
+	rm.UpdateHighWaterMark(1, 5100000)
+
+	// Dropped to 5,050,000 → 50k reversal from HWM, within 60k distance
+	targets := rm.CheckTrailingStop(7, 5050000)
+	if len(targets) != 0 {
+		t.Fatalf("expected no trailing stop at 50k reversal (distance=60k), got %d", len(targets))
+	}
+
+	// Dropped to 5,040,000 → 60k reversal, trigger
+	targets = rm.CheckTrailingStop(7, 5040000)
+	if len(targets) != 1 {
+		t.Fatalf("expected trailing stop at 60k reversal, got %d", len(targets))
+	}
+}
+
+func TestRiskManager_ATR_DisabledUsesPercent(t *testing.T) {
+	cfg := defaultRiskConfig()
+	cfg.StopLossATRMultiplier = 0 // ATR disabled
+	cfg.StopLossPercent = 5
+	rm := NewRiskManager(cfg)
+
+	rm.UpdateATR(50000) // ATR set but disabled by multiplier=0
+	rm.UpdatePositions([]entity.Position{
+		{ID: 1, SymbolID: 7, OrderSide: entity.OrderSideBuy, Price: 5000000, Amount: 0.01, RemainingAmount: 0.01},
+	})
+
+	// Should use 5% = 250,000, not ATR
+	targets := rm.CheckStopLoss(7, 4800000) // 200k drop, within 5%
+	if len(targets) != 0 {
+		t.Fatalf("expected no trigger (ATR disabled, using 5%%), got %d", len(targets))
+	}
+
+	targets = rm.CheckStopLoss(7, 4750000) // exactly 5%
+	if len(targets) != 1 {
+		t.Fatalf("expected trigger at 5%%, got %d", len(targets))
+	}
+}

--- a/backend/internal/usecase/strategy.go
+++ b/backend/internal/usecase/strategy.go
@@ -19,6 +19,54 @@ func NewStrategyEngine(stanceResolver StanceResolver) *StrategyEngine {
 	}
 }
 
+// EvaluateWithHigherTF はマルチタイムフレーム分析付きでシグナルを生成する。
+// higherTFがnon-nilの場合、Trend Followシグナルが上位トレンドに逆行していればHOLDにフィルタする。
+// 上位トレンドと一致している場合はconfidenceを10%ブーストする。
+// Contrarianシグナルは意図的に逆張りなのでフィルタしない。
+func (e *StrategyEngine) EvaluateWithHigherTF(ctx context.Context, indicators entity.IndicatorSet, higherTF *entity.IndicatorSet, lastPrice float64) (*entity.Signal, error) {
+	signal, err := e.Evaluate(ctx, indicators, lastPrice)
+	if err != nil || signal.Action == entity.SignalActionHold {
+		return signal, err
+	}
+
+	if higherTF == nil || higherTF.SMA20 == nil || higherTF.SMA50 == nil {
+		return signal, nil
+	}
+
+	// Contrarian signals are intentionally counter-trend; don't filter them
+	result := e.stanceResolver.Resolve(ctx, indicators)
+	if result.Stance == entity.MarketStanceContrarian {
+		return signal, nil
+	}
+
+	higherUptrend := *higherTF.SMA20 > *higherTF.SMA50
+
+	if signal.Action == entity.SignalActionBuy && !higherUptrend {
+		return &entity.Signal{
+			SymbolID:  indicators.SymbolID,
+			Action:    entity.SignalActionHold,
+			Reason:    "MTF filter: higher timeframe downtrend blocks buy",
+			Timestamp: signal.Timestamp,
+		}, nil
+	}
+	if signal.Action == entity.SignalActionSell && higherUptrend {
+		return &entity.Signal{
+			SymbolID:  indicators.SymbolID,
+			Action:    entity.SignalActionHold,
+			Reason:    "MTF filter: higher timeframe uptrend blocks sell",
+			Timestamp: signal.Timestamp,
+		}, nil
+	}
+
+	// Signal aligns with higher TF: boost confidence by 10% (capped at 1.0)
+	boosted := signal.Confidence + 0.1
+	if boosted > 1.0 {
+		boosted = 1.0
+	}
+	signal.Confidence = boosted
+	return signal, nil
+}
+
 // Evaluate はテクニカル指標と現在価格から売買シグナルを生成する。
 // 指標データが不足している場合はHOLDを返す。
 func (e *StrategyEngine) Evaluate(ctx context.Context, indicators entity.IndicatorSet, lastPrice float64) (*entity.Signal, error) {

--- a/backend/internal/usecase/strategy.go
+++ b/backend/internal/usecase/strategy.go
@@ -2,6 +2,7 @@ package usecase
 
 import (
 	"context"
+	"math"
 	"time"
 
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
@@ -70,10 +71,11 @@ func (e *StrategyEngine) evaluateTrendFollow(symbolID int64, sma20, sma50, rsi f
 			reason += ", MACD confirmed"
 		}
 		return &entity.Signal{
-			SymbolID:  symbolID,
-			Action:    entity.SignalActionBuy,
-			Reason:    reason,
-			Timestamp: now,
+			SymbolID:   symbolID,
+			Action:     entity.SignalActionBuy,
+			Confidence: trendFollowConfidence(sma20, sma50, rsi, histogram, true),
+			Reason:     reason,
+			Timestamp:  now,
 		}
 	}
 	if sma20 < sma50 && rsi > 30 {
@@ -91,10 +93,11 @@ func (e *StrategyEngine) evaluateTrendFollow(symbolID int64, sma20, sma50, rsi f
 			reason += ", MACD confirmed"
 		}
 		return &entity.Signal{
-			SymbolID:  symbolID,
-			Action:    entity.SignalActionSell,
-			Reason:    reason,
-			Timestamp: now,
+			SymbolID:   symbolID,
+			Action:     entity.SignalActionSell,
+			Confidence: trendFollowConfidence(sma20, sma50, rsi, histogram, false),
+			Reason:     reason,
+			Timestamp:  now,
 		}
 	}
 	return &entity.Signal{
@@ -103,6 +106,30 @@ func (e *StrategyEngine) evaluateTrendFollow(symbolID int64, sma20, sma50, rsi f
 		Reason:    "trend follow: no clear signal",
 		Timestamp: now,
 	}
+}
+
+// trendFollowConfidence computes a 0.0–1.0 confidence score for trend-follow signals.
+// Factors: SMA divergence strength (40%), RSI headroom (30%), MACD histogram agreement (30%).
+func trendFollowConfidence(sma20, sma50, rsi float64, histogram *float64, isBuy bool) float64 {
+	// SMA divergence: how strongly the cross is established (capped at 2%)
+	smaDivergence := math.Min(math.Abs(sma20-sma50)/sma50*100, 2.0) / 2.0
+
+	// RSI headroom: distance from the overbought/oversold boundary
+	var rsiRoom float64
+	if isBuy {
+		rsiRoom = (70 - rsi) / 40 // 30→1.0, 70→0.0
+	} else {
+		rsiRoom = (rsi - 30) / 40 // 70→1.0, 30→0.0
+	}
+	rsiRoom = math.Max(0, math.Min(1, rsiRoom))
+
+	// MACD histogram confirmation
+	macdConfirm := 0.5 // neutral when histogram unavailable
+	if histogram != nil {
+		macdConfirm = math.Min(math.Abs(*histogram)/10, 1.0)
+	}
+
+	return smaDivergence*0.4 + rsiRoom*0.3 + macdConfirm*0.3
 }
 
 func (e *StrategyEngine) evaluateContrarian(symbolID int64, rsi float64, histogram *float64) *entity.Signal {
@@ -123,10 +150,11 @@ func (e *StrategyEngine) evaluateContrarian(symbolID int64, rsi float64, histogr
 			reason += ", MACD not strongly against"
 		}
 		return &entity.Signal{
-			SymbolID:  symbolID,
-			Action:    entity.SignalActionBuy,
-			Reason:    reason,
-			Timestamp: now,
+			SymbolID:   symbolID,
+			Action:     entity.SignalActionBuy,
+			Confidence: contrarianConfidence(rsi, histogram, true),
+			Reason:     reason,
+			Timestamp:  now,
 		}
 	}
 	if rsi > 70 {
@@ -144,10 +172,11 @@ func (e *StrategyEngine) evaluateContrarian(symbolID int64, rsi float64, histogr
 			reason += ", MACD not strongly against"
 		}
 		return &entity.Signal{
-			SymbolID:  symbolID,
-			Action:    entity.SignalActionSell,
-			Reason:    reason,
-			Timestamp: now,
+			SymbolID:   symbolID,
+			Action:     entity.SignalActionSell,
+			Confidence: contrarianConfidence(rsi, histogram, false),
+			Reason:     reason,
+			Timestamp:  now,
 		}
 	}
 	return &entity.Signal{
@@ -156,4 +185,25 @@ func (e *StrategyEngine) evaluateContrarian(symbolID int64, rsi float64, histogr
 		Reason:    "contrarian: RSI in neutral zone",
 		Timestamp: now,
 	}
+}
+
+// contrarianConfidence computes a 0.0–1.0 confidence score for contrarian signals.
+// Factors: RSI extremity (60%), MACD not-against (40%).
+func contrarianConfidence(rsi float64, histogram *float64, isBuy bool) float64 {
+	// RSI extremity: how deep into oversold/overbought territory
+	var rsiExtreme float64
+	if isBuy {
+		rsiExtreme = (30 - rsi) / 30 // 0→1.0, 30→0.0
+	} else {
+		rsiExtreme = (rsi - 70) / 30 // 100→1.0, 70→0.0
+	}
+	rsiExtreme = math.Max(0, math.Min(1, rsiExtreme))
+
+	// MACD not-against: lower opposing momentum = higher confidence
+	macdNotAgainst := 0.5 // neutral when histogram unavailable
+	if histogram != nil {
+		macdNotAgainst = 1.0 - math.Min(math.Abs(*histogram)/20, 1.0)
+	}
+
+	return rsiExtreme*0.6 + macdNotAgainst*0.4
 }

--- a/backend/internal/usecase/strategy.go
+++ b/backend/internal/usecase/strategy.go
@@ -23,18 +23,42 @@ func NewStrategyEngine(stanceResolver StanceResolver) *StrategyEngine {
 // higherTFがnon-nilの場合、Trend Followシグナルが上位トレンドに逆行していればHOLDにフィルタする。
 // 上位トレンドと一致している場合はconfidenceを10%ブーストする。
 // Contrarianシグナルは意図的に逆張りなのでフィルタしない。
+// ボラティリティフィルター: BBバンド幅が非常に狭い(squeeze)場合、Trend Followシグナルを抑制する。
 func (e *StrategyEngine) EvaluateWithHigherTF(ctx context.Context, indicators entity.IndicatorSet, higherTF *entity.IndicatorSet, lastPrice float64) (*entity.Signal, error) {
 	signal, err := e.Evaluate(ctx, indicators, lastPrice)
 	if err != nil || signal.Action == entity.SignalActionHold {
 		return signal, err
 	}
 
+	result := e.stanceResolver.Resolve(ctx, indicators)
+
+	// Volatility filter: squeeze detection for trend-follow signals
+	// BBBandwidth < 0.02 (2%) indicates very low volatility / consolidation
+	if result.Stance == entity.MarketStanceTrendFollow && indicators.BBBandwidth != nil && *indicators.BBBandwidth < 0.02 {
+		return &entity.Signal{
+			SymbolID:  indicators.SymbolID,
+			Action:    entity.SignalActionHold,
+			Reason:    "volatility filter: Bollinger squeeze, trend signal unreliable",
+			Timestamp: signal.Timestamp,
+		}, nil
+	}
+
+	// BB position can boost/penalize confidence for contrarian
+	if result.Stance == entity.MarketStanceContrarian && indicators.BBLower != nil && indicators.BBUpper != nil {
+		if signal.Action == entity.SignalActionBuy && lastPrice <= *indicators.BBLower {
+			// Price at/below lower band: extra confidence for buy
+			signal.Confidence = math.Min(signal.Confidence+0.1, 1.0)
+		} else if signal.Action == entity.SignalActionSell && lastPrice >= *indicators.BBUpper {
+			// Price at/above upper band: extra confidence for sell
+			signal.Confidence = math.Min(signal.Confidence+0.1, 1.0)
+		}
+	}
+
 	if higherTF == nil || higherTF.SMA20 == nil || higherTF.SMA50 == nil {
 		return signal, nil
 	}
 
-	// Contrarian signals are intentionally counter-trend; don't filter them
-	result := e.stanceResolver.Resolve(ctx, indicators)
+	// Contrarian signals are intentionally counter-trend; don't filter by higher TF
 	if result.Stance == entity.MarketStanceContrarian {
 		return signal, nil
 	}
@@ -59,11 +83,7 @@ func (e *StrategyEngine) EvaluateWithHigherTF(ctx context.Context, indicators en
 	}
 
 	// Signal aligns with higher TF: boost confidence by 10% (capped at 1.0)
-	boosted := signal.Confidence + 0.1
-	if boosted > 1.0 {
-		boosted = 1.0
-	}
-	signal.Confidence = boosted
+	signal.Confidence = math.Min(signal.Confidence+0.1, 1.0)
 	return signal, nil
 }
 

--- a/backend/internal/usecase/strategy.go
+++ b/backend/internal/usecase/strategy.go
@@ -108,7 +108,7 @@ func (e *StrategyEngine) Evaluate(ctx context.Context, indicators entity.Indicat
 
 	switch result.Stance {
 	case entity.MarketStanceTrendFollow:
-		return e.evaluateTrendFollow(indicators.SymbolID, sma20, sma50, rsi, indicators.Histogram), nil
+		return e.evaluateTrendFollow(indicators.SymbolID, sma20, sma50, rsi, indicators.EMA12, indicators.EMA26, indicators.Histogram), nil
 	case entity.MarketStanceContrarian:
 		return e.evaluateContrarian(indicators.SymbolID, rsi, indicators.Histogram), nil
 	default:
@@ -121,10 +121,37 @@ func (e *StrategyEngine) Evaluate(ctx context.Context, indicators entity.Indicat
 	}
 }
 
-func (e *StrategyEngine) evaluateTrendFollow(symbolID int64, sma20, sma50, rsi float64, histogram *float64) *entity.Signal {
+func (e *StrategyEngine) evaluateTrendFollow(symbolID int64, sma20, sma50, rsi float64, ema12, ema26, histogram *float64) *entity.Signal {
 	now := time.Now().Unix()
 
-	if sma20 > sma50 && rsi < 70 {
+	// Primary signal: EMA12/26 crossover (faster than SMA cross)
+	// Fallback to SMA20/50 when EMA is unavailable
+	var fastAboveSlow bool
+	var fastBelowSlow bool
+	useEMA := ema12 != nil && ema26 != nil
+
+	if useEMA {
+		fastAboveSlow = *ema12 > *ema26
+		fastBelowSlow = *ema12 < *ema26
+	} else {
+		fastAboveSlow = sma20 > sma50
+		fastBelowSlow = sma20 < sma50
+	}
+
+	// SMA filter: require SMA trend alignment when EMA is the primary signal
+	if useEMA {
+		smaAligned := (fastAboveSlow && sma20 >= sma50) || (fastBelowSlow && sma20 <= sma50)
+		if !smaAligned {
+			return &entity.Signal{
+				SymbolID:  symbolID,
+				Action:    entity.SignalActionHold,
+				Reason:    "trend follow: EMA cross but SMA not aligned",
+				Timestamp: now,
+			}
+		}
+	}
+
+	if fastAboveSlow && rsi < 70 {
 		// MACD histogram confirmation: skip buy if momentum is negative
 		if histogram != nil && *histogram < 0 {
 			return &entity.Signal{
@@ -134,19 +161,22 @@ func (e *StrategyEngine) evaluateTrendFollow(symbolID int64, sma20, sma50, rsi f
 				Timestamp: now,
 			}
 		}
-		reason := "trend follow: SMA20 > SMA50, RSI not overbought"
+		reason := "trend follow: EMA12 > EMA26, SMA aligned, RSI not overbought"
+		if !useEMA {
+			reason = "trend follow: SMA20 > SMA50, RSI not overbought"
+		}
 		if histogram != nil {
 			reason += ", MACD confirmed"
 		}
 		return &entity.Signal{
 			SymbolID:   symbolID,
 			Action:     entity.SignalActionBuy,
-			Confidence: trendFollowConfidence(sma20, sma50, rsi, histogram, true),
+			Confidence: trendFollowConfidence(sma20, sma50, rsi, ema12, ema26, histogram, true),
 			Reason:     reason,
 			Timestamp:  now,
 		}
 	}
-	if sma20 < sma50 && rsi > 30 {
+	if fastBelowSlow && rsi > 30 {
 		// MACD histogram confirmation: skip sell if momentum is positive
 		if histogram != nil && *histogram > 0 {
 			return &entity.Signal{
@@ -156,14 +186,17 @@ func (e *StrategyEngine) evaluateTrendFollow(symbolID int64, sma20, sma50, rsi f
 				Timestamp: now,
 			}
 		}
-		reason := "trend follow: SMA20 < SMA50, RSI not oversold"
+		reason := "trend follow: EMA12 < EMA26, SMA aligned, RSI not oversold"
+		if !useEMA {
+			reason = "trend follow: SMA20 < SMA50, RSI not oversold"
+		}
 		if histogram != nil {
 			reason += ", MACD confirmed"
 		}
 		return &entity.Signal{
 			SymbolID:   symbolID,
 			Action:     entity.SignalActionSell,
-			Confidence: trendFollowConfidence(sma20, sma50, rsi, histogram, false),
+			Confidence: trendFollowConfidence(sma20, sma50, rsi, ema12, ema26, histogram, false),
 			Reason:     reason,
 			Timestamp:  now,
 		}
@@ -177,27 +210,33 @@ func (e *StrategyEngine) evaluateTrendFollow(symbolID int64, sma20, sma50, rsi f
 }
 
 // trendFollowConfidence computes a 0.0–1.0 confidence score for trend-follow signals.
-// Factors: SMA divergence strength (40%), RSI headroom (30%), MACD histogram agreement (30%).
-func trendFollowConfidence(sma20, sma50, rsi float64, histogram *float64, isBuy bool) float64 {
-	// SMA divergence: how strongly the cross is established (capped at 2%)
+// Factors: EMA/SMA divergence (30%), SMA trend strength (15%), RSI headroom (25%), MACD (30%).
+func trendFollowConfidence(sma20, sma50, rsi float64, ema12, ema26, histogram *float64, isBuy bool) float64 {
+	// EMA divergence: how strongly the EMA cross is established
+	emaDivergence := 0.5
+	if ema12 != nil && ema26 != nil && *ema26 != 0 {
+		emaDivergence = math.Min(math.Abs(*ema12-*ema26)/math.Abs(*ema26)*100, 2.0) / 2.0
+	}
+
+	// SMA trend strength (capped at 2%)
 	smaDivergence := math.Min(math.Abs(sma20-sma50)/sma50*100, 2.0) / 2.0
 
 	// RSI headroom: distance from the overbought/oversold boundary
 	var rsiRoom float64
 	if isBuy {
-		rsiRoom = (70 - rsi) / 40 // 30→1.0, 70→0.0
+		rsiRoom = (70 - rsi) / 40
 	} else {
-		rsiRoom = (rsi - 30) / 40 // 70→1.0, 30→0.0
+		rsiRoom = (rsi - 30) / 40
 	}
 	rsiRoom = math.Max(0, math.Min(1, rsiRoom))
 
 	// MACD histogram confirmation
-	macdConfirm := 0.5 // neutral when histogram unavailable
+	macdConfirm := 0.5
 	if histogram != nil {
 		macdConfirm = math.Min(math.Abs(*histogram)/10, 1.0)
 	}
 
-	return smaDivergence*0.4 + rsiRoom*0.3 + macdConfirm*0.3
+	return emaDivergence*0.3 + smaDivergence*0.15 + rsiRoom*0.25 + macdConfirm*0.3
 }
 
 func (e *StrategyEngine) evaluateContrarian(symbolID int64, rsi float64, histogram *float64) *entity.Signal {

--- a/backend/internal/usecase/strategy_test.go
+++ b/backend/internal/usecase/strategy_test.go
@@ -609,6 +609,92 @@ func TestStrategyEngine_MTF_ContrarianNotFiltered(t *testing.T) {
 	}
 }
 
+func TestStrategyEngine_VolatilityFilter_SqueezeBlocksTrendFollow(t *testing.T) {
+	// BB bandwidth < 0.02 during trend follow → HOLD
+	resolver := &mockStanceResolver{
+		result: StanceResult{Stance: entity.MarketStanceTrendFollow, Reasoning: "uptrend", Source: "rule-based", UpdatedAt: time.Now().Unix()},
+	}
+	engine := NewStrategyEngine(resolver)
+
+	indicators := entity.IndicatorSet{
+		SymbolID:    7,
+		SMA20:       ptr(5100000.0),
+		SMA50:       ptr(5000000.0),
+		RSI14:       ptr(55.0),
+		Histogram:   ptr(3.0),
+		BBBandwidth: ptr(0.015), // squeeze
+	}
+	signal, err := engine.EvaluateWithHigherTF(context.Background(), indicators, nil, 5100000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if signal.Action != entity.SignalActionHold {
+		t.Fatalf("expected HOLD during BB squeeze, got %s", signal.Action)
+	}
+	if signal.Reason != "volatility filter: Bollinger squeeze, trend signal unreliable" {
+		t.Fatalf("unexpected reason: %s", signal.Reason)
+	}
+}
+
+func TestStrategyEngine_VolatilityFilter_NormalBandwidthAllowsTrade(t *testing.T) {
+	// BB bandwidth >= 0.02 → normal trading
+	resolver := &mockStanceResolver{
+		result: StanceResult{Stance: entity.MarketStanceTrendFollow, Reasoning: "uptrend", Source: "rule-based", UpdatedAt: time.Now().Unix()},
+	}
+	engine := NewStrategyEngine(resolver)
+
+	indicators := entity.IndicatorSet{
+		SymbolID:    7,
+		SMA20:       ptr(5100000.0),
+		SMA50:       ptr(5000000.0),
+		RSI14:       ptr(55.0),
+		Histogram:   ptr(3.0),
+		BBBandwidth: ptr(0.05), // normal volatility
+	}
+	signal, err := engine.EvaluateWithHigherTF(context.Background(), indicators, nil, 5100000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if signal.Action != entity.SignalActionBuy {
+		t.Fatalf("expected BUY with normal bandwidth, got %s", signal.Action)
+	}
+}
+
+func TestStrategyEngine_BB_ContrarianBuyAtLowerBandBoost(t *testing.T) {
+	// Contrarian BUY with price at lower BB → confidence boosted
+	resolver := &mockStanceResolver{
+		result: StanceResult{Stance: entity.MarketStanceContrarian, Reasoning: "oversold", Source: "rule-based", UpdatedAt: time.Now().Unix()},
+	}
+	engine := NewStrategyEngine(resolver)
+
+	indicators := entity.IndicatorSet{
+		SymbolID:  7,
+		SMA20:     ptr(4900000.0),
+		SMA50:     ptr(5000000.0),
+		RSI14:     ptr(25.0),
+		Histogram: ptr(-3.0),
+		BBUpper:   ptr(5200000.0),
+		BBLower:   ptr(4850000.0),
+	}
+	// Price at lower band
+	signal, err := engine.EvaluateWithHigherTF(context.Background(), indicators, nil, 4850000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if signal.Action != entity.SignalActionBuy {
+		t.Fatalf("expected BUY, got %s", signal.Action)
+	}
+
+	// Compare with same signal without BB
+	indicatorsNoBB := indicators
+	indicatorsNoBB.BBLower = nil
+	indicatorsNoBB.BBUpper = nil
+	signalNoBB, _ := engine.EvaluateWithHigherTF(context.Background(), indicatorsNoBB, nil, 4850000)
+	if signal.Confidence <= signalNoBB.Confidence {
+		t.Fatalf("expected BB-boosted confidence (%.4f) > base (%.4f)", signal.Confidence, signalNoBB.Confidence)
+	}
+}
+
 func TestStrategyEngine_Confidence_HoldIsZero(t *testing.T) {
 	// HOLD signals should have 0.0 confidence
 	resolver := &mockStanceResolver{

--- a/backend/internal/usecase/strategy_test.go
+++ b/backend/internal/usecase/strategy_test.go
@@ -377,3 +377,117 @@ func TestStrategyEngine_TrendFollow_NilHistogramStillTrades(t *testing.T) {
 		t.Fatalf("expected BUY with nil histogram (backward compat), got %s", signal.Action)
 	}
 }
+
+func TestStrategyEngine_Confidence_TrendFollowStrong(t *testing.T) {
+	// Strong uptrend: SMA divergence 2%, RSI 55, histogram +5 → high confidence
+	resolver := &mockStanceResolver{
+		result: StanceResult{Stance: entity.MarketStanceTrendFollow, Reasoning: "uptrend", Source: "rule-based", UpdatedAt: time.Now().Unix()},
+	}
+	engine := NewStrategyEngine(resolver)
+
+	indicators := entity.IndicatorSet{
+		SymbolID:  7,
+		SMA20:     ptr(5100000.0), // 2% above SMA50
+		SMA50:     ptr(5000000.0),
+		RSI14:     ptr(55.0),
+		Histogram: ptr(5.0),
+	}
+	signal, err := engine.Evaluate(context.Background(), indicators, 5100000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if signal.Action != entity.SignalActionBuy {
+		t.Fatalf("expected BUY, got %s", signal.Action)
+	}
+	// SMA divergence: min(2.0, 2.0)/2.0 = 1.0 * 0.4 = 0.4
+	// RSI room: (70-55)/40 = 0.375 * 0.3 = 0.1125
+	// MACD confirm: min(5/10, 1.0) = 0.5 * 0.3 = 0.15
+	// Total: 0.6625
+	if signal.Confidence < 0.6 || signal.Confidence > 0.75 {
+		t.Fatalf("expected confidence ~0.66, got %.4f", signal.Confidence)
+	}
+}
+
+func TestStrategyEngine_Confidence_TrendFollowWeak(t *testing.T) {
+	// Weak uptrend: SMA barely crossing (0.1% divergence), RSI 68, no histogram
+	resolver := &mockStanceResolver{
+		result: StanceResult{Stance: entity.MarketStanceTrendFollow, Reasoning: "uptrend", Source: "rule-based", UpdatedAt: time.Now().Unix()},
+	}
+	engine := NewStrategyEngine(resolver)
+
+	indicators := entity.IndicatorSet{
+		SymbolID:  7,
+		SMA20:     ptr(5005000.0), // 0.1% above SMA50
+		SMA50:     ptr(5000000.0),
+		RSI14:     ptr(68.0),
+		Histogram: nil,
+	}
+	signal, err := engine.Evaluate(context.Background(), indicators, 5005000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if signal.Action != entity.SignalActionBuy {
+		t.Fatalf("expected BUY, got %s", signal.Action)
+	}
+	// SMA divergence: min(0.1, 2.0)/2.0 = 0.05 * 0.4 = 0.02
+	// RSI room: (70-68)/40 = 0.05 * 0.3 = 0.015
+	// MACD confirm: nil → 0.5 * 0.3 = 0.15
+	// Total: 0.185
+	if signal.Confidence > 0.25 {
+		t.Fatalf("expected low confidence (<0.25), got %.4f", signal.Confidence)
+	}
+}
+
+func TestStrategyEngine_Confidence_ContrarianStrong(t *testing.T) {
+	// Deep oversold: RSI 15, histogram mildly negative (-3)
+	resolver := &mockStanceResolver{
+		result: StanceResult{Stance: entity.MarketStanceContrarian, Reasoning: "oversold", Source: "rule-based", UpdatedAt: time.Now().Unix()},
+	}
+	engine := NewStrategyEngine(resolver)
+
+	indicators := entity.IndicatorSet{
+		SymbolID:  7,
+		SMA20:     ptr(4900000.0),
+		SMA50:     ptr(5000000.0),
+		RSI14:     ptr(15.0),
+		Histogram: ptr(-3.0),
+	}
+	signal, err := engine.Evaluate(context.Background(), indicators, 4900000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if signal.Action != entity.SignalActionBuy {
+		t.Fatalf("expected BUY, got %s", signal.Action)
+	}
+	// RSI extreme: (30-15)/30 = 0.5 * 0.6 = 0.3
+	// MACD not against: 1.0 - min(3/20, 1.0) = 0.85 * 0.4 = 0.34
+	// Total: 0.64
+	if signal.Confidence < 0.55 || signal.Confidence > 0.75 {
+		t.Fatalf("expected confidence ~0.64, got %.4f", signal.Confidence)
+	}
+}
+
+func TestStrategyEngine_Confidence_HoldIsZero(t *testing.T) {
+	// HOLD signals should have 0.0 confidence
+	resolver := &mockStanceResolver{
+		result: StanceResult{Stance: entity.MarketStanceHold, Reasoning: "uncertain", Source: "rule-based", UpdatedAt: time.Now().Unix()},
+	}
+	engine := NewStrategyEngine(resolver)
+
+	indicators := entity.IndicatorSet{
+		SymbolID: 7,
+		SMA20:    ptr(5100000.0),
+		SMA50:    ptr(5000000.0),
+		RSI14:    ptr(55.0),
+	}
+	signal, err := engine.Evaluate(context.Background(), indicators, 5100000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if signal.Action != entity.SignalActionHold {
+		t.Fatalf("expected HOLD, got %s", signal.Action)
+	}
+	if signal.Confidence != 0.0 {
+		t.Fatalf("expected confidence 0.0 for HOLD, got %.4f", signal.Confidence)
+	}
+}

--- a/backend/internal/usecase/strategy_test.go
+++ b/backend/internal/usecase/strategy_test.go
@@ -467,6 +467,148 @@ func TestStrategyEngine_Confidence_ContrarianStrong(t *testing.T) {
 	}
 }
 
+func TestStrategyEngine_MTF_BuyBlockedByHigherDowntrend(t *testing.T) {
+	// PT15M says BUY, but PT1H SMA20 < SMA50 (higher timeframe downtrend) → HOLD
+	resolver := &mockStanceResolver{
+		result: StanceResult{Stance: entity.MarketStanceTrendFollow, Reasoning: "uptrend", Source: "rule-based", UpdatedAt: time.Now().Unix()},
+	}
+	engine := NewStrategyEngine(resolver)
+
+	indicators := entity.IndicatorSet{
+		SymbolID:  7,
+		SMA20:     ptr(5100000.0),
+		SMA50:     ptr(5000000.0),
+		RSI14:     ptr(55.0),
+		Histogram: ptr(3.0),
+	}
+	higherTF := &entity.IndicatorSet{
+		SymbolID: 7,
+		SMA20:    ptr(4900000.0), // downtrend on higher TF
+		SMA50:    ptr(5000000.0),
+	}
+	signal, err := engine.EvaluateWithHigherTF(context.Background(), indicators, higherTF, 5100000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if signal.Action != entity.SignalActionHold {
+		t.Fatalf("expected HOLD when higher TF is downtrend but signal is BUY, got %s (reason: %s)", signal.Action, signal.Reason)
+	}
+}
+
+func TestStrategyEngine_MTF_SellBlockedByHigherUptrend(t *testing.T) {
+	// PT15M says SELL, but PT1H SMA20 > SMA50 (higher timeframe uptrend) → HOLD
+	resolver := &mockStanceResolver{
+		result: StanceResult{Stance: entity.MarketStanceTrendFollow, Reasoning: "downtrend", Source: "rule-based", UpdatedAt: time.Now().Unix()},
+	}
+	engine := NewStrategyEngine(resolver)
+
+	indicators := entity.IndicatorSet{
+		SymbolID:  7,
+		SMA20:     ptr(4900000.0),
+		SMA50:     ptr(5000000.0),
+		RSI14:     ptr(45.0),
+		Histogram: ptr(-3.0),
+	}
+	higherTF := &entity.IndicatorSet{
+		SymbolID: 7,
+		SMA20:    ptr(5100000.0), // uptrend on higher TF
+		SMA50:    ptr(5000000.0),
+	}
+	signal, err := engine.EvaluateWithHigherTF(context.Background(), indicators, higherTF, 4900000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if signal.Action != entity.SignalActionHold {
+		t.Fatalf("expected HOLD when higher TF is uptrend but signal is SELL, got %s (reason: %s)", signal.Action, signal.Reason)
+	}
+}
+
+func TestStrategyEngine_MTF_BuyAlignedWithHigherUptrend(t *testing.T) {
+	// PT15M says BUY, PT1H also uptrend → BUY with boosted confidence
+	resolver := &mockStanceResolver{
+		result: StanceResult{Stance: entity.MarketStanceTrendFollow, Reasoning: "uptrend", Source: "rule-based", UpdatedAt: time.Now().Unix()},
+	}
+	engine := NewStrategyEngine(resolver)
+
+	indicators := entity.IndicatorSet{
+		SymbolID:  7,
+		SMA20:     ptr(5100000.0),
+		SMA50:     ptr(5000000.0),
+		RSI14:     ptr(55.0),
+		Histogram: ptr(5.0),
+	}
+	higherTF := &entity.IndicatorSet{
+		SymbolID: 7,
+		SMA20:    ptr(5200000.0), // uptrend on higher TF too
+		SMA50:    ptr(5000000.0),
+	}
+
+	signalWithMTF, err := engine.EvaluateWithHigherTF(context.Background(), indicators, higherTF, 5100000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if signalWithMTF.Action != entity.SignalActionBuy {
+		t.Fatalf("expected BUY, got %s", signalWithMTF.Action)
+	}
+
+	// Compare: without higher TF
+	signalBase, _ := engine.Evaluate(context.Background(), indicators, 5100000)
+	if signalWithMTF.Confidence <= signalBase.Confidence {
+		t.Fatalf("expected MTF-aligned confidence (%.4f) > base confidence (%.4f)", signalWithMTF.Confidence, signalBase.Confidence)
+	}
+}
+
+func TestStrategyEngine_MTF_NilHigherTFFallsBack(t *testing.T) {
+	// nil higherTF → behaves same as Evaluate()
+	resolver := &mockStanceResolver{
+		result: StanceResult{Stance: entity.MarketStanceTrendFollow, Reasoning: "uptrend", Source: "rule-based", UpdatedAt: time.Now().Unix()},
+	}
+	engine := NewStrategyEngine(resolver)
+
+	indicators := entity.IndicatorSet{
+		SymbolID:  7,
+		SMA20:     ptr(5100000.0),
+		SMA50:     ptr(5000000.0),
+		RSI14:     ptr(55.0),
+		Histogram: ptr(3.0),
+	}
+	signal, err := engine.EvaluateWithHigherTF(context.Background(), indicators, nil, 5100000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if signal.Action != entity.SignalActionBuy {
+		t.Fatalf("expected BUY with nil higherTF, got %s", signal.Action)
+	}
+}
+
+func TestStrategyEngine_MTF_ContrarianNotFiltered(t *testing.T) {
+	// Contrarian signals are NOT filtered by higher TF (they're intentionally counter-trend)
+	resolver := &mockStanceResolver{
+		result: StanceResult{Stance: entity.MarketStanceContrarian, Reasoning: "oversold", Source: "rule-based", UpdatedAt: time.Now().Unix()},
+	}
+	engine := NewStrategyEngine(resolver)
+
+	indicators := entity.IndicatorSet{
+		SymbolID:  7,
+		SMA20:     ptr(4900000.0),
+		SMA50:     ptr(5000000.0),
+		RSI14:     ptr(25.0),
+		Histogram: ptr(-3.0),
+	}
+	higherTF := &entity.IndicatorSet{
+		SymbolID: 7,
+		SMA20:    ptr(4800000.0), // downtrend on higher TF
+		SMA50:    ptr(5000000.0),
+	}
+	signal, err := engine.EvaluateWithHigherTF(context.Background(), indicators, higherTF, 4900000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if signal.Action != entity.SignalActionBuy {
+		t.Fatalf("expected contrarian BUY even with higher TF downtrend, got %s", signal.Action)
+	}
+}
+
 func TestStrategyEngine_Confidence_HoldIsZero(t *testing.T) {
 	// HOLD signals should have 0.0 confidence
 	resolver := &mockStanceResolver{

--- a/backend/internal/usecase/strategy_test.go
+++ b/backend/internal/usecase/strategy_test.go
@@ -379,7 +379,7 @@ func TestStrategyEngine_TrendFollow_NilHistogramStillTrades(t *testing.T) {
 }
 
 func TestStrategyEngine_Confidence_TrendFollowStrong(t *testing.T) {
-	// Strong uptrend: SMA divergence 2%, RSI 55, histogram +5 → high confidence
+	// Strong uptrend: EMA and SMA divergent, RSI 55, histogram +5 → high confidence
 	resolver := &mockStanceResolver{
 		result: StanceResult{Stance: entity.MarketStanceTrendFollow, Reasoning: "uptrend", Source: "rule-based", UpdatedAt: time.Now().Unix()},
 	}
@@ -389,6 +389,8 @@ func TestStrategyEngine_Confidence_TrendFollowStrong(t *testing.T) {
 		SymbolID:  7,
 		SMA20:     ptr(5100000.0), // 2% above SMA50
 		SMA50:     ptr(5000000.0),
+		EMA12:     ptr(5120000.0), // ~2.4% above EMA26
+		EMA26:     ptr(5000000.0),
 		RSI14:     ptr(55.0),
 		Histogram: ptr(5.0),
 	}
@@ -397,19 +399,20 @@ func TestStrategyEngine_Confidence_TrendFollowStrong(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if signal.Action != entity.SignalActionBuy {
-		t.Fatalf("expected BUY, got %s", signal.Action)
+		t.Fatalf("expected BUY, got %s (reason: %s)", signal.Action, signal.Reason)
 	}
-	// SMA divergence: min(2.0, 2.0)/2.0 = 1.0 * 0.4 = 0.4
-	// RSI room: (70-55)/40 = 0.375 * 0.3 = 0.1125
+	// EMA divergence: min(2.4, 2.0)/2.0 = 1.0 * 0.3 = 0.3
+	// SMA divergence: min(2.0, 2.0)/2.0 = 1.0 * 0.15 = 0.15
+	// RSI room: (70-55)/40 = 0.375 * 0.25 = 0.09375
 	// MACD confirm: min(5/10, 1.0) = 0.5 * 0.3 = 0.15
-	// Total: 0.6625
-	if signal.Confidence < 0.6 || signal.Confidence > 0.75 {
-		t.Fatalf("expected confidence ~0.66, got %.4f", signal.Confidence)
+	// Total: ~0.69
+	if signal.Confidence < 0.6 || signal.Confidence > 0.8 {
+		t.Fatalf("expected confidence ~0.69, got %.4f", signal.Confidence)
 	}
 }
 
 func TestStrategyEngine_Confidence_TrendFollowWeak(t *testing.T) {
-	// Weak uptrend: SMA barely crossing (0.1% divergence), RSI 68, no histogram
+	// Weak uptrend: EMA/SMA barely crossing, RSI 68, no histogram
 	resolver := &mockStanceResolver{
 		result: StanceResult{Stance: entity.MarketStanceTrendFollow, Reasoning: "uptrend", Source: "rule-based", UpdatedAt: time.Now().Unix()},
 	}
@@ -419,6 +422,8 @@ func TestStrategyEngine_Confidence_TrendFollowWeak(t *testing.T) {
 		SymbolID:  7,
 		SMA20:     ptr(5005000.0), // 0.1% above SMA50
 		SMA50:     ptr(5000000.0),
+		EMA12:     ptr(5003000.0), // 0.06% above EMA26
+		EMA26:     ptr(5000000.0),
 		RSI14:     ptr(68.0),
 		Histogram: nil,
 	}
@@ -427,14 +432,64 @@ func TestStrategyEngine_Confidence_TrendFollowWeak(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if signal.Action != entity.SignalActionBuy {
-		t.Fatalf("expected BUY, got %s", signal.Action)
+		t.Fatalf("expected BUY, got %s (reason: %s)", signal.Action, signal.Reason)
 	}
-	// SMA divergence: min(0.1, 2.0)/2.0 = 0.05 * 0.4 = 0.02
-	// RSI room: (70-68)/40 = 0.05 * 0.3 = 0.015
+	// EMA divergence: min(0.06, 2.0)/2.0 = 0.03 * 0.3 = 0.009
+	// SMA divergence: min(0.1, 2.0)/2.0 = 0.05 * 0.15 = 0.0075
+	// RSI room: (70-68)/40 = 0.05 * 0.25 = 0.0125
 	// MACD confirm: nil → 0.5 * 0.3 = 0.15
-	// Total: 0.185
+	// Total: ~0.179
 	if signal.Confidence > 0.25 {
 		t.Fatalf("expected low confidence (<0.25), got %.4f", signal.Confidence)
+	}
+}
+
+func TestStrategyEngine_EMA_CrossWithSMAMisalignment(t *testing.T) {
+	// EMA12 > EMA26 (bullish) but SMA20 < SMA50 (SMA not aligned) → HOLD
+	resolver := &mockStanceResolver{
+		result: StanceResult{Stance: entity.MarketStanceTrendFollow, Reasoning: "uptrend", Source: "rule-based", UpdatedAt: time.Now().Unix()},
+	}
+	engine := NewStrategyEngine(resolver)
+
+	indicators := entity.IndicatorSet{
+		SymbolID:  7,
+		SMA20:     ptr(4990000.0), // SMA still bearish
+		SMA50:     ptr(5000000.0),
+		EMA12:     ptr(5010000.0), // EMA already bullish
+		EMA26:     ptr(5000000.0),
+		RSI14:     ptr(55.0),
+	}
+	signal, err := engine.Evaluate(context.Background(), indicators, 5010000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if signal.Action != entity.SignalActionHold {
+		t.Fatalf("expected HOLD when EMA crossed but SMA not aligned, got %s (reason: %s)", signal.Action, signal.Reason)
+	}
+}
+
+func TestStrategyEngine_EMA_FallbackToSMAWhenNil(t *testing.T) {
+	// EMA nil → falls back to SMA-only evaluation
+	resolver := &mockStanceResolver{
+		result: StanceResult{Stance: entity.MarketStanceTrendFollow, Reasoning: "uptrend", Source: "rule-based", UpdatedAt: time.Now().Unix()},
+	}
+	engine := NewStrategyEngine(resolver)
+
+	indicators := entity.IndicatorSet{
+		SymbolID:  7,
+		SMA20:     ptr(5100000.0),
+		SMA50:     ptr(5000000.0),
+		EMA12:     nil, // no EMA data
+		EMA26:     nil,
+		RSI14:     ptr(55.0),
+		Histogram: ptr(3.0),
+	}
+	signal, err := engine.Evaluate(context.Background(), indicators, 5100000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if signal.Action != entity.SignalActionBuy {
+		t.Fatalf("expected BUY with SMA fallback, got %s", signal.Action)
 	}
 }
 


### PR DESCRIPTION
## Summary
- ATR (Average True Range, 14期間 Wilder 平滑化) インジケーターを追加
- `RISK_STOP_LOSS_ATR_MULTIPLIER` (デフォルト 2.0) で ATR ベースの動的ストップロス
- ATR 未設定または multiplier=0 の場合は従来の固定 % にフォールバック
- CheckStopLoss / CheckTrailingStop の両方が統一された `stopLossDistance()` を使用
- Pipeline が毎評価サイクルで ATR を RiskManager に供給
- RiskStatus に `currentAtr` を追加しダッシュボードで確認可能

## Test plan
- [x] ATR: 不十分データで NaN
- [x] ATR: ミスマッチ配列長で NaN
- [x] ATR: 既知値で正確な計算
- [x] ATR: Wilder 平滑化の検証
- [x] ATR ストップロス: ATR*2 = 100k で 90k 下落→トリガーなし、100k→トリガー
- [x] ATR フォールバック: ATR 未設定時に固定 5% で動作
- [x] ATR トレーリングストップ: ATR*1.5 = 60k で HWM からの逆行検知
- [x] ATR 無効化: multiplier=0 で固定 % にフォールバック
- [x] 既存テスト全件 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)