### PR TITLE
feat: add phase1 backtest engine and APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,8 @@ package-lock.json
 # Database
 data/
 *.db
+backend/results/
+results/
 
 # Backend
 go.sum

--- a/backend/cmd/backtest/main.go
+++ b/backend/cmd/backtest/main.go
@@ -1,0 +1,419 @@
+package main
+
+import (
+	"context"
+	"encoding/csv"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"time"
+
+	"github.com/joho/godotenv"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/config"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+	csvinfra "github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/infrastructure/csv"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/infrastructure/rakuten"
+	bt "github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/backtest"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		usage()
+		os.Exit(2)
+	}
+
+	switch os.Args[1] {
+	case "run":
+		if err := runCommand(os.Args[2:]); err != nil {
+			fmt.Fprintf(os.Stderr, "backtest run failed: %v\n", err)
+			os.Exit(1)
+		}
+	case "download":
+		if err := downloadCommand(os.Args[2:]); err != nil {
+			fmt.Fprintf(os.Stderr, "backtest download failed: %v\n", err)
+			os.Exit(1)
+		}
+	default:
+		usage()
+		os.Exit(2)
+	}
+}
+
+func usage() {
+	fmt.Println("Usage:")
+	fmt.Println("  go run ./cmd/backtest run --data <primary.csv> [--data-htf <htf.csv>] [flags]")
+	fmt.Println("  go run ./cmd/backtest download ...")
+}
+
+func runCommand(args []string) error {
+	fs := flag.NewFlagSet("run", flag.ContinueOnError)
+	var (
+		dataPath       = fs.String("data", "", "primary timeframe CSV path")
+		dataHTFPath    = fs.String("data-htf", "", "higher timeframe CSV path")
+		fromDate       = fs.String("from", "", "start date (YYYY-MM-DD)")
+		toDate         = fs.String("to", "", "end date (YYYY-MM-DD)")
+		initialBalance = fs.Float64("initial-balance", 100000, "initial balance in JPY")
+		spread         = fs.Float64("spread", 0.1, "spread percent")
+		carryingCost   = fs.Float64("carrying-cost", 0.04, "daily carrying cost percent")
+		slippage       = fs.Float64("slippage", 0, "slippage percent")
+		tradeAmount    = fs.Float64("trade-amount", 0.01, "trade amount")
+		outputDir      = fs.String("output", "", "output directory for trades/result")
+	)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *dataPath == "" {
+		return fmt.Errorf("--data is required")
+	}
+
+	primary, err := csvinfra.LoadCandles(*dataPath)
+	if err != nil {
+		return fmt.Errorf("load primary csv: %w", err)
+	}
+	var higherCandles []entity.Candle
+	if *dataHTFPath != "" {
+		htf, err := csvinfra.LoadCandles(*dataHTFPath)
+		if err != nil {
+			return fmt.Errorf("load higher tf csv: %w", err)
+		}
+		higherCandles = htf.Candles
+	}
+
+	fromTs, err := parseDateStart(*fromDate)
+	if err != nil {
+		return err
+	}
+	toTs, err := parseDateEnd(*toDate)
+	if err != nil {
+		return err
+	}
+	if fromTs == 0 && len(primary.Candles) > 0 {
+		fromTs = primary.Candles[0].Time
+	}
+	if toTs == 0 && len(primary.Candles) > 0 {
+		toTs = primary.Candles[len(primary.Candles)-1].Time
+	}
+
+	cfg := entity.BacktestConfig{
+		Symbol:           primary.Symbol,
+		SymbolID:         primary.SymbolID,
+		PrimaryInterval:  primary.Interval,
+		HigherTFInterval: "PT1H",
+		FromTimestamp:    fromTs,
+		ToTimestamp:      toTs,
+		InitialBalance:   *initialBalance,
+		SpreadPercent:    *spread,
+		DailyCarryCost:   *carryingCost,
+		SlippagePercent:  *slippage,
+	}
+	if len(higherCandles) == 0 {
+		cfg.HigherTFInterval = ""
+	}
+
+	runner := bt.NewBacktestRunner()
+	result, err := runner.Run(context.Background(), bt.RunInput{
+		Config:         cfg,
+		TradeAmount:    *tradeAmount,
+		PrimaryCandles: primary.Candles,
+		HigherCandles:  higherCandles,
+		RiskConfig: entity.RiskConfig{
+			MaxPositionAmount:    1_000_000_000,
+			MaxDailyLoss:         1_000_000_000,
+			StopLossPercent:      5,
+			TakeProfitPercent:    10,
+			InitialCapital:       *initialBalance,
+			MaxConsecutiveLosses: 0,
+			CooldownMinutes:      0,
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	printSummary(result.Summary)
+	if *outputDir != "" {
+		if err := os.MkdirAll(*outputDir, 0o755); err != nil {
+			return fmt.Errorf("create output dir: %w", err)
+		}
+		tradesPath := filepath.Join(*outputDir, "trades.csv")
+		if err := writeTradesCSV(tradesPath, result.Trades); err != nil {
+			return fmt.Errorf("write trades csv: %w", err)
+		}
+		fmt.Printf("trades csv: %s\n", tradesPath)
+	}
+
+	return nil
+}
+
+func downloadCommand(args []string) error {
+	fs := flag.NewFlagSet("download", flag.ContinueOnError)
+	var (
+		symbol   = fs.String("symbol", "BTC_JPY", "currency pair (e.g. BTC_JPY)")
+		interval = fs.String("interval", "PT15M", "candle interval")
+		fromDate = fs.String("from", "", "start date (YYYY-MM-DD)")
+		update   = fs.Bool("update", false, "incremental update from latest csv timestamp")
+		output   = fs.String("output", "", "output csv path (default: data/candles_{symbol}_{interval}.csv)")
+	)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *symbol == "" {
+		return fmt.Errorf("--symbol is required")
+	}
+
+	outPath := *output
+	if outPath == "" {
+		outPath = filepath.Join("data", fmt.Sprintf("candles_%s_%s.csv", *symbol, *interval))
+	}
+
+	_ = godotenv.Load()
+	cfg := config.Load()
+	client := rakuten.NewRESTClient(cfg.Rakuten.BaseURL, cfg.Rakuten.APIKey, cfg.Rakuten.APISecret)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	symbolID, err := resolveSymbolID(ctx, client, *symbol)
+	if err != nil {
+		return err
+	}
+
+	var fromTs int64
+	if *update {
+		if _, statErr := os.Stat(outPath); statErr == nil {
+			latest, latestErr := csvinfra.LatestTimestamp(outPath)
+			if latestErr != nil {
+				return fmt.Errorf("read latest timestamp: %w", latestErr)
+			}
+			fromTs = latest + 1
+		}
+	}
+	if fromTs == 0 {
+		fromTs, err = parseDateStart(*fromDate)
+		if err != nil {
+			return err
+		}
+		if fromTs == 0 {
+			return fmt.Errorf("--from is required for initial download")
+		}
+	}
+	toTs := time.Now().UnixMilli()
+
+	existing := csvinfra.CandleFile{
+		Symbol:   *symbol,
+		SymbolID: symbolID,
+		Interval: *interval,
+	}
+	if _, statErr := os.Stat(outPath); statErr == nil {
+		loaded, loadErr := csvinfra.LoadCandles(outPath)
+		if loadErr != nil {
+			return loadErr
+		}
+		existing = *loaded
+	}
+
+	collected, err := fetchCandlesRange(ctx, client, symbolID, *interval, fromTs, toTs)
+	if err != nil {
+		return err
+	}
+	merged := mergeCandles(existing.Candles, collected)
+	existing.Candles = merged
+	existing.Symbol = *symbol
+	existing.SymbolID = symbolID
+	existing.Interval = *interval
+
+	if err := csvinfra.SaveCandles(outPath, existing); err != nil {
+		return err
+	}
+	slog.Info("download complete", "symbol", *symbol, "interval", *interval, "rows", len(merged), "output", outPath)
+	return nil
+}
+
+func resolveSymbolID(ctx context.Context, client *rakuten.RESTClient, symbol string) (int64, error) {
+	symbols, err := client.GetSymbols(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("get symbols: %w", err)
+	}
+	for _, s := range symbols {
+		if s.CurrencyPair == symbol {
+			return s.ID, nil
+		}
+	}
+	return 0, fmt.Errorf("symbol not found: %s", symbol)
+}
+
+func fetchCandlesRange(ctx context.Context, client *rakuten.RESTClient, symbolID int64, interval string, fromTs, toTs int64) ([]entity.Candle, error) {
+	if fromTs <= 0 || toTs <= 0 || fromTs > toTs {
+		return nil, fmt.Errorf("invalid range")
+	}
+	collected := make([]entity.Candle, 0, 2048)
+	cursor := fromTs
+	for cursor <= toTs {
+		df := cursor
+		dt := toTs
+		resp, err := client.GetCandlestick(ctx, symbolID, interval, &df, &dt)
+		if err != nil {
+			return nil, fmt.Errorf("get candlestick: %w", err)
+		}
+		if resp == nil || len(resp.Candlesticks) == 0 {
+			break
+		}
+
+		maxTs := cursor
+		for _, c := range resp.Candlesticks {
+			if c.Time < fromTs || c.Time > toTs {
+				continue
+			}
+			collected = append(collected, c)
+			if c.Time > maxTs {
+				maxTs = c.Time
+			}
+		}
+		if maxTs < cursor {
+			break
+		}
+		cursor = maxTs + 1
+	}
+	return collected, nil
+}
+
+func mergeCandles(existing, incoming []entity.Candle) []entity.Candle {
+	byTime := make(map[int64]entity.Candle, len(existing)+len(incoming))
+	for _, c := range existing {
+		byTime[c.Time] = c
+	}
+	for _, c := range incoming {
+		byTime[c.Time] = c
+	}
+	out := make([]entity.Candle, 0, len(byTime))
+	for _, c := range byTime {
+		out = append(out, c)
+	}
+	slices.SortFunc(out, func(a, b entity.Candle) int {
+		if a.Time < b.Time {
+			return -1
+		}
+		if a.Time > b.Time {
+			return 1
+		}
+		return 0
+	})
+	return out
+}
+
+func parseDateStart(v string) (int64, error) {
+	if v == "" {
+		return 0, nil
+	}
+	loc, _ := time.LoadLocation("Asia/Tokyo")
+	t, err := time.ParseInLocation("2006-01-02", v, loc)
+	if err != nil {
+		return 0, fmt.Errorf("invalid --from date: %w", err)
+	}
+	return t.UnixMilli(), nil
+}
+
+func parseDateEnd(v string) (int64, error) {
+	if v == "" {
+		return 0, nil
+	}
+	loc, _ := time.LoadLocation("Asia/Tokyo")
+	t, err := time.ParseInLocation("2006-01-02", v, loc)
+	if err != nil {
+		return 0, fmt.Errorf("invalid --to date: %w", err)
+	}
+	t = t.Add(24*time.Hour - time.Millisecond)
+	return t.UnixMilli(), nil
+}
+
+func printSummary(summary entity.BacktestSummary) {
+	fmt.Println("=== Backtest Result ===")
+	fmt.Printf("Period:           %s ~ %s\n", formatDate(summary.PeriodFrom), formatDate(summary.PeriodTo))
+	fmt.Printf("Initial Balance:  ¥%s\n", comma(int64(summary.InitialBalance)))
+	fmt.Printf("Final Balance:    ¥%s\n", comma(int64(summary.FinalBalance)))
+	fmt.Printf("Total Return:     %+0.2f%%\n", summary.TotalReturn*100)
+	fmt.Printf("Total Trades:     %d\n", summary.TotalTrades)
+	fmt.Printf("Win Rate:         %.1f%% (%dW / %dL)\n", summary.WinRate, summary.WinTrades, summary.LossTrades)
+	fmt.Printf("Profit Factor:    %.2f\n", summary.ProfitFactor)
+	fmt.Printf("Max Drawdown:     -%.2f%% (¥%s)\n", summary.MaxDrawdown*100, comma(int64(summary.MaxDrawdownBalance)))
+	fmt.Printf("Sharpe Ratio:     %.2f\n", summary.SharpeRatio)
+	fmt.Printf("Avg Hold Time:    %s\n", formatDurationSeconds(summary.AvgHoldSeconds))
+	fmt.Printf("Carrying Cost:    ¥%s\n", comma(int64(summary.TotalCarryingCost)))
+	fmt.Printf("Spread Cost:      ¥%s\n", comma(int64(summary.TotalSpreadCost)))
+}
+
+func formatDate(ts int64) string {
+	loc, _ := time.LoadLocation("Asia/Tokyo")
+	return time.UnixMilli(ts).In(loc).Format("2006-01-02")
+}
+
+func formatDurationSeconds(sec int64) string {
+	if sec <= 0 {
+		return "0m"
+	}
+	d := time.Duration(sec) * time.Second
+	h := int64(d.Hours())
+	m := int64(d.Minutes()) % 60
+	if h > 0 {
+		return fmt.Sprintf("%dh %dm", h, m)
+	}
+	return fmt.Sprintf("%dm", m)
+}
+
+func comma(v int64) string {
+	s := strconv.FormatInt(v, 10)
+	n := len(s)
+	if n <= 3 {
+		return s
+	}
+	out := make([]byte, 0, n+n/3)
+	for i, c := range []byte(s) {
+		if i > 0 && (n-i)%3 == 0 {
+			out = append(out, ',')
+		}
+		out = append(out, c)
+	}
+	return string(out)
+}
+
+func writeTradesCSV(path string, trades []entity.BacktestTradeRecord) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	w := csv.NewWriter(f)
+	defer w.Flush()
+
+	if err := w.Write([]string{
+		"trade_id", "entry_time", "exit_time", "side", "entry_price", "exit_price",
+		"amount", "pnl", "pnl_percent", "carrying_cost", "spread_cost", "reason_entry", "reason_exit",
+	}); err != nil {
+		return err
+	}
+	loc, _ := time.LoadLocation("Asia/Tokyo")
+	for _, tr := range trades {
+		if err := w.Write([]string{
+			strconv.FormatInt(tr.TradeID, 10),
+			time.UnixMilli(tr.EntryTime).In(loc).Format(time.RFC3339),
+			time.UnixMilli(tr.ExitTime).In(loc).Format(time.RFC3339),
+			tr.Side,
+			strconv.FormatFloat(tr.EntryPrice, 'f', -1, 64),
+			strconv.FormatFloat(tr.ExitPrice, 'f', -1, 64),
+			strconv.FormatFloat(tr.Amount, 'f', -1, 64),
+			strconv.FormatFloat(tr.PnL, 'f', -1, 64),
+			strconv.FormatFloat(tr.PnLPercent, 'f', -1, 64),
+			strconv.FormatFloat(tr.CarryingCost, 'f', -1, 64),
+			strconv.FormatFloat(tr.SpreadCost, 'f', -1, 64),
+			tr.ReasonEntry,
+			tr.ReasonExit,
+		}); err != nil {
+			return err
+		}
+	}
+	return w.Error()
+}

--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -12,10 +12,12 @@ import (
 	"github.com/joho/godotenv"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/config"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+	backtestinfra "github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/infrastructure/backtest"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/infrastructure/database"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/infrastructure/rakuten"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/interfaces/api"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase"
+	backtestuc "github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/backtest"
 )
 
 func main() {
@@ -52,8 +54,10 @@ func main() {
 	indicatorCalc := usecase.NewIndicatorCalculator(marketDataRepo)
 	stanceOverrideRepo := database.NewStanceOverrideRepo(db)
 	clientOrderRepo := database.NewClientOrderRepo(db)
+	backtestResultRepo := backtestinfra.NewResultRepository(db)
 	stanceResolver := usecase.NewRuleBasedStanceResolver(stanceOverrideRepo)
 	strategyEngine := usecase.NewStrategyEngine(stanceResolver)
+	backtestRunner := backtestuc.NewBacktestRunner()
 	riskMgr := usecase.NewRiskManager(entity.RiskConfig{
 		MaxPositionAmount:     cfg.Risk.MaxPositionAmount,
 		MaxDailyLoss:          cfg.Risk.MaxDailyLoss,
@@ -147,6 +151,8 @@ func main() {
 		Pipeline:            pipeline,
 		RESTClient:          restClient,
 		ClientOrderRepo:     clientOrderRepo,
+		BacktestRunner:      backtestRunner,
+		BacktestResultRepo:  backtestResultRepo,
 		OnSymbolSwitch:      onSymbolSwitch,
 		DailyPnLCalculator:  dailyPnLCalc,
 	})
@@ -340,9 +346,9 @@ type rawMarketTradesResponse struct {
 }
 
 type rawOrderbook struct {
-	SymbolID  int64               `json:"symbolId"`
-	Asks      []rawOrderbookEntry `json:"asks"`
-	Bids      []rawOrderbookEntry `json:"bids"`
+	SymbolID  int64                `json:"symbolId"`
+	Asks      []rawOrderbookEntry  `json:"asks"`
+	Bids      []rawOrderbookEntry  `json:"bids"`
 	BestAsk   entity.StringFloat64 `json:"bestAsk"`
 	BestBid   entity.StringFloat64 `json:"bestBid"`
 	MidPrice  entity.StringFloat64 `json:"midPrice"`

--- a/backend/internal/domain/entity/backtest.go
+++ b/backend/internal/domain/entity/backtest.go
@@ -1,0 +1,62 @@
+package entity
+
+// BacktestConfig defines execution parameters for a single backtest run.
+type BacktestConfig struct {
+	Symbol           string  `json:"symbol"`
+	SymbolID         int64   `json:"symbolId"`
+	PrimaryInterval  string  `json:"primaryInterval"`
+	HigherTFInterval string  `json:"higherTfInterval"`
+	FromTimestamp    int64   `json:"fromTimestamp"`
+	ToTimestamp      int64   `json:"toTimestamp"`
+	InitialBalance   float64 `json:"initialBalance"`
+	SpreadPercent    float64 `json:"spreadPercent"`
+	DailyCarryCost   float64 `json:"dailyCarryCost"`
+	SlippagePercent  float64 `json:"slippagePercent"`
+}
+
+// BacktestSummary stores fixed output metrics for a run.
+type BacktestSummary struct {
+	PeriodFrom         int64   `json:"periodFrom"`
+	PeriodTo           int64   `json:"periodTo"`
+	InitialBalance     float64 `json:"initialBalance"`
+	FinalBalance       float64 `json:"finalBalance"`
+	TotalReturn        float64 `json:"totalReturn"`
+	TotalTrades        int     `json:"totalTrades"`
+	WinTrades          int     `json:"winTrades"`
+	LossTrades         int     `json:"lossTrades"`
+	WinRate            float64 `json:"winRate"`
+	ProfitFactor       float64 `json:"profitFactor"`
+	MaxDrawdown        float64 `json:"maxDrawdown"`
+	MaxDrawdownBalance float64 `json:"maxDrawdownBalance"`
+	SharpeRatio        float64 `json:"sharpeRatio"`
+	AvgHoldSeconds     int64   `json:"avgHoldSeconds"`
+	TotalCarryingCost  float64 `json:"totalCarryingCost"`
+	TotalSpreadCost    float64 `json:"totalSpreadCost"`
+}
+
+// BacktestTradeRecord is a closed trade record produced by the simulator.
+type BacktestTradeRecord struct {
+	TradeID      int64   `json:"tradeId"`
+	SymbolID     int64   `json:"symbolId"`
+	EntryTime    int64   `json:"entryTime"`
+	ExitTime     int64   `json:"exitTime"`
+	Side         string  `json:"side"`
+	EntryPrice   float64 `json:"entryPrice"`
+	ExitPrice    float64 `json:"exitPrice"`
+	Amount       float64 `json:"amount"`
+	PnL          float64 `json:"pnl"`
+	PnLPercent   float64 `json:"pnlPercent"`
+	CarryingCost float64 `json:"carryingCost"`
+	SpreadCost   float64 `json:"spreadCost"`
+	ReasonEntry  string  `json:"reasonEntry"`
+	ReasonExit   string  `json:"reasonExit"`
+}
+
+// BacktestResult is the persisted aggregate output of one run.
+type BacktestResult struct {
+	ID        string                `json:"id"`
+	CreatedAt int64                 `json:"createdAt"`
+	Config    BacktestConfig        `json:"config"`
+	Summary   BacktestSummary       `json:"summary"`
+	Trades    []BacktestTradeRecord `json:"trades,omitempty"`
+}

--- a/backend/internal/domain/entity/backtest_event.go
+++ b/backend/internal/domain/entity/backtest_event.go
@@ -1,0 +1,84 @@
+package entity
+
+const (
+	EventTypeCandle    = "candle"
+	EventTypeIndicator = "indicator"
+	EventTypeTick      = "tick"
+	EventTypeSignal    = "signal"
+	EventTypeApproved  = "approved_signal"
+	EventTypeOrder     = "order"
+)
+
+// Event is a minimal contract used by the backtest event bus.
+type Event interface {
+	EventType() string
+	EventTimestamp() int64
+}
+
+// CandleEvent treats Candle.Time as close timestamp.
+type CandleEvent struct {
+	SymbolID  int64
+	Interval  string
+	Candle    Candle
+	Timestamp int64
+}
+
+func (e CandleEvent) EventType() string     { return EventTypeCandle }
+func (e CandleEvent) EventTimestamp() int64 { return e.Timestamp }
+
+// IndicatorEvent binds Strategy input contract in a single payload.
+type IndicatorEvent struct {
+	SymbolID  int64
+	Interval  string
+	Primary   IndicatorSet
+	HigherTF  *IndicatorSet
+	LastPrice float64
+	Timestamp int64
+}
+
+func (e IndicatorEvent) EventType() string     { return EventTypeIndicator }
+func (e IndicatorEvent) EventTimestamp() int64 { return e.Timestamp }
+
+// TickEvent represents synthetic in-bar ticks for SL/TP simulation.
+type TickEvent struct {
+	SymbolID   int64
+	Price      float64
+	Timestamp  int64
+	TickType   string
+	ParentTime int64
+}
+
+func (e TickEvent) EventType() string     { return EventTypeTick }
+func (e TickEvent) EventTimestamp() int64 { return e.Timestamp }
+
+type SignalEvent struct {
+	Signal    Signal
+	Price     float64
+	Timestamp int64
+}
+
+func (e SignalEvent) EventType() string     { return EventTypeSignal }
+func (e SignalEvent) EventTimestamp() int64 { return e.Timestamp }
+
+type ApprovedSignalEvent struct {
+	Signal    Signal
+	Price     float64
+	Timestamp int64
+}
+
+func (e ApprovedSignalEvent) EventType() string     { return EventTypeApproved }
+func (e ApprovedSignalEvent) EventTimestamp() int64 { return e.Timestamp }
+
+type OrderEvent struct {
+	OrderID   int64
+	SymbolID  int64
+	Side      string
+	Action    string
+	Price     float64
+	Amount    float64
+	Reason    string
+	Timestamp int64
+}
+
+func (e OrderEvent) EventType() string     { return EventTypeOrder }
+func (e OrderEvent) EventTimestamp() int64 { return e.Timestamp }

--- a/backend/internal/domain/repository/backtest_result.go
+++ b/backend/internal/domain/repository/backtest_result.go
@@ -1,0 +1,21 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+)
+
+// BacktestResultFilter defines query options for listing persisted results.
+type BacktestResultFilter struct {
+	Limit  int
+	Offset int
+}
+
+// BacktestResultRepository persists backtest summaries and trade logs.
+type BacktestResultRepository interface {
+	Save(ctx context.Context, result entity.BacktestResult) error
+	List(ctx context.Context, filter BacktestResultFilter) ([]entity.BacktestResult, error)
+	FindByID(ctx context.Context, id string) (*entity.BacktestResult, error)
+	DeleteOlderThan(ctx context.Context, timestamp int64) (int64, error)
+}

--- a/backend/internal/infrastructure/backtest/result_repository.go
+++ b/backend/internal/infrastructure/backtest/result_repository.go
@@ -1,0 +1,258 @@
+package backtest
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/repository"
+)
+
+type ResultRepository struct {
+	db *sql.DB
+}
+
+func NewResultRepository(db *sql.DB) *ResultRepository {
+	return &ResultRepository{db: db}
+}
+
+func (r *ResultRepository) Save(ctx context.Context, result entity.BacktestResult) error {
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	_, err = tx.ExecContext(ctx, `
+		INSERT INTO backtest_results (
+			id, created_at, symbol, symbol_id, primary_interval, higher_tf_interval,
+			from_ts, to_ts, initial_balance, final_balance, total_return, total_trades,
+			win_trades, loss_trades, win_rate, profit_factor, max_drawdown, max_drawdown_balance,
+			sharpe_ratio, avg_hold_seconds, total_carrying_cost, total_spread_cost
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`,
+		result.ID,
+		result.CreatedAt,
+		result.Config.Symbol,
+		result.Config.SymbolID,
+		result.Config.PrimaryInterval,
+		result.Config.HigherTFInterval,
+		result.Config.FromTimestamp,
+		result.Config.ToTimestamp,
+		result.Summary.InitialBalance,
+		result.Summary.FinalBalance,
+		result.Summary.TotalReturn,
+		result.Summary.TotalTrades,
+		result.Summary.WinTrades,
+		result.Summary.LossTrades,
+		result.Summary.WinRate,
+		result.Summary.ProfitFactor,
+		result.Summary.MaxDrawdown,
+		result.Summary.MaxDrawdownBalance,
+		result.Summary.SharpeRatio,
+		result.Summary.AvgHoldSeconds,
+		result.Summary.TotalCarryingCost,
+		result.Summary.TotalSpreadCost,
+	)
+	if err != nil {
+		return fmt.Errorf("insert backtest result: %w", err)
+	}
+
+	stmt, err := tx.PrepareContext(ctx, `
+		INSERT INTO backtest_trades (
+			result_id, trade_id, symbol_id, entry_time, exit_time, side,
+			entry_price, exit_price, amount, pnl, pnl_percent, carrying_cost, spread_cost, reason_entry, reason_exit
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`)
+	if err != nil {
+		return fmt.Errorf("prepare trade insert: %w", err)
+	}
+	defer stmt.Close()
+
+	for _, tr := range result.Trades {
+		if _, err := stmt.ExecContext(
+			ctx,
+			result.ID,
+			tr.TradeID,
+			tr.SymbolID,
+			tr.EntryTime,
+			tr.ExitTime,
+			tr.Side,
+			tr.EntryPrice,
+			tr.ExitPrice,
+			tr.Amount,
+			tr.PnL,
+			tr.PnLPercent,
+			tr.CarryingCost,
+			tr.SpreadCost,
+			tr.ReasonEntry,
+			tr.ReasonExit,
+		); err != nil {
+			return fmt.Errorf("insert trade: %w", err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit tx: %w", err)
+	}
+	return nil
+}
+
+func (r *ResultRepository) List(ctx context.Context, filter repository.BacktestResultFilter) ([]entity.BacktestResult, error) {
+	limit := filter.Limit
+	if limit <= 0 {
+		limit = 20
+	}
+	offset := filter.Offset
+	if offset < 0 {
+		offset = 0
+	}
+
+	rows, err := r.db.QueryContext(ctx, `
+		SELECT
+			id, created_at, symbol, symbol_id, primary_interval, higher_tf_interval,
+			from_ts, to_ts, initial_balance, final_balance, total_return, total_trades,
+			win_trades, loss_trades, win_rate, profit_factor, max_drawdown, max_drawdown_balance,
+			sharpe_ratio, avg_hold_seconds, total_carrying_cost, total_spread_cost
+		FROM backtest_results
+		ORDER BY created_at DESC, id DESC
+		LIMIT ? OFFSET ?
+	`, limit, offset)
+	if err != nil {
+		return nil, fmt.Errorf("list backtest results: %w", err)
+	}
+	defer rows.Close()
+
+	var results []entity.BacktestResult
+	for rows.Next() {
+		var result entity.BacktestResult
+		if err := scanResultRow(rows, &result); err != nil {
+			return nil, err
+		}
+		results = append(results, result)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate list rows: %w", err)
+	}
+	return results, nil
+}
+
+func (r *ResultRepository) FindByID(ctx context.Context, id string) (*entity.BacktestResult, error) {
+	row := r.db.QueryRowContext(ctx, `
+		SELECT
+			id, created_at, symbol, symbol_id, primary_interval, higher_tf_interval,
+			from_ts, to_ts, initial_balance, final_balance, total_return, total_trades,
+			win_trades, loss_trades, win_rate, profit_factor, max_drawdown, max_drawdown_balance,
+			sharpe_ratio, avg_hold_seconds, total_carrying_cost, total_spread_cost
+		FROM backtest_results
+		WHERE id = ?
+	`, id)
+
+	var result entity.BacktestResult
+	if err := scanResultRow(row, &result); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	trades, err := r.loadTrades(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	result.Trades = trades
+	return &result, nil
+}
+
+func (r *ResultRepository) DeleteOlderThan(ctx context.Context, timestamp int64) (int64, error) {
+	res, err := r.db.ExecContext(ctx, `DELETE FROM backtest_results WHERE created_at < ?`, timestamp)
+	if err != nil {
+		return 0, fmt.Errorf("delete old results: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("rows affected: %w", err)
+	}
+	return n, nil
+}
+
+func (r *ResultRepository) loadTrades(ctx context.Context, resultID string) ([]entity.BacktestTradeRecord, error) {
+	rows, err := r.db.QueryContext(ctx, `
+		SELECT
+			trade_id, symbol_id, entry_time, exit_time, side,
+			entry_price, exit_price, amount, pnl, pnl_percent, carrying_cost, spread_cost, reason_entry, reason_exit
+		FROM backtest_trades
+		WHERE result_id = ?
+		ORDER BY trade_id ASC
+	`, resultID)
+	if err != nil {
+		return nil, fmt.Errorf("query trades: %w", err)
+	}
+	defer rows.Close()
+
+	trades := make([]entity.BacktestTradeRecord, 0)
+	for rows.Next() {
+		var tr entity.BacktestTradeRecord
+		if err := rows.Scan(
+			&tr.TradeID,
+			&tr.SymbolID,
+			&tr.EntryTime,
+			&tr.ExitTime,
+			&tr.Side,
+			&tr.EntryPrice,
+			&tr.ExitPrice,
+			&tr.Amount,
+			&tr.PnL,
+			&tr.PnLPercent,
+			&tr.CarryingCost,
+			&tr.SpreadCost,
+			&tr.ReasonEntry,
+			&tr.ReasonExit,
+		); err != nil {
+			return nil, fmt.Errorf("scan trade: %w", err)
+		}
+		trades = append(trades, tr)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate trades: %w", err)
+	}
+	return trades, nil
+}
+
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanResultRow(scanner rowScanner, result *entity.BacktestResult) error {
+	err := scanner.Scan(
+		&result.ID,
+		&result.CreatedAt,
+		&result.Config.Symbol,
+		&result.Config.SymbolID,
+		&result.Config.PrimaryInterval,
+		&result.Config.HigherTFInterval,
+		&result.Config.FromTimestamp,
+		&result.Config.ToTimestamp,
+		&result.Summary.InitialBalance,
+		&result.Summary.FinalBalance,
+		&result.Summary.TotalReturn,
+		&result.Summary.TotalTrades,
+		&result.Summary.WinTrades,
+		&result.Summary.LossTrades,
+		&result.Summary.WinRate,
+		&result.Summary.ProfitFactor,
+		&result.Summary.MaxDrawdown,
+		&result.Summary.MaxDrawdownBalance,
+		&result.Summary.SharpeRatio,
+		&result.Summary.AvgHoldSeconds,
+		&result.Summary.TotalCarryingCost,
+		&result.Summary.TotalSpreadCost,
+	)
+	if err != nil {
+		return err
+	}
+	result.Summary.PeriodFrom = result.Config.FromTimestamp
+	result.Summary.PeriodTo = result.Config.ToTimestamp
+	return nil
+}

--- a/backend/internal/infrastructure/backtest/result_repository_test.go
+++ b/backend/internal/infrastructure/backtest/result_repository_test.go
@@ -1,0 +1,107 @@
+package backtest
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/repository"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/infrastructure/database"
+)
+
+func TestResultRepository_SaveListFindDelete(t *testing.T) {
+	tmp := t.TempDir()
+	db, err := database.NewDB(filepath.Join(tmp, "test.db"))
+	if err != nil {
+		t.Fatalf("new db: %v", err)
+	}
+	defer db.Close()
+	if err := database.RunMigrations(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	repo := NewResultRepository(db)
+	now := time.Now().Unix()
+
+	result := entity.BacktestResult{
+		ID:        "bt-test-1",
+		CreatedAt: now,
+		Config: entity.BacktestConfig{
+			Symbol:           "BTC_JPY",
+			SymbolID:         7,
+			PrimaryInterval:  "PT15M",
+			HigherTFInterval: "PT1H",
+			FromTimestamp:    1000,
+			ToTimestamp:      2000,
+		},
+		Summary: entity.BacktestSummary{
+			InitialBalance:     100000,
+			FinalBalance:       110000,
+			TotalReturn:        0.1,
+			TotalTrades:        1,
+			WinTrades:          1,
+			LossTrades:         0,
+			WinRate:            100,
+			ProfitFactor:       2,
+			MaxDrawdown:        0.05,
+			MaxDrawdownBalance: 95000,
+			SharpeRatio:        1.2,
+			AvgHoldSeconds:     3600,
+			TotalCarryingCost:  100,
+			TotalSpreadCost:    50,
+		},
+		Trades: []entity.BacktestTradeRecord{
+			{
+				TradeID:      1,
+				SymbolID:     7,
+				EntryTime:    1100,
+				ExitTime:     1500,
+				Side:         "BUY",
+				EntryPrice:   100,
+				ExitPrice:    110,
+				Amount:       0.01,
+				PnL:          10,
+				PnLPercent:   10,
+				CarryingCost: 1,
+				SpreadCost:   0.5,
+				ReasonEntry:  "entry",
+				ReasonExit:   "exit",
+			},
+		},
+	}
+	if err := repo.Save(context.Background(), result); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	list, err := repo.List(context.Background(), repository.BacktestResultFilter{Limit: 10, Offset: 0})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(list))
+	}
+	if list[0].ID != result.ID {
+		t.Fatalf("unexpected list id: %s", list[0].ID)
+	}
+
+	found, err := repo.FindByID(context.Background(), result.ID)
+	if err != nil {
+		t.Fatalf("find: %v", err)
+	}
+	if found == nil {
+		t.Fatal("expected found result")
+	}
+	if len(found.Trades) != 1 {
+		t.Fatalf("expected 1 trade, got %d", len(found.Trades))
+	}
+
+	deleted, err := repo.DeleteOlderThan(context.Background(), now+1)
+	if err != nil {
+		t.Fatalf("delete older than: %v", err)
+	}
+	if deleted != 1 {
+		t.Fatalf("expected 1 deleted row, got %d", deleted)
+	}
+}

--- a/backend/internal/infrastructure/backtest/simulator.go
+++ b/backend/internal/infrastructure/backtest/simulator.go
@@ -1,0 +1,258 @@
+package backtest
+
+import (
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+)
+
+type SimConfig struct {
+	InitialBalance    float64
+	SpreadPercent     float64
+	DailyCarryingCost float64
+	SlippagePercent   float64
+}
+
+type SimPosition struct {
+	PositionID     int64
+	SymbolID       int64
+	Side           entity.OrderSide
+	EntryPrice     float64
+	Amount         float64
+	EntryTimestamp int64
+	SpreadCostOpen float64
+	ReasonEntry    string
+}
+
+type SimExecutor struct {
+	positions    []SimPosition
+	closedTrades []entity.BacktestTradeRecord
+	balance      float64
+	config       SimConfig
+	nextOrderID  int64
+	nextTradeID  int64
+	nextPosID    int64
+}
+
+func NewSimExecutor(config SimConfig) *SimExecutor {
+	return &SimExecutor{
+		balance:     config.InitialBalance,
+		config:      config,
+		nextOrderID: 1,
+		nextTradeID: 1,
+		nextPosID:   1,
+	}
+}
+
+func (s *SimExecutor) Open(symbolID int64, side entity.OrderSide, signalPrice, amount float64, reason string, timestamp int64) (entity.OrderEvent, error) {
+	if amount <= 0 {
+		return entity.OrderEvent{}, fmt.Errorf("amount must be positive")
+	}
+	if signalPrice <= 0 {
+		return entity.OrderEvent{}, fmt.Errorf("signal price must be positive")
+	}
+
+	// Reverse signal: close opposite positions first.
+	for i := len(s.positions) - 1; i >= 0; i-- {
+		pos := s.positions[i]
+		if pos.SymbolID == symbolID && pos.Side != side {
+			_, _, _ = s.Close(pos.PositionID, signalPrice, "reverse_signal", timestamp)
+		}
+	}
+
+	fill := s.entryFillPrice(side, signalPrice)
+	position := SimPosition{
+		PositionID:     s.nextPosID,
+		SymbolID:       symbolID,
+		Side:           side,
+		EntryPrice:     fill,
+		Amount:         amount,
+		EntryTimestamp: timestamp,
+		SpreadCostOpen: signalPrice * amount * (s.config.SpreadPercent / 100.0) / 2.0,
+		ReasonEntry:    reason,
+	}
+	s.positions = append(s.positions, position)
+	s.nextPosID++
+
+	order := entity.OrderEvent{
+		OrderID:   s.nextOrderID,
+		SymbolID:  symbolID,
+		Side:      string(side),
+		Action:    "open",
+		Price:     fill,
+		Amount:    amount,
+		Reason:    reason,
+		Timestamp: timestamp,
+	}
+	s.nextOrderID++
+	return order, nil
+}
+
+func (s *SimExecutor) Close(positionID int64, signalPrice float64, reason string, timestamp int64) (entity.OrderEvent, *entity.BacktestTradeRecord, error) {
+	idx := -1
+	for i := range s.positions {
+		if s.positions[i].PositionID == positionID {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		return entity.OrderEvent{}, nil, fmt.Errorf("position not found: %d", positionID)
+	}
+	if signalPrice <= 0 {
+		return entity.OrderEvent{}, nil, fmt.Errorf("signal price must be positive")
+	}
+
+	pos := s.positions[idx]
+	exitFill := s.exitFillPrice(pos.Side, signalPrice)
+	spreadCostClose := signalPrice * pos.Amount * (s.config.SpreadPercent / 100.0) / 2.0
+	spreadCostTotal := pos.SpreadCostOpen + spreadCostClose
+	carrying := s.carryingCost(pos, timestamp)
+	pnl := s.calcPnL(pos, exitFill) - carrying
+	pnlPct := 0.0
+	if pos.EntryPrice != 0 {
+		if pos.Side == entity.OrderSideBuy {
+			pnlPct = (exitFill-pos.EntryPrice)/pos.EntryPrice*100 - (carrying/(pos.EntryPrice*pos.Amount))*100
+		} else {
+			pnlPct = (pos.EntryPrice-exitFill)/pos.EntryPrice*100 - (carrying/(pos.EntryPrice*pos.Amount))*100
+		}
+	}
+
+	s.balance += pnl
+	s.positions = append(s.positions[:idx], s.positions[idx+1:]...)
+
+	sideText := string(pos.Side)
+	order := entity.OrderEvent{
+		OrderID:   s.nextOrderID,
+		SymbolID:  pos.SymbolID,
+		Side:      sideText,
+		Action:    "close",
+		Price:     exitFill,
+		Amount:    pos.Amount,
+		Reason:    reason,
+		Timestamp: timestamp,
+	}
+	s.nextOrderID++
+
+	trade := entity.BacktestTradeRecord{
+		TradeID:      s.nextTradeID,
+		SymbolID:     pos.SymbolID,
+		EntryTime:    pos.EntryTimestamp,
+		ExitTime:     timestamp,
+		Side:         sideText,
+		EntryPrice:   pos.EntryPrice,
+		ExitPrice:    exitFill,
+		Amount:       pos.Amount,
+		PnL:          pnl,
+		PnLPercent:   pnlPct,
+		CarryingCost: carrying,
+		SpreadCost:   spreadCostTotal,
+		ReasonEntry:  pos.ReasonEntry,
+		ReasonExit:   reason,
+	}
+	s.nextTradeID++
+	s.closedTrades = append(s.closedTrades, trade)
+	return order, &trade, nil
+}
+
+// SelectSLTPExit chooses exit level for same-bar SL/TP hits.
+// Policy: worst-case fixed (always stop-loss when both hit).
+func (s *SimExecutor) SelectSLTPExit(
+	side entity.OrderSide,
+	stopLossPrice float64,
+	takeProfitPrice float64,
+	barLow float64,
+	barHigh float64,
+) (exitPrice float64, reason string, hit bool) {
+	switch side {
+	case entity.OrderSideBuy:
+		slHit := barLow <= stopLossPrice
+		tpHit := barHigh >= takeProfitPrice
+		if slHit && tpHit {
+			return stopLossPrice, "stop_loss", true
+		}
+		if slHit {
+			return stopLossPrice, "stop_loss", true
+		}
+		if tpHit {
+			return takeProfitPrice, "take_profit", true
+		}
+	case entity.OrderSideSell:
+		slHit := barHigh >= stopLossPrice
+		tpHit := barLow <= takeProfitPrice
+		if slHit && tpHit {
+			return stopLossPrice, "stop_loss", true
+		}
+		if slHit {
+			return stopLossPrice, "stop_loss", true
+		}
+		if tpHit {
+			return takeProfitPrice, "take_profit", true
+		}
+	}
+	return 0, "", false
+}
+
+func (s *SimExecutor) Balance() float64 {
+	return s.balance
+}
+
+func (s *SimExecutor) Positions() []SimPosition {
+	out := make([]SimPosition, len(s.positions))
+	copy(out, s.positions)
+	return out
+}
+
+func (s *SimExecutor) ClosedTrades() []entity.BacktestTradeRecord {
+	out := make([]entity.BacktestTradeRecord, len(s.closedTrades))
+	copy(out, s.closedTrades)
+	return out
+}
+
+func (s *SimExecutor) entryFillPrice(side entity.OrderSide, signalPrice float64) float64 {
+	adjust := (s.config.SpreadPercent / 100.0 / 2.0) + (s.config.SlippagePercent / 100.0)
+	switch side {
+	case entity.OrderSideSell:
+		return signalPrice * (1 - adjust)
+	default:
+		return signalPrice * (1 + adjust)
+	}
+}
+
+func (s *SimExecutor) exitFillPrice(side entity.OrderSide, signalPrice float64) float64 {
+	adjust := (s.config.SpreadPercent / 100.0 / 2.0) + (s.config.SlippagePercent / 100.0)
+	switch side {
+	case entity.OrderSideSell:
+		// Close SELL by BUY.
+		return signalPrice * (1 + adjust)
+	default:
+		// Close BUY by SELL.
+		return signalPrice * (1 - adjust)
+	}
+}
+
+func (s *SimExecutor) carryingCost(pos SimPosition, exitTimestamp int64) float64 {
+	if s.config.DailyCarryingCost <= 0 {
+		return 0
+	}
+	entry := time.UnixMilli(pos.EntryTimestamp)
+	exit := time.UnixMilli(exitTimestamp)
+	if !exit.After(entry) {
+		return 0
+	}
+	days := exit.Sub(entry).Hours() / 24.0
+	notional := pos.EntryPrice * pos.Amount
+	cost := notional * (s.config.DailyCarryingCost / 100.0) * days
+	return math.Max(cost, 0)
+}
+
+func (s *SimExecutor) calcPnL(pos SimPosition, exitPrice float64) float64 {
+	switch pos.Side {
+	case entity.OrderSideSell:
+		return (pos.EntryPrice - exitPrice) * pos.Amount
+	default:
+		return (exitPrice - pos.EntryPrice) * pos.Amount
+	}
+}

--- a/backend/internal/infrastructure/backtest/simulator_test.go
+++ b/backend/internal/infrastructure/backtest/simulator_test.go
@@ -1,0 +1,85 @@
+package backtest
+
+import (
+	"testing"
+	"time"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+)
+
+func TestSimExecutor_SelectSLTPExit_BuyWorstCase(t *testing.T) {
+	sim := NewSimExecutor(SimConfig{})
+	price, reason, hit := sim.SelectSLTPExit(
+		entity.OrderSideBuy,
+		95,
+		105,
+		94,  // sl hit
+		106, // tp hit
+	)
+	if !hit {
+		t.Fatal("expected hit")
+	}
+	if reason != "stop_loss" {
+		t.Fatalf("expected stop_loss, got %s", reason)
+	}
+	if price != 95 {
+		t.Fatalf("expected stop-loss price 95, got %f", price)
+	}
+}
+
+func TestSimExecutor_SelectSLTPExit_SellWorstCase(t *testing.T) {
+	sim := NewSimExecutor(SimConfig{})
+	price, reason, hit := sim.SelectSLTPExit(
+		entity.OrderSideSell,
+		105,
+		95,
+		94,  // tp hit
+		106, // sl hit
+	)
+	if !hit {
+		t.Fatal("expected hit")
+	}
+	if reason != "stop_loss" {
+		t.Fatalf("expected stop_loss, got %s", reason)
+	}
+	if price != 105 {
+		t.Fatalf("expected stop-loss price 105, got %f", price)
+	}
+}
+
+func TestSimExecutor_OpenClose_AppliesCarryingAndSpread(t *testing.T) {
+	sim := NewSimExecutor(SimConfig{
+		InitialBalance:    100000,
+		SpreadPercent:     0.1,
+		DailyCarryingCost: 0.04,
+		SlippagePercent:   0,
+	})
+
+	entryTS := time.Date(2026, 4, 14, 0, 0, 0, 0, time.UTC).UnixMilli()
+	orderOpen, err := sim.Open(7, entity.OrderSideBuy, 100, 1, "entry", entryTS)
+	if err != nil {
+		t.Fatalf("open error: %v", err)
+	}
+	if orderOpen.Action != "open" {
+		t.Fatalf("expected open action, got %s", orderOpen.Action)
+	}
+
+	pos := sim.Positions()[0]
+	exitTS := time.Date(2026, 4, 15, 0, 0, 0, 0, time.UTC).UnixMilli()
+	_, trade, err := sim.Close(pos.PositionID, 110, "exit", exitTS)
+	if err != nil {
+		t.Fatalf("close error: %v", err)
+	}
+	if trade == nil {
+		t.Fatal("trade record should not be nil")
+	}
+	if trade.CarryingCost <= 0 {
+		t.Fatalf("expected positive carrying cost, got %f", trade.CarryingCost)
+	}
+	if trade.SpreadCost <= 0 {
+		t.Fatalf("expected positive spread cost, got %f", trade.SpreadCost)
+	}
+	if sim.Balance() <= 100000 {
+		t.Fatalf("expected profitable close balance > initial, got %f", sim.Balance())
+	}
+}

--- a/backend/internal/infrastructure/csv/candle_csv.go
+++ b/backend/internal/infrastructure/csv/candle_csv.go
@@ -1,0 +1,174 @@
+package csv
+
+import (
+	"encoding/csv"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+)
+
+const (
+	csvHeaderSymbol   = "symbol"
+	csvHeaderSymbolID = "symbol_id"
+	csvHeaderInterval = "interval"
+	csvHeaderTime     = "time"
+	csvHeaderOpen     = "open"
+	csvHeaderHigh     = "high"
+	csvHeaderLow      = "low"
+	csvHeaderClose    = "close"
+	csvHeaderVolume   = "volume"
+)
+
+type CandleFile struct {
+	Symbol   string
+	SymbolID int64
+	Interval string
+	Candles  []entity.Candle
+}
+
+func LoadCandles(path string) (*CandleFile, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open csv: %w", err)
+	}
+	defer f.Close()
+
+	r := csv.NewReader(f)
+	r.FieldsPerRecord = 9
+
+	header, err := r.Read()
+	if err != nil {
+		return nil, fmt.Errorf("read header: %w", err)
+	}
+	expected := []string{
+		csvHeaderSymbol, csvHeaderSymbolID, csvHeaderInterval, csvHeaderTime,
+		csvHeaderOpen, csvHeaderHigh, csvHeaderLow, csvHeaderClose, csvHeaderVolume,
+	}
+	for i := range expected {
+		if header[i] != expected[i] {
+			return nil, fmt.Errorf("invalid header at %d: got=%s want=%s", i, header[i], expected[i])
+		}
+	}
+
+	out := &CandleFile{}
+	for {
+		row, err := r.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("read row: %w", err)
+		}
+
+		symbolID, err := strconv.ParseInt(row[1], 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("parse symbol_id: %w", err)
+		}
+		ts, err := strconv.ParseInt(row[3], 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("parse time: %w", err)
+		}
+		open, err := strconv.ParseFloat(row[4], 64)
+		if err != nil {
+			return nil, fmt.Errorf("parse open: %w", err)
+		}
+		high, err := strconv.ParseFloat(row[5], 64)
+		if err != nil {
+			return nil, fmt.Errorf("parse high: %w", err)
+		}
+		low, err := strconv.ParseFloat(row[6], 64)
+		if err != nil {
+			return nil, fmt.Errorf("parse low: %w", err)
+		}
+		closePrice, err := strconv.ParseFloat(row[7], 64)
+		if err != nil {
+			return nil, fmt.Errorf("parse close: %w", err)
+		}
+		volume, err := strconv.ParseFloat(row[8], 64)
+		if err != nil {
+			return nil, fmt.Errorf("parse volume: %w", err)
+		}
+
+		if out.Symbol == "" {
+			out.Symbol = row[0]
+			out.SymbolID = symbolID
+			out.Interval = row[2]
+		}
+
+		out.Candles = append(out.Candles, entity.Candle{
+			Open:   open,
+			High:   high,
+			Low:    low,
+			Close:  closePrice,
+			Volume: volume,
+			Time:   ts,
+		})
+	}
+
+	sort.Slice(out.Candles, func(i, j int) bool {
+		return out.Candles[i].Time < out.Candles[j].Time
+	})
+	return out, nil
+}
+
+func SaveCandles(path string, file CandleFile) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("mkdir: %w", err)
+	}
+
+	sort.Slice(file.Candles, func(i, j int) bool {
+		return file.Candles[i].Time < file.Candles[j].Time
+	})
+
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("create csv: %w", err)
+	}
+	defer f.Close()
+
+	w := csv.NewWriter(f)
+	defer w.Flush()
+
+	if err := w.Write([]string{
+		csvHeaderSymbol, csvHeaderSymbolID, csvHeaderInterval, csvHeaderTime,
+		csvHeaderOpen, csvHeaderHigh, csvHeaderLow, csvHeaderClose, csvHeaderVolume,
+	}); err != nil {
+		return fmt.Errorf("write header: %w", err)
+	}
+
+	for _, c := range file.Candles {
+		if err := w.Write([]string{
+			file.Symbol,
+			strconv.FormatInt(file.SymbolID, 10),
+			file.Interval,
+			strconv.FormatInt(c.Time, 10),
+			strconv.FormatFloat(c.Open, 'f', -1, 64),
+			strconv.FormatFloat(c.High, 'f', -1, 64),
+			strconv.FormatFloat(c.Low, 'f', -1, 64),
+			strconv.FormatFloat(c.Close, 'f', -1, 64),
+			strconv.FormatFloat(c.Volume, 'f', -1, 64),
+		}); err != nil {
+			return fmt.Errorf("write row: %w", err)
+		}
+	}
+	if err := w.Error(); err != nil {
+		return fmt.Errorf("flush writer: %w", err)
+	}
+	return nil
+}
+
+func LatestTimestamp(path string) (int64, error) {
+	file, err := LoadCandles(path)
+	if err != nil {
+		return 0, err
+	}
+	if len(file.Candles) == 0 {
+		return 0, nil
+	}
+	return file.Candles[len(file.Candles)-1].Time, nil
+}

--- a/backend/internal/infrastructure/csv/candle_csv_test.go
+++ b/backend/internal/infrastructure/csv/candle_csv_test.go
@@ -1,0 +1,66 @@
+package csv
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+)
+
+func TestSaveLoadCandles_RoundTrip(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "candles.csv")
+
+	err := SaveCandles(path, CandleFile{
+		Symbol:   "BTC_JPY",
+		SymbolID: 7,
+		Interval: "PT15M",
+		Candles: []entity.Candle{
+			{Open: 2, High: 3, Low: 1, Close: 2.5, Volume: 10, Time: 2000},
+			{Open: 1, High: 2, Low: 0.5, Close: 1.5, Volume: 5, Time: 1000},
+		},
+	})
+	if err != nil {
+		t.Fatalf("save error: %v", err)
+	}
+
+	got, err := LoadCandles(path)
+	if err != nil {
+		t.Fatalf("load error: %v", err)
+	}
+	if got.Symbol != "BTC_JPY" || got.SymbolID != 7 || got.Interval != "PT15M" {
+		t.Fatalf("metadata mismatch: %+v", got)
+	}
+	if len(got.Candles) != 2 {
+		t.Fatalf("expected 2 candles, got %d", len(got.Candles))
+	}
+	if got.Candles[0].Time != 1000 || got.Candles[1].Time != 2000 {
+		t.Fatalf("expected sorted candles, got %+v", got.Candles)
+	}
+}
+
+func TestLatestTimestamp(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "candles.csv")
+
+	err := SaveCandles(path, CandleFile{
+		Symbol:   "BTC_JPY",
+		SymbolID: 7,
+		Interval: "PT1H",
+		Candles: []entity.Candle{
+			{Open: 1, High: 2, Low: 0.5, Close: 1.5, Volume: 5, Time: 1000},
+			{Open: 2, High: 3, Low: 1, Close: 2.5, Volume: 10, Time: 2000},
+		},
+	})
+	if err != nil {
+		t.Fatalf("save error: %v", err)
+	}
+
+	ts, err := LatestTimestamp(path)
+	if err != nil {
+		t.Fatalf("latest timestamp error: %v", err)
+	}
+	if ts != 2000 {
+		t.Fatalf("expected 2000, got %d", ts)
+	}
+}

--- a/backend/internal/infrastructure/database/migrations.go
+++ b/backend/internal/infrastructure/database/migrations.go
@@ -125,6 +125,55 @@ func RunMigrations(db *sql.DB) error {
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_client_orders_created
 			ON client_orders(created_at)`,
+
+		`CREATE TABLE IF NOT EXISTS backtest_results (
+			id TEXT PRIMARY KEY,
+			created_at INTEGER NOT NULL,
+			symbol TEXT NOT NULL,
+			symbol_id INTEGER NOT NULL,
+			primary_interval TEXT NOT NULL,
+			higher_tf_interval TEXT NOT NULL DEFAULT '',
+			from_ts INTEGER NOT NULL,
+			to_ts INTEGER NOT NULL,
+			initial_balance REAL NOT NULL,
+			final_balance REAL NOT NULL,
+			total_return REAL NOT NULL,
+			total_trades INTEGER NOT NULL,
+			win_trades INTEGER NOT NULL,
+			loss_trades INTEGER NOT NULL,
+			win_rate REAL NOT NULL,
+			profit_factor REAL NOT NULL,
+			max_drawdown REAL NOT NULL,
+			max_drawdown_balance REAL NOT NULL,
+			sharpe_ratio REAL NOT NULL,
+			avg_hold_seconds INTEGER NOT NULL,
+			total_carrying_cost REAL NOT NULL,
+			total_spread_cost REAL NOT NULL
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_backtest_results_created
+			ON backtest_results(created_at DESC, id DESC)`,
+
+		`CREATE TABLE IF NOT EXISTS backtest_trades (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			result_id TEXT NOT NULL,
+			trade_id INTEGER NOT NULL,
+			symbol_id INTEGER NOT NULL,
+			entry_time INTEGER NOT NULL,
+			exit_time INTEGER NOT NULL,
+			side TEXT NOT NULL,
+			entry_price REAL NOT NULL,
+			exit_price REAL NOT NULL,
+			amount REAL NOT NULL,
+			pnl REAL NOT NULL,
+			pnl_percent REAL NOT NULL,
+			carrying_cost REAL NOT NULL,
+			spread_cost REAL NOT NULL,
+			reason_entry TEXT NOT NULL DEFAULT '',
+			reason_exit TEXT NOT NULL DEFAULT '',
+			FOREIGN KEY(result_id) REFERENCES backtest_results(id) ON DELETE CASCADE
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_backtest_trades_result
+			ON backtest_trades(result_id, trade_id)`,
 	}
 
 	for _, m := range migrations {

--- a/backend/internal/interfaces/api/handler/backtest.go
+++ b/backend/internal/interfaces/api/handler/backtest.go
@@ -1,0 +1,216 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/repository"
+	csvinfra "github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/infrastructure/csv"
+	bt "github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/backtest"
+)
+
+type BacktestHandler struct {
+	runner *bt.BacktestRunner
+	repo   repository.BacktestResultRepository
+}
+
+func NewBacktestHandler(runner *bt.BacktestRunner, repo repository.BacktestResultRepository) *BacktestHandler {
+	return &BacktestHandler{
+		runner: runner,
+		repo:   repo,
+	}
+}
+
+type runBacktestRequest struct {
+	DataPath       string  `json:"data" binding:"required"`
+	DataHTFPath    string  `json:"dataHtf"`
+	From           string  `json:"from"`
+	To             string  `json:"to"`
+	InitialBalance float64 `json:"initialBalance"`
+	Spread         float64 `json:"spread"`
+	CarryingCost   float64 `json:"carryingCost"`
+	Slippage       float64 `json:"slippage"`
+	TradeAmount    float64 `json:"tradeAmount"`
+}
+
+func (h *BacktestHandler) Run(c *gin.Context) {
+	if h.runner == nil || h.repo == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "backtest services are not configured"})
+		return
+	}
+
+	var req runBacktestRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if req.InitialBalance <= 0 {
+		req.InitialBalance = 100000
+	}
+	if req.Spread <= 0 {
+		req.Spread = 0.1
+	}
+	if req.CarryingCost <= 0 {
+		req.CarryingCost = 0.04
+	}
+	if req.TradeAmount <= 0 {
+		req.TradeAmount = 0.01
+	}
+
+	primary, err := csvinfra.LoadCandles(req.DataPath)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "failed to load primary csv: " + err.Error()})
+		return
+	}
+
+	var higherCandles []entity.Candle
+	if req.DataHTFPath != "" {
+		htf, err := csvinfra.LoadCandles(req.DataHTFPath)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "failed to load higher tf csv: " + err.Error()})
+			return
+		}
+		higherCandles = htf.Candles
+	}
+
+	fromTs, err := parseBacktestDateStart(req.From)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	toTs, err := parseBacktestDateEnd(req.To)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if fromTs == 0 && len(primary.Candles) > 0 {
+		fromTs = primary.Candles[0].Time
+	}
+	if toTs == 0 && len(primary.Candles) > 0 {
+		toTs = primary.Candles[len(primary.Candles)-1].Time
+	}
+
+	cfg := entity.BacktestConfig{
+		Symbol:           primary.Symbol,
+		SymbolID:         primary.SymbolID,
+		PrimaryInterval:  primary.Interval,
+		HigherTFInterval: "PT1H",
+		FromTimestamp:    fromTs,
+		ToTimestamp:      toTs,
+		InitialBalance:   req.InitialBalance,
+		SpreadPercent:    req.Spread,
+		DailyCarryCost:   req.CarryingCost,
+		SlippagePercent:  req.Slippage,
+	}
+	if len(higherCandles) == 0 {
+		cfg.HigherTFInterval = ""
+	}
+
+	result, err := h.runner.Run(context.Background(), bt.RunInput{
+		Config:         cfg,
+		TradeAmount:    req.TradeAmount,
+		PrimaryCandles: primary.Candles,
+		HigherCandles:  higherCandles,
+		RiskConfig: entity.RiskConfig{
+			MaxPositionAmount:    1_000_000_000,
+			MaxDailyLoss:         1_000_000_000,
+			StopLossPercent:      5,
+			TakeProfitPercent:    10,
+			InitialCapital:       req.InitialBalance,
+			MaxConsecutiveLosses: 0,
+			CooldownMinutes:      0,
+		},
+	})
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	if err := h.repo.Save(c.Request.Context(), *result); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to save backtest result: " + err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, result)
+}
+
+func (h *BacktestHandler) ListResults(c *gin.Context) {
+	if h.repo == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "backtest repository is not configured"})
+		return
+	}
+	limit := 20
+	offset := 0
+	if v := c.Query("limit"); v != "" {
+		parsed, err := strconv.Atoi(v)
+		if err != nil || parsed <= 0 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid limit"})
+			return
+		}
+		limit = parsed
+	}
+	if v := c.Query("offset"); v != "" {
+		parsed, err := strconv.Atoi(v)
+		if err != nil || parsed < 0 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid offset"})
+			return
+		}
+		offset = parsed
+	}
+
+	results, err := h.repo.List(c.Request.Context(), repository.BacktestResultFilter{
+		Limit:  limit,
+		Offset: offset,
+	})
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"results": results})
+}
+
+func (h *BacktestHandler) GetResult(c *gin.Context) {
+	if h.repo == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "backtest repository is not configured"})
+		return
+	}
+	id := c.Param("id")
+	result, err := h.repo.FindByID(c.Request.Context(), id)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	if result == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "backtest result not found"})
+		return
+	}
+	c.JSON(http.StatusOK, result)
+}
+
+func parseBacktestDateStart(v string) (int64, error) {
+	if v == "" {
+		return 0, nil
+	}
+	loc, _ := time.LoadLocation("Asia/Tokyo")
+	t, err := time.ParseInLocation("2006-01-02", v, loc)
+	if err != nil {
+		return 0, err
+	}
+	return t.UnixMilli(), nil
+}
+
+func parseBacktestDateEnd(v string) (int64, error) {
+	if v == "" {
+		return 0, nil
+	}
+	loc, _ := time.LoadLocation("Asia/Tokyo")
+	t, err := time.ParseInLocation("2006-01-02", v, loc)
+	if err != nil {
+		return 0, err
+	}
+	t = t.Add(24*time.Hour - time.Millisecond)
+	return t.UnixMilli(), nil
+}

--- a/backend/internal/interfaces/api/handler/backtest_test.go
+++ b/backend/internal/interfaces/api/handler/backtest_test.go
@@ -1,0 +1,70 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/repository"
+	bt "github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/backtest"
+)
+
+type mockBacktestResultRepo struct {
+	listResults []entity.BacktestResult
+	findResult  *entity.BacktestResult
+}
+
+func (m *mockBacktestResultRepo) Save(_ context.Context, _ entity.BacktestResult) error { return nil }
+func (m *mockBacktestResultRepo) List(_ context.Context, _ repository.BacktestResultFilter) ([]entity.BacktestResult, error) {
+	return m.listResults, nil
+}
+func (m *mockBacktestResultRepo) FindByID(_ context.Context, _ string) (*entity.BacktestResult, error) {
+	return m.findResult, nil
+}
+func (m *mockBacktestResultRepo) DeleteOlderThan(_ context.Context, _ int64) (int64, error) {
+	return 0, nil
+}
+
+func TestBacktestHandler_ListResults_OK(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	repo := &mockBacktestResultRepo{
+		listResults: []entity.BacktestResult{{ID: "bt-1"}},
+	}
+	h := NewBacktestHandler(bt.NewBacktestRunner(), repo)
+	w := httptestGet(h.ListResults, "/backtest/results", "/backtest/results?limit=10&offset=0")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestBacktestHandler_GetResult_NotFound(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	repo := &mockBacktestResultRepo{}
+	h := NewBacktestHandler(bt.NewBacktestRunner(), repo)
+
+	w := httptestRequestWithParam(h.GetResult, "/backtest/results/:id", "id", "missing")
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+func httptestRequestWithParam(handler gin.HandlerFunc, route, paramKey, paramValue string) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	r := gin.New()
+	r.GET(route, handler)
+	req := httptest.NewRequest(http.MethodGet, "/backtest/results/"+paramValue, nil)
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func httptestGet(handler gin.HandlerFunc, route, reqPath string) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	r := gin.New()
+	r.GET(route, handler)
+	req := httptest.NewRequest(http.MethodGet, reqPath, nil)
+	r.ServeHTTP(w, req)
+	return w
+}

--- a/backend/internal/interfaces/api/router.go
+++ b/backend/internal/interfaces/api/router.go
@@ -7,6 +7,7 @@ import (
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/infrastructure/rakuten"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/interfaces/api/handler"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase"
+	backtestuc "github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/backtest"
 )
 
 // PipelineController はTrading Pipelineの開始/停止・銘柄切替を制御するインターフェース。
@@ -31,6 +32,8 @@ type Dependencies struct {
 	RESTClient          *rakuten.RESTClient
 	ClientOrderRepo     repository.ClientOrderRepository
 	DailyPnLCalculator  *usecase.DailyPnLCalculator
+	BacktestRunner      *backtestuc.BacktestRunner
+	BacktestResultRepo  repository.BacktestResultRepository
 	// OnSymbolSwitch はシンボル切替時に pipeline から呼び出されるコールバック。
 	// main 側で WebSocket 購読切替とローソク足 bootstrap を実行する。
 	OnSymbolSwitch func(oldID, newID int64)
@@ -121,6 +124,13 @@ func NewRouter(deps Dependencies) *gin.Engine {
 	if deps.OrderExecutor != nil && deps.ClientOrderRepo != nil {
 		orderHandler := handler.NewOrderHandler(deps.OrderExecutor, deps.ClientOrderRepo)
 		v1.POST("/orders", orderHandler.CreateOrder)
+	}
+
+	if deps.BacktestRunner != nil && deps.BacktestResultRepo != nil {
+		backtestHandler := handler.NewBacktestHandler(deps.BacktestRunner, deps.BacktestResultRepo)
+		v1.POST("/backtest/run", backtestHandler.Run)
+		v1.GET("/backtest/results", backtestHandler.ListResults)
+		v1.GET("/backtest/results/:id", backtestHandler.GetResult)
 	}
 
 	return r

--- a/backend/internal/usecase/backtest/engine.go
+++ b/backend/internal/usecase/backtest/engine.go
@@ -1,0 +1,23 @@
+package backtest
+
+import (
+	"context"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+)
+
+// EventEngine drives deterministic event dispatch for backtests.
+type EventEngine struct {
+	bus *EventBus
+}
+
+func NewEventEngine(bus *EventBus) *EventEngine {
+	return &EventEngine{bus: bus}
+}
+
+func (e *EventEngine) Run(ctx context.Context, events []entity.Event) error {
+	if e.bus == nil {
+		return nil
+	}
+	return e.bus.Dispatch(ctx, events)
+}

--- a/backend/internal/usecase/backtest/event_bus.go
+++ b/backend/internal/usecase/backtest/event_bus.go
@@ -1,0 +1,71 @@
+package backtest
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+)
+
+// EventHandler handles one event and can emit chained events.
+type EventHandler interface {
+	Handle(ctx context.Context, event entity.Event) ([]entity.Event, error)
+}
+
+type RegisteredHandler struct {
+	Priority int
+	Handler  EventHandler
+}
+
+// EventBus executes handlers synchronously with deterministic ordering.
+type EventBus struct {
+	handlers map[string][]RegisteredHandler
+}
+
+func NewEventBus() *EventBus {
+	return &EventBus{
+		handlers: make(map[string][]RegisteredHandler),
+	}
+}
+
+func (b *EventBus) Register(eventType string, priority int, handler EventHandler) {
+	b.handlers[eventType] = append(b.handlers[eventType], RegisteredHandler{
+		Priority: priority,
+		Handler:  handler,
+	})
+	sort.SliceStable(b.handlers[eventType], func(i, j int) bool {
+		return b.handlers[eventType][i].Priority < b.handlers[eventType][j].Priority
+	})
+}
+
+// Dispatch runs events with FIFO queue and appends chained events in return order.
+func (b *EventBus) Dispatch(ctx context.Context, initial []entity.Event) error {
+	queue := append([]entity.Event(nil), initial...)
+
+	for len(queue) > 0 {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		ev := queue[0]
+		queue = queue[1:]
+		if ev == nil {
+			continue
+		}
+
+		for _, reg := range b.handlers[ev.EventType()] {
+			chained, err := reg.Handler.Handle(ctx, ev)
+			if err != nil {
+				return fmt.Errorf("eventType=%s priority=%d: %w", ev.EventType(), reg.Priority, err)
+			}
+			if len(chained) > 0 {
+				queue = append(queue, chained...)
+			}
+		}
+	}
+
+	return nil
+}

--- a/backend/internal/usecase/backtest/event_bus_test.go
+++ b/backend/internal/usecase/backtest/event_bus_test.go
@@ -1,0 +1,82 @@
+package backtest
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+)
+
+type testEvent struct {
+	typ string
+	id  string
+	ts  int64
+}
+
+func (e testEvent) EventType() string     { return e.typ }
+func (e testEvent) EventTimestamp() int64 { return e.ts }
+
+type testHandler struct {
+	name   string
+	logs   *[]string
+	emit   func(event entity.Event) []entity.Event
+	handle func(event entity.Event) error
+}
+
+func (h *testHandler) Handle(_ context.Context, event entity.Event) ([]entity.Event, error) {
+	*h.logs = append(*h.logs, fmt.Sprintf("%s:%s", h.name, event.(testEvent).id))
+	if h.handle != nil {
+		if err := h.handle(event); err != nil {
+			return nil, err
+		}
+	}
+	if h.emit != nil {
+		return h.emit(event), nil
+	}
+	return nil, nil
+}
+
+func TestEventBus_FIFOAndPriority(t *testing.T) {
+	bus := NewEventBus()
+	var logs []string
+
+	bus.Register("a", 20, &testHandler{name: "p20", logs: &logs})
+	bus.Register("a", 10, &testHandler{name: "p10", logs: &logs})
+	bus.Register("b", 10, &testHandler{name: "b10", logs: &logs})
+
+	bus.Register("a", 15, &testHandler{
+		name: "p15",
+		logs: &logs,
+		emit: func(event entity.Event) []entity.Event {
+			id := event.(testEvent).id
+			return []entity.Event{
+				testEvent{typ: "b", id: id + "-b1", ts: 1},
+				testEvent{typ: "b", id: id + "-b2", ts: 2},
+			}
+		},
+	})
+
+	err := bus.Dispatch(context.Background(), []entity.Event{
+		testEvent{typ: "a", id: "a1", ts: 1},
+		testEvent{typ: "a", id: "a2", ts: 2},
+	})
+	if err != nil {
+		t.Fatalf("dispatch error: %v", err)
+	}
+
+	want := []string{
+		"p10:a1", "p15:a1", "p20:a1",
+		"p10:a2", "p15:a2", "p20:a2",
+		"b10:a1-b1", "b10:a1-b2",
+		"b10:a2-b1", "b10:a2-b2",
+	}
+	if len(logs) != len(want) {
+		t.Fatalf("log length mismatch: got=%d want=%d logs=%v", len(logs), len(want), logs)
+	}
+	for i := range want {
+		if logs[i] != want[i] {
+			t.Fatalf("log[%d] mismatch: got=%s want=%s full=%v", i, logs[i], want[i], logs)
+		}
+	}
+}

--- a/backend/internal/usecase/backtest/handler.go
+++ b/backend/internal/usecase/backtest/handler.go
@@ -1,0 +1,266 @@
+package backtest
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/infrastructure/indicator"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase"
+)
+
+// IndicatorHandler calculates indicator snapshots from buffered candles.
+// Buffers are maintained oldest-first to keep indicator calculations path-correct.
+type IndicatorHandler struct {
+	PrimaryInterval  string
+	HigherTFInterval string
+	BufferSize       int
+
+	primaryCandles map[int64][]entity.Candle
+	higherCandles  map[int64][]entity.Candle
+}
+
+func NewIndicatorHandler(primaryInterval, higherTFInterval string, bufferSize int) *IndicatorHandler {
+	if bufferSize <= 0 {
+		bufferSize = 500
+	}
+	return &IndicatorHandler{
+		PrimaryInterval:  primaryInterval,
+		HigherTFInterval: higherTFInterval,
+		BufferSize:       bufferSize,
+		primaryCandles:   make(map[int64][]entity.Candle),
+		higherCandles:    make(map[int64][]entity.Candle),
+	}
+}
+
+func (h *IndicatorHandler) Handle(_ context.Context, event entity.Event) ([]entity.Event, error) {
+	candleEvent, ok := event.(entity.CandleEvent)
+	if !ok {
+		return nil, nil
+	}
+
+	switch candleEvent.Interval {
+	case h.PrimaryInterval:
+		h.primaryCandles[candleEvent.SymbolID] = appendCapped(h.primaryCandles[candleEvent.SymbolID], candleEvent.Candle, h.BufferSize)
+		primary := calculateIndicatorSet(candleEvent.SymbolID, h.primaryCandles[candleEvent.SymbolID])
+
+		var higherTF *entity.IndicatorSet
+		if h.HigherTFInterval != "" {
+			if selected := selectCandlesAtOrBefore(h.higherCandles[candleEvent.SymbolID], candleEvent.Timestamp); len(selected) > 0 {
+				set := calculateIndicatorSet(candleEvent.SymbolID, selected)
+				higherTF = &set
+			}
+		}
+
+		return []entity.Event{
+			entity.IndicatorEvent{
+				SymbolID:  candleEvent.SymbolID,
+				Interval:  candleEvent.Interval,
+				Primary:   primary,
+				HigherTF:  higherTF,
+				LastPrice: candleEvent.Candle.Close,
+				Timestamp: candleEvent.Timestamp,
+			},
+		}, nil
+
+	case h.HigherTFInterval:
+		h.higherCandles[candleEvent.SymbolID] = appendCapped(h.higherCandles[candleEvent.SymbolID], candleEvent.Candle, h.BufferSize)
+	}
+
+	return nil, nil
+}
+
+// StrategyHandler converts IndicatorEvent to SignalEvent using StrategyEngine.
+type StrategyHandler struct {
+	Engine *usecase.StrategyEngine
+}
+
+func (h *StrategyHandler) Handle(ctx context.Context, event entity.Event) ([]entity.Event, error) {
+	indicatorEvent, ok := event.(entity.IndicatorEvent)
+	if !ok {
+		return nil, nil
+	}
+	if h.Engine == nil {
+		return nil, fmt.Errorf("strategy engine is nil")
+	}
+
+	signal, err := h.Engine.EvaluateWithHigherTFAt(
+		ctx,
+		indicatorEvent.Primary,
+		indicatorEvent.HigherTF,
+		indicatorEvent.LastPrice,
+		time.UnixMilli(indicatorEvent.Timestamp),
+	)
+	if err != nil {
+		return nil, err
+	}
+	if signal == nil || signal.Action == entity.SignalActionHold {
+		return nil, nil
+	}
+
+	return []entity.Event{
+		entity.SignalEvent{
+			Signal:    *signal,
+			Price:     indicatorEvent.LastPrice,
+			Timestamp: indicatorEvent.Timestamp,
+		},
+	}, nil
+}
+
+// RiskHandler gates SignalEvents using RiskManager with injected event time.
+type RiskHandler struct {
+	RiskManager *usecase.RiskManager
+	TradeAmount float64
+}
+
+func (h *RiskHandler) Handle(ctx context.Context, event entity.Event) ([]entity.Event, error) {
+	signalEvent, ok := event.(entity.SignalEvent)
+	if !ok {
+		return nil, nil
+	}
+	if h.RiskManager == nil {
+		return nil, fmt.Errorf("risk manager is nil")
+	}
+	if h.TradeAmount <= 0 {
+		return nil, fmt.Errorf("trade amount must be positive")
+	}
+
+	side := entity.OrderSideBuy
+	if signalEvent.Signal.Action == entity.SignalActionSell {
+		side = entity.OrderSideSell
+	}
+	proposal := entity.OrderProposal{
+		SymbolID: signalEvent.Signal.SymbolID,
+		Side:     side,
+		Amount:   h.TradeAmount,
+		Price:    signalEvent.Price,
+		IsClose:  false,
+	}
+
+	check := h.RiskManager.CheckOrderAt(ctx, time.UnixMilli(signalEvent.Timestamp), proposal)
+	if !check.Approved {
+		return nil, nil
+	}
+
+	return []entity.Event{
+		entity.ApprovedSignalEvent{
+			Signal:    signalEvent.Signal,
+			Price:     signalEvent.Price,
+			Timestamp: signalEvent.Timestamp,
+		},
+	}, nil
+}
+
+// SignalExecutor opens simulated orders from approved signals.
+type SignalExecutor interface {
+	Open(symbolID int64, side entity.OrderSide, signalPrice, amount float64, reason string, timestamp int64) (entity.OrderEvent, error)
+}
+
+// ExecutionHandler converts approved SignalEvents into OrderEvents.
+type ExecutionHandler struct {
+	Executor    SignalExecutor
+	TradeAmount float64
+}
+
+func (h *ExecutionHandler) Handle(_ context.Context, event entity.Event) ([]entity.Event, error) {
+	signalEvent, ok := event.(entity.ApprovedSignalEvent)
+	if !ok {
+		return nil, nil
+	}
+	if h.Executor == nil {
+		return nil, fmt.Errorf("executor is nil")
+	}
+	if h.TradeAmount <= 0 {
+		return nil, fmt.Errorf("trade amount must be positive")
+	}
+
+	side := entity.OrderSideBuy
+	if signalEvent.Signal.Action == entity.SignalActionSell {
+		side = entity.OrderSideSell
+	}
+
+	orderEvent, err := h.Executor.Open(
+		signalEvent.Signal.SymbolID,
+		side,
+		signalEvent.Price,
+		h.TradeAmount,
+		signalEvent.Signal.Reason,
+		signalEvent.Timestamp,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return []entity.Event{orderEvent}, nil
+}
+
+func appendCapped(candles []entity.Candle, candle entity.Candle, capSize int) []entity.Candle {
+	candles = append(candles, candle)
+	if len(candles) > capSize {
+		candles = candles[len(candles)-capSize:]
+	}
+	return candles
+}
+
+func selectCandlesAtOrBefore(candles []entity.Candle, timestamp int64) []entity.Candle {
+	idx := -1
+	for i := len(candles) - 1; i >= 0; i-- {
+		if candles[i].Time <= timestamp {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		return nil
+	}
+	return candles[:idx+1]
+}
+
+func calculateIndicatorSet(symbolID int64, candles []entity.Candle) entity.IndicatorSet {
+	n := len(candles)
+	if n == 0 {
+		return entity.IndicatorSet{SymbolID: symbolID}
+	}
+
+	closes := make([]float64, n)
+	highs := make([]float64, n)
+	lows := make([]float64, n)
+	for i, c := range candles {
+		closes[i] = c.Close
+		highs[i] = c.High
+		lows[i] = c.Low
+	}
+
+	result := entity.IndicatorSet{
+		SymbolID:  symbolID,
+		SMA20:     floatToPtr(indicator.SMA(closes, 20)),
+		SMA50:     floatToPtr(indicator.SMA(closes, 50)),
+		EMA12:     floatToPtr(indicator.EMA(closes, 12)),
+		EMA26:     floatToPtr(indicator.EMA(closes, 26)),
+		RSI14:     floatToPtr(indicator.RSI(closes, 14)),
+		Timestamp: candles[n-1].Time,
+	}
+
+	macdLine, signalLine, histogram := indicator.MACD(closes, 12, 26, 9)
+	result.MACDLine = floatToPtr(macdLine)
+	result.SignalLine = floatToPtr(signalLine)
+	result.Histogram = floatToPtr(histogram)
+
+	bbUpper, bbMiddle, bbLower, bbBandwidth := indicator.BollingerBands(closes, 20, 2.0)
+	result.BBUpper = floatToPtr(bbUpper)
+	result.BBMiddle = floatToPtr(bbMiddle)
+	result.BBLower = floatToPtr(bbLower)
+	result.BBBandwidth = floatToPtr(bbBandwidth)
+
+	result.ATR14 = floatToPtr(indicator.ATR(highs, lows, closes, 14))
+
+	return result
+}
+
+func floatToPtr(v float64) *float64 {
+	if math.IsNaN(v) {
+		return nil
+	}
+	return &v
+}

--- a/backend/internal/usecase/backtest/handler_test.go
+++ b/backend/internal/usecase/backtest/handler_test.go
@@ -1,0 +1,201 @@
+package backtest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase"
+)
+
+func TestIndicatorHandler_NoFutureHigherTFLeak(t *testing.T) {
+	handler := NewIndicatorHandler("PT15M", "PT1H", 500)
+
+	symbolID := int64(7)
+	_, _ = handler.Handle(context.Background(), entity.CandleEvent{
+		SymbolID: symbolID,
+		Interval: "PT1H",
+		Candle: entity.Candle{
+			Open: 100, High: 101, Low: 99, Close: 100, Time: 1000,
+		},
+		Timestamp: 1000,
+	})
+	_, _ = handler.Handle(context.Background(), entity.CandleEvent{
+		SymbolID: symbolID,
+		Interval: "PT1H",
+		Candle: entity.Candle{
+			Open: 200, High: 201, Low: 199, Close: 200, Time: 2000,
+		},
+		Timestamp: 2000,
+	})
+
+	events, err := handler.Handle(context.Background(), entity.CandleEvent{
+		SymbolID: symbolID,
+		Interval: "PT15M",
+		Candle: entity.Candle{
+			Open: 150, High: 151, Low: 149, Close: 150, Time: 1500,
+		},
+		Timestamp: 1500,
+	})
+	if err != nil {
+		t.Fatalf("handle error: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+
+	indicatorEvent, ok := events[0].(entity.IndicatorEvent)
+	if !ok {
+		t.Fatalf("expected IndicatorEvent, got %T", events[0])
+	}
+	if indicatorEvent.HigherTF == nil {
+		t.Fatal("expected higherTF indicator set")
+	}
+	if indicatorEvent.HigherTF.Timestamp != 1000 {
+		t.Fatalf("expected higherTF timestamp 1000, got %d", indicatorEvent.HigherTF.Timestamp)
+	}
+	if indicatorEvent.Primary.Timestamp != 1500 {
+		t.Fatalf("expected primary timestamp 1500, got %d", indicatorEvent.Primary.Timestamp)
+	}
+}
+
+func TestStrategyHandler_UsesIndicatorTimestamp(t *testing.T) {
+	resolver := usecase.NewRuleBasedStanceResolver(nil)
+	engine := usecase.NewStrategyEngine(resolver)
+	handler := &StrategyHandler{Engine: engine}
+
+	ts := time.Date(2026, 4, 14, 12, 0, 0, 0, time.UTC).UnixMilli()
+	events, err := handler.Handle(context.Background(), entity.IndicatorEvent{
+		SymbolID:  7,
+		Interval:  "PT15M",
+		Timestamp: ts,
+		LastPrice: 100,
+		Primary: entity.IndicatorSet{
+			SymbolID:  7,
+			SMA20:     floatPtr(120),
+			SMA50:     floatPtr(100),
+			EMA12:     floatPtr(120),
+			EMA26:     floatPtr(100),
+			RSI14:     floatPtr(55),
+			Histogram: floatPtr(1),
+			Timestamp: ts,
+		},
+	})
+	if err != nil {
+		t.Fatalf("handle error: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected 1 signal event, got %d", len(events))
+	}
+
+	signalEvent, ok := events[0].(entity.SignalEvent)
+	if !ok {
+		t.Fatalf("expected SignalEvent, got %T", events[0])
+	}
+	if signalEvent.Signal.Timestamp != ts/1000 {
+		t.Fatalf("expected signal timestamp %d, got %d", ts/1000, signalEvent.Signal.Timestamp)
+	}
+}
+
+func floatPtr(v float64) *float64 { return &v }
+
+type fakeSignalExecutor struct {
+	lastSymbolID  int64
+	lastSide      entity.OrderSide
+	lastPrice     float64
+	lastAmount    float64
+	lastReason    string
+	lastTimestamp int64
+}
+
+func (f *fakeSignalExecutor) Open(symbolID int64, side entity.OrderSide, signalPrice, amount float64, reason string, timestamp int64) (entity.OrderEvent, error) {
+	f.lastSymbolID = symbolID
+	f.lastSide = side
+	f.lastPrice = signalPrice
+	f.lastAmount = amount
+	f.lastReason = reason
+	f.lastTimestamp = timestamp
+	return entity.OrderEvent{
+		OrderID:   1,
+		SymbolID:  symbolID,
+		Side:      string(side),
+		Action:    "open",
+		Price:     signalPrice,
+		Amount:    amount,
+		Reason:    reason,
+		Timestamp: timestamp,
+	}, nil
+}
+
+func TestExecutionHandler_ConvertsSignalToOrderEvent(t *testing.T) {
+	exec := &fakeSignalExecutor{}
+	handler := &ExecutionHandler{
+		Executor:    exec,
+		TradeAmount: 0.01,
+	}
+
+	events, err := handler.Handle(context.Background(), entity.ApprovedSignalEvent{
+		Signal: entity.Signal{
+			SymbolID: 7,
+			Action:   entity.SignalActionSell,
+			Reason:   "trend",
+		},
+		Price:     100,
+		Timestamp: 12345,
+	})
+	if err != nil {
+		t.Fatalf("handle error: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	orderEvent, ok := events[0].(entity.OrderEvent)
+	if !ok {
+		t.Fatalf("expected OrderEvent, got %T", events[0])
+	}
+	if orderEvent.Action != "open" {
+		t.Fatalf("expected open action, got %s", orderEvent.Action)
+	}
+	if exec.lastSide != entity.OrderSideSell {
+		t.Fatalf("expected sell side, got %s", exec.lastSide)
+	}
+	if exec.lastAmount != 0.01 {
+		t.Fatalf("expected amount 0.01, got %f", exec.lastAmount)
+	}
+}
+
+func TestRiskHandler_EmitsApprovedSignalEvent(t *testing.T) {
+	riskMgr := usecase.NewRiskManager(entity.RiskConfig{
+		MaxPositionAmount:    1000000,
+		MaxDailyLoss:         1000000,
+		StopLossPercent:      5,
+		TakeProfitPercent:    10,
+		InitialCapital:       1000000,
+		MaxConsecutiveLosses: 3,
+		CooldownMinutes:      30,
+	})
+	handler := &RiskHandler{
+		RiskManager: riskMgr,
+		TradeAmount: 0.01,
+	}
+
+	events, err := handler.Handle(context.Background(), entity.SignalEvent{
+		Signal: entity.Signal{
+			SymbolID: 7,
+			Action:   entity.SignalActionBuy,
+			Reason:   "trend",
+		},
+		Price:     10000,
+		Timestamp: time.Now().UnixMilli(),
+	})
+	if err != nil {
+		t.Fatalf("handle error: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected 1 approved event, got %d", len(events))
+	}
+	if _, ok := events[0].(entity.ApprovedSignalEvent); !ok {
+		t.Fatalf("expected ApprovedSignalEvent, got %T", events[0])
+	}
+}

--- a/backend/internal/usecase/backtest/reporter.go
+++ b/backend/internal/usecase/backtest/reporter.go
@@ -1,0 +1,181 @@
+package backtest
+
+import (
+	"math"
+	"sort"
+	"time"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+)
+
+type SummaryReporter struct{}
+
+func NewSummaryReporter() *SummaryReporter {
+	return &SummaryReporter{}
+}
+
+func (r *SummaryReporter) BuildSummary(
+	config entity.BacktestConfig,
+	finalBalance float64,
+	trades []entity.BacktestTradeRecord,
+) entity.BacktestSummary {
+	totalTrades := len(trades)
+	winTrades := 0
+	lossTrades := 0
+	profitSum := 0.0
+	lossSum := 0.0
+	carryingCost := 0.0
+	spreadCost := 0.0
+	holdSecondsTotal := int64(0)
+
+	balance := config.InitialBalance
+	equityCurve := []float64{balance}
+	equityTimes := []int64{config.FromTimestamp}
+
+	for _, tr := range trades {
+		if tr.PnL >= 0 {
+			winTrades++
+			profitSum += tr.PnL
+		} else {
+			lossTrades++
+			lossSum += math.Abs(tr.PnL)
+		}
+		carryingCost += tr.CarryingCost
+		spreadCost += tr.SpreadCost
+		if tr.ExitTime > tr.EntryTime {
+			holdSecondsTotal += (tr.ExitTime - tr.EntryTime) / 1000
+		}
+
+		balance += tr.PnL
+		equityCurve = append(equityCurve, balance)
+		equityTimes = append(equityTimes, tr.ExitTime)
+	}
+
+	winRate := 0.0
+	if totalTrades > 0 {
+		winRate = float64(winTrades) / float64(totalTrades) * 100
+	}
+	profitFactor := 0.0
+	if lossSum > 0 {
+		profitFactor = profitSum / lossSum
+	}
+	avgHold := int64(0)
+	if totalTrades > 0 {
+		avgHold = holdSecondsTotal / int64(totalTrades)
+	}
+
+	maxDDRatio, maxDDBalance := calcMaxDrawdown(equityCurve)
+	sharpe := calcSharpe(config.InitialBalance, trades)
+
+	return entity.BacktestSummary{
+		PeriodFrom:         config.FromTimestamp,
+		PeriodTo:           config.ToTimestamp,
+		InitialBalance:     config.InitialBalance,
+		FinalBalance:       finalBalance,
+		TotalReturn:        calcTotalReturn(config.InitialBalance, finalBalance),
+		TotalTrades:        totalTrades,
+		WinTrades:          winTrades,
+		LossTrades:         lossTrades,
+		WinRate:            winRate,
+		ProfitFactor:       profitFactor,
+		MaxDrawdown:        maxDDRatio,
+		MaxDrawdownBalance: maxDDBalance,
+		SharpeRatio:        sharpe,
+		AvgHoldSeconds:     avgHold,
+		TotalCarryingCost:  carryingCost,
+		TotalSpreadCost:    spreadCost,
+	}
+}
+
+func calcTotalReturn(initialBalance, finalBalance float64) float64 {
+	if initialBalance == 0 {
+		return 0
+	}
+	return (finalBalance - initialBalance) / initialBalance
+}
+
+func calcMaxDrawdown(equity []float64) (ratio float64, trough float64) {
+	if len(equity) == 0 {
+		return 0, 0
+	}
+	peak := equity[0]
+	maxDD := 0.0
+	troughBalance := equity[0]
+	for _, v := range equity {
+		if v > peak {
+			peak = v
+		}
+		if peak <= 0 {
+			continue
+		}
+		dd := (peak - v) / peak
+		if dd > maxDD {
+			maxDD = dd
+			troughBalance = v
+		}
+	}
+	return maxDD, troughBalance
+}
+
+func calcSharpe(initialBalance float64, trades []entity.BacktestTradeRecord) float64 {
+	if initialBalance <= 0 {
+		return 0
+	}
+	if len(trades) == 0 {
+		return 0
+	}
+
+	sorted := make([]entity.BacktestTradeRecord, len(trades))
+	copy(sorted, trades)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].ExitTime < sorted[j].ExitTime
+	})
+
+	dailyBalance := make(map[string]float64)
+	balance := initialBalance
+	for _, tr := range sorted {
+		balance += tr.PnL
+		key := time.UnixMilli(tr.ExitTime).UTC().Format("2006-01-02")
+		dailyBalance[key] = balance
+	}
+	if len(dailyBalance) < 2 {
+		return 0
+	}
+
+	keys := make([]string, 0, len(dailyBalance))
+	for k := range dailyBalance {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	returns := make([]float64, 0, len(keys)-1)
+	prev := dailyBalance[keys[0]]
+	for _, k := range keys[1:] {
+		curr := dailyBalance[k]
+		if prev != 0 {
+			returns = append(returns, (curr-prev)/prev)
+		}
+		prev = curr
+	}
+	if len(returns) == 0 {
+		return 0
+	}
+
+	mean := 0.0
+	for _, v := range returns {
+		mean += v
+	}
+	mean /= float64(len(returns))
+
+	variance := 0.0
+	for _, v := range returns {
+		diff := v - mean
+		variance += diff * diff
+	}
+	variance /= float64(len(returns))
+	stddev := math.Sqrt(variance)
+	if stddev == 0 {
+		return 0
+	}
+	return mean / stddev * math.Sqrt(365)
+}

--- a/backend/internal/usecase/backtest/reporter_test.go
+++ b/backend/internal/usecase/backtest/reporter_test.go
@@ -1,0 +1,47 @@
+package backtest
+
+import (
+	"math"
+	"testing"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+)
+
+func TestSummaryReporter_BuildSummary(t *testing.T) {
+	reporter := NewSummaryReporter()
+	cfg := entity.BacktestConfig{
+		FromTimestamp:  1000,
+		ToTimestamp:    3000,
+		InitialBalance: 1000,
+	}
+	trades := []entity.BacktestTradeRecord{
+		{
+			TradeID: 1, EntryTime: 1000, ExitTime: 1600,
+			PnL: 100, CarryingCost: 10, SpreadCost: 4,
+		},
+		{
+			TradeID: 2, EntryTime: 2000, ExitTime: 2600,
+			PnL: -50, CarryingCost: 5, SpreadCost: 3,
+		},
+	}
+	s := reporter.BuildSummary(cfg, 1050, trades)
+
+	if s.TotalTrades != 2 || s.WinTrades != 1 || s.LossTrades != 1 {
+		t.Fatalf("unexpected trade counts: %+v", s)
+	}
+	if math.Abs(s.TotalReturn-0.05) > 1e-9 {
+		t.Fatalf("expected total return 0.05, got %f", s.TotalReturn)
+	}
+	if math.Abs(s.WinRate-50.0) > 1e-9 {
+		t.Fatalf("expected win rate 50, got %f", s.WinRate)
+	}
+	if math.Abs(s.ProfitFactor-2.0) > 1e-9 {
+		t.Fatalf("expected profit factor 2.0, got %f", s.ProfitFactor)
+	}
+	if s.TotalCarryingCost != 15 {
+		t.Fatalf("expected carrying cost 15, got %f", s.TotalCarryingCost)
+	}
+	if s.TotalSpreadCost != 7 {
+		t.Fatalf("expected spread cost 7, got %f", s.TotalSpreadCost)
+	}
+}

--- a/backend/internal/usecase/backtest/runner.go
+++ b/backend/internal/usecase/backtest/runner.go
@@ -1,0 +1,172 @@
+package backtest
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"sort"
+	"time"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+	infra "github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/infrastructure/backtest"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase"
+)
+
+type RunInput struct {
+	Config         entity.BacktestConfig
+	RiskConfig     entity.RiskConfig
+	TradeAmount    float64
+	PrimaryCandles []entity.Candle
+	HigherCandles  []entity.Candle
+}
+
+type BacktestRunner struct {
+	reporter *SummaryReporter
+}
+
+func NewBacktestRunner() *BacktestRunner {
+	return &BacktestRunner{
+		reporter: NewSummaryReporter(),
+	}
+}
+
+func (r *BacktestRunner) Run(ctx context.Context, input RunInput) (*entity.BacktestResult, error) {
+	if len(input.PrimaryCandles) == 0 {
+		return nil, fmt.Errorf("primary candles are required")
+	}
+	if input.TradeAmount <= 0 {
+		return nil, fmt.Errorf("trade amount must be positive")
+	}
+	if input.Config.InitialBalance <= 0 {
+		return nil, fmt.Errorf("initial balance must be positive")
+	}
+
+	riskCfg := input.RiskConfig
+	if riskCfg.InitialCapital <= 0 {
+		riskCfg.InitialCapital = input.Config.InitialBalance
+	}
+	if riskCfg.MaxPositionAmount <= 0 {
+		riskCfg.MaxPositionAmount = math.MaxFloat64 / 4
+	}
+	if riskCfg.MaxDailyLoss <= 0 {
+		riskCfg.MaxDailyLoss = math.MaxFloat64 / 4
+	}
+	if riskCfg.StopLossPercent <= 0 {
+		riskCfg.StopLossPercent = 5
+	}
+
+	stanceResolver := usecase.NewRuleBasedStanceResolverWithOptions(nil, usecase.RuleBasedStanceResolverOptions{
+		DisableOverride:    true,
+		DisablePersistence: true,
+	})
+	strategyEngine := usecase.NewStrategyEngine(stanceResolver)
+	riskMgr := usecase.NewRiskManager(riskCfg)
+
+	sim := infra.NewSimExecutor(infra.SimConfig{
+		InitialBalance:    input.Config.InitialBalance,
+		SpreadPercent:     input.Config.SpreadPercent,
+		DailyCarryingCost: input.Config.DailyCarryCost,
+		SlippagePercent:   input.Config.SlippagePercent,
+	})
+
+	indicatorHandler := NewIndicatorHandler(input.Config.PrimaryInterval, input.Config.HigherTFInterval, 500)
+	strategyHandler := &StrategyHandler{Engine: strategyEngine}
+	riskHandler := &RiskHandler{
+		RiskManager: riskMgr,
+		TradeAmount: input.TradeAmount,
+	}
+	executionHandler := &ExecutionHandler{
+		Executor:    sim,
+		TradeAmount: input.TradeAmount,
+	}
+
+	bus := NewEventBus()
+	bus.Register(entity.EventTypeCandle, 10, indicatorHandler)
+	bus.Register(entity.EventTypeIndicator, 20, strategyHandler)
+	bus.Register(entity.EventTypeSignal, 30, riskHandler)
+	bus.Register(entity.EventTypeApproved, 40, executionHandler)
+
+	engine := NewEventEngine(bus)
+	events := mergeCandleEvents(
+		filterCandlesByRange(input.PrimaryCandles, input.Config.FromTimestamp, input.Config.ToTimestamp),
+		filterCandlesByRange(input.HigherCandles, input.Config.FromTimestamp, input.Config.ToTimestamp),
+		input.Config.PrimaryInterval,
+		input.Config.HigherTFInterval,
+		input.Config.SymbolID,
+	)
+
+	if err := engine.Run(ctx, events); err != nil {
+		return nil, err
+	}
+
+	lastCandle := input.PrimaryCandles[len(input.PrimaryCandles)-1]
+	for _, pos := range sim.Positions() {
+		_, _, _ = sim.Close(pos.PositionID, lastCandle.Close, "end_of_test", lastCandle.Time)
+	}
+
+	trades := sim.ClosedTrades()
+	summary := r.reporter.BuildSummary(input.Config, sim.Balance(), trades)
+	result := &entity.BacktestResult{
+		ID:        fmt.Sprintf("bt-%d", time.Now().UnixMilli()),
+		CreatedAt: time.Now().Unix(),
+		Config:    input.Config,
+		Summary:   summary,
+		Trades:    trades,
+	}
+	return result, nil
+}
+
+func filterCandlesByRange(candles []entity.Candle, from, to int64) []entity.Candle {
+	if from == 0 && to == 0 {
+		out := make([]entity.Candle, len(candles))
+		copy(out, candles)
+		sort.Slice(out, func(i, j int) bool { return out[i].Time < out[j].Time })
+		return out
+	}
+
+	out := make([]entity.Candle, 0, len(candles))
+	for _, c := range candles {
+		if from > 0 && c.Time < from {
+			continue
+		}
+		if to > 0 && c.Time > to {
+			continue
+		}
+		out = append(out, c)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Time < out[j].Time })
+	return out
+}
+
+func mergeCandleEvents(primary, higher []entity.Candle, primaryInterval, higherInterval string, symbolID int64) []entity.Event {
+	events := make([]entity.Event, 0, len(primary)+len(higher))
+	i := 0
+	j := 0
+
+	for i < len(primary) || j < len(higher) {
+		if i >= len(primary) {
+			c := higher[j]
+			events = append(events, entity.CandleEvent{SymbolID: symbolID, Interval: higherInterval, Candle: c, Timestamp: c.Time})
+			j++
+			continue
+		}
+		if j >= len(higher) {
+			c := primary[i]
+			events = append(events, entity.CandleEvent{SymbolID: symbolID, Interval: primaryInterval, Candle: c, Timestamp: c.Time})
+			i++
+			continue
+		}
+
+		p := primary[i]
+		h := higher[j]
+		if h.Time <= p.Time {
+			events = append(events, entity.CandleEvent{SymbolID: symbolID, Interval: higherInterval, Candle: h, Timestamp: h.Time})
+			j++
+		} else {
+			events = append(events, entity.CandleEvent{SymbolID: symbolID, Interval: primaryInterval, Candle: p, Timestamp: p.Time})
+			i++
+		}
+	}
+
+	return events
+}

--- a/backend/internal/usecase/backtest/runner_test.go
+++ b/backend/internal/usecase/backtest/runner_test.go
@@ -1,0 +1,99 @@
+package backtest
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+)
+
+func TestMergeCandleEvents_PrefersHigherOnSameTimestamp(t *testing.T) {
+	primary := []entity.Candle{
+		{Time: 2000, Close: 2},
+	}
+	higher := []entity.Candle{
+		{Time: 2000, Close: 20},
+	}
+	events := mergeCandleEvents(primary, higher, "PT15M", "PT1H", 7)
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(events))
+	}
+	first, ok := events[0].(entity.CandleEvent)
+	if !ok {
+		t.Fatalf("expected CandleEvent, got %T", events[0])
+	}
+	if first.Interval != "PT1H" {
+		t.Fatalf("expected higher timeframe first, got %s", first.Interval)
+	}
+}
+
+func TestBacktestRunner_Run(t *testing.T) {
+	primary := make([]entity.Candle, 0, 80)
+	higher := make([]entity.Candle, 0, 20)
+	baseTime := int64(1_770_000_000_000)
+
+	price := 100.0
+	for i := 0; i < 80; i++ {
+		price += math.Sin(float64(i)/7.0) * 0.8
+		ts := baseTime + int64(i)*15*60*1000
+		primary = append(primary, entity.Candle{
+			Open:  price - 0.5,
+			High:  price + 1.0,
+			Low:   price - 1.0,
+			Close: price,
+			Time:  ts,
+		})
+	}
+	for i := 0; i < 20; i++ {
+		idx := i * 4
+		ts := primary[idx].Time
+		p := primary[idx].Close
+		higher = append(higher, entity.Candle{
+			Open:  p - 0.6,
+			High:  p + 1.2,
+			Low:   p - 1.2,
+			Close: p,
+			Time:  ts,
+		})
+	}
+
+	runner := NewBacktestRunner()
+	result, err := runner.Run(context.Background(), RunInput{
+		Config: entity.BacktestConfig{
+			Symbol:           "BTC_JPY",
+			SymbolID:         7,
+			PrimaryInterval:  "PT15M",
+			HigherTFInterval: "PT1H",
+			FromTimestamp:    primary[0].Time,
+			ToTimestamp:      primary[len(primary)-1].Time,
+			InitialBalance:   100000,
+			SpreadPercent:    0.1,
+			DailyCarryCost:   0.04,
+		},
+		RiskConfig: entity.RiskConfig{
+			MaxPositionAmount:    1_000_000_000,
+			MaxDailyLoss:         1_000_000_000,
+			StopLossPercent:      5,
+			TakeProfitPercent:    10,
+			InitialCapital:       100000,
+			MaxConsecutiveLosses: 0,
+			CooldownMinutes:      0,
+		},
+		TradeAmount:    0.01,
+		PrimaryCandles: primary,
+		HigherCandles:  higher,
+	})
+	if err != nil {
+		t.Fatalf("runner error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("result must not be nil")
+	}
+	if result.Summary.InitialBalance != 100000 {
+		t.Fatalf("unexpected initial balance: %f", result.Summary.InitialBalance)
+	}
+	if result.Summary.FinalBalance <= 0 {
+		t.Fatalf("final balance must be positive: %f", result.Summary.FinalBalance)
+	}
+}

--- a/backend/internal/usecase/risk.go
+++ b/backend/internal/usecase/risk.go
@@ -10,13 +10,13 @@ import (
 )
 
 type RiskStatus struct {
-	Balance       float64           `json:"balance"`
-	DailyLoss     float64           `json:"dailyLoss"`
-	TotalPosition float64           `json:"totalPosition"`
-	TradingHalted bool              `json:"tradingHalted"`
-	ManuallyStopped bool            `json:"manuallyStopped"`
-	CurrentATR    float64           `json:"currentAtr"`
-	Config        entity.RiskConfig `json:"config"`
+	Balance         float64           `json:"balance"`
+	DailyLoss       float64           `json:"dailyLoss"`
+	TotalPosition   float64           `json:"totalPosition"`
+	TradingHalted   bool              `json:"tradingHalted"`
+	ManuallyStopped bool              `json:"manuallyStopped"`
+	CurrentATR      float64           `json:"currentAtr"`
+	Config          entity.RiskConfig `json:"config"`
 }
 
 type RiskManager struct {
@@ -41,6 +41,15 @@ func NewRiskManager(config entity.RiskConfig) *RiskManager {
 }
 
 func (rm *RiskManager) CheckOrder(ctx context.Context, proposal entity.OrderProposal) entity.RiskCheckResult {
+	return rm.CheckOrderAt(ctx, time.Now(), proposal)
+}
+
+// CheckOrderAt evaluates a proposal at caller-supplied time (for deterministic backtests).
+func (rm *RiskManager) CheckOrderAt(ctx context.Context, now time.Time, proposal entity.OrderProposal) entity.RiskCheckResult {
+	if now.IsZero() {
+		now = time.Now()
+	}
+
 	if proposal.IsClose {
 		return entity.RiskCheckResult{Approved: true}
 	}
@@ -57,7 +66,7 @@ func (rm *RiskManager) CheckOrder(ctx context.Context, proposal entity.OrderProp
 		}
 	}
 
-	if rm.config.MaxConsecutiveLosses > 0 && !rm.cooldownUntil.IsZero() && time.Now().Before(rm.cooldownUntil) {
+	if rm.config.MaxConsecutiveLosses > 0 && !rm.cooldownUntil.IsZero() && now.Before(rm.cooldownUntil) {
 		return entity.RiskCheckResult{
 			Approved: false,
 			Reason:   fmt.Sprintf("cooldown: %d consecutive losses, trading paused until %s", rm.consecutiveLosses, rm.cooldownUntil.Format("15:04")),
@@ -152,11 +161,20 @@ func (rm *RiskManager) ResetDailyLoss() {
 // RecordConsecutiveLoss increments the consecutive loss counter.
 // If the counter reaches MaxConsecutiveLosses, a cooldown period is activated.
 func (rm *RiskManager) RecordConsecutiveLoss() {
+	rm.RecordConsecutiveLossAt(time.Now())
+}
+
+// RecordConsecutiveLossAt increments loss counter at caller-supplied time.
+func (rm *RiskManager) RecordConsecutiveLossAt(now time.Time) {
+	if now.IsZero() {
+		now = time.Now()
+	}
+
 	rm.mu.Lock()
 	defer rm.mu.Unlock()
 	rm.consecutiveLosses++
 	if rm.config.MaxConsecutiveLosses > 0 && rm.consecutiveLosses >= rm.config.MaxConsecutiveLosses {
-		rm.cooldownUntil = time.Now().Add(time.Duration(rm.config.CooldownMinutes) * time.Minute)
+		rm.cooldownUntil = now.Add(time.Duration(rm.config.CooldownMinutes) * time.Minute)
 	}
 }
 

--- a/backend/internal/usecase/risk_test.go
+++ b/backend/internal/usecase/risk_test.go
@@ -3,6 +3,7 @@ package usecase
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
 )
@@ -455,5 +456,29 @@ func TestRiskManager_ATR_DisabledUsesPercent(t *testing.T) {
 	targets = rm.CheckStopLoss(7, 4750000) // exactly 5%
 	if len(targets) != 1 {
 		t.Fatalf("expected trigger at 5%%, got %d", len(targets))
+	}
+}
+
+func TestRiskManager_CheckOrderAt_UsesInjectedTimeForCooldown(t *testing.T) {
+	rm := NewRiskManager(defaultRiskConfig())
+	base := time.Date(2026, 4, 14, 12, 0, 0, 0, time.UTC)
+
+	rm.RecordConsecutiveLossAt(base)
+	rm.RecordConsecutiveLossAt(base)
+	rm.RecordConsecutiveLossAt(base)
+
+	proposal := entity.OrderProposal{
+		SymbolID: 7, Side: entity.OrderSideBuy, OrderType: entity.OrderTypeMarket,
+		Amount: 0.001, Price: 1000000,
+	}
+
+	blocked := rm.CheckOrderAt(context.Background(), base.Add(29*time.Minute), proposal)
+	if blocked.Approved {
+		t.Fatal("order should be rejected before injected cooldown end")
+	}
+
+	allowed := rm.CheckOrderAt(context.Background(), base.Add(31*time.Minute), proposal)
+	if !allowed.Approved {
+		t.Fatalf("order should be approved after injected cooldown end: %s", allowed.Reason)
 	}
 }

--- a/backend/internal/usecase/stance.go
+++ b/backend/internal/usecase/stance.go
@@ -23,6 +23,7 @@ type StanceResult struct {
 // StanceResolver はマーケットスタンスを解決するインターフェース。
 type StanceResolver interface {
 	Resolve(ctx context.Context, indicators entity.IndicatorSet) StanceResult
+	ResolveAt(ctx context.Context, indicators entity.IndicatorSet, now time.Time) StanceResult
 }
 
 type stanceOverride struct {
@@ -32,20 +33,39 @@ type stanceOverride struct {
 	ExpiresAt time.Time
 }
 
+// RuleBasedStanceResolverOptions controls override behavior.
+type RuleBasedStanceResolverOptions struct {
+	// DisableOverride forces resolver to always use rule-based result.
+	DisableOverride bool
+	// DisablePersistence prevents loading/saving/deleting override records.
+	DisablePersistence bool
+}
+
 // RuleBasedStanceResolver はルールベースでマーケットスタンスを解決する。
 type RuleBasedStanceResolver struct {
 	mu       sync.RWMutex
 	override *stanceOverride
 	repo     repository.StanceOverrideRepository
+	options  RuleBasedStanceResolverOptions
 }
 
 // NewRuleBasedStanceResolver はRuleBasedStanceResolverを生成する。
 // repoがnon-nilの場合、起動時にDBからオーバーライドを復元する。
 func NewRuleBasedStanceResolver(repo repository.StanceOverrideRepository) *RuleBasedStanceResolver {
-	r := &RuleBasedStanceResolver{
-		repo: repo,
+	return NewRuleBasedStanceResolverWithOptions(repo, RuleBasedStanceResolverOptions{})
+}
+
+// NewRuleBasedStanceResolverWithOptions creates resolver with explicit options.
+func NewRuleBasedStanceResolverWithOptions(repo repository.StanceOverrideRepository, options RuleBasedStanceResolverOptions) *RuleBasedStanceResolver {
+	if options.DisablePersistence {
+		repo = nil
 	}
-	if repo != nil {
+
+	r := &RuleBasedStanceResolver{
+		repo:    repo,
+		options: options,
+	}
+	if repo != nil && !options.DisableOverride {
 		record, err := repo.Load(context.Background())
 		if err == nil && record != nil {
 			setAt := time.Unix(record.SetAt, 0)
@@ -71,7 +91,18 @@ func NewRuleBasedStanceResolver(repo repository.StanceOverrideRepository) *RuleB
 // Resolve はインジケータに基づいてマーケットスタンスを解決する。
 // オーバーライドが有効な場合はそれを優先する。
 func (r *RuleBasedStanceResolver) Resolve(ctx context.Context, indicators entity.IndicatorSet) StanceResult {
-	now := time.Now()
+	return r.ResolveAt(ctx, indicators, time.Now())
+}
+
+// ResolveAt resolves stance at caller-supplied time (for deterministic backtests).
+func (r *RuleBasedStanceResolver) ResolveAt(ctx context.Context, indicators entity.IndicatorSet, now time.Time) StanceResult {
+	if now.IsZero() {
+		now = time.Now()
+	}
+
+	if r.options.DisableOverride {
+		return r.applyRules(indicators, now)
+	}
 
 	// オーバーライドチェック
 	r.mu.RLock()
@@ -162,6 +193,10 @@ const (
 // SetOverride はスタンスオーバーライドを設定する。
 // TTLは1分〜1440分(24時間)の範囲にクランプされる。
 func (r *RuleBasedStanceResolver) SetOverride(stance entity.MarketStance, reasoning string, ttl time.Duration) {
+	if r.options.DisableOverride {
+		return
+	}
+
 	if ttl < minOverrideTTL {
 		ttl = minOverrideTTL
 	}
@@ -195,6 +230,9 @@ func (r *RuleBasedStanceResolver) SetOverride(stance entity.MarketStance, reason
 
 // ClearOverride はスタンスオーバーライドをクリアする。
 func (r *RuleBasedStanceResolver) ClearOverride() {
+	if r.options.DisableOverride {
+		return
+	}
 	r.clearOverrideInternal()
 }
 
@@ -212,6 +250,10 @@ func (r *RuleBasedStanceResolver) clearOverrideInternal() {
 
 // GetOverride は現在有効なオーバーライドを返す。期限切れの場合はnilを返す。
 func (r *RuleBasedStanceResolver) GetOverride() *StanceResult {
+	if r.options.DisableOverride {
+		return nil
+	}
+
 	r.mu.RLock()
 	override := r.override
 	r.mu.RUnlock()

--- a/backend/internal/usecase/stance_test.go
+++ b/backend/internal/usecase/stance_test.go
@@ -376,3 +376,45 @@ func TestRuleBasedStanceResolver_RepoDeleteError_LoggedNotPanicked(t *testing.T)
 		t.Fatalf("expected Delete to be called, got %d", repo.deleteCalled)
 	}
 }
+
+func TestRuleBasedStanceResolver_ResolveAt_UsesInjectedTimeForExpiry(t *testing.T) {
+	resolver := NewRuleBasedStanceResolver(nil)
+	resolver.SetOverride(entity.MarketStanceContrarian, "manual", 2*time.Minute)
+
+	early := resolver.ResolveAt(context.Background(), entity.IndicatorSet{
+		SMA20: ptr(5100000),
+		SMA50: ptr(5000000),
+		RSI14: ptr(50.0),
+	}, time.Now().Add(1*time.Minute))
+	if early.Source != "override" {
+		t.Fatalf("expected override before expiry, got %s", early.Source)
+	}
+
+	late := resolver.ResolveAt(context.Background(), entity.IndicatorSet{
+		SMA20: ptr(5100000),
+		SMA50: ptr(5000000),
+		RSI14: ptr(50.0),
+	}, time.Now().Add(3*time.Minute))
+	if late.Source != "rule-based" {
+		t.Fatalf("expected rule-based after expiry, got %s", late.Source)
+	}
+}
+
+func TestRuleBasedStanceResolverWithOptions_DisableOverride(t *testing.T) {
+	resolver := NewRuleBasedStanceResolverWithOptions(nil, RuleBasedStanceResolverOptions{
+		DisableOverride: true,
+	})
+	resolver.SetOverride(entity.MarketStanceContrarian, "manual", 5*time.Minute)
+
+	result := resolver.Resolve(context.Background(), entity.IndicatorSet{
+		SMA20: ptr(5100000),
+		SMA50: ptr(5000000),
+		RSI14: ptr(50.0),
+	})
+	if result.Source != "rule-based" {
+		t.Fatalf("expected rule-based when override disabled, got %s", result.Source)
+	}
+	if resolver.GetOverride() != nil {
+		t.Fatal("expected no active override when override disabled")
+	}
+}

--- a/backend/internal/usecase/strategy.go
+++ b/backend/internal/usecase/strategy.go
@@ -25,12 +25,23 @@ func NewStrategyEngine(stanceResolver StanceResolver) *StrategyEngine {
 // Contrarianシグナルは意図的に逆張りなのでフィルタしない。
 // ボラティリティフィルター: BBバンド幅が非常に狭い(squeeze)場合、Trend Followシグナルを抑制する。
 func (e *StrategyEngine) EvaluateWithHigherTF(ctx context.Context, indicators entity.IndicatorSet, higherTF *entity.IndicatorSet, lastPrice float64) (*entity.Signal, error) {
-	signal, err := e.Evaluate(ctx, indicators, lastPrice)
+	return e.EvaluateWithHigherTFAt(ctx, indicators, higherTF, lastPrice, time.Now())
+}
+
+// EvaluateWithHigherTFAt is a deterministic variant for backtests.
+func (e *StrategyEngine) EvaluateWithHigherTFAt(
+	ctx context.Context,
+	indicators entity.IndicatorSet,
+	higherTF *entity.IndicatorSet,
+	lastPrice float64,
+	now time.Time,
+) (*entity.Signal, error) {
+	signal, err := e.EvaluateAt(ctx, indicators, lastPrice, now)
 	if err != nil || signal.Action == entity.SignalActionHold {
 		return signal, err
 	}
 
-	result := e.stanceResolver.Resolve(ctx, indicators)
+	result := e.resolveAt(ctx, indicators, now)
 
 	// Volatility filter: squeeze detection for trend-follow signals
 	// BBBandwidth < 0.02 (2%) indicates very low volatility / consolidation
@@ -90,17 +101,27 @@ func (e *StrategyEngine) EvaluateWithHigherTF(ctx context.Context, indicators en
 // Evaluate はテクニカル指標と現在価格から売買シグナルを生成する。
 // 指標データが不足している場合はHOLDを返す。
 func (e *StrategyEngine) Evaluate(ctx context.Context, indicators entity.IndicatorSet, lastPrice float64) (*entity.Signal, error) {
+	return e.EvaluateAt(ctx, indicators, lastPrice, time.Now())
+}
+
+// EvaluateAt is a deterministic variant for backtests.
+func (e *StrategyEngine) EvaluateAt(ctx context.Context, indicators entity.IndicatorSet, lastPrice float64, now time.Time) (*entity.Signal, error) {
+	if now.IsZero() {
+		now = time.Now()
+	}
+	nowUnix := now.Unix()
+
 	// 指標チェックを先に行い、不要な処理を防ぐ
 	if indicators.SMA20 == nil || indicators.SMA50 == nil || indicators.RSI14 == nil {
 		return &entity.Signal{
 			SymbolID:  indicators.SymbolID,
 			Action:    entity.SignalActionHold,
 			Reason:    "insufficient indicator data",
-			Timestamp: time.Now().Unix(),
+			Timestamp: nowUnix,
 		}, nil
 	}
 
-	result := e.stanceResolver.Resolve(ctx, indicators)
+	result := e.resolveAt(ctx, indicators, now)
 
 	sma20 := *indicators.SMA20
 	sma50 := *indicators.SMA50
@@ -108,21 +129,24 @@ func (e *StrategyEngine) Evaluate(ctx context.Context, indicators entity.Indicat
 
 	switch result.Stance {
 	case entity.MarketStanceTrendFollow:
-		return e.evaluateTrendFollow(indicators.SymbolID, sma20, sma50, rsi, indicators.EMA12, indicators.EMA26, indicators.Histogram), nil
+		return e.evaluateTrendFollow(indicators.SymbolID, sma20, sma50, rsi, indicators.EMA12, indicators.EMA26, indicators.Histogram, nowUnix), nil
 	case entity.MarketStanceContrarian:
-		return e.evaluateContrarian(indicators.SymbolID, rsi, indicators.Histogram), nil
+		return e.evaluateContrarian(indicators.SymbolID, rsi, indicators.Histogram, nowUnix), nil
 	default:
 		return &entity.Signal{
 			SymbolID:  indicators.SymbolID,
 			Action:    entity.SignalActionHold,
 			Reason:    "stance is HOLD",
-			Timestamp: time.Now().Unix(),
+			Timestamp: nowUnix,
 		}, nil
 	}
 }
 
-func (e *StrategyEngine) evaluateTrendFollow(symbolID int64, sma20, sma50, rsi float64, ema12, ema26, histogram *float64) *entity.Signal {
-	now := time.Now().Unix()
+func (e *StrategyEngine) resolveAt(ctx context.Context, indicators entity.IndicatorSet, now time.Time) StanceResult {
+	return e.stanceResolver.ResolveAt(ctx, indicators, now)
+}
+
+func (e *StrategyEngine) evaluateTrendFollow(symbolID int64, sma20, sma50, rsi float64, ema12, ema26, histogram *float64, nowUnix int64) *entity.Signal {
 
 	// Primary signal: EMA12/26 crossover (faster than SMA cross)
 	// Fallback to SMA20/50 when EMA is unavailable
@@ -146,7 +170,7 @@ func (e *StrategyEngine) evaluateTrendFollow(symbolID int64, sma20, sma50, rsi f
 				SymbolID:  symbolID,
 				Action:    entity.SignalActionHold,
 				Reason:    "trend follow: EMA cross but SMA not aligned",
-				Timestamp: now,
+				Timestamp: nowUnix,
 			}
 		}
 	}
@@ -158,7 +182,7 @@ func (e *StrategyEngine) evaluateTrendFollow(symbolID int64, sma20, sma50, rsi f
 				SymbolID:  symbolID,
 				Action:    entity.SignalActionHold,
 				Reason:    "trend follow: MACD histogram negative, skipping buy",
-				Timestamp: now,
+				Timestamp: nowUnix,
 			}
 		}
 		reason := "trend follow: EMA12 > EMA26, SMA aligned, RSI not overbought"
@@ -173,7 +197,7 @@ func (e *StrategyEngine) evaluateTrendFollow(symbolID int64, sma20, sma50, rsi f
 			Action:     entity.SignalActionBuy,
 			Confidence: trendFollowConfidence(sma20, sma50, rsi, ema12, ema26, histogram, true),
 			Reason:     reason,
-			Timestamp:  now,
+			Timestamp:  nowUnix,
 		}
 	}
 	if fastBelowSlow && rsi > 30 {
@@ -183,7 +207,7 @@ func (e *StrategyEngine) evaluateTrendFollow(symbolID int64, sma20, sma50, rsi f
 				SymbolID:  symbolID,
 				Action:    entity.SignalActionHold,
 				Reason:    "trend follow: MACD histogram positive, skipping sell",
-				Timestamp: now,
+				Timestamp: nowUnix,
 			}
 		}
 		reason := "trend follow: EMA12 < EMA26, SMA aligned, RSI not oversold"
@@ -198,14 +222,14 @@ func (e *StrategyEngine) evaluateTrendFollow(symbolID int64, sma20, sma50, rsi f
 			Action:     entity.SignalActionSell,
 			Confidence: trendFollowConfidence(sma20, sma50, rsi, ema12, ema26, histogram, false),
 			Reason:     reason,
-			Timestamp:  now,
+			Timestamp:  nowUnix,
 		}
 	}
 	return &entity.Signal{
 		SymbolID:  symbolID,
 		Action:    entity.SignalActionHold,
 		Reason:    "trend follow: no clear signal",
-		Timestamp: now,
+		Timestamp: nowUnix,
 	}
 }
 
@@ -239,8 +263,7 @@ func trendFollowConfidence(sma20, sma50, rsi float64, ema12, ema26, histogram *f
 	return emaDivergence*0.3 + smaDivergence*0.15 + rsiRoom*0.25 + macdConfirm*0.3
 }
 
-func (e *StrategyEngine) evaluateContrarian(symbolID int64, rsi float64, histogram *float64) *entity.Signal {
-	now := time.Now().Unix()
+func (e *StrategyEngine) evaluateContrarian(symbolID int64, rsi float64, histogram *float64, nowUnix int64) *entity.Signal {
 
 	if rsi < 30 {
 		// Skip contrarian buy if MACD momentum is still strongly negative
@@ -249,7 +272,7 @@ func (e *StrategyEngine) evaluateContrarian(symbolID int64, rsi float64, histogr
 				SymbolID:  symbolID,
 				Action:    entity.SignalActionHold,
 				Reason:    "contrarian: RSI oversold but MACD momentum still strongly negative",
-				Timestamp: now,
+				Timestamp: nowUnix,
 			}
 		}
 		reason := "contrarian: RSI oversold, expecting bounce"
@@ -261,7 +284,7 @@ func (e *StrategyEngine) evaluateContrarian(symbolID int64, rsi float64, histogr
 			Action:     entity.SignalActionBuy,
 			Confidence: contrarianConfidence(rsi, histogram, true),
 			Reason:     reason,
-			Timestamp:  now,
+			Timestamp:  nowUnix,
 		}
 	}
 	if rsi > 70 {
@@ -271,7 +294,7 @@ func (e *StrategyEngine) evaluateContrarian(symbolID int64, rsi float64, histogr
 				SymbolID:  symbolID,
 				Action:    entity.SignalActionHold,
 				Reason:    "contrarian: RSI overbought but MACD momentum still strongly positive",
-				Timestamp: now,
+				Timestamp: nowUnix,
 			}
 		}
 		reason := "contrarian: RSI overbought, expecting pullback"
@@ -283,14 +306,14 @@ func (e *StrategyEngine) evaluateContrarian(symbolID int64, rsi float64, histogr
 			Action:     entity.SignalActionSell,
 			Confidence: contrarianConfidence(rsi, histogram, false),
 			Reason:     reason,
-			Timestamp:  now,
+			Timestamp:  nowUnix,
 		}
 	}
 	return &entity.Signal{
 		SymbolID:  symbolID,
 		Action:    entity.SignalActionHold,
 		Reason:    "contrarian: RSI in neutral zone",
-		Timestamp: now,
+		Timestamp: nowUnix,
 	}
 }
 

--- a/backend/internal/usecase/strategy_test.go
+++ b/backend/internal/usecase/strategy_test.go
@@ -16,6 +16,10 @@ func (m *mockStanceResolver) Resolve(ctx context.Context, indicators entity.Indi
 	return m.result
 }
 
+func (m *mockStanceResolver) ResolveAt(ctx context.Context, indicators entity.IndicatorSet, now time.Time) StanceResult {
+	return m.result
+}
+
 func TestStrategyEngine_TrendFollow_BuySignal(t *testing.T) {
 	// TREND_FOLLOW: SMA20 > SMA50 かつ RSI < 70 → BUY
 	resolver := &mockStanceResolver{
@@ -452,12 +456,12 @@ func TestStrategyEngine_EMA_CrossWithSMAMisalignment(t *testing.T) {
 	engine := NewStrategyEngine(resolver)
 
 	indicators := entity.IndicatorSet{
-		SymbolID:  7,
-		SMA20:     ptr(4990000.0), // SMA still bearish
-		SMA50:     ptr(5000000.0),
-		EMA12:     ptr(5010000.0), // EMA already bullish
-		EMA26:     ptr(5000000.0),
-		RSI14:     ptr(55.0),
+		SymbolID: 7,
+		SMA20:    ptr(4990000.0), // SMA still bearish
+		SMA50:    ptr(5000000.0),
+		EMA12:    ptr(5010000.0), // EMA already bullish
+		EMA26:    ptr(5000000.0),
+		RSI14:    ptr(55.0),
 	}
 	signal, err := engine.Evaluate(context.Background(), indicators, 5010000)
 	if err != nil {
@@ -772,5 +776,64 @@ func TestStrategyEngine_Confidence_HoldIsZero(t *testing.T) {
 	}
 	if signal.Confidence != 0.0 {
 		t.Fatalf("expected confidence 0.0 for HOLD, got %.4f", signal.Confidence)
+	}
+}
+
+func TestStrategyEngine_EvaluateAt_UsesInjectedTimestamp(t *testing.T) {
+	resolver := &mockStanceResolver{
+		result: StanceResult{
+			Stance:    entity.MarketStanceTrendFollow,
+			Reasoning: "uptrend",
+			Source:    "rule-based",
+			UpdatedAt: time.Now().Unix(),
+		},
+	}
+	engine := NewStrategyEngine(resolver)
+	at := time.Date(2026, 4, 14, 12, 30, 0, 0, time.UTC)
+
+	signal, err := engine.EvaluateAt(context.Background(), entity.IndicatorSet{SymbolID: 7}, 5000000, at)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if signal.Timestamp != at.Unix() {
+		t.Fatalf("expected timestamp %d, got %d", at.Unix(), signal.Timestamp)
+	}
+}
+
+func TestStrategyEngine_EvaluateWithHigherTFAt_UsesInjectedTimestampForMTFHold(t *testing.T) {
+	resolver := &mockStanceResolver{
+		result: StanceResult{
+			Stance:    entity.MarketStanceTrendFollow,
+			Reasoning: "uptrend",
+			Source:    "rule-based",
+			UpdatedAt: time.Now().Unix(),
+		},
+	}
+	engine := NewStrategyEngine(resolver)
+	at := time.Date(2026, 4, 14, 13, 45, 0, 0, time.UTC)
+
+	indicators := entity.IndicatorSet{
+		SymbolID:  7,
+		SMA20:     ptr(5100000),
+		SMA50:     ptr(5000000),
+		EMA12:     ptr(101),
+		EMA26:     ptr(100),
+		RSI14:     ptr(55),
+		Histogram: ptr(2),
+	}
+	higherTF := &entity.IndicatorSet{
+		SMA20: ptr(5000000),
+		SMA50: ptr(5100000), // downtrend blocks buy
+	}
+
+	signal, err := engine.EvaluateWithHigherTFAt(context.Background(), indicators, higherTF, 5100000, at)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if signal.Action != entity.SignalActionHold {
+		t.Fatalf("expected HOLD by MTF filter, got %s", signal.Action)
+	}
+	if signal.Timestamp != at.Unix() {
+		t.Fatalf("expected timestamp %d, got %d", at.Unix(), signal.Timestamp)
 	}
 }

--- a/docs/design/2026-04-14-backtest-engine-design.md
+++ b/docs/design/2026-04-14-backtest-engine-design.md
@@ -1,0 +1,460 @@
+# バックテストエンジン設計
+
+- **作成日**: 2026-04-14
+- **更新日**: 2026-04-15
+- **ステータス**: Draft
+
+## 概要
+
+既存の自動売買戦略が有効かを過去データで検証するバックテストエンジンを実装する。MT5 のストラテジーテスターに相当する機能を、既存の Clean Architecture を活かしたイベントドリブン設計で構築する。
+
+### 目的
+
+- 過去データに基づく戦略パフォーマンス検証
+- パラメータ最適化による戦略チューニング
+- 将来の本番パイプラインのイベントドリブン化への布石
+
+### スコープ
+
+| フェーズ | 内容 |
+|---|---|
+| **Phase 1（初期）** | バックテスト実行 + サマリー + 全トレードCSV出力 + 結果永続化API |
+| **Phase 2（次期）** | パラメータ最適化（段階探索） |
+| **将来** | フロントエンド可視化、本番パイプラインのイベントドリブン置換 |
+
+## 設計方針
+
+- **イベントドリブン**: キャンドルを1本ずつ処理し、将来の1分足/ティック対応に拡張可能な形にする。
+- **既存ロジック再利用 + 最小拡張**: `StrategyEngine` / `RiskManager` / `infrastructure/indicator` を再利用しつつ、バックテストではイベント時刻を注入できる形に拡張する。
+- **時刻基準の単一化**: バックテスト中の判定時刻はすべて「履歴イベント時刻」を使い、`time.Now()`基準での非決定性を排除する。
+- **先読みバイアス防止**: マルチタイムフレームは「その時点で確定済みの上位足のみ参照」を必須ルールとする。
+- **保守的な約定仮定**: 同一バー内でSL/TPが両ヒットする場合は `worst-case` を採用し、過大評価を避ける。
+- **データ管理**: 楽天API → SQLite/CSV キャッシュ。差分更新を前提にAPI呼び出しを最小化する。
+
+## 1. 全体アーキテクチャ
+
+```
+┌────────────────────────────────────────────────────────────┐
+│                        EventEngine                         │
+│                                                            │
+│  EventSource ──→ EventBus(FIFO) ──→ Handlers              │
+│  (Candle/Tick)             │         ├─ IndicatorHandler   │
+│                            │         ├─ StrategyHandler    │
+│                            │         ├─ RiskHandler        │
+│                            │         └─ ExecutionHandler   │
+│                                            │               │
+│                                      OrderExecutor         │
+│                                      (interface)           │
+│                                ┌──────────┴──────────┐     │
+│                              SimExecutor       RealExecutor│
+│                              (backtest)        (将来)      │
+└────────────────────────────────────────────────────────────┘
+```
+
+### EventSource の実装
+
+| 実装 | 用途 | データソース |
+|---|---|---|
+| `HistoricalSource` | バックテスト | CSV または SQLite |
+| `LiveSource` | 将来の本番 | 楽天API WebSocket |
+
+## 2. イベント設計
+
+### 2.1 イベントの種類
+
+```go
+// Candle.Time は「確定時刻（close時刻）」として扱う
+type CandleEvent struct {
+    SymbolID  int64
+    Interval  string        // "PT15M", "PT1H"
+    Candle    entity.Candle // OHLCV + Time(close)
+    Timestamp int64         // Candle.Time と同値（Unix ms）
+}
+
+// IndicatorHandler が生成し、StrategyHandler の入力契約を固定する
+type IndicatorEvent struct {
+    SymbolID   int64
+    Interval   string // 生成元（主に PT15M）
+    Primary    entity.IndicatorSet
+    HigherTF   *entity.IndicatorSet // close_time <= Primary.Timestamp の最新1本
+    LastPrice  float64
+    Timestamp  int64
+}
+
+// バー内擬似ティック
+type TickEvent struct {
+    SymbolID   int64
+    Price      float64
+    Timestamp  int64 // 疑似時刻（2.3で定義）
+    TickType   string // "open" | "high" | "low" | "close"
+    ParentTime int64  // 親キャンドルの close 時刻
+}
+
+type SignalEvent struct {
+    Signal    entity.Signal
+    Price     float64
+    Timestamp int64
+}
+
+type OrderEvent struct {
+    OrderID    int64
+    SymbolID   int64
+    Side       string  // "BUY" | "SELL"
+    Action     string  // "open" | "close"
+    Price      float64
+    Amount     float64
+    Reason     string
+    Timestamp  int64
+}
+```
+
+### 2.2 イベントフロー
+
+```
+CandleEvent(PT15M)
+  → IndicatorHandler: 指標計算 + 上位足同期 → IndicatorEvent
+  → StrategyHandler: IndicatorEvent からシグナル生成 → SignalEvent
+
+SignalEvent
+  → RiskHandler: ポジション上限、日次損失、クールダウン確認
+  → ExecutionHandler: 注文シミュレーション → OrderEvent
+
+TickEvent（バー内価格変動）
+  → RiskHandler: SL/TP/トレーリング判定 → OrderEvent（決済）
+
+OrderEvent
+  → PositionTracker: ポジション更新（建玉管理料含む）
+  → TradeLogger: トレードログ記録
+```
+
+### 2.3 バー内ティック擬似生成とSL/TP優先順位
+
+バックテストではティックがないため、1本のキャンドルから4つの `TickEvent` を生成する。
+
+```
+陽線(Open < Close): Open → High → Low → Close
+陰線(Open > Close): Open → Low → High → Close
+同値(Open == Close): Open → High → Low → Close
+```
+
+`TickEvent.Timestamp` はキャンドル区間を4分割して割り当てる（決定論保証）。
+
+- `intervalStart = candle.Time - intervalDuration`
+- `t1 = intervalStart + 25%`
+- `t2 = intervalStart + 50%`
+- `t3 = intervalStart + 75%`
+- `t4 = candle.Time`
+
+同一バー内で同一ポジションに対して **SL と TP が両方到達**した場合は次を採用する。
+
+- デフォルトは **`worst-case` 固定**
+- BUY: `StopLoss` を先に約定したものとして扱う
+- SELL: `StopLoss` を先に約定したものとして扱う
+- 理由: 楽観的バイアスを避け、再現性と保守性を優先する
+
+## 3. コアコンポーネント
+
+### 3.1 EventBus
+
+バックテストは決定論が必須のため、処理順序を固定する。
+
+- 同期実行 + FIFOキュー（幅優先）
+- 1イベント内のハンドラー実行順は `priority` 昇順で固定
+- 各ハンドラーが返した連鎖イベントは「返却順」のままキュー末尾へ追加
+- 同一入力データ + 同一設定なら常に同一結果になることを要件化
+
+```go
+type EventBus struct {
+    handlers map[string][]RegisteredHandler // priority で事前ソート
+    queue    []Event
+}
+
+type RegisteredHandler struct {
+    Priority int
+    Handler  EventHandler
+}
+```
+
+### 3.2 IndicatorHandler
+
+`IndicatorHandler` は `infrastructure/indicator/` の純粋関数を呼ぶ薄いラッパーとする。  
+`usecase/IndicatorCalculator`（DB依存）はバックテストでは使用しない。
+
+- intervalごとにキャンドルバッファを保持（既定 500 本）
+- PT15M 受信時に `Primary` 指標を計算
+- 同時に「`close_time <= PT15M時刻` の最新 PT1H」を選び `HigherTF` 指標を計算
+- 生成結果を `IndicatorEvent` として発行
+
+### 3.3 StrategyHandler
+
+`StrategyHandler` は `IndicatorEvent` を受けて `StrategyEngine` を呼ぶ。  
+主入力契約は以下で固定する。
+
+```
+CandleEvent(PT15M)
+  -> IndicatorEvent{Primary, HigherTF, LastPrice, Timestamp}
+  -> StrategyEngine.EvaluateWithHigherTFAt(...)
+```
+
+先読みバイアス防止ルール:
+
+- PT15M 時刻 `T` で参照可能な PT1H は「close 時刻 `<= T` の最新1本のみ」
+- `T` より後に確定する PT1H は絶対に参照しない
+
+### 3.4 RiskHandler
+
+`RiskManager` を再利用しつつ、バックテストでは時刻注入APIを使う。
+
+- `CheckOrderAt(now, proposal)` を使用（クールダウン判定をイベント時刻基準に統一）
+- `RecordConsecutiveLossAt(now)` を使用（`cooldownUntil` を履歴時刻で計算）
+- `CheckStopLoss` / `CheckTakeProfit` / `CheckTrailingStop` は `TickEvent` 駆動
+
+### 3.5 StanceResolver 方針
+
+バックテストではオーバーライド永続化を無効化する。
+
+- `RuleBasedStanceResolver(nil)` を注入（DBアクセスなし）
+- `Source` は常に `rule-based`
+- TTLベースの override はバックテスト対象外
+
+### 3.6 SimExecutor（注文シミュレーター）
+
+```go
+type SimExecutor struct {
+    positions    []SimPosition
+    closedTrades []TradeRecord
+    balance      float64
+    config       SimConfig
+}
+
+type SimConfig struct {
+    InitialBalance      float64 // JPY
+    SpreadPercent       float64 // 例: 0.1%
+    DailyCarryingCost   float64 // 0.04%/日
+    SlippagePercent     float64 // 初期は0
+}
+```
+
+約定ロジック:
+
+- エントリー: シグナル価格 ± スプレッド/2
+- 決済: SL/TPヒット価格またはシグナル決済価格 ± スプレッド/2
+- 建玉管理料: `保有日数 × 0.04%` を決済時に差し引く
+
+## 4. データ管理
+
+### 4.1 キャンドルデータのライフサイクル
+
+```
+初回: 楽天API → SaveCandles() → SQLite → ExportCSV()
+2回目以降: CSV/SQLite キャッシュ利用
+更新時: 最新タイムスタンプ以降だけ API で取得し追記
+```
+
+### 4.2 CSVフォーマット
+
+CLIは `--symbol BTC_JPY` の文字列指定を受けるため、CSVには `symbol` と `symbol_id` を両方保持する。
+
+```csv
+symbol,symbol_id,interval,time,open,high,low,close,volume
+BTC_JPY,7,PT15M,1772984700000,15000000,15050000,14980000,15030000,1.5
+BTC_JPY,7,PT15M,1772985600000,15030000,15100000,15010000,15080000,2.1
+```
+
+- `time`: Unixミリ秒（キャンドル確定時刻）
+- ファイル名: `data/candles_{symbol}_{interval}.csv`
+
+### 4.3 データ取得コマンドとAPIパラメータ
+
+```bash
+go run ./cmd/backtest download --symbol BTC_JPY --interval PT15M --from 2026-01-01
+go run ./cmd/backtest download --symbol BTC_JPY --interval PT15M --update
+```
+
+楽天API呼び出しは既存 `GetCandlestick(symbolID, candlestickType, dateFrom, dateTo)` に合わせ、**`dateFrom/dateTo` を使用**する。`before` は使わない。
+
+差分取得ルール:
+
+- `--from` 指定時: `dateFrom = fromTs`, `dateTo = nowTs`
+- `--update` 時: `dateFrom = lastCSVTs + 1`, `dateTo = nowTs`
+- 1回の応答が上限件数に達した場合は、未取得区間が残っていれば `dateFrom/dateTo` を更新して再取得する
+
+## 5. バックテスト実行
+
+### 5.1 CLI
+
+```bash
+go run ./cmd/backtest run \
+  --data data/candles_BTC_JPY_PT15M.csv \
+  --data-htf data/candles_BTC_JPY_PT1H.csv \
+  --from 2026-01-01 \
+  --to 2026-04-01 \
+  --initial-balance 100000
+
+go run ./cmd/backtest run ... --spread 0.1 --carrying-cost 0.04
+go run ./cmd/backtest run ... --output results/
+```
+
+### 5.2 APIエンドポイントと永続化
+
+```
+POST /api/v1/backtest/run
+GET  /api/v1/backtest/results?limit=20&offset=0&sort=created_at:desc
+GET  /api/v1/backtest/results/:id
+```
+
+`/backtest/results` の保存仕様:
+
+- 保存先: SQLite（`backtest_results`, `backtest_trades`）
+- 結果ID: ULID文字列（時系列ソート可能）
+- 一覧ソート: `created_at DESC` 固定（同時刻は `id DESC`）
+- 保持期間: 180日（設定で変更可能、期限切れはバッチ削除）
+- `GET /results/:id`: サマリー + トレード一覧を返す。未存在は `404`
+
+CLIとAPIは同じ `BacktestRunner` を使用する。
+
+### 5.3 出力と指標定義（固定仕様）
+
+サマリー表示例:
+
+```
+=== Backtest Result ===
+Period:           2026-01-01 ~ 2026-04-01
+Initial Balance:  ¥100,000
+Final Balance:    ¥112,345
+Total Return:     +12.35%
+Total Trades:     48
+Win Rate:         62.5% (30W / 18L)
+Profit Factor:    1.85
+Max Drawdown:     -8.2% (¥91,800)
+Sharpe Ratio:     1.42
+Avg Hold Time:    4h 23m
+Carrying Cost:    ¥1,234
+Spread Cost:      ¥567
+```
+
+評価指標の計算定義:
+
+- `Total Return`: `(final_balance - initial_balance) / initial_balance`
+- `Sharpe Ratio`:
+  - リターン系列: **日次の資産曲線終値**から算出した日次リターン
+  - リスクフリー率: `0.0` 固定
+  - 年率化: `sqrt(365)`（365日基準）
+- `Max Drawdown`:
+  - 基準曲線: **15分足クローズ時点の評価資産（実現+含み）**
+  - `peak-to-trough` の最大下落率
+- `Avg Hold Time`:
+  - `exit_timestamp - entry_timestamp`（秒）
+  - 集計は全クローズドトレードの単純平均
+
+トレードCSV:
+
+```csv
+trade_id,entry_time,exit_time,side,entry_price,exit_price,amount,pnl,pnl_percent,carrying_cost,spread_cost,reason_entry,reason_exit
+1,2026-01-05T10:00:00+09:00,2026-01-05T14:30:00+09:00,BUY,15000000,15120000,0.01,1200,0.80,24,30,trend_follow_ema_cross,take_profit
+```
+
+## 6. パラメータ最適化（Phase 2）
+
+### 6.1 最適化対象
+
+| カテゴリ | パラメータ | デフォルト | 探索例 |
+|---|---|---|---|
+| リスク | StopLossPercent | 5% | 1-10% |
+| リスク | TakeProfitPercent | 10% | 3-20% |
+| シグナル | MinConfidence | 0.3 | 0.1-0.7 |
+| Stance | RSI閾値 | 25/75 | 20-35 / 65-80 |
+| 指標 | EMA短期/長期 | 12/26 | 8-20 / 20-50 |
+
+### 6.2 探索戦略（組み合わせ爆発対策）
+
+- Phase 2a: ランダムサーチ（粗探索）
+- Phase 2b: 上位N件近傍のみグリッド（局所探索）
+- 1ジョブあたりの最大評価件数を設定（例: 10,000）
+- スコアは `Sharpe` と `MaxDD` の複合条件でランキング
+
+### 6.3 CLI
+
+```bash
+go run ./cmd/backtest optimize \
+  --data data/candles_BTC_JPY_PT15M.csv \
+  --data-htf data/candles_BTC_JPY_PT1H.csv \
+  --param "stop_loss_percent=1:10:1" \
+  --param "take_profit_percent=3:20:1" \
+  --param "min_confidence=0.1:0.7:0.1" \
+  --sort-by sharpe_ratio \
+  --top 10 \
+  --workers 8
+```
+
+## 7. ディレクトリ構成
+
+```
+backend/
+├── cmd/
+│   └── backtest/
+│       └── main.go
+├── internal/
+│   ├── domain/
+│   │   └── entity/
+│   │       ├── backtest.go
+│   │       └── backtest_event.go       # イベント型定義
+│   ├── usecase/
+│   │   ├── backtest/
+│   │   │   ├── engine.go
+│   │   │   ├── event_bus.go
+│   │   │   ├── handler.go
+│   │   │   ├── optimizer.go
+│   │   │   └── reporter.go
+│   │   ├── strategy.go                 # At系メソッド追加
+│   │   ├── risk.go                     # At系メソッド追加
+│   │   └── stance.go                   # backtest設定の注入対応
+│   ├── infrastructure/
+│   │   ├── backtest/
+│   │   │   ├── simulator.go
+│   │   │   └── result_repository.go
+│   │   ├── csv/
+│   │   │   └── candle_csv.go
+│   │   ├── indicator/
+│   │   └── database/
+│   └── interfaces/
+│       └── api/handler/backtest.go
+└── data/
+```
+
+## 8. 既存コードへの影響
+
+### 変更が必要なファイル
+
+| ファイル | 変更内容 |
+|---|---|
+| `interfaces/api/router.go` | バックテストAPIルート追加 |
+| `usecase/strategy.go` | `EvaluateWithHigherTFAt` 追加（既存メソッドは互換維持） |
+| `usecase/risk.go` | `CheckOrderAt`, `RecordConsecutiveLossAt` 追加 |
+| `usecase/stance.go` | バックテスト時のoverride無効化設定 |
+| `.gitignore` | `backend/data/` と結果出力を追加 |
+
+### 互換性ポリシー
+
+- 既存の本番エントリポイント（`cmd/main.go`, `cmd/pipeline.go`）は挙動互換を維持
+- 既存メソッドは残し、新メソッドを追加してバックテスト側のみ利用
+- `infrastructure/indicator/*` の計算ロジックは変更しない
+
+## 9. テスト戦略
+
+| テスト対象 | テスト方法 |
+|---|---|
+| EventBus | FIFO・priority・連鎖順序の決定論テスト |
+| IndicatorHandler | PT15M/PT1H同期・先読み防止（未来HTFを参照しない） |
+| StrategyHandler | `IndicatorEvent` 契約どおりに `StrategyEngine` へ入力されること |
+| RiskHandler | クールダウンがイベント時刻基準で再現すること |
+| SimExecutor | 同一バーSL/TP両ヒットで `worst-case` が適用されること |
+| Metrics | Sharpe/MaxDD/AvgHoldTime が定義どおり算出されること |
+| API | `/backtest/results` の保存・一覧順・ID検索 |
+
+## 10. 将来拡張
+
+- `SL/TP priority mode` に `best-case` を追加（比較分析用）
+- ウォークフォワード分析（学習/検証分離）
+- モンテカルロシミュレーション
+- `EventEngine + LiveSource + RealExecutor` による本番置換


### PR DESCRIPTION
## Summary
- implement Phase 1 backtest engine foundation with deterministic EventBus and event handlers
- add time-injected methods to strategy/risk/stance for backtest determinism
- add simulator, reporter, runner, candle CSV IO, and `cmd/backtest` (`run` + `download`)
- add backtest result persistence (SQLite tables + repository) and API endpoints
  - `POST /api/v1/backtest/run`
  - `GET /api/v1/backtest/results`
  - `GET /api/v1/backtest/results/:id`

## Test
- `cd backend && GOCACHE=$(pwd)/.gocache go test ./cmd ./cmd/backtest ./internal/domain/... ./internal/infrastructure/database ./internal/infrastructure/csv ./internal/infrastructure/backtest ./internal/interfaces/api ./internal/interfaces/api/handler ./internal/usecase/...`
- `docker compose up --build -d` (backend healthy / frontend started)

## Notes
- `go test ./...` still fails in this sandbox due to existing `internal/infrastructure/rakuten` tests requiring `httptest` listener socket permissions.
