### PR TITLE
feat: backtest engine phase1 + tick-driven risk handling

### DIFF
--- a/backend/internal/domain/entity/backtest_event.go
+++ b/backend/internal/domain/entity/backtest_event.go
@@ -42,10 +42,13 @@ func (e IndicatorEvent) EventTimestamp() int64 { return e.Timestamp }
 // TickEvent represents synthetic in-bar ticks for SL/TP simulation.
 type TickEvent struct {
 	SymbolID   int64
+	Interval   string
 	Price      float64
 	Timestamp  int64
 	TickType   string
 	ParentTime int64
+	BarLow     float64
+	BarHigh    float64
 }
 
 func (e TickEvent) EventType() string     { return EventTypeTick }

--- a/backend/internal/usecase/backtest/handler.go
+++ b/backend/internal/usecase/backtest/handler.go
@@ -4,12 +4,101 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/infrastructure/indicator"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase"
 )
+
+// TickGeneratorHandler creates deterministic synthetic in-bar ticks from primary candles.
+type TickGeneratorHandler struct {
+	PrimaryInterval string
+}
+
+func (h *TickGeneratorHandler) Handle(_ context.Context, event entity.Event) ([]entity.Event, error) {
+	candleEvent, ok := event.(entity.CandleEvent)
+	if !ok {
+		return nil, nil
+	}
+	if h.PrimaryInterval == "" || candleEvent.Interval != h.PrimaryInterval {
+		return nil, nil
+	}
+
+	durationMs, err := intervalDurationMillis(candleEvent.Interval)
+	if err != nil {
+		return nil, err
+	}
+	intervalStart := candleEvent.Candle.Time - durationMs
+
+	t1 := intervalStart + durationMs/4
+	t2 := intervalStart + durationMs/2
+	t3 := intervalStart + durationMs*3/4
+	t4 := candleEvent.Candle.Time
+
+	openPrice := candleEvent.Candle.Open
+	highPrice := candleEvent.Candle.High
+	lowPrice := candleEvent.Candle.Low
+	closePrice := candleEvent.Candle.Close
+
+	prices := []struct {
+		typ string
+		val float64
+		ts  int64
+	}{
+		{typ: "open", val: openPrice, ts: t1},
+	}
+
+	if closePrice >= openPrice {
+		prices = append(prices,
+			struct {
+				typ string
+				val float64
+				ts  int64
+			}{typ: "high", val: highPrice, ts: t2},
+			struct {
+				typ string
+				val float64
+				ts  int64
+			}{typ: "low", val: lowPrice, ts: t3},
+		)
+	} else {
+		prices = append(prices,
+			struct {
+				typ string
+				val float64
+				ts  int64
+			}{typ: "low", val: lowPrice, ts: t2},
+			struct {
+				typ string
+				val float64
+				ts  int64
+			}{typ: "high", val: highPrice, ts: t3},
+		)
+	}
+	prices = append(prices, struct {
+		typ string
+		val float64
+		ts  int64
+	}{typ: "close", val: closePrice, ts: t4})
+
+	events := make([]entity.Event, 0, len(prices))
+	for _, p := range prices {
+		events = append(events, entity.TickEvent{
+			SymbolID:   candleEvent.SymbolID,
+			Interval:   candleEvent.Interval,
+			Price:      p.val,
+			Timestamp:  p.ts,
+			TickType:   p.typ,
+			ParentTime: candleEvent.Candle.Time,
+			BarLow:     candleEvent.Candle.Low,
+			BarHigh:    candleEvent.Candle.High,
+		})
+	}
+	return events, nil
+}
 
 // IndicatorHandler calculates indicator snapshots from buffered candles.
 // Buffers are maintained oldest-first to keep indicator calculations path-correct.
@@ -153,6 +242,134 @@ func (h *RiskHandler) Handle(ctx context.Context, event entity.Event) ([]entity.
 	}, nil
 }
 
+type SimPosition struct {
+	PositionID     int64
+	SymbolID       int64
+	Side           entity.OrderSide
+	EntryPrice     float64
+	Amount         float64
+	EntryTimestamp int64
+}
+
+// TickRiskExecutor exposes minimum close-related operations for tick-driven risk checks.
+type TickRiskExecutor interface {
+	Positions() []SimPosition
+	SelectSLTPExit(side entity.OrderSide, stopLossPrice, takeProfitPrice, barLow, barHigh float64) (float64, string, bool)
+	Close(positionID int64, signalPrice float64, reason string, timestamp int64) (entity.OrderEvent, *entity.BacktestTradeRecord, error)
+}
+
+// TickRiskHandler evaluates SL/TP/TrailingStop on synthetic ticks.
+type TickRiskHandler struct {
+	PrimaryInterval   string
+	Executor          TickRiskExecutor
+	StopLossPercent   float64
+	TakeProfitPercent float64
+	highWaterMarks    map[int64]float64
+}
+
+func NewTickRiskHandler(primaryInterval string, executor TickRiskExecutor, stopLossPercent, takeProfitPercent float64) *TickRiskHandler {
+	return &TickRiskHandler{
+		PrimaryInterval:   primaryInterval,
+		Executor:          executor,
+		StopLossPercent:   stopLossPercent,
+		TakeProfitPercent: takeProfitPercent,
+		highWaterMarks:    make(map[int64]float64),
+	}
+}
+
+func (h *TickRiskHandler) Handle(_ context.Context, event entity.Event) ([]entity.Event, error) {
+	tickEvent, ok := event.(entity.TickEvent)
+	if !ok {
+		return nil, nil
+	}
+	if h.PrimaryInterval != "" && tickEvent.Interval != h.PrimaryInterval {
+		return nil, nil
+	}
+	if h.Executor == nil {
+		return nil, fmt.Errorf("tick risk executor is nil")
+	}
+
+	positions := h.Executor.Positions()
+	active := make(map[int64]bool, len(positions))
+	emitted := make([]entity.Event, 0)
+
+	for _, pos := range positions {
+		if pos.SymbolID != tickEvent.SymbolID {
+			continue
+		}
+		active[pos.PositionID] = true
+
+		// TP/SL: decide with bar range and worst-case policy.
+		if h.StopLossPercent > 0 && h.TakeProfitPercent > 0 {
+			stopLossPrice, takeProfitPrice := calcSLTP(pos, h.StopLossPercent, h.TakeProfitPercent)
+			exitPrice, reason, hit := h.Executor.SelectSLTPExit(
+				pos.Side,
+				stopLossPrice,
+				takeProfitPrice,
+				tickEvent.BarLow,
+				tickEvent.BarHigh,
+			)
+			if hit {
+				orderEvent, _, err := h.Executor.Close(pos.PositionID, exitPrice, reason, tickEvent.Timestamp)
+				if err != nil {
+					return nil, err
+				}
+				emitted = append(emitted, orderEvent)
+				delete(h.highWaterMarks, pos.PositionID)
+				continue
+			}
+		}
+
+		// Trailing stop: use stop-loss distance for reversal distance.
+		best, ok := h.highWaterMarks[pos.PositionID]
+		if !ok {
+			best = pos.EntryPrice
+		}
+		if pos.Side == entity.OrderSideBuy {
+			if tickEvent.Price > best {
+				best = tickEvent.Price
+			}
+		} else {
+			if tickEvent.Price < best {
+				best = tickEvent.Price
+			}
+		}
+		h.highWaterMarks[pos.PositionID] = best
+
+		distance := pos.EntryPrice * h.StopLossPercent / 100.0
+		if distance <= 0 {
+			continue
+		}
+		if pos.Side == entity.OrderSideBuy {
+			if best > pos.EntryPrice && best-tickEvent.Price >= distance {
+				orderEvent, _, err := h.Executor.Close(pos.PositionID, tickEvent.Price, "trailing_stop", tickEvent.Timestamp)
+				if err != nil {
+					return nil, err
+				}
+				emitted = append(emitted, orderEvent)
+				delete(h.highWaterMarks, pos.PositionID)
+			}
+		} else {
+			if best < pos.EntryPrice && tickEvent.Price-best >= distance {
+				orderEvent, _, err := h.Executor.Close(pos.PositionID, tickEvent.Price, "trailing_stop", tickEvent.Timestamp)
+				if err != nil {
+					return nil, err
+				}
+				emitted = append(emitted, orderEvent)
+				delete(h.highWaterMarks, pos.PositionID)
+			}
+		}
+	}
+
+	for positionID := range h.highWaterMarks {
+		if !active[positionID] {
+			delete(h.highWaterMarks, positionID)
+		}
+	}
+
+	return emitted, nil
+}
+
 // SignalExecutor opens simulated orders from approved signals.
 type SignalExecutor interface {
 	Open(symbolID int64, side entity.OrderSide, signalPrice, amount float64, reason string, timestamp int64) (entity.OrderEvent, error)
@@ -263,4 +480,38 @@ func floatToPtr(v float64) *float64 {
 		return nil
 	}
 	return &v
+}
+
+func intervalDurationMillis(interval string) (int64, error) {
+	if !strings.HasPrefix(interval, "PT") {
+		return 0, fmt.Errorf("unsupported interval: %s", interval)
+	}
+	body := strings.TrimPrefix(interval, "PT")
+	if strings.HasSuffix(body, "M") {
+		n, err := strconv.Atoi(strings.TrimSuffix(body, "M"))
+		if err != nil || n <= 0 {
+			return 0, fmt.Errorf("invalid minute interval: %s", interval)
+		}
+		return int64(n) * int64(time.Minute/time.Millisecond), nil
+	}
+	if strings.HasSuffix(body, "H") {
+		n, err := strconv.Atoi(strings.TrimSuffix(body, "H"))
+		if err != nil || n <= 0 {
+			return 0, fmt.Errorf("invalid hour interval: %s", interval)
+		}
+		return int64(n) * int64(time.Hour/time.Millisecond), nil
+	}
+	return 0, fmt.Errorf("unsupported interval: %s", interval)
+}
+
+func calcSLTP(pos SimPosition, stopLossPercent, takeProfitPercent float64) (stopLossPrice float64, takeProfitPrice float64) {
+	switch pos.Side {
+	case entity.OrderSideSell:
+		stopLossPrice = pos.EntryPrice * (1 + stopLossPercent/100.0)
+		takeProfitPrice = pos.EntryPrice * (1 - takeProfitPercent/100.0)
+	default:
+		stopLossPrice = pos.EntryPrice * (1 - stopLossPercent/100.0)
+		takeProfitPrice = pos.EntryPrice * (1 + takeProfitPercent/100.0)
+	}
+	return stopLossPrice, takeProfitPrice
 }

--- a/backend/internal/usecase/backtest/handler_test.go
+++ b/backend/internal/usecase/backtest/handler_test.go
@@ -98,6 +98,40 @@ func TestStrategyHandler_UsesIndicatorTimestamp(t *testing.T) {
 	}
 }
 
+func TestTickGeneratorHandler_SequenceAndTimestamps(t *testing.T) {
+	handler := &TickGeneratorHandler{PrimaryInterval: "PT15M"}
+	c := entity.CandleEvent{
+		SymbolID:  7,
+		Interval:  "PT15M",
+		Timestamp: 15 * 60 * 1000,
+		Candle: entity.Candle{
+			Open: 100, High: 110, Low: 90, Close: 105, Time: 15 * 60 * 1000,
+		},
+	}
+	events, err := handler.Handle(context.Background(), c)
+	if err != nil {
+		t.Fatalf("handle error: %v", err)
+	}
+	if len(events) != 4 {
+		t.Fatalf("expected 4 ticks, got %d", len(events))
+	}
+
+	t1 := events[0].(entity.TickEvent)
+	t2 := events[1].(entity.TickEvent)
+	t3 := events[2].(entity.TickEvent)
+	t4 := events[3].(entity.TickEvent)
+
+	if t1.TickType != "open" || t2.TickType != "high" || t3.TickType != "low" || t4.TickType != "close" {
+		t.Fatalf("unexpected tick order: %s %s %s %s", t1.TickType, t2.TickType, t3.TickType, t4.TickType)
+	}
+	if t1.Timestamp != 15*60*1000/4 {
+		t.Fatalf("unexpected t1 timestamp: %d", t1.Timestamp)
+	}
+	if t4.Timestamp != c.Candle.Time {
+		t.Fatalf("unexpected t4 timestamp: %d", t4.Timestamp)
+	}
+}
+
 func floatPtr(v float64) *float64 { return &v }
 
 type fakeSignalExecutor struct {
@@ -197,5 +231,103 @@ func TestRiskHandler_EmitsApprovedSignalEvent(t *testing.T) {
 	}
 	if _, ok := events[0].(entity.ApprovedSignalEvent); !ok {
 		t.Fatalf("expected ApprovedSignalEvent, got %T", events[0])
+	}
+}
+
+type fakeTickRiskExecutor struct {
+	positions []SimPosition
+	closedIDs []int64
+}
+
+func (f *fakeTickRiskExecutor) Positions() []SimPosition {
+	out := make([]SimPosition, len(f.positions))
+	copy(out, f.positions)
+	return out
+}
+
+func (f *fakeTickRiskExecutor) SelectSLTPExit(side entity.OrderSide, stopLossPrice, takeProfitPrice, barLow, barHigh float64) (float64, string, bool) {
+	switch side {
+	case entity.OrderSideBuy:
+		slHit := barLow <= stopLossPrice
+		tpHit := barHigh >= takeProfitPrice
+		if slHit && tpHit {
+			return stopLossPrice, "stop_loss", true
+		}
+		if slHit {
+			return stopLossPrice, "stop_loss", true
+		}
+		if tpHit {
+			return takeProfitPrice, "take_profit", true
+		}
+	case entity.OrderSideSell:
+		slHit := barHigh >= stopLossPrice
+		tpHit := barLow <= takeProfitPrice
+		if slHit && tpHit {
+			return stopLossPrice, "stop_loss", true
+		}
+		if slHit {
+			return stopLossPrice, "stop_loss", true
+		}
+		if tpHit {
+			return takeProfitPrice, "take_profit", true
+		}
+	}
+	return 0, "", false
+}
+
+func (f *fakeTickRiskExecutor) Close(positionID int64, signalPrice float64, reason string, timestamp int64) (entity.OrderEvent, *entity.BacktestTradeRecord, error) {
+	f.closedIDs = append(f.closedIDs, positionID)
+	filtered := make([]SimPosition, 0, len(f.positions))
+	for _, p := range f.positions {
+		if p.PositionID != positionID {
+			filtered = append(filtered, p)
+		}
+	}
+	f.positions = filtered
+	return entity.OrderEvent{
+		OrderID:   1,
+		SymbolID:  7,
+		Side:      "BUY",
+		Action:    "close",
+		Price:     signalPrice,
+		Amount:    0.01,
+		Reason:    reason,
+		Timestamp: timestamp,
+	}, nil, nil
+}
+
+func TestTickRiskHandler_WorstCaseStopLossOnBothHit(t *testing.T) {
+	exec := &fakeTickRiskExecutor{
+		positions: []SimPosition{
+			{
+				PositionID: 1,
+				SymbolID:   7,
+				Side:       entity.OrderSideBuy,
+				EntryPrice: 100,
+				Amount:     0.01,
+			},
+		},
+	}
+	handler := NewTickRiskHandler("PT15M", exec, 5, 5)
+
+	events, err := handler.Handle(context.Background(), entity.TickEvent{
+		SymbolID:   7,
+		Interval:   "PT15M",
+		Price:      100,
+		Timestamp:  1000,
+		TickType:   "high",
+		ParentTime: 2000,
+		BarLow:     94,  // stop-loss hit
+		BarHigh:    106, // take-profit hit
+	})
+	if err != nil {
+		t.Fatalf("handle error: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected 1 order event, got %d", len(events))
+	}
+	order := events[0].(entity.OrderEvent)
+	if order.Reason != "stop_loss" {
+		t.Fatalf("expected stop_loss by worst-case, got %s", order.Reason)
 	}
 }

--- a/backend/internal/usecase/backtest/runner.go
+++ b/backend/internal/usecase/backtest/runner.go
@@ -68,7 +68,15 @@ func (r *BacktestRunner) Run(ctx context.Context, input RunInput) (*entity.Backt
 		DailyCarryingCost: input.Config.DailyCarryCost,
 		SlippagePercent:   input.Config.SlippagePercent,
 	})
+	simAdapter := &simExecutorAdapter{sim: sim}
 
+	tickGenerator := &TickGeneratorHandler{PrimaryInterval: input.Config.PrimaryInterval}
+	tickRiskHandler := NewTickRiskHandler(
+		input.Config.PrimaryInterval,
+		simAdapter,
+		riskCfg.StopLossPercent,
+		riskCfg.TakeProfitPercent,
+	)
 	indicatorHandler := NewIndicatorHandler(input.Config.PrimaryInterval, input.Config.HigherTFInterval, 500)
 	strategyHandler := &StrategyHandler{Engine: strategyEngine}
 	riskHandler := &RiskHandler{
@@ -76,12 +84,14 @@ func (r *BacktestRunner) Run(ctx context.Context, input RunInput) (*entity.Backt
 		TradeAmount: input.TradeAmount,
 	}
 	executionHandler := &ExecutionHandler{
-		Executor:    sim,
+		Executor:    simAdapter,
 		TradeAmount: input.TradeAmount,
 	}
 
 	bus := NewEventBus()
+	bus.Register(entity.EventTypeCandle, 5, tickGenerator)
 	bus.Register(entity.EventTypeCandle, 10, indicatorHandler)
+	bus.Register(entity.EventTypeTick, 15, tickRiskHandler)
 	bus.Register(entity.EventTypeIndicator, 20, strategyHandler)
 	bus.Register(entity.EventTypeSignal, 30, riskHandler)
 	bus.Register(entity.EventTypeApproved, 40, executionHandler)
@@ -169,4 +179,36 @@ func mergeCandleEvents(primary, higher []entity.Candle, primaryInterval, higherI
 	}
 
 	return events
+}
+
+type simExecutorAdapter struct {
+	sim *infra.SimExecutor
+}
+
+func (a *simExecutorAdapter) Open(symbolID int64, side entity.OrderSide, signalPrice, amount float64, reason string, timestamp int64) (entity.OrderEvent, error) {
+	return a.sim.Open(symbolID, side, signalPrice, amount, reason, timestamp)
+}
+
+func (a *simExecutorAdapter) Positions() []SimPosition {
+	raw := a.sim.Positions()
+	out := make([]SimPosition, 0, len(raw))
+	for _, p := range raw {
+		out = append(out, SimPosition{
+			PositionID:     p.PositionID,
+			SymbolID:       p.SymbolID,
+			Side:           p.Side,
+			EntryPrice:     p.EntryPrice,
+			Amount:         p.Amount,
+			EntryTimestamp: p.EntryTimestamp,
+		})
+	}
+	return out
+}
+
+func (a *simExecutorAdapter) SelectSLTPExit(side entity.OrderSide, stopLossPrice, takeProfitPrice, barLow, barHigh float64) (float64, string, bool) {
+	return a.sim.SelectSLTPExit(side, stopLossPrice, takeProfitPrice, barLow, barHigh)
+}
+
+func (a *simExecutorAdapter) Close(positionID int64, signalPrice float64, reason string, timestamp int64) (entity.OrderEvent, *entity.BacktestTradeRecord, error) {
+	return a.sim.Close(positionID, signalPrice, reason, timestamp)
 }


### PR DESCRIPTION
## Summary
- add `TickGeneratorHandler` to generate deterministic synthetic tick events from each primary candle
- add `TickRiskHandler` to evaluate in-bar SL/TP and trailing-stop on `TickEvent`
- enforce same-bar SL/TP conflict resolution with `worst-case` policy (stop-loss prioritized)
- wire tick handlers into runner event flow (`Candle -> Tick -> Risk -> Execution`)
- add tests for tick sequence/timestamps and worst-case stop-loss behavior

## Test
- `cd backend && GOCACHE=$(pwd)/.gocache go test ./internal/usecase/backtest ./internal/infrastructure/backtest ./internal/infrastructure/csv`
- `cd backend && GOCACHE=$(pwd)/.gocache go test ./cmd/backtest ./internal/interfaces/api/handler ./internal/interfaces/api ./internal/usecase/... ./internal/infrastructure/backtest ./internal/infrastructure/database`
