### PR TITLE
feat: add Phase 2b local neighborhood refinement

### DIFF
--- a/backend/cmd/backtest/main.go
+++ b/backend/cmd/backtest/main.go
@@ -38,6 +38,11 @@ func main() {
 			fmt.Fprintf(os.Stderr, "backtest optimize failed: %v\n", err)
 			os.Exit(1)
 		}
+	case "refine":
+		if err := refineCommand(os.Args[2:]); err != nil {
+			fmt.Fprintf(os.Stderr, "backtest refine failed: %v\n", err)
+			os.Exit(1)
+		}
 	case "download":
 		if err := downloadCommand(os.Args[2:]); err != nil {
 			fmt.Fprintf(os.Stderr, "backtest download failed: %v\n", err)
@@ -53,6 +58,7 @@ func usage() {
 	fmt.Println("Usage:")
 	fmt.Println("  go run ./cmd/backtest run --data <primary.csv> [--data-htf <htf.csv>] [flags]")
 	fmt.Println("  go run ./cmd/backtest optimize --data <primary.csv> --param \"stop_loss_percent=1:10:1\" [flags]")
+	fmt.Println("  go run ./cmd/backtest refine --data <primary.csv> --param \"stop_loss_percent=1:10:1\" [--top 5] [--step-div 4] [flags]")
 	fmt.Println("  go run ./cmd/backtest download ...")
 }
 
@@ -209,6 +215,125 @@ func optimizeCommand(args []string) error {
 			r.Params,
 		)
 	}
+	return nil
+}
+
+func refineCommand(args []string) error {
+	fs := flag.NewFlagSet("refine", flag.ContinueOnError)
+	var (
+		dataPath       = fs.String("data", "", "primary timeframe CSV path")
+		dataHTFPath    = fs.String("data-htf", "", "higher timeframe CSV path")
+		fromDate       = fs.String("from", "", "start date (YYYY-MM-DD)")
+		toDate         = fs.String("to", "", "end date (YYYY-MM-DD)")
+		initialBalance = fs.Float64("initial-balance", 100000, "initial balance in JPY")
+		spread         = fs.Float64("spread", 0.1, "spread percent")
+		carryingCost   = fs.Float64("carrying-cost", 0.04, "daily carrying cost percent")
+		slippage       = fs.Float64("slippage", 0, "slippage percent")
+		tradeAmount    = fs.Float64("trade-amount", 0.01, "trade amount")
+		stopLoss       = fs.Float64("stop-loss", 5, "stop loss percent")
+		takeProfit     = fs.Float64("take-profit", 10, "take profit percent")
+		coarseTop      = fs.Int("top", 10, "top N results from coarse search")
+		coarseMaxEvals = fs.Int("max-evals", 10000, "max evaluated combinations for coarse search")
+		coarseWorkers  = fs.Int("workers", 8, "number of parallel workers")
+		coarseSeed     = fs.Int64("seed", 0, "random seed for sampling")
+		refineTopN     = fs.Int("refine-top", 5, "top N coarse results to refine around")
+		refineStepDiv  = fs.Float64("step-div", 4, "divide original step by this for finer grid")
+		refineMaxEvals = fs.Int("refine-max-evals", 5000, "max evaluations for refinement phase")
+	)
+	var params paramFlags
+	fs.Var(&params, "param", `parameter range: "name=min:max:step"`)
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *dataPath == "" {
+		return fmt.Errorf("--data is required")
+	}
+	if len(params) == 0 {
+		return fmt.Errorf("at least one --param is required")
+	}
+
+	baseInput, err := buildRunInput(
+		*dataPath,
+		*dataHTFPath,
+		*fromDate,
+		*toDate,
+		*initialBalance,
+		*spread,
+		*carryingCost,
+		*slippage,
+		*tradeAmount,
+		*stopLoss,
+		*takeProfit,
+	)
+	if err != nil {
+		return err
+	}
+
+	ranges := make([]bt.ParamRange, 0, len(params))
+	for _, spec := range params {
+		r, err := parseParamRange(spec)
+		if err != nil {
+			return err
+		}
+		ranges = append(ranges, r)
+	}
+
+	optimizer := bt.NewOptimizer(bt.NewBacktestRunner())
+
+	fmt.Println("=== Phase 2a: Coarse Search ===")
+	coarseResults, err := optimizer.Optimize(context.Background(), baseInput, ranges, bt.OptimizeConfig{
+		MaxEvals: *coarseMaxEvals,
+		TopN:     *coarseTop,
+		Seed:     *coarseSeed,
+		Workers:  *coarseWorkers,
+	})
+	if err != nil {
+		return fmt.Errorf("coarse search: %w", err)
+	}
+
+	fmt.Printf("coarse search: top %d results\n", len(coarseResults))
+	for i, r := range coarseResults {
+		fmt.Printf(
+			"  %d) sharpe=%.4f maxDD=%.2f%% return=%+.2f%% trades=%d params=%v\n",
+			i+1,
+			r.Summary.SharpeRatio,
+			r.Summary.MaxDrawdown*100,
+			r.Summary.TotalReturn*100,
+			r.Summary.TotalTrades,
+			r.Params,
+		)
+	}
+
+	fmt.Println("\n=== Phase 2b: Refinement (Local Neighborhood Search) ===")
+	refinedResults, err := optimizer.Refine(context.Background(), baseInput, coarseResults, ranges, bt.RefineConfig{
+		TopN:     *refineTopN,
+		StepDiv:  *refineStepDiv,
+		MaxEvals: *refineMaxEvals,
+		Workers:  *coarseWorkers,
+	})
+	if err != nil {
+		return fmt.Errorf("refinement: %w", err)
+	}
+
+	topPrint := len(refinedResults)
+	if topPrint > *coarseTop {
+		topPrint = *coarseTop
+	}
+	fmt.Printf("refined: top %d results\n", topPrint)
+	for i := 0; i < topPrint; i++ {
+		r := refinedResults[i]
+		fmt.Printf(
+			"  %d) sharpe=%.4f maxDD=%.2f%% return=%+.2f%% trades=%d params=%v\n",
+			i+1,
+			r.Summary.SharpeRatio,
+			r.Summary.MaxDrawdown*100,
+			r.Summary.TotalReturn*100,
+			r.Summary.TotalTrades,
+			r.Params,
+		)
+	}
+
 	return nil
 }
 

--- a/backend/internal/usecase/backtest/optimizer.go
+++ b/backend/internal/usecase/backtest/optimizer.go
@@ -203,3 +203,144 @@ func cloneParams(src map[string]float64) map[string]float64 {
 func round(v float64) float64 {
 	return math.Round(v*1e9) / 1e9
 }
+
+// --- Phase 2b: Local Neighborhood Refinement ---
+
+type RefineConfig struct {
+	TopN     int     // how many top coarse results to refine around
+	StepDiv  float64 // divide original step by this for finer grid
+	MaxEvals int     // max evaluations for refinement phase
+	Workers  int
+}
+
+func (o *Optimizer) Refine(ctx context.Context, base RunInput, coarseResults []OptimizationResult, originalRanges []ParamRange, cfg RefineConfig) ([]OptimizationResult, error) {
+	if len(coarseResults) == 0 {
+		return nil, fmt.Errorf("coarse results are required for refinement")
+	}
+	if len(originalRanges) == 0 {
+		return nil, fmt.Errorf("original ranges are required for refinement")
+	}
+	if cfg.TopN <= 0 {
+		cfg.TopN = 5
+	}
+	if cfg.StepDiv <= 0 {
+		cfg.StepDiv = 4.0
+	}
+	if cfg.MaxEvals <= 0 {
+		cfg.MaxEvals = 5000
+	}
+	if cfg.Workers <= 0 {
+		cfg.Workers = runtime.GOMAXPROCS(0)
+	}
+
+	topN := cfg.TopN
+	if topN > len(coarseResults) {
+		topN = len(coarseResults)
+	}
+
+	var allCombos []map[string]float64
+	for i := 0; i < topN; i++ {
+		neighborRanges := buildNeighborhoodRanges(coarseResults[i].Params, originalRanges, cfg.StepDiv)
+		grid, err := buildGrid(neighborRanges)
+		if err != nil {
+			return nil, fmt.Errorf("build neighborhood grid for result %d: %w", i, err)
+		}
+		allCombos = append(allCombos, grid...)
+	}
+
+	allCombos = deduplicateCombos(allCombos)
+	if len(allCombos) == 0 {
+		return nil, fmt.Errorf("no refinement candidates generated")
+	}
+
+	selected := allCombos
+	if len(selected) > cfg.MaxEvals {
+		selected = sampleCombos(allCombos, cfg.MaxEvals, time.Now().UnixNano())
+	}
+
+	results := make([]OptimizationResult, len(selected))
+	sem := make(chan struct{}, cfg.Workers)
+	g, gctx := errgroup.WithContext(ctx)
+
+	for i, combo := range selected {
+		i := i
+		combo := cloneParams(combo)
+		sem <- struct{}{}
+		g.Go(func() error {
+			defer func() { <-sem }()
+			candidate := applyParams(base, combo)
+			result, err := o.runner.Run(gctx, candidate)
+			if err != nil {
+				return err
+			}
+			results[i] = OptimizationResult{
+				Params:  combo,
+				Summary: result.Summary,
+			}
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+
+	sort.Slice(results, func(i, j int) bool {
+		if results[i].Summary.SharpeRatio == results[j].Summary.SharpeRatio {
+			return results[i].Summary.MaxDrawdown < results[j].Summary.MaxDrawdown
+		}
+		return results[i].Summary.SharpeRatio > results[j].Summary.SharpeRatio
+	})
+
+	if cfg.TopN > 0 && len(results) > cfg.TopN {
+		results = results[:cfg.TopN]
+	}
+	return results, nil
+}
+
+func buildNeighborhoodRanges(center map[string]float64, originalRanges []ParamRange, stepDiv float64) []ParamRange {
+	out := make([]ParamRange, 0, len(originalRanges))
+	for _, orig := range originalRanges {
+		cv, ok := center[orig.Name]
+		if !ok {
+			out = append(out, orig)
+			continue
+		}
+		fineStep := orig.Step / stepDiv
+		lo := math.Max(orig.Min, cv-orig.Step)
+		hi := math.Min(orig.Max, cv+orig.Step)
+		out = append(out, ParamRange{
+			Name: orig.Name,
+			Min:  round(lo),
+			Max:  round(hi),
+			Step: round(fineStep),
+		})
+	}
+	return out
+}
+
+func deduplicateCombos(combos []map[string]float64) []map[string]float64 {
+	seen := make(map[string]struct{}, len(combos))
+	out := make([]map[string]float64, 0, len(combos))
+	for _, combo := range combos {
+		key := comboKey(combo)
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, combo)
+	}
+	return out
+}
+
+func comboKey(params map[string]float64) string {
+	keys := make([]string, 0, len(params))
+	for k := range params {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var b []byte
+	for _, k := range keys {
+		b = append(b, []byte(fmt.Sprintf("%s=%.9f;", k, params[k]))...)
+	}
+	return string(b)
+}

--- a/backend/internal/usecase/backtest/optimizer_test.go
+++ b/backend/internal/usecase/backtest/optimizer_test.go
@@ -78,3 +78,149 @@ func TestOptimizer_Optimize(t *testing.T) {
 		t.Fatalf("expected at most top 3 results, got %d", len(results))
 	}
 }
+
+func TestOptimizer_Refine(t *testing.T) {
+	primary := make([]entity.Candle, 0, 80)
+	baseTime := int64(1_770_000_000_000)
+	price := 100.0
+	for i := 0; i < 80; i++ {
+		price += math.Sin(float64(i)/5.0) * 1.2
+		ts := baseTime + int64(i)*15*60*1000
+		primary = append(primary, entity.Candle{
+			Open:  price - 0.7,
+			High:  price + 1.1,
+			Low:   price - 1.1,
+			Close: price,
+			Time:  ts,
+		})
+	}
+
+	baseInput := RunInput{
+		Config: entity.BacktestConfig{
+			Symbol:          "BTC_JPY",
+			SymbolID:        7,
+			PrimaryInterval: "PT15M",
+			FromTimestamp:   primary[0].Time,
+			ToTimestamp:     primary[len(primary)-1].Time,
+			InitialBalance:  100000,
+			SpreadPercent:   0.1,
+			DailyCarryCost:  0.04,
+		},
+		RiskConfig: entity.RiskConfig{
+			MaxPositionAmount:    1_000_000_000,
+			MaxDailyLoss:         1_000_000_000,
+			StopLossPercent:      5,
+			TakeProfitPercent:    10,
+			InitialCapital:       100000,
+			MaxConsecutiveLosses: 0,
+			CooldownMinutes:      0,
+		},
+		TradeAmount:    0.01,
+		PrimaryCandles: primary,
+	}
+
+	ranges := []ParamRange{
+		{Name: "stop_loss_percent", Min: 3, Max: 7, Step: 2},
+		{Name: "take_profit_percent", Min: 6, Max: 12, Step: 3},
+	}
+
+	optimizer := NewOptimizer(NewBacktestRunner())
+
+	// Phase 2a: coarse search
+	coarseResults, err := optimizer.Optimize(context.Background(), baseInput, ranges, OptimizeConfig{
+		MaxEvals: 20,
+		TopN:     5,
+		Seed:     42,
+	})
+	if err != nil {
+		t.Fatalf("coarse optimize error: %v", err)
+	}
+	if len(coarseResults) == 0 {
+		t.Fatal("expected non-empty coarse results")
+	}
+
+	// Phase 2b: refinement
+	refinedResults, err := optimizer.Refine(context.Background(), baseInput, coarseResults, ranges, RefineConfig{
+		TopN:     3,
+		StepDiv:  4.0,
+		MaxEvals: 50,
+		Workers:  2,
+	})
+	if err != nil {
+		t.Fatalf("refine error: %v", err)
+	}
+	if len(refinedResults) == 0 {
+		t.Fatal("expected non-empty refined results")
+	}
+
+	// Verify sorted by Sharpe desc
+	for i := 1; i < len(refinedResults); i++ {
+		if refinedResults[i].Summary.SharpeRatio > refinedResults[i-1].Summary.SharpeRatio {
+			t.Fatalf("results not sorted by Sharpe desc at index %d", i)
+		}
+	}
+}
+
+func TestBuildNeighborhoodRanges(t *testing.T) {
+	center := map[string]float64{
+		"stop_loss_percent":   5.0,
+		"take_profit_percent": 10.0,
+	}
+	origRanges := []ParamRange{
+		{Name: "stop_loss_percent", Min: 1, Max: 10, Step: 2},
+		{Name: "take_profit_percent", Min: 3, Max: 20, Step: 3},
+	}
+
+	result := buildNeighborhoodRanges(center, origRanges, 4.0)
+
+	if len(result) != 2 {
+		t.Fatalf("expected 2 ranges, got %d", len(result))
+	}
+
+	// stop_loss: center=5, step=2, so neighborhood [3, 7], fineStep=0.5
+	sl := result[0]
+	if sl.Min != 3 || sl.Max != 7 {
+		t.Fatalf("stop_loss range: expected [3, 7], got [%v, %v]", sl.Min, sl.Max)
+	}
+	if sl.Step != 0.5 {
+		t.Fatalf("stop_loss step: expected 0.5, got %v", sl.Step)
+	}
+
+	// take_profit: center=10, step=3, so neighborhood [7, 13], fineStep=0.75
+	tp := result[1]
+	if tp.Min != 7 || tp.Max != 13 {
+		t.Fatalf("take_profit range: expected [7, 13], got [%v, %v]", tp.Min, tp.Max)
+	}
+	if tp.Step != 0.75 {
+		t.Fatalf("take_profit step: expected 0.75, got %v", tp.Step)
+	}
+}
+
+func TestBuildNeighborhoodRanges_Clamping(t *testing.T) {
+	center := map[string]float64{"stop_loss_percent": 1.5}
+	origRanges := []ParamRange{
+		{Name: "stop_loss_percent", Min: 1, Max: 10, Step: 2},
+	}
+
+	result := buildNeighborhoodRanges(center, origRanges, 4.0)
+	sl := result[0]
+	// center=1.5, step=2 -> neighborhood max(1, 1.5-2)=1, min(10, 1.5+2)=3.5
+	if sl.Min != 1 {
+		t.Fatalf("clamped min: expected 1, got %v", sl.Min)
+	}
+	if sl.Max != 3.5 {
+		t.Fatalf("clamped max: expected 3.5, got %v", sl.Max)
+	}
+}
+
+func TestDeduplicateCombos(t *testing.T) {
+	combos := []map[string]float64{
+		{"a": 1.0, "b": 2.0},
+		{"a": 1.0, "b": 2.0},
+		{"a": 1.0, "b": 3.0},
+	}
+	result := deduplicateCombos(combos)
+	if len(result) != 2 {
+		t.Fatalf("expected 2 unique combos, got %d", len(result))
+	}
+}


### PR DESCRIPTION
## Summary
- `Optimizer.Refine()` メソッド追加: 粗探索上位N件のパラメータ近傍を細粒度グリッドで再探索
- `buildNeighborhoodRanges()`: 元のstepをstepDivで割った細かいステップで±1ステップ範囲を生成（元の[min,max]でクランプ）
- `deduplicateCombos()`: 複数近傍から生成された重複パラメータ組み合わせを除去
- CLI `refine` サブコマンド: 粗探索→局所探索を一括実行
- テスト4件追加（Refine統合テスト、近傍レンジ生成、クランプ、重複除去）

## Test plan
- [x] `go build ./...` パス
- [x] `go test ./internal/usecase/backtest/` 全19テストパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)