### PR TITLE
feat: add LiveSource and RealExecutor for event-driven trading

### DIFF
--- a/backend/internal/infrastructure/live/live_source.go
+++ b/backend/internal/infrastructure/live/live_source.go
@@ -1,0 +1,166 @@
+package live
+
+import (
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+)
+
+// LiveSource bridges real-time ticker data to EventEngine events.
+// It accumulates ticks into candles and emits CandleEvent when periods close.
+type LiveSource struct {
+	symbolID        int64
+	primaryInterval string // e.g. "PT15M"
+	candleBuilder   *CandleBuilder
+}
+
+func NewLiveSource(symbolID int64, primaryInterval string) *LiveSource {
+	interval := parseInterval(primaryInterval)
+	return &LiveSource{
+		symbolID:        symbolID,
+		primaryInterval: primaryInterval,
+		candleBuilder:   NewCandleBuilder(symbolID, interval),
+	}
+}
+
+// HandleTick processes a real-time ticker and returns events to feed into EventEngine.
+// Every ticker produces a TickEvent. When a candle period closes, a CandleEvent is also emitted.
+func (s *LiveSource) HandleTick(ticker entity.Ticker) []entity.Event {
+	var events []entity.Event
+
+	// Always emit a TickEvent for SL/TP checking.
+	tickEvent := entity.TickEvent{
+		SymbolID:  ticker.SymbolID,
+		Interval:  s.primaryInterval,
+		Price:     ticker.Last,
+		Timestamp: ticker.Timestamp,
+		TickType:  "live",
+		BarLow:    ticker.Low,
+		BarHigh:   ticker.High,
+	}
+	events = append(events, tickEvent)
+
+	// Feed into candle builder; may produce a CandleEvent on period boundary.
+	if candleEvent := s.candleBuilder.AddTick(ticker); candleEvent != nil {
+		candleEvent.Interval = s.primaryInterval
+		events = append(events, *candleEvent)
+	}
+
+	return events
+}
+
+// CandleBuilder accumulates ticks and emits a CandleEvent when a candle period closes.
+type CandleBuilder struct {
+	mu            sync.Mutex
+	interval      time.Duration
+	symbolID      int64
+	currentCandle *entity.Candle
+	currentStart  time.Time
+}
+
+func NewCandleBuilder(symbolID int64, interval time.Duration) *CandleBuilder {
+	return &CandleBuilder{
+		symbolID: symbolID,
+		interval: interval,
+	}
+}
+
+// AddTick ingests a ticker. Returns a CandleEvent if the current period has closed, nil otherwise.
+func (b *CandleBuilder) AddTick(ticker entity.Ticker) *entity.CandleEvent {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	tickTime := time.UnixMilli(ticker.Timestamp)
+	periodStart := b.periodStart(tickTime)
+
+	price := ticker.Last
+
+	// If no candle yet, or this tick belongs to the same period, accumulate.
+	if b.currentCandle == nil {
+		b.currentStart = periodStart
+		b.currentCandle = &entity.Candle{
+			Open:   price,
+			High:   price,
+			Low:    price,
+			Close:  price,
+			Volume: ticker.Volume,
+			Time:   periodStart.UnixMilli(),
+		}
+		return nil
+	}
+
+	// If the tick is in the same period, update OHLCV.
+	if periodStart.Equal(b.currentStart) {
+		b.updateCandle(price, ticker.Volume)
+		return nil
+	}
+
+	// Period boundary crossed: finalize current candle and emit event.
+	completed := *b.currentCandle
+	completedStart := b.currentStart
+	closedTimestamp := completedStart.Add(b.interval).UnixMilli()
+
+	// Start a new candle for the current period.
+	b.currentStart = periodStart
+	b.currentCandle = &entity.Candle{
+		Open:   price,
+		High:   price,
+		Low:    price,
+		Close:  price,
+		Volume: ticker.Volume,
+		Time:   periodStart.UnixMilli(),
+	}
+
+	return &entity.CandleEvent{
+		SymbolID:  b.symbolID,
+		Interval:  "", // filled by LiveSource
+		Candle:    completed,
+		Timestamp: closedTimestamp,
+	}
+}
+
+// periodStart returns the start of the period that contains the given time.
+func (b *CandleBuilder) periodStart(t time.Time) time.Time {
+	if b.interval <= 0 {
+		return t
+	}
+	return t.Truncate(b.interval)
+}
+
+// updateCandle updates the current candle with a new tick price and volume.
+func (b *CandleBuilder) updateCandle(price, volume float64) {
+	if price > b.currentCandle.High {
+		b.currentCandle.High = price
+	}
+	if price < b.currentCandle.Low {
+		b.currentCandle.Low = price
+	}
+	b.currentCandle.Close = price
+	b.currentCandle.Volume = volume
+}
+
+// parseInterval converts an ISO 8601 duration string to time.Duration.
+// Supports common intervals: PT1M, PT5M, PT15M, PT30M, PT1H, PT4H, P1D.
+func parseInterval(s string) time.Duration {
+	s = strings.ToUpper(s)
+	switch s {
+	case "PT1M":
+		return time.Minute
+	case "PT5M":
+		return 5 * time.Minute
+	case "PT15M":
+		return 15 * time.Minute
+	case "PT30M":
+		return 30 * time.Minute
+	case "PT1H":
+		return time.Hour
+	case "PT4H":
+		return 4 * time.Hour
+	case "P1D":
+		return 24 * time.Hour
+	default:
+		return 15 * time.Minute // default to 15 minutes
+	}
+}

--- a/backend/internal/infrastructure/live/live_source_test.go
+++ b/backend/internal/infrastructure/live/live_source_test.go
@@ -1,0 +1,288 @@
+package live
+
+import (
+	"testing"
+	"time"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+)
+
+func TestLiveSource_HandleTick_EmitsTickEvent(t *testing.T) {
+	src := NewLiveSource(7, "PT15M")
+
+	ticker := entity.Ticker{
+		SymbolID:  7,
+		BestAsk:   50100,
+		BestBid:   49900,
+		Last:      50000,
+		High:      50500,
+		Low:       49500,
+		Volume:    100,
+		Timestamp: time.Date(2026, 4, 15, 10, 3, 0, 0, time.UTC).UnixMilli(),
+	}
+
+	events := src.HandleTick(ticker)
+	if len(events) == 0 {
+		t.Fatal("expected at least one event")
+	}
+
+	// First event should always be a TickEvent.
+	tickEv, ok := events[0].(entity.TickEvent)
+	if !ok {
+		t.Fatalf("expected TickEvent, got %T", events[0])
+	}
+	if tickEv.EventType() != entity.EventTypeTick {
+		t.Fatalf("expected event type %s, got %s", entity.EventTypeTick, tickEv.EventType())
+	}
+	if tickEv.Price != 50000 {
+		t.Fatalf("expected price=50000, got %f", tickEv.Price)
+	}
+	if tickEv.SymbolID != 7 {
+		t.Fatalf("expected symbolID=7, got %d", tickEv.SymbolID)
+	}
+	if tickEv.TickType != "live" {
+		t.Fatalf("expected tickType=live, got %s", tickEv.TickType)
+	}
+}
+
+func TestLiveSource_HandleTick_NoCandleForSamePeriod(t *testing.T) {
+	src := NewLiveSource(7, "PT15M")
+
+	base := time.Date(2026, 4, 15, 10, 0, 0, 0, time.UTC)
+
+	// All ticks within the same 15-minute period.
+	for i := 0; i < 5; i++ {
+		ticker := entity.Ticker{
+			SymbolID:  7,
+			Last:      50000 + float64(i*100),
+			High:      50500,
+			Low:       49500,
+			Volume:    float64(100 + i),
+			Timestamp: base.Add(time.Duration(i) * time.Minute).UnixMilli(),
+		}
+		events := src.HandleTick(ticker)
+		// Each tick should produce only a TickEvent (no CandleEvent within same period).
+		for _, ev := range events {
+			if ev.EventType() == entity.EventTypeCandle {
+				t.Fatalf("unexpected CandleEvent within same period at tick %d", i)
+			}
+		}
+	}
+}
+
+func TestLiveSource_HandleTick_EmitsCandleOnPeriodBoundary(t *testing.T) {
+	src := NewLiveSource(7, "PT15M")
+
+	// Tick 1: within first 15-min period (10:00 - 10:15).
+	t1 := entity.Ticker{
+		SymbolID:  7,
+		Last:      50000,
+		High:      50500,
+		Low:       49500,
+		Volume:    100,
+		Timestamp: time.Date(2026, 4, 15, 10, 0, 0, 0, time.UTC).UnixMilli(),
+	}
+	events := src.HandleTick(t1)
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event (TickEvent), got %d", len(events))
+	}
+
+	// Tick 2: still in first period.
+	t2 := entity.Ticker{
+		SymbolID:  7,
+		Last:      50200,
+		High:      50700,
+		Low:       49800,
+		Volume:    110,
+		Timestamp: time.Date(2026, 4, 15, 10, 5, 0, 0, time.UTC).UnixMilli(),
+	}
+	events = src.HandleTick(t2)
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+
+	// Tick 3: higher price, still first period.
+	t3 := entity.Ticker{
+		SymbolID:  7,
+		Last:      50500,
+		High:      51000,
+		Low:       49900,
+		Volume:    120,
+		Timestamp: time.Date(2026, 4, 15, 10, 14, 0, 0, time.UTC).UnixMilli(),
+	}
+	events = src.HandleTick(t3)
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+
+	// Tick 4: crosses into second period (10:15). Should emit CandleEvent for first period.
+	t4 := entity.Ticker{
+		SymbolID:  7,
+		Last:      50300,
+		High:      50800,
+		Low:       50000,
+		Volume:    130,
+		Timestamp: time.Date(2026, 4, 15, 10, 15, 0, 0, time.UTC).UnixMilli(),
+	}
+	events = src.HandleTick(t4)
+
+	var candleEvent *entity.CandleEvent
+	tickCount := 0
+	for _, ev := range events {
+		switch e := ev.(type) {
+		case entity.TickEvent:
+			tickCount++
+		case entity.CandleEvent:
+			candleEvent = &e
+		}
+	}
+
+	if tickCount != 1 {
+		t.Fatalf("expected 1 TickEvent, got %d", tickCount)
+	}
+	if candleEvent == nil {
+		t.Fatal("expected CandleEvent on period boundary")
+	}
+
+	// Verify candle OHLCV from ticks t1, t2, t3.
+	if candleEvent.Candle.Open != 50000 {
+		t.Fatalf("expected open=50000, got %f", candleEvent.Candle.Open)
+	}
+	if candleEvent.Candle.High != 50500 {
+		t.Fatalf("expected high=50500, got %f", candleEvent.Candle.High)
+	}
+	if candleEvent.Candle.Low != 50000 {
+		t.Fatalf("expected low=50000, got %f", candleEvent.Candle.Low)
+	}
+	if candleEvent.Candle.Close != 50500 {
+		t.Fatalf("expected close=50500, got %f", candleEvent.Candle.Close)
+	}
+
+	// Verify interval is set.
+	if candleEvent.Interval != "PT15M" {
+		t.Fatalf("expected interval=PT15M, got %s", candleEvent.Interval)
+	}
+
+	// Verify candle timestamp is the end of the first period.
+	expectedTS := time.Date(2026, 4, 15, 10, 15, 0, 0, time.UTC).UnixMilli()
+	if candleEvent.Timestamp != expectedTS {
+		t.Fatalf("expected timestamp=%d, got %d", expectedTS, candleEvent.Timestamp)
+	}
+}
+
+func TestCandleBuilder_MultiplePeriodsEmitMultipleCandles(t *testing.T) {
+	builder := NewCandleBuilder(7, 15*time.Minute)
+
+	base := time.Date(2026, 4, 15, 10, 0, 0, 0, time.UTC)
+
+	// Period 1: one tick.
+	ticker1 := entity.Ticker{
+		SymbolID:  7,
+		Last:      100,
+		Volume:    10,
+		Timestamp: base.UnixMilli(),
+	}
+	ev := builder.AddTick(ticker1)
+	if ev != nil {
+		t.Fatal("should not emit on first tick")
+	}
+
+	// Period 2: first tick triggers candle for period 1.
+	ticker2 := entity.Ticker{
+		SymbolID:  7,
+		Last:      110,
+		Volume:    20,
+		Timestamp: base.Add(15 * time.Minute).UnixMilli(),
+	}
+	ev = builder.AddTick(ticker2)
+	if ev == nil {
+		t.Fatal("expected CandleEvent for period 1")
+	}
+	if ev.Candle.Open != 100 || ev.Candle.Close != 100 {
+		t.Fatalf("expected single-tick candle O=C=100, got O=%f C=%f", ev.Candle.Open, ev.Candle.Close)
+	}
+
+	// Period 3: first tick triggers candle for period 2.
+	ticker3 := entity.Ticker{
+		SymbolID:  7,
+		Last:      120,
+		Volume:    30,
+		Timestamp: base.Add(30 * time.Minute).UnixMilli(),
+	}
+	ev = builder.AddTick(ticker3)
+	if ev == nil {
+		t.Fatal("expected CandleEvent for period 2")
+	}
+	if ev.Candle.Open != 110 || ev.Candle.Close != 110 {
+		t.Fatalf("expected single-tick candle O=C=110, got O=%f C=%f", ev.Candle.Open, ev.Candle.Close)
+	}
+}
+
+func TestCandleBuilder_OHLCV_AccumulatesCorrectly(t *testing.T) {
+	builder := NewCandleBuilder(7, 5*time.Minute)
+
+	base := time.Date(2026, 4, 15, 10, 0, 0, 0, time.UTC)
+
+	tickers := []entity.Ticker{
+		{SymbolID: 7, Last: 100, Volume: 10, Timestamp: base.UnixMilli()},                         // open
+		{SymbolID: 7, Last: 105, Volume: 15, Timestamp: base.Add(1 * time.Minute).UnixMilli()},    // high
+		{SymbolID: 7, Last: 95, Volume: 20, Timestamp: base.Add(2 * time.Minute).UnixMilli()},     // low
+		{SymbolID: 7, Last: 102, Volume: 25, Timestamp: base.Add(4 * time.Minute).UnixMilli()},    // close
+	}
+
+	for _, tk := range tickers {
+		ev := builder.AddTick(tk)
+		if ev != nil {
+			t.Fatal("should not emit during same period")
+		}
+	}
+
+	// Next period tick triggers the candle.
+	nextTick := entity.Ticker{
+		SymbolID:  7,
+		Last:      108,
+		Volume:    30,
+		Timestamp: base.Add(5 * time.Minute).UnixMilli(),
+	}
+	ev := builder.AddTick(nextTick)
+	if ev == nil {
+		t.Fatal("expected CandleEvent")
+	}
+
+	if ev.Candle.Open != 100 {
+		t.Fatalf("expected open=100, got %f", ev.Candle.Open)
+	}
+	if ev.Candle.High != 105 {
+		t.Fatalf("expected high=105, got %f", ev.Candle.High)
+	}
+	if ev.Candle.Low != 95 {
+		t.Fatalf("expected low=95, got %f", ev.Candle.Low)
+	}
+	if ev.Candle.Close != 102 {
+		t.Fatalf("expected close=102, got %f", ev.Candle.Close)
+	}
+}
+
+func TestParseInterval(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected time.Duration
+	}{
+		{"PT1M", time.Minute},
+		{"PT5M", 5 * time.Minute},
+		{"PT15M", 15 * time.Minute},
+		{"PT30M", 30 * time.Minute},
+		{"PT1H", time.Hour},
+		{"PT4H", 4 * time.Hour},
+		{"P1D", 24 * time.Hour},
+		{"pt15m", 15 * time.Minute}, // lowercase
+		{"UNKNOWN", 15 * time.Minute},  // default
+	}
+
+	for _, tt := range tests {
+		got := parseInterval(tt.input)
+		if got != tt.expected {
+			t.Errorf("parseInterval(%q) = %v, want %v", tt.input, got, tt.expected)
+		}
+	}
+}

--- a/backend/internal/infrastructure/live/real_executor.go
+++ b/backend/internal/infrastructure/live/real_executor.go
@@ -1,0 +1,308 @@
+package live
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/repository"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/eventengine"
+)
+
+// RealExecutor implements eventengine.OrderExecutor by executing real orders
+// via the Rakuten API OrderClient.
+type RealExecutor struct {
+	orderClient   repository.OrderClient
+	symbolID      int64
+	positions     []eventengine.Position
+	mu            sync.Mutex
+	spreadPercent float64
+	nextOrderID   int64
+}
+
+func NewRealExecutor(orderClient repository.OrderClient, symbolID int64, spreadPercent float64) *RealExecutor {
+	return &RealExecutor{
+		orderClient:   orderClient,
+		symbolID:      symbolID,
+		spreadPercent: spreadPercent,
+		nextOrderID:   1,
+	}
+}
+
+// Open creates a real market order via orderClient.CreateOrder.
+func (r *RealExecutor) Open(symbolID int64, side entity.OrderSide, signalPrice, amount float64, reason string, timestamp int64) (entity.OrderEvent, error) {
+	if amount <= 0 {
+		return entity.OrderEvent{}, fmt.Errorf("amount must be positive")
+	}
+	if signalPrice <= 0 {
+		return entity.OrderEvent{}, fmt.Errorf("signal price must be positive")
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// Reverse signal: close opposite positions first.
+	for i := len(r.positions) - 1; i >= 0; i-- {
+		pos := r.positions[i]
+		if pos.SymbolID == symbolID && pos.Side != side {
+			_, _, _ = r.closeLocked(pos.PositionID, signalPrice, "reverse_signal", timestamp)
+		}
+	}
+
+	req := entity.OrderRequest{
+		SymbolID:     symbolID,
+		OrderPattern: entity.OrderPatternNormal,
+		OrderData: entity.OrderData{
+			OrderBehavior: entity.OrderBehaviorOpen,
+			OrderSide:     side,
+			OrderType:     entity.OrderTypeMarket,
+			Amount:        amount,
+		},
+	}
+
+	orders, err := r.orderClient.CreateOrder(context.Background(), req)
+	if err != nil {
+		return entity.OrderEvent{}, fmt.Errorf("failed to create open order: %w", err)
+	}
+
+	var orderID int64
+	fillPrice := signalPrice
+	if len(orders) > 0 {
+		orderID = orders[0].ID
+		if orders[0].Price > 0 {
+			fillPrice = orders[0].Price
+		}
+	}
+
+	slog.Info("live order opened",
+		"orderID", orderID,
+		"symbolID", symbolID,
+		"side", side,
+		"amount", amount,
+		"reason", reason,
+	)
+
+	// Track position in-memory. Use API order ID as position ID.
+	posID := orderID
+	if posID == 0 {
+		posID = r.nextOrderID
+		r.nextOrderID++
+	}
+	r.positions = append(r.positions, eventengine.Position{
+		PositionID:     posID,
+		SymbolID:       symbolID,
+		Side:           side,
+		EntryPrice:     fillPrice,
+		Amount:         amount,
+		EntryTimestamp: timestamp,
+	})
+
+	return entity.OrderEvent{
+		OrderID:   orderID,
+		SymbolID:  symbolID,
+		Side:      string(side),
+		Action:    "open",
+		Price:     fillPrice,
+		Amount:    amount,
+		Reason:    reason,
+		Timestamp: timestamp,
+	}, nil
+}
+
+// Close creates a close order via orderClient.CreateOrder with BehaviorClose.
+func (r *RealExecutor) Close(positionID int64, signalPrice float64, reason string, timestamp int64) (entity.OrderEvent, *entity.BacktestTradeRecord, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.closeLocked(positionID, signalPrice, reason, timestamp)
+}
+
+// closeLocked performs the close while the mutex is already held.
+func (r *RealExecutor) closeLocked(positionID int64, signalPrice float64, reason string, timestamp int64) (entity.OrderEvent, *entity.BacktestTradeRecord, error) {
+	idx := -1
+	for i := range r.positions {
+		if r.positions[i].PositionID == positionID {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		return entity.OrderEvent{}, nil, fmt.Errorf("position not found: %d", positionID)
+	}
+	if signalPrice <= 0 {
+		return entity.OrderEvent{}, nil, fmt.Errorf("signal price must be positive")
+	}
+
+	pos := r.positions[idx]
+
+	closeSide := entity.OrderSideSell
+	if pos.Side == entity.OrderSideSell {
+		closeSide = entity.OrderSideBuy
+	}
+
+	posID := pos.PositionID
+	req := entity.OrderRequest{
+		SymbolID:     pos.SymbolID,
+		OrderPattern: entity.OrderPatternNormal,
+		OrderData: entity.OrderData{
+			OrderBehavior: entity.OrderBehaviorClose,
+			PositionID:    &posID,
+			OrderSide:     closeSide,
+			OrderType:     entity.OrderTypeMarket,
+			Amount:        pos.Amount,
+		},
+	}
+
+	orders, err := r.orderClient.CreateOrder(context.Background(), req)
+	if err != nil {
+		return entity.OrderEvent{}, nil, fmt.Errorf("failed to create close order: %w", err)
+	}
+
+	var orderID int64
+	exitPrice := signalPrice
+	if len(orders) > 0 {
+		orderID = orders[0].ID
+		if orders[0].Price > 0 {
+			exitPrice = orders[0].Price
+		}
+	}
+
+	slog.Info("live position closed",
+		"positionID", positionID,
+		"orderID", orderID,
+		"side", closeSide,
+		"reason", reason,
+	)
+
+	// Remove from in-memory tracking.
+	r.positions = append(r.positions[:idx], r.positions[idx+1:]...)
+
+	// Build trade record for compatibility with event engine.
+	pnl := r.calcPnL(pos, exitPrice)
+	pnlPct := 0.0
+	if pos.EntryPrice != 0 {
+		if pos.Side == entity.OrderSideBuy {
+			pnlPct = (exitPrice - pos.EntryPrice) / pos.EntryPrice * 100
+		} else {
+			pnlPct = (pos.EntryPrice - exitPrice) / pos.EntryPrice * 100
+		}
+	}
+
+	holding := time.UnixMilli(timestamp).Sub(time.UnixMilli(pos.EntryTimestamp))
+	_ = holding // available for future carrying cost
+
+	trade := &entity.BacktestTradeRecord{
+		TradeID:     positionID,
+		SymbolID:    pos.SymbolID,
+		EntryTime:   pos.EntryTimestamp,
+		ExitTime:    timestamp,
+		Side:        string(pos.Side),
+		EntryPrice:  pos.EntryPrice,
+		ExitPrice:   exitPrice,
+		Amount:      pos.Amount,
+		PnL:         pnl,
+		PnLPercent:  pnlPct,
+		ReasonEntry: "", // not tracked in live yet
+		ReasonExit:  reason,
+	}
+
+	return entity.OrderEvent{
+		OrderID:   orderID,
+		SymbolID:  pos.SymbolID,
+		Side:      string(pos.Side),
+		Action:    "close",
+		Price:     exitPrice,
+		Amount:    pos.Amount,
+		Reason:    reason,
+		Timestamp: timestamp,
+	}, trade, nil
+}
+
+// Positions returns a copy of tracked positions.
+func (r *RealExecutor) Positions() []eventengine.Position {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]eventengine.Position, len(r.positions))
+	copy(out, r.positions)
+	return out
+}
+
+// SelectSLTPExit uses worst-case logic: when both SL and TP are hit in the same bar,
+// stop-loss wins. Same logic as SimExecutor.
+func (r *RealExecutor) SelectSLTPExit(
+	side entity.OrderSide,
+	stopLossPrice float64,
+	takeProfitPrice float64,
+	barLow float64,
+	barHigh float64,
+) (exitPrice float64, reason string, hit bool) {
+	switch side {
+	case entity.OrderSideBuy:
+		slHit := barLow <= stopLossPrice
+		tpHit := barHigh >= takeProfitPrice
+		if slHit && tpHit {
+			return stopLossPrice, "stop_loss", true
+		}
+		if slHit {
+			return stopLossPrice, "stop_loss", true
+		}
+		if tpHit {
+			return takeProfitPrice, "take_profit", true
+		}
+	case entity.OrderSideSell:
+		slHit := barHigh >= stopLossPrice
+		tpHit := barLow <= takeProfitPrice
+		if slHit && tpHit {
+			return stopLossPrice, "stop_loss", true
+		}
+		if slHit {
+			return stopLossPrice, "stop_loss", true
+		}
+		if tpHit {
+			return takeProfitPrice, "take_profit", true
+		}
+	}
+	return 0, "", false
+}
+
+// SyncPositions fetches current positions from the API and reconciles in-memory state.
+func (r *RealExecutor) SyncPositions(ctx context.Context) error {
+	apiPositions, err := r.orderClient.GetPositions(ctx, r.symbolID)
+	if err != nil {
+		return fmt.Errorf("failed to get positions: %w", err)
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	synced := make([]eventengine.Position, 0, len(apiPositions))
+	for _, ap := range apiPositions {
+		synced = append(synced, eventengine.Position{
+			PositionID:     ap.ID,
+			SymbolID:       ap.SymbolID,
+			Side:           ap.OrderSide,
+			EntryPrice:     ap.Price,
+			Amount:         ap.RemainingAmount,
+			EntryTimestamp: ap.CreatedAt,
+		})
+	}
+	r.positions = synced
+
+	slog.Info("positions synced from API",
+		"symbolID", r.symbolID,
+		"count", len(synced),
+	)
+	return nil
+}
+
+// calcPnL computes profit/loss for a position at a given exit price.
+func (r *RealExecutor) calcPnL(pos eventengine.Position, exitPrice float64) float64 {
+	switch pos.Side {
+	case entity.OrderSideSell:
+		return (pos.EntryPrice - exitPrice) * pos.Amount
+	default:
+		return (exitPrice - pos.EntryPrice) * pos.Amount
+	}
+}

--- a/backend/internal/infrastructure/live/real_executor_test.go
+++ b/backend/internal/infrastructure/live/real_executor_test.go
@@ -1,0 +1,322 @@
+package live
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/repository"
+)
+
+// mockOrderClient implements repository.OrderClient for testing.
+type mockOrderClient struct {
+	mu             sync.Mutex
+	createOrderFn  func(ctx context.Context, req entity.OrderRequest) ([]entity.Order, error)
+	getPositionsFn func(ctx context.Context, symbolID int64) ([]entity.Position, error)
+	calls          []entity.OrderRequest
+}
+
+func (m *mockOrderClient) CreateOrder(ctx context.Context, req entity.OrderRequest) ([]entity.Order, error) {
+	m.mu.Lock()
+	m.calls = append(m.calls, req)
+	m.mu.Unlock()
+	if m.createOrderFn != nil {
+		return m.createOrderFn(ctx, req)
+	}
+	return []entity.Order{{ID: 1, Price: 100}}, nil
+}
+
+func (m *mockOrderClient) CreateOrderRaw(ctx context.Context, req entity.OrderRequest) (repository.CreateOrderOutcome, error) {
+	return repository.CreateOrderOutcome{}, fmt.Errorf("not implemented")
+}
+
+func (m *mockOrderClient) CancelOrder(ctx context.Context, symbolID, orderID int64) ([]entity.Order, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (m *mockOrderClient) GetOrders(ctx context.Context, symbolID int64) ([]entity.Order, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (m *mockOrderClient) GetPositions(ctx context.Context, symbolID int64) ([]entity.Position, error) {
+	if m.getPositionsFn != nil {
+		return m.getPositionsFn(ctx, symbolID)
+	}
+	return nil, nil
+}
+
+func (m *mockOrderClient) GetMyTrades(ctx context.Context, symbolID int64) ([]entity.MyTrade, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (m *mockOrderClient) GetAssets(ctx context.Context) ([]entity.Asset, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func TestRealExecutor_SelectSLTPExit_BuyWorstCase(t *testing.T) {
+	exec := NewRealExecutor(&mockOrderClient{}, 7, 0.1)
+	price, reason, hit := exec.SelectSLTPExit(
+		entity.OrderSideBuy,
+		95,  // stop-loss
+		105, // take-profit
+		94,  // bar low (triggers SL)
+		106, // bar high (triggers TP)
+	)
+	if !hit {
+		t.Fatal("expected hit")
+	}
+	if reason != "stop_loss" {
+		t.Fatalf("expected stop_loss, got %s", reason)
+	}
+	if price != 95 {
+		t.Fatalf("expected stop-loss price 95, got %f", price)
+	}
+}
+
+func TestRealExecutor_SelectSLTPExit_SellWorstCase(t *testing.T) {
+	exec := NewRealExecutor(&mockOrderClient{}, 7, 0.1)
+	price, reason, hit := exec.SelectSLTPExit(
+		entity.OrderSideSell,
+		105, // stop-loss
+		95,  // take-profit
+		94,  // bar low (triggers TP)
+		106, // bar high (triggers SL)
+	)
+	if !hit {
+		t.Fatal("expected hit")
+	}
+	if reason != "stop_loss" {
+		t.Fatalf("expected stop_loss, got %s", reason)
+	}
+	if price != 105 {
+		t.Fatalf("expected stop-loss price 105, got %f", price)
+	}
+}
+
+func TestRealExecutor_SelectSLTPExit_BuyOnlySL(t *testing.T) {
+	exec := NewRealExecutor(&mockOrderClient{}, 7, 0.1)
+	price, reason, hit := exec.SelectSLTPExit(
+		entity.OrderSideBuy,
+		95,
+		105,
+		94,  // SL hit
+		104, // TP not hit
+	)
+	if !hit {
+		t.Fatal("expected hit")
+	}
+	if reason != "stop_loss" {
+		t.Fatalf("expected stop_loss, got %s", reason)
+	}
+	if price != 95 {
+		t.Fatalf("expected 95, got %f", price)
+	}
+}
+
+func TestRealExecutor_SelectSLTPExit_BuyOnlyTP(t *testing.T) {
+	exec := NewRealExecutor(&mockOrderClient{}, 7, 0.1)
+	price, reason, hit := exec.SelectSLTPExit(
+		entity.OrderSideBuy,
+		95,
+		105,
+		96,  // SL not hit
+		106, // TP hit
+	)
+	if !hit {
+		t.Fatal("expected hit")
+	}
+	if reason != "take_profit" {
+		t.Fatalf("expected take_profit, got %s", reason)
+	}
+	if price != 105 {
+		t.Fatalf("expected 105, got %f", price)
+	}
+}
+
+func TestRealExecutor_SelectSLTPExit_NoHit(t *testing.T) {
+	exec := NewRealExecutor(&mockOrderClient{}, 7, 0.1)
+	_, _, hit := exec.SelectSLTPExit(
+		entity.OrderSideBuy,
+		95,
+		105,
+		96,  // SL not hit
+		104, // TP not hit
+	)
+	if hit {
+		t.Fatal("expected no hit")
+	}
+}
+
+func TestRealExecutor_OpenAndPositions(t *testing.T) {
+	nextID := int64(100)
+	mock := &mockOrderClient{
+		createOrderFn: func(ctx context.Context, req entity.OrderRequest) ([]entity.Order, error) {
+			id := nextID
+			nextID++
+			return []entity.Order{{ID: id, Price: 50000}}, nil
+		},
+	}
+	exec := NewRealExecutor(mock, 7, 0.1)
+
+	orderEv, err := exec.Open(7, entity.OrderSideBuy, 50000, 0.01, "test_entry", 1000)
+	if err != nil {
+		t.Fatalf("open error: %v", err)
+	}
+	if orderEv.Action != "open" {
+		t.Fatalf("expected action=open, got %s", orderEv.Action)
+	}
+	if orderEv.OrderID != 100 {
+		t.Fatalf("expected orderID=100, got %d", orderEv.OrderID)
+	}
+
+	positions := exec.Positions()
+	if len(positions) != 1 {
+		t.Fatalf("expected 1 position, got %d", len(positions))
+	}
+	if positions[0].PositionID != 100 {
+		t.Fatalf("expected positionID=100, got %d", positions[0].PositionID)
+	}
+	if positions[0].Side != entity.OrderSideBuy {
+		t.Fatalf("expected BUY, got %s", positions[0].Side)
+	}
+	if positions[0].Amount != 0.01 {
+		t.Fatalf("expected amount=0.01, got %f", positions[0].Amount)
+	}
+}
+
+func TestRealExecutor_OpenAndClose(t *testing.T) {
+	nextID := int64(200)
+	callCount := 0
+	mock := &mockOrderClient{
+		createOrderFn: func(ctx context.Context, req entity.OrderRequest) ([]entity.Order, error) {
+			id := nextID
+			nextID++
+			callCount++
+			// First call (open) returns 50000, second call (close) returns 51000.
+			price := 50000.0
+			if callCount >= 2 {
+				price = 51000.0
+			}
+			return []entity.Order{{ID: id, Price: price}}, nil
+		},
+	}
+	exec := NewRealExecutor(mock, 7, 0.1)
+
+	_, err := exec.Open(7, entity.OrderSideBuy, 50000, 0.01, "entry", 1000)
+	if err != nil {
+		t.Fatalf("open error: %v", err)
+	}
+
+	positions := exec.Positions()
+	if len(positions) != 1 {
+		t.Fatalf("expected 1 position, got %d", len(positions))
+	}
+
+	orderEv, trade, err := exec.Close(positions[0].PositionID, 51000, "exit", 2000)
+	if err != nil {
+		t.Fatalf("close error: %v", err)
+	}
+	if orderEv.Action != "close" {
+		t.Fatalf("expected action=close, got %s", orderEv.Action)
+	}
+	if trade == nil {
+		t.Fatal("trade record should not be nil")
+	}
+	if trade.PnL == 0 {
+		t.Fatal("expected non-zero PnL")
+	}
+
+	// Position should be removed.
+	positions = exec.Positions()
+	if len(positions) != 0 {
+		t.Fatalf("expected 0 positions after close, got %d", len(positions))
+	}
+}
+
+func TestRealExecutor_CloseNotFound(t *testing.T) {
+	exec := NewRealExecutor(&mockOrderClient{}, 7, 0.1)
+	_, _, err := exec.Close(999, 50000, "exit", 1000)
+	if err == nil {
+		t.Fatal("expected error for missing position")
+	}
+}
+
+func TestRealExecutor_SyncPositions(t *testing.T) {
+	mock := &mockOrderClient{
+		getPositionsFn: func(ctx context.Context, symbolID int64) ([]entity.Position, error) {
+			return []entity.Position{
+				{
+					ID:              10,
+					SymbolID:        7,
+					OrderSide:       entity.OrderSideBuy,
+					Price:           50000,
+					RemainingAmount: 0.01,
+					CreatedAt:       1000,
+				},
+				{
+					ID:              11,
+					SymbolID:        7,
+					OrderSide:       entity.OrderSideSell,
+					Price:           51000,
+					RemainingAmount: 0.02,
+					CreatedAt:       2000,
+				},
+			}, nil
+		},
+	}
+	exec := NewRealExecutor(mock, 7, 0.1)
+
+	err := exec.SyncPositions(context.Background())
+	if err != nil {
+		t.Fatalf("sync error: %v", err)
+	}
+
+	positions := exec.Positions()
+	if len(positions) != 2 {
+		t.Fatalf("expected 2 positions, got %d", len(positions))
+	}
+	if positions[0].PositionID != 10 {
+		t.Fatalf("expected positionID=10, got %d", positions[0].PositionID)
+	}
+	if positions[1].Side != entity.OrderSideSell {
+		t.Fatalf("expected SELL, got %s", positions[1].Side)
+	}
+}
+
+func TestRealExecutor_OpenReversesOpposite(t *testing.T) {
+	nextID := int64(300)
+	mock := &mockOrderClient{
+		createOrderFn: func(ctx context.Context, req entity.OrderRequest) ([]entity.Order, error) {
+			id := nextID
+			nextID++
+			return []entity.Order{{ID: id, Price: 50000}}, nil
+		},
+	}
+	exec := NewRealExecutor(mock, 7, 0.1)
+
+	// Open a BUY position.
+	_, err := exec.Open(7, entity.OrderSideBuy, 50000, 0.01, "buy_entry", 1000)
+	if err != nil {
+		t.Fatalf("open error: %v", err)
+	}
+	if len(exec.Positions()) != 1 {
+		t.Fatalf("expected 1 position")
+	}
+
+	// Open a SELL on the same symbol should close the BUY first.
+	_, err = exec.Open(7, entity.OrderSideSell, 51000, 0.01, "sell_entry", 2000)
+	if err != nil {
+		t.Fatalf("reverse open error: %v", err)
+	}
+
+	positions := exec.Positions()
+	// Only the SELL position should remain (BUY was closed by reverse signal).
+	if len(positions) != 1 {
+		t.Fatalf("expected 1 position after reverse, got %d", len(positions))
+	}
+	if positions[0].Side != entity.OrderSideSell {
+		t.Fatalf("expected SELL, got %s", positions[0].Side)
+	}
+}


### PR DESCRIPTION
## Summary
- `RealExecutor`: `eventengine.OrderExecutor` の実装。楽天REST APIで実注文を出す
  - Open/Close: market order実行 + インメモリポジション追跡
  - 反対シグナル時の自動クローズ
  - SyncPositions: APIからポジションを同期
  - SelectSLTPExit: worst-case ロジック（SimExecutorと同一）
  - `sync.Mutex` によるスレッドセーフ
- `LiveSource` + `CandleBuilder`: リアルタイムティッカーをEventEngineのイベントに変換
  - 各ティッカー → TickEvent（SL/TP チェック用）
  - 15分足などの期間境界で CandleEvent を生成
- テスト16件（RealExecutor 10件 + LiveSource 6件）

## Test plan
- [x] `go build ./...` パス
- [x] `go test ./internal/infrastructure/live/ -v` 全16テストパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)