### PR TITLE
docs: バックテスト設計書の進捗を更新

### DIFF
--- a/docs/design/2026-04-14-backtest-engine-design.md
+++ b/docs/design/2026-04-14-backtest-engine-design.md
@@ -2,7 +2,7 @@
 
 - **作成日**: 2026-04-14
 - **更新日**: 2026-04-15
-- **ステータス**: Draft
+- **ステータス**: In Progress（Phase 1 実装済み + 仕上げ中）
 
 ## 概要
 
@@ -21,6 +21,47 @@
 | **Phase 1（初期）** | バックテスト実行 + サマリー + 全トレードCSV出力 + 結果永続化API |
 | **Phase 2（次期）** | パラメータ最適化（段階探索） |
 | **将来** | フロントエンド可視化、本番パイプラインのイベントドリブン置換 |
+
+## 0. 実装進捗（2026-04-15 時点）
+
+### 0.1 全体進捗
+
+| 区分 | 進捗 | 補足 |
+|---|---|---|
+| Phase 1 コア機能 | ✅ ほぼ完了 | EventEngine / SimExecutor / CLI run / API保存取得まで実装済み |
+| Phase 1 仕上げ | 🔄 進行中 | API入力契約の最終固定・統合テスト強化が残り |
+| Phase 2a 粗探索 | ✅ 実装済み | `cmd/backtest optimize` + `--workers` 並列評価あり |
+| Phase 2b 局所探索 | ⏳ 未実装 | 上位N近傍グリッド再探索は未着手 |
+
+### 0.2 実装済み
+
+- EventBus（FIFO + priority + 連鎖順）とハンドラー群（Indicator/Strategy/Risk/Execution/TickRisk）
+- `TickEvent` 擬似生成（Open→High/Low→Close）と同一バー SL/TP 両ヒット時の `worst-case`
+- `StrategyEngine`/`RiskManager`/`StanceResolver` の At系メソッド（時刻注入）
+- SimExecutor（spread/slippage/carrying cost、反対シグナル時クローズ、評価資産計算）
+- Metrics（TotalReturn, WinRate, ProfitFactor, AvgHoldTime）
+  - Sharpe: 日次終値（JST）ベース
+  - MaxDD: 15分足クローズ時の評価資産カーブ
+- CLI
+  - `backtest run`
+  - `backtest download`（`--from` / `--update`）
+  - `backtest optimize`（パラメータ探索、`--workers` 並列）
+- API
+  - `POST /api/v1/backtest/run`
+  - `GET /api/v1/backtest/results`
+  - `GET /api/v1/backtest/results/:id`
+- SQLite 永続化
+  - `backtest_results`, `backtest_trades`
+  - 結果ID: ULID
+- Retention
+  - `BACKTEST_RETENTION_DAYS`（既定 180）
+  - 起動時 + 24時間ごとの期限切れ削除
+
+### 0.3 未完了（次アクション）
+
+- `POST /backtest/run` の入力仕様を最終固定（CSVパス方式を維持するか再定義するか）
+- API統合テストの強化（`run -> list -> get` 一連のE2E）
+- Phase 2b: 上位N近傍グリッド探索の追加
 
 ## 設計方針
 


### PR DESCRIPTION
## Summary
- docs/design/2026-04-14-backtest-engine-design.md のステータスを Draft から In Progress に更新
- 2026-04-15 時点の実装進捗セクションを追加
- 実装済み項目と未完了タスク（次アクション）を明記

## Scope
- ドキュメント更新のみ
