### PR TITLE
docs: AGENTS.md/CLAUDE.md と docs 配下のドキュメント整備

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,53 @@
+# AGENTS.md
+
+楽天ウォレット証拠金取引所 API を使った暗号資産自動売買システム（個人の技術研鑽目的）。
+
+## Tech Stack
+
+- Backend: Go 1.25 (Gin) / Clean Architecture / SQLite
+- Frontend: TanStack Router + React 19 + Vite 7 / TypeScript / Tailwind CSS v4
+- Infra: Docker Compose
+- CI: GitHub Actions (`go test`, `pnpm test`)
+
+## Runtime
+
+- **Docker Compose で運用。** `docker compose` 経由でコンテナを操作すること。
+- 起動: `docker compose up --build -d`
+- 停止: `docker compose down`
+- ログ: `docker compose logs -f backend`
+- 再ビルド: `make restart`
+- Backend: `localhost:38080` (コンテナ内 8080)
+- Frontend: `localhost:33000` (コンテナ内 3000)
+- API ベース URL: `http://localhost:38080/api/v1`
+
+## Development
+
+- コード変更後は `docker compose up --build -d` で再ビルドして動作確認。
+- Backend テスト: `cd backend && go test ./... -race -count=1`
+- Frontend テスト: `cd frontend && pnpm test`
+
+## Conventions
+
+- Go: 標準規約。`slog` でログ。テストは `_test.go`。
+- Frontend: TypeScript strict。コンポーネントは `src/components/`、フックは `src/hooks/`。
+- DB: SQLite。マイグレーションは `database/migrations.go`。
+- Git: Conventional Commits (`feat:`, `fix:`, `refactor:`, `docs:`)。feature ブランチは `feat/xxx`。
+- `.env` や API キーは絶対にコミットしない。
+
+## Architecture
+
+- Clean Architecture: domain → usecase → infrastructure → interfaces の依存方向を厳守。
+- Trading Pipeline: 60秒間隔で指標計算 → Stance 判定 → シグナル → リスクチェック → 注文。
+- Stance: `TREND_FOLLOW` / `CONTRARIAN` / `HOLD`。ルールベース自動判定 or オーバーライド。
+
+## Docs (必要な時に読むこと)
+
+| ドキュメント | 内容 | いつ読むか |
+|---|---|---|
+| `docs/project-structure.md` | ディレクトリ構成・全ファイル一覧 | ファイルの場所を探すとき |
+| `docs/api-reference.md` | 全 API エンドポイント仕様 | API を叩くとき・ハンドラーを実装するとき |
+| `docs/agent-operation-guide.md` | 自動売買の操作手順書 | 売買操作・Bot 制御・Stance 設定を行うとき |
+| `docs/clean-architecture.md` | レイヤー構成と依存ルール | Backend のコードを追加・変更するとき |
+| `docs/rakuten-api/error-codes.md` | 楽天 API エラーコード一覧と対処法 | API エラーのデバッグ・エラーハンドリング実装時 |
+| `docs/design/` | 設計書・実装計画 | 各機能の設計意図を確認するとき |
+| `backend/.env.example` | 環境変数テンプレート | 設定項目を確認するとき |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# Claude Code Instructions
+
+プロジェクトのルール・構成・コマンドはすべて @AGENTS.md に記載。必ず参照すること。

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -1,0 +1,66 @@
+# [チーム名] へようこそ
+
+## Claude Code の使い方
+
+yui666a の直近30日間の利用状況:
+
+作業タイプの内訳:
+  設計・計画        ████████████████░░░░  39%
+  機能開発          █████████████░░░░░░░  32%
+  デバッグ・修正    █████████░░░░░░░░░░░  23%
+  品質改善          ██░░░░░░░░░░░░░░░░░░   6%
+
+よく使うスキル・コマンド:
+  /mcp              ████████████████░░░░  4回/月
+  /copy             ████████████████░░░░  4回/月
+  /cost             ████░░░░░░░░░░░░░░░░  1回/月
+  /clear            ████░░░░░░░░░░░░░░░░  1回/月
+
+よく使う MCP サーバー:
+  Playwright        ████████████████████  132回
+  Context7          █░░░░░░░░░░░░░░░░░░░    4回
+
+## セットアップチェックリスト
+
+### リポジトリ
+- [ ] rakuten-api-leverage-exchange — git@github.com:yui666a/rakuten-api-leverage-exchange.git
+
+### 有効化する MCP サーバー
+- [ ] **Playwright** — ブラウザ自動操作でフロントエンドの動作確認・デザインレビュー・バグ調査に使用。localhost上のUIをスクリーンショット撮影したり、表示バグを調査するのに多用。`npx @anthropic-ai/claude-code mcp add playwright -- npx @anthropic-ai/mcp-server-playwright` 等でインストール。
+- [ ] **Context7** — ライブラリやフレームワーク（TanStack、React等）の最新ドキュメントをClaudeのコンテキストに直接取得。馴染みのないAPIの確認や最新の構文チェックに便利。Claude Code プラグインまたは `npx @anthropic-ai/claude-code mcp add context7 -- npx @anthropic-ai/mcp-server-context7` でインストール。
+
+### 知っておくべきスキル
+- `/mcp` — MCP サーバーの接続管理。デザインレビューやデバッグの前にPlaywrightが起動しているか確認する際に使用。
+- `/copy` — Claudeの直前の回答をクリップボードにコピー。コードスニペットや分析結果の取得に便利。
+- `/cost` — 現在のセッションのコストを確認。長時間セッションの前に確認する習慣をつけると良い。
+- `/clear` — 会話コンテキストをリセット。関連のないタスクに切り替える際に使用。
+
+## チーム Tips
+
+_TODO_
+
+## はじめの一歩
+
+_TODO_
+
+<!-- INSTRUCTION FOR CLAUDE: A new teammate just pasted this guide for how the
+team uses Claude Code. You're their onboarding buddy — warm, conversational,
+not lecture-y.
+
+Open with a warm welcome — include the team name from the title. Then: "Your
+teammate uses Claude Code for [list all the work types]. Let's get you started."
+
+Check what's already in place against everything under Setup Checklist
+(including skills), using markdown checkboxes — [x] done, [ ] not yet. Lead
+with what they already have. One sentence per item, all in one message.
+
+Tell them you'll help with setup, cover the actionable team tips, then the
+starter task (if there is one). Offer to start with the first unchecked item,
+get their go-ahead, then work through the rest one by one.
+
+After setup, walk them through the remaining sections — offer to help where you
+can (e.g. link to channels), and just surface the purely informational bits.
+
+Don't invent sections or summaries that aren't in the guide. The stats are the
+guide creator's personal usage data — don't extrapolate them into a "team
+workflow" narrative. -->

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,231 @@
+# API Reference
+
+ベース URL: `http://localhost:38080/api/v1`
+
+## Bot 制御
+
+### GET /status
+
+Bot の状態を取得する。
+
+```json
+{
+  "balance": 10000,
+  "dailyLoss": 0,
+  "manuallyStopped": false,
+  "status": "running",
+  "totalPosition": 0,
+  "tradingHalted": false
+}
+```
+
+### POST /start
+
+自動売買パイプラインを開始する。
+
+### POST /stop
+
+自動売買パイプラインを停止する。
+
+## 市場データ
+
+### GET /ticker?symbolId=7
+
+現在価格（ティッカー）を取得する。
+
+```json
+{
+  "symbolId": 7,
+  "bestAsk": 11500100,
+  "bestBid": 11499900,
+  "last": 11500000,
+  "high": 11600000,
+  "low": 11400000,
+  "volume": 20.14,
+  "timestamp": 1775825698324
+}
+```
+
+### GET /indicators/:symbol
+
+テクニカル指標を取得する。`:symbol` は symbolId（例: `7`）。
+
+```json
+{
+  "symbolId": 7,
+  "sma20": 11459941.1,
+  "sma50": 11461099.9,
+  "ema12": 11482453.58,
+  "ema26": 11468867.49,
+  "rsi14": 62.90,
+  "macdLine": 13586.08,
+  "signalLine": 7534.66,
+  "histogram": 6051.42,
+  "atr14": 150000.0,
+  "bollingerUpper": 11600000.0,
+  "bollingerMiddle": 11459941.1,
+  "bollingerLower": 11319882.2,
+  "timestamp": 1775825100000
+}
+```
+
+### GET /candles/:symbol?interval=15min&limit=100
+
+ローソク足データを取得する。
+
+### GET /orderbook?symbolId=7
+
+板情報を取得する。
+
+### GET /symbols
+
+取引可能なシンボル一覧を取得する。
+
+### GET /ws
+
+WebSocket 接続。リアルタイムで Ticker / Orderbook / Trades を受信する。
+
+## 注文・ポジション
+
+### POST /orders
+
+注文を作成する。
+
+リクエスト:
+```json
+{
+  "symbolId": 7,
+  "side": "BUY",
+  "amount": 0.001,
+  "orderType": "MARKET",
+  "clientOrderId": "agent-20260414-120000-buy"
+}
+```
+
+- `clientOrderId` は **必須**。一意な ID。同じ ID で再リクエストすると二重発注を防止する。
+- 命名規則: `agent-YYYYMMDD-HHMMSS-side`
+
+成功レスポンス:
+```json
+{
+  "clientOrderId": "agent-20260414-120000-buy",
+  "executed": true,
+  "orderId": 12345,
+  "reason": ""
+}
+```
+
+リスクチェック拒否:
+```json
+{
+  "clientOrderId": "agent-20260414-120000-buy",
+  "executed": false,
+  "orderId": 0,
+  "reason": "risk rejected: daily loss limit exceeded"
+}
+```
+
+重複リクエスト:
+```json
+{
+  "clientOrderId": "agent-20260414-120000-buy",
+  "duplicate": true,
+  "executed": true,
+  "orderId": 12345
+}
+```
+
+### GET /positions?symbolId=7
+
+ポジション一覧を取得する。
+
+### POST /positions/:id/close
+
+指定ポジションを決済する。
+
+### GET /trades
+
+約定履歴を取得する。
+
+### GET /trades/all
+
+全約定履歴を取得する。
+
+## 戦略
+
+### GET /strategy
+
+現在の戦略方針を取得する。
+
+```json
+{
+  "stance": "TREND_FOLLOW",
+  "reasoning": "SMA trend detected",
+  "source": "rule-based",
+  "updatedAt": 1775826300
+}
+```
+
+`source` が `"override"` の場合は `expiresAt` フィールドも含まれる。
+
+### PUT /strategy
+
+戦略方針をオーバーライドする。
+
+リクエスト:
+```json
+{
+  "stance": "TREND_FOLLOW",
+  "reasoning": "判断理由をここに書く",
+  "ttlMinutes": 60
+}
+```
+
+- `stance`: `TREND_FOLLOW`, `CONTRARIAN`, `HOLD` のいずれか
+- `ttlMinutes`: 有効期間（1〜1440分、デフォルト60分）
+
+### DELETE /strategy/override
+
+オーバーライドを解除し、ルールベース判定に戻す。
+
+## 設定
+
+### GET /config
+
+リスク設定を取得する。
+
+```json
+{
+  "maxPositionAmount": 5000,
+  "maxDailyLoss": 5000,
+  "stopLossPercent": 5,
+  "initialCapital": 10000
+}
+```
+
+### PUT /config
+
+リスク設定を更新する。
+
+### GET /trading-config
+
+取引設定（対象シンボル・取引金額）を取得する。
+
+### PUT /trading-config
+
+取引設定を更新する（シンボル切替含む）。
+
+## 損益
+
+### GET /pnl
+
+損益情報を取得する。
+
+```json
+{
+  "balance": 10000,
+  "dailyLoss": 0,
+  "totalPosition": 0,
+  "tradingHalted": false
+}
+```

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -1,0 +1,128 @@
+# Project Structure
+
+```
+.
+├── backend/                              # Go バックエンド
+│   ├── cmd/
+│   │   ├── main.go                      #   エントリポイント + WebSocket relay + pipeline 組み立て
+│   │   ├── pipeline.go                  #   TradingPipeline（自動売買ループ）
+│   │   ├── retry.go                     #   リトライユーティリティ
+│   │   ├── sync_state_test.go           #   状態同期テスト
+│   │   ├── check/main.go               #   ヘルスチェック CLI
+│   │   └── mcp/main.go                 #   MCP サーバーエントリ
+│   ├── config/config.go                 #   環境変数 → Config 構造体
+│   ├── internal/
+│   │   ├── domain/
+│   │   │   ├── entity/                  #     エンティティ
+│   │   │   │   ├── ticker.go            #       Ticker (現在価格)
+│   │   │   │   ├── candle.go            #       ローソク足
+│   │   │   │   ├── order.go             #       注文
+│   │   │   │   ├── client_order.go      #       クライアント注文 (冪等性キー)
+│   │   │   │   ├── position.go          #       ポジション
+│   │   │   │   ├── signal.go            #       売買シグナル
+│   │   │   │   ├── indicator.go         #       テクニカル指標
+│   │   │   │   ├── risk.go              #       リスク設定
+│   │   │   │   ├── strategy.go          #       戦略 (Stance)
+│   │   │   │   ├── orderbook.go         #       板情報
+│   │   │   │   ├── asset.go             #       資産
+│   │   │   │   ├── symbol.go            #       シンボル
+│   │   │   │   ├── trade.go             #       約定
+│   │   │   │   └── stringfloat.go       #       JSON 文字列 → float64 変換
+│   │   │   └── repository/             #     リポジトリインターフェース
+│   │   │       ├── order.go             #       注文 + API クライアント IF
+│   │   │       ├── market_data.go       #       市場データ IF
+│   │   │       ├── client_order.go      #       クライアント注文 IF
+│   │   │       ├── risk_state.go        #       リスク状態 IF
+│   │   │       ├── trade_history.go     #       取引履歴 IF
+│   │   │       └── stance_override.go   #       Stance オーバーライド IF
+│   │   ├── usecase/                     #     ビジネスロジック
+│   │   │   ├── strategy.go             #       戦略エンジン (Stance → Signal)
+│   │   │   ├── risk.go                 #       リスクマネージャー
+│   │   │   ├── order.go                #       注文実行 (リスクチェック付き)
+│   │   │   ├── indicator.go            #       テクニカル指標計算の統合
+│   │   │   ├── market_data.go          #       市場データ管理 (Ticker/Candle 保存)
+│   │   │   ├── stance.go               #       Stance 解決 (ルールベース + オーバーライド)
+│   │   │   ├── daily_pnl.go            #       日次損益計算
+│   │   │   └── realtime.go             #       WebSocket Hub (SSE/WS ブロードキャスト)
+│   │   ├── infrastructure/
+│   │   │   ├── database/               #       SQLite リポジトリ実装 + マイグレーション
+│   │   │   │   ├── sqlite.go            #         DB 接続
+│   │   │   │   ├── migrations.go        #         スキーママイグレーション
+│   │   │   │   ├── market_data_repo.go  #         市場データリポジトリ
+│   │   │   │   ├── client_order_repo.go #         クライアント注文リポジトリ
+│   │   │   │   ├── trade_history_repo.go#         取引履歴リポジトリ
+│   │   │   │   ├── risk_state_repo.go   #         リスク状態リポジトリ
+│   │   │   │   └── stance_override_repo.go #      Stance オーバーライドリポジトリ
+│   │   │   ├── indicator/              #       テクニカル指標の個別計算
+│   │   │   │   ├── sma.go / ema.go      #         移動平均
+│   │   │   │   ├── rsi.go              #         RSI
+│   │   │   │   ├── macd.go             #         MACD
+│   │   │   │   ├── atr.go              #         ATR
+│   │   │   │   └── bollinger.go        #         ボリンジャーバンド
+│   │   │   └── rakuten/                #       楽天ウォレット API クライアント
+│   │   │       ├── rest_client.go       #         REST (Public + Private)
+│   │   │       ├── auth.go             #         HMAC 署名・認証
+│   │   │       ├── public_api.go       #         Public API (Ticker, Candle 等)
+│   │   │       ├── private_api.go      #         Private API (Order, Position 等)
+│   │   │       └── ws_client.go        #         WebSocket クライアント
+│   │   └── interfaces/
+│   │       ├── api/                     #       Gin HTTP ハンドラー + ルーター
+│   │       │   ├── router.go            #         ルーティング定義
+│   │       │   └── handler/             #         各エンドポイントのハンドラー
+│   │       └── mcp/                     #       MCP サーバー実装
+│   │           └── server.go
+│   ├── Dockerfile
+│   └── .env.example                     #   環境変数テンプレート
+│
+├── frontend/                             # React + TanStack フロントエンド
+│   ├── src/
+│   │   ├── components/                  #   UI コンポーネント
+│   │   │   ├── AppFrame.tsx             #     レイアウト枠
+│   │   │   ├── CandlestickChart.tsx     #     ローソク足チャート
+│   │   │   ├── LiveTickerCard.tsx       #     リアルタイム価格カード
+│   │   │   ├── BotControlCard.tsx       #     Bot 起動/停止カード
+│   │   │   ├── IndicatorPanel.tsx       #     テクニカル指標パネル
+│   │   │   ├── PositionPanel.tsx        #     ポジションパネル
+│   │   │   ├── TradeHistoryTable.tsx    #     取引履歴テーブル
+│   │   │   ├── KpiCard.tsx              #     KPI カード
+│   │   │   └── SymbolSelector.tsx       #     シンボル選択
+│   │   ├── hooks/                       #   カスタムフック
+│   │   │   ├── useBotControl.ts         #     Bot 制御
+│   │   │   ├── useMarketTickerStream.ts #     WebSocket Ticker
+│   │   │   ├── usePositions.ts          #     ポジション取得
+│   │   │   ├── useCandles.ts            #     ローソク足取得
+│   │   │   ├── useIndicators.ts         #     指標取得
+│   │   │   ├── useTradeHistory.ts       #     取引履歴
+│   │   │   ├── usePnl.ts               #     損益
+│   │   │   ├── useStrategy.ts           #     戦略
+│   │   │   ├── useConfig.ts             #     設定
+│   │   │   ├── useTradingConfig.ts      #     取引設定
+│   │   │   ├── useSymbols.ts            #     シンボル一覧
+│   │   │   ├── useStatus.ts             #     ステータス
+│   │   │   ├── useAllTickers.ts         #     全ティッカー
+│   │   │   └── useAllTrades.ts          #     全約定
+│   │   ├── contexts/SymbolContext.tsx    #   シンボル選択 Context
+│   │   ├── lib/api.ts                   #   API クライアント (fetch ラッパー)
+│   │   ├── routes/                      #   ページ
+│   │   │   ├── index.tsx                #     ダッシュボード (メイン画面)
+│   │   │   ├── history.tsx              #     取引履歴ページ
+│   │   │   └── settings.tsx             #     設定ページ
+│   │   ├── router.tsx                   #   TanStack Router 設定
+│   │   └── styles.css                   #   Tailwind エントリ
+│   ├── Dockerfile
+│   └── package.json
+│
+├── docs/                                 # ドキュメント
+│   ├── project-structure.md             #   本ファイル
+│   ├── api-reference.md                 #   API エンドポイント仕様
+│   ├── agent-operation-guide.md         #   エージェント運用手順書
+│   ├── clean-architecture.md            #   アーキテクチャ設計
+│   ├── rakuten-api/error-codes.md       #   楽天 API エラーコード
+│   └── design/                          #   設計書 + 実装計画
+│
+├── .agent/mcp.json                       # MCP サーバー設定
+├── compose.yaml                          # Docker Compose 定義
+├── Makefile                              # make up/down/logs/restart
+├── AGENTS.md                             # エージェント共通ルール (エントリポイント)
+└── CLAUDE.md                             # Claude Code 用 (AGENTS.md を参照)
+```


### PR DESCRIPTION
## Summary

- AGENTS.md をエージェント(Claude Code / Codex)共通のエントリポイントとして新規作成
- CLAUDE.md は `@AGENTS.md` への参照のみに簡素化
- 詳細ドキュメントを docs/ 配下に分割し、必要な時だけ読み込む構成に

### 追加ファイル
- `AGENTS.md` — Tech Stack, Runtime, Conventions, Architecture + docs 参照テーブル
- `CLAUDE.md` — AGENTS.md への参照
- `docs/project-structure.md` — 全ファイル・ディレクトリの詳細マップ
- `docs/api-reference.md` — 全 API エンドポイント仕様（リクエスト/レスポンス例付き）
- `ONBOARDING.md` — チームオンボーディングガイド

## Test plan
- [ ] AGENTS.md の内容がプロジェクトの現状と一致していることを確認
- [ ] docs/api-reference.md のエンドポイントが router.go と整合していることを確認
- [ ] docs/project-structure.md のファイル一覧が実際のディレクトリ構成と一致していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)