### PR TITLE
feat: expose risk config params in backtest API/CLI

### DIFF
--- a/backend/cmd/backtest/main.go
+++ b/backend/cmd/backtest/main.go
@@ -68,6 +68,8 @@ func runCommand(args []string) error {
 		carryingCost   = fs.Float64("carrying-cost", 0.04, "daily carrying cost percent")
 		slippage       = fs.Float64("slippage", 0, "slippage percent")
 		tradeAmount    = fs.Float64("trade-amount", 0.01, "trade amount")
+		stopLoss       = fs.Float64("stop-loss", 5, "stop loss percent")
+		takeProfit     = fs.Float64("take-profit", 10, "take profit percent")
 		outputDir      = fs.String("output", "", "output directory for trades/result")
 	)
 	if err := fs.Parse(args); err != nil {
@@ -87,6 +89,8 @@ func runCommand(args []string) error {
 		*carryingCost,
 		*slippage,
 		*tradeAmount,
+		*stopLoss,
+		*takeProfit,
 	)
 	if err != nil {
 		return err
@@ -132,6 +136,8 @@ func optimizeCommand(args []string) error {
 		carryingCost   = fs.Float64("carrying-cost", 0.04, "daily carrying cost percent")
 		slippage       = fs.Float64("slippage", 0, "slippage percent")
 		tradeAmount    = fs.Float64("trade-amount", 0.01, "trade amount")
+		stopLoss       = fs.Float64("stop-loss", 5, "stop loss percent")
+		takeProfit     = fs.Float64("take-profit", 10, "take profit percent")
 		sortBy         = fs.String("sort-by", "sharpe_ratio", "ranking metric (sharpe_ratio only)")
 		top            = fs.Int("top", 10, "top N results to print")
 		maxEvals       = fs.Int("max-evals", 10000, "max evaluated combinations")
@@ -164,6 +170,8 @@ func optimizeCommand(args []string) error {
 		*carryingCost,
 		*slippage,
 		*tradeAmount,
+		*stopLoss,
+		*takeProfit,
 	)
 	if err != nil {
 		return err
@@ -363,6 +371,7 @@ func mergeCandles(existing, incoming []entity.Candle) []entity.Candle {
 func buildRunInput(
 	dataPath, dataHTFPath, fromDate, toDate string,
 	initialBalance, spread, carryingCost, slippage, tradeAmount float64,
+	stopLossPercent, takeProfitPercent float64,
 ) (bt.RunInput, error) {
 	primary, err := csvinfra.LoadCandles(dataPath)
 	if err != nil {
@@ -416,8 +425,8 @@ func buildRunInput(
 		RiskConfig: entity.RiskConfig{
 			MaxPositionAmount:    1_000_000_000,
 			MaxDailyLoss:         1_000_000_000,
-			StopLossPercent:      5,
-			TakeProfitPercent:    10,
+			StopLossPercent:      stopLossPercent,
+			TakeProfitPercent:    takeProfitPercent,
 			InitialCapital:       initialBalance,
 			MaxConsecutiveLosses: 0,
 			CooldownMinutes:      0,

--- a/backend/internal/interfaces/api/handler/backtest.go
+++ b/backend/internal/interfaces/api/handler/backtest.go
@@ -26,15 +26,21 @@ func NewBacktestHandler(runner *bt.BacktestRunner, repo repository.BacktestResul
 }
 
 type runBacktestRequest struct {
-	DataPath       string  `json:"data" binding:"required"`
-	DataHTFPath    string  `json:"dataHtf"`
-	From           string  `json:"from"`
-	To             string  `json:"to"`
-	InitialBalance float64 `json:"initialBalance"`
-	Spread         float64 `json:"spread"`
-	CarryingCost   float64 `json:"carryingCost"`
-	Slippage       float64 `json:"slippage"`
-	TradeAmount    float64 `json:"tradeAmount"`
+	DataPath             string  `json:"data" binding:"required"`
+	DataHTFPath          string  `json:"dataHtf"`
+	From                 string  `json:"from"`
+	To                   string  `json:"to"`
+	InitialBalance       float64 `json:"initialBalance"`
+	Spread               float64 `json:"spread"`
+	CarryingCost         float64 `json:"carryingCost"`
+	Slippage             float64 `json:"slippage"`
+	TradeAmount          float64 `json:"tradeAmount"`
+	StopLossPercent      float64 `json:"stopLossPercent"`
+	TakeProfitPercent    float64 `json:"takeProfitPercent"`
+	MaxPositionAmount    float64 `json:"maxPositionAmount"`
+	MaxDailyLoss         float64 `json:"maxDailyLoss"`
+	MaxConsecutiveLosses int     `json:"maxConsecutiveLosses"`
+	CooldownMinutes      int     `json:"cooldownMinutes"`
 }
 
 func (h *BacktestHandler) Run(c *gin.Context) {
@@ -59,6 +65,18 @@ func (h *BacktestHandler) Run(c *gin.Context) {
 	}
 	if req.TradeAmount <= 0 {
 		req.TradeAmount = 0.01
+	}
+	if req.StopLossPercent <= 0 {
+		req.StopLossPercent = 5
+	}
+	if req.TakeProfitPercent <= 0 {
+		req.TakeProfitPercent = 10
+	}
+	if req.MaxPositionAmount <= 0 {
+		req.MaxPositionAmount = 1_000_000_000
+	}
+	if req.MaxDailyLoss <= 0 {
+		req.MaxDailyLoss = 1_000_000_000
 	}
 
 	primary, err := csvinfra.LoadCandles(req.DataPath)
@@ -116,13 +134,13 @@ func (h *BacktestHandler) Run(c *gin.Context) {
 		PrimaryCandles: primary.Candles,
 		HigherCandles:  higherCandles,
 		RiskConfig: entity.RiskConfig{
-			MaxPositionAmount:    1_000_000_000,
-			MaxDailyLoss:         1_000_000_000,
-			StopLossPercent:      5,
-			TakeProfitPercent:    10,
+			MaxPositionAmount:    req.MaxPositionAmount,
+			MaxDailyLoss:         req.MaxDailyLoss,
+			StopLossPercent:      req.StopLossPercent,
+			TakeProfitPercent:    req.TakeProfitPercent,
 			InitialCapital:       req.InitialBalance,
-			MaxConsecutiveLosses: 0,
-			CooldownMinutes:      0,
+			MaxConsecutiveLosses: req.MaxConsecutiveLosses,
+			CooldownMinutes:      req.CooldownMinutes,
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
## Summary
- `POST /backtest/run` のリクエストボディでリスク設定パラメータ（SL/TP/最大ポジション/日次損失上限/連敗上限/クールダウン）を指定可能に
- CLI `run`/`optimize` コマンドに `--stop-loss`/`--take-profit` フラグを追加
- 既存の呼び出し元は後方互換: 未指定時は従来と同じデフォルト値を使用

## Test plan
- [x] `go build ./...` パス
- [x] 既存ハンドラーテスト全パス
- [ ] 手動: API にリスクパラメータを渡して結果が変わることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)