### PR TITLE
refactor: extract EventEngine to shared eventengine package

### DIFF
--- a/backend/internal/usecase/backtest/handler.go
+++ b/backend/internal/usecase/backtest/handler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/infrastructure/indicator"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/eventengine"
 )
 
 // TickGeneratorHandler creates deterministic synthetic in-bar ticks from primary candles.
@@ -242,18 +243,9 @@ func (h *RiskHandler) Handle(ctx context.Context, event entity.Event) ([]entity.
 	}, nil
 }
 
-type SimPosition struct {
-	PositionID     int64
-	SymbolID       int64
-	Side           entity.OrderSide
-	EntryPrice     float64
-	Amount         float64
-	EntryTimestamp int64
-}
-
 // TickRiskExecutor exposes minimum close-related operations for tick-driven risk checks.
 type TickRiskExecutor interface {
-	Positions() []SimPosition
+	Positions() []eventengine.Position
 	SelectSLTPExit(side entity.OrderSide, stopLossPrice, takeProfitPrice, barLow, barHigh float64) (float64, string, bool)
 	Close(positionID int64, signalPrice float64, reason string, timestamp int64) (entity.OrderEvent, *entity.BacktestTradeRecord, error)
 }
@@ -504,7 +496,7 @@ func intervalDurationMillis(interval string) (int64, error) {
 	return 0, fmt.Errorf("unsupported interval: %s", interval)
 }
 
-func calcSLTP(pos SimPosition, stopLossPercent, takeProfitPercent float64) (stopLossPrice float64, takeProfitPrice float64) {
+func calcSLTP(pos eventengine.Position, stopLossPercent, takeProfitPercent float64) (stopLossPrice float64, takeProfitPrice float64) {
 	switch pos.Side {
 	case entity.OrderSideSell:
 		stopLossPrice = pos.EntryPrice * (1 + stopLossPercent/100.0)

--- a/backend/internal/usecase/backtest/handler_test.go
+++ b/backend/internal/usecase/backtest/handler_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/eventengine"
 )
 
 func TestIndicatorHandler_NoFutureHigherTFLeak(t *testing.T) {
@@ -235,12 +236,12 @@ func TestRiskHandler_EmitsApprovedSignalEvent(t *testing.T) {
 }
 
 type fakeTickRiskExecutor struct {
-	positions []SimPosition
+	positions []eventengine.Position
 	closedIDs []int64
 }
 
-func (f *fakeTickRiskExecutor) Positions() []SimPosition {
-	out := make([]SimPosition, len(f.positions))
+func (f *fakeTickRiskExecutor) Positions() []eventengine.Position {
+	out := make([]eventengine.Position, len(f.positions))
 	copy(out, f.positions)
 	return out
 }
@@ -277,7 +278,7 @@ func (f *fakeTickRiskExecutor) SelectSLTPExit(side entity.OrderSide, stopLossPri
 
 func (f *fakeTickRiskExecutor) Close(positionID int64, signalPrice float64, reason string, timestamp int64) (entity.OrderEvent, *entity.BacktestTradeRecord, error) {
 	f.closedIDs = append(f.closedIDs, positionID)
-	filtered := make([]SimPosition, 0, len(f.positions))
+	filtered := make([]eventengine.Position, 0, len(f.positions))
 	for _, p := range f.positions {
 		if p.PositionID != positionID {
 			filtered = append(filtered, p)
@@ -298,7 +299,7 @@ func (f *fakeTickRiskExecutor) Close(positionID int64, signalPrice float64, reas
 
 func TestTickRiskHandler_WorstCaseStopLossOnBothHit(t *testing.T) {
 	exec := &fakeTickRiskExecutor{
-		positions: []SimPosition{
+		positions: []eventengine.Position{
 			{
 				PositionID: 1,
 				SymbolID:   7,

--- a/backend/internal/usecase/backtest/runner.go
+++ b/backend/internal/usecase/backtest/runner.go
@@ -10,6 +10,7 @@ import (
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
 	infra "github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/infrastructure/backtest"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/eventengine"
 )
 
 type RunInput struct {
@@ -88,7 +89,7 @@ func (r *BacktestRunner) Run(ctx context.Context, input RunInput) (*entity.Backt
 		TradeAmount: input.TradeAmount,
 	}
 
-	bus := NewEventBus()
+	bus := eventengine.NewEventBus()
 	bus.Register(entity.EventTypeCandle, 5, tickGenerator)
 	bus.Register(entity.EventTypeCandle, 10, indicatorHandler)
 	bus.Register(entity.EventTypeTick, 15, tickRiskHandler)
@@ -102,7 +103,7 @@ func (r *BacktestRunner) Run(ctx context.Context, input RunInput) (*entity.Backt
 		return nil, fmt.Errorf("no primary candles in requested range")
 	}
 
-	engine := NewEventEngine(bus)
+	engine := eventengine.NewEventEngine(bus)
 	events := mergeCandleEvents(
 		primaryCandles,
 		higherCandles,
@@ -215,11 +216,11 @@ func (a *simExecutorAdapter) Open(symbolID int64, side entity.OrderSide, signalP
 	return a.sim.Open(symbolID, side, signalPrice, amount, reason, timestamp)
 }
 
-func (a *simExecutorAdapter) Positions() []SimPosition {
+func (a *simExecutorAdapter) Positions() []eventengine.Position {
 	raw := a.sim.Positions()
-	out := make([]SimPosition, 0, len(raw))
+	out := make([]eventengine.Position, 0, len(raw))
 	for _, p := range raw {
-		out = append(out, SimPosition{
+		out = append(out, eventengine.Position{
 			PositionID:     p.PositionID,
 			SymbolID:       p.SymbolID,
 			Side:           p.Side,

--- a/backend/internal/usecase/eventengine/bus.go
+++ b/backend/internal/usecase/eventengine/bus.go
@@ -1,4 +1,4 @@
-package backtest
+package eventengine
 
 import (
 	"context"

--- a/backend/internal/usecase/eventengine/bus_test.go
+++ b/backend/internal/usecase/eventengine/bus_test.go
@@ -1,4 +1,4 @@
-package backtest
+package eventengine
 
 import (
 	"context"
@@ -78,5 +78,15 @@ func TestEventBus_FIFOAndPriority(t *testing.T) {
 		if logs[i] != want[i] {
 			t.Fatalf("log[%d] mismatch: got=%s want=%s full=%v", i, logs[i], want[i], logs)
 		}
+	}
+}
+
+func TestEventEngine_NilBus(t *testing.T) {
+	engine := NewEventEngine(nil)
+	err := engine.Run(context.Background(), []entity.Event{
+		testEvent{typ: "a", id: "x", ts: 1},
+	})
+	if err != nil {
+		t.Fatalf("expected nil error for nil bus, got: %v", err)
 	}
 }

--- a/backend/internal/usecase/eventengine/engine.go
+++ b/backend/internal/usecase/eventengine/engine.go
@@ -1,4 +1,4 @@
-package backtest
+package eventengine
 
 import (
 	"context"
@@ -6,7 +6,7 @@ import (
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
 )
 
-// EventEngine drives deterministic event dispatch for backtests.
+// EventEngine drives deterministic event dispatch.
 type EventEngine struct {
 	bus *EventBus
 }

--- a/backend/internal/usecase/eventengine/executor.go
+++ b/backend/internal/usecase/eventengine/executor.go
@@ -1,0 +1,21 @@
+package eventengine
+
+import "github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+
+// OrderExecutor is the interface that both SimExecutor (backtest) and RealExecutor (live) implement.
+type OrderExecutor interface {
+	Open(symbolID int64, side entity.OrderSide, signalPrice, amount float64, reason string, timestamp int64) (entity.OrderEvent, error)
+	Close(positionID int64, signalPrice float64, reason string, timestamp int64) (entity.OrderEvent, *entity.BacktestTradeRecord, error)
+	Positions() []Position
+	SelectSLTPExit(side entity.OrderSide, stopLossPrice, takeProfitPrice, barLow, barHigh float64) (float64, string, bool)
+}
+
+// Position represents an open position for the event engine.
+type Position struct {
+	PositionID     int64
+	SymbolID       int64
+	Side           entity.OrderSide
+	EntryPrice     float64
+	Amount         float64
+	EntryTimestamp int64
+}


### PR DESCRIPTION
## Summary
- `EventBus`, `EventEngine` を `usecase/backtest/` → `usecase/eventengine/` に移動
- 共通 `OrderExecutor` インターフェース + `Position` 型を定義
- backtest パッケージは `eventengine` をimport（`SimPosition` → `eventengine.Position`）
- ライブトレーディングパイプラインで同一EventEngineを使うための基盤

## Test plan
- [x] `go build ./...` パス
- [x] `go test ./internal/usecase/backtest/` 全テストパス
- [x] `go test ./internal/usecase/eventengine/` 全テストパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)