### PR TITLE
feat(strategy): add BB breakout stance with volume confirmation

### DIFF
--- a/backend/internal/domain/entity/indicator.go
+++ b/backend/internal/domain/entity/indicator.go
@@ -17,5 +17,8 @@ type IndicatorSet struct {
 	BBLower        *float64 `json:"bbLower"`
 	BBBandwidth    *float64 `json:"bbBandwidth"`
 	ATR14          *float64 `json:"atr14"`
+	VolumeSMA20    *float64 `json:"volumeSma20"`   // 出来高20期間SMA
+	VolumeRatio    *float64 `json:"volumeRatio"`   // 最新出来高 / VolumeSMA20
+	RecentSqueeze  *bool    `json:"recentSqueeze"` // 直近5本以内に BBBandwidth < 0.02
 	Timestamp      int64    `json:"timestamp"`
 }

--- a/backend/internal/domain/entity/strategy.go
+++ b/backend/internal/domain/entity/strategy.go
@@ -7,6 +7,7 @@ const (
 	MarketStanceTrendFollow MarketStance = "TREND_FOLLOW"
 	MarketStanceContrarian  MarketStance = "CONTRARIAN"
 	MarketStanceHold        MarketStance = "HOLD"
+	MarketStanceBreakout    MarketStance = "BREAKOUT"
 )
 
 // StrategyAdvice はLLM Serviceが返す戦略アドバイス。

--- a/backend/internal/infrastructure/indicator/volume.go
+++ b/backend/internal/infrastructure/indicator/volume.go
@@ -1,0 +1,25 @@
+package indicator
+
+import "math"
+
+// VolumeSMA computes the simple moving average of volume over the last `period` candles.
+// Returns NaN if len(volumes) < period.
+func VolumeSMA(volumes []float64, period int) float64 {
+	if len(volumes) < period {
+		return math.NaN()
+	}
+	sum := 0.0
+	for _, v := range volumes[len(volumes)-period:] {
+		sum += v
+	}
+	return sum / float64(period)
+}
+
+// VolumeRatio computes currentVolume / sma.
+// Returns NaN if sma is zero.
+func VolumeRatio(currentVolume, sma float64) float64 {
+	if sma == 0 {
+		return math.NaN()
+	}
+	return currentVolume / sma
+}

--- a/backend/internal/infrastructure/indicator/volume_test.go
+++ b/backend/internal/infrastructure/indicator/volume_test.go
@@ -1,0 +1,62 @@
+package indicator
+
+import (
+	"math"
+	"testing"
+)
+
+func TestVolumeSMA_InsufficientData(t *testing.T) {
+	result := VolumeSMA([]float64{100, 200}, 20)
+	if !math.IsNaN(result) {
+		t.Fatalf("expected NaN for insufficient data, got %f", result)
+	}
+}
+
+func TestVolumeSMA_ExactPeriod(t *testing.T) {
+	volumes := make([]float64, 20)
+	for i := range volumes {
+		volumes[i] = 100.0
+	}
+	result := VolumeSMA(volumes, 20)
+	if result != 100.0 {
+		t.Fatalf("expected 100.0, got %f", result)
+	}
+}
+
+func TestVolumeSMA_UsesLastNPeriod(t *testing.T) {
+	// 30 candles, last 20 are all 200, first 10 are all 100
+	volumes := make([]float64, 30)
+	for i := range volumes {
+		if i < 10 {
+			volumes[i] = 100.0
+		} else {
+			volumes[i] = 200.0
+		}
+	}
+	result := VolumeSMA(volumes, 20)
+	if result != 200.0 {
+		t.Fatalf("expected 200.0, got %f", result)
+	}
+}
+
+func TestVolumeRatio_Normal(t *testing.T) {
+	// Current volume = 300, SMA = 100 → ratio = 3.0
+	result := VolumeRatio(300, 100)
+	if result != 3.0 {
+		t.Fatalf("expected 3.0, got %f", result)
+	}
+}
+
+func TestVolumeRatio_ZeroSMA(t *testing.T) {
+	result := VolumeRatio(300, 0)
+	if !math.IsNaN(result) {
+		t.Fatalf("expected NaN for zero SMA, got %f", result)
+	}
+}
+
+func TestVolumeRatio_ZeroVolume(t *testing.T) {
+	result := VolumeRatio(0, 100)
+	if result != 0.0 {
+		t.Fatalf("expected 0.0, got %f", result)
+	}
+}

--- a/backend/internal/interfaces/api/handler/handler_test.go
+++ b/backend/internal/interfaces/api/handler/handler_test.go
@@ -910,7 +910,7 @@ func TestStrategyHandler_SetStrategy_InvalidStance(t *testing.T) {
 		t.Fatalf("expected 400, got %d", w.Code)
 	}
 	resp := decodeBody(t, w)
-	if resp["error"] != "stance must be TREND_FOLLOW, CONTRARIAN, or HOLD" {
+	if resp["error"] != "stance must be TREND_FOLLOW, CONTRARIAN, HOLD, or BREAKOUT" {
 		t.Fatalf("unexpected error: %v", resp["error"])
 	}
 }

--- a/backend/internal/interfaces/api/handler/strategy.go
+++ b/backend/internal/interfaces/api/handler/strategy.go
@@ -19,7 +19,7 @@ func NewStrategyHandler(stanceResolver *usecase.RuleBasedStanceResolver) *Strate
 
 func (h *StrategyHandler) GetStrategy(c *gin.Context) {
 	indicators := entity.IndicatorSet{}
-	result := h.stanceResolver.Resolve(c.Request.Context(), indicators)
+	result := h.stanceResolver.Resolve(c.Request.Context(), indicators, 0)
 	c.JSON(http.StatusOK, result)
 }
 

--- a/backend/internal/interfaces/api/handler/strategy.go
+++ b/backend/internal/interfaces/api/handler/strategy.go
@@ -37,8 +37,8 @@ func (h *StrategyHandler) SetStrategy(c *gin.Context) {
 	}
 
 	stance := entity.MarketStance(req.Stance)
-	if stance != entity.MarketStanceTrendFollow && stance != entity.MarketStanceContrarian && stance != entity.MarketStanceHold {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "stance must be TREND_FOLLOW, CONTRARIAN, or HOLD"})
+	if stance != entity.MarketStanceTrendFollow && stance != entity.MarketStanceContrarian && stance != entity.MarketStanceHold && stance != entity.MarketStanceBreakout {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "stance must be TREND_FOLLOW, CONTRARIAN, HOLD, or BREAKOUT"})
 		return
 	}
 

--- a/backend/internal/usecase/backtest/handler.go
+++ b/backend/internal/usecase/backtest/handler.go
@@ -464,6 +464,37 @@ func calculateIndicatorSet(symbolID int64, candles []entity.Candle) entity.Indic
 
 	result.ATR14 = floatToPtr(indicator.ATR(highs, lows, closes, 14))
 
+	// Volume indicators
+	volumes := make([]float64, n)
+	for i, c := range candles {
+		volumes[i] = c.Volume
+	}
+	volSMA := indicator.VolumeSMA(volumes, 20)
+	result.VolumeSMA20 = floatToPtr(volSMA)
+	if !math.IsNaN(volSMA) && volSMA > 0 && n > 0 {
+		vr := indicator.VolumeRatio(volumes[n-1], volSMA)
+		result.VolumeRatio = floatToPtr(vr)
+	}
+
+	// RecentSqueeze: check if any of the last 5 candles had BBBandwidth < 0.02
+	if n >= 20 {
+		recentSqueeze := false
+		lookback := 5
+		if lookback > n-19 {
+			lookback = n - 19
+		}
+		for i := 0; i < lookback; i++ {
+			offset := n - 1 - i
+			windowCloses := closes[:offset+1]
+			_, _, _, bw := indicator.BollingerBands(windowCloses, 20, 2.0)
+			if !math.IsNaN(bw) && bw < 0.02 {
+				recentSqueeze = true
+				break
+			}
+		}
+		result.RecentSqueeze = &recentSqueeze
+	}
+
 	return result
 }
 

--- a/backend/internal/usecase/indicator.go
+++ b/backend/internal/usecase/indicator.go
@@ -69,6 +69,37 @@ func (c *IndicatorCalculator) Calculate(ctx context.Context, symbolID int64, int
 
 	result.ATR14 = toPtr(indicator.ATR(highs, lows, prices, 14))
 
+	// Volume indicators
+	volumes := make([]float64, n)
+	for i, cd := range candles {
+		volumes[n-1-i] = cd.Volume
+	}
+	volSMA := indicator.VolumeSMA(volumes, 20)
+	result.VolumeSMA20 = toPtr(volSMA)
+	if !math.IsNaN(volSMA) && volSMA > 0 && n > 0 {
+		vr := indicator.VolumeRatio(volumes[n-1], volSMA)
+		result.VolumeRatio = toPtr(vr)
+	}
+
+	// RecentSqueeze: check if any of the last 5 candles had BBBandwidth < 0.02
+	if n >= 20 {
+		recentSqueeze := false
+		lookback := 5
+		if lookback > n-19 {
+			lookback = n - 19
+		}
+		for i := 0; i < lookback; i++ {
+			offset := n - 1 - i
+			windowPrices := prices[:offset+1]
+			_, _, _, bw := indicator.BollingerBands(windowPrices, 20, 2.0)
+			if !math.IsNaN(bw) && bw < 0.02 {
+				recentSqueeze = true
+				break
+			}
+		}
+		result.RecentSqueeze = &recentSqueeze
+	}
+
 	return result, nil
 }
 

--- a/backend/internal/usecase/stance.go
+++ b/backend/internal/usecase/stance.go
@@ -22,8 +22,8 @@ type StanceResult struct {
 
 // StanceResolver はマーケットスタンスを解決するインターフェース。
 type StanceResolver interface {
-	Resolve(ctx context.Context, indicators entity.IndicatorSet) StanceResult
-	ResolveAt(ctx context.Context, indicators entity.IndicatorSet, now time.Time) StanceResult
+	Resolve(ctx context.Context, indicators entity.IndicatorSet, lastPrice float64) StanceResult
+	ResolveAt(ctx context.Context, indicators entity.IndicatorSet, lastPrice float64, now time.Time) StanceResult
 }
 
 type stanceOverride struct {
@@ -90,18 +90,18 @@ func NewRuleBasedStanceResolverWithOptions(repo repository.StanceOverrideReposit
 
 // Resolve はインジケータに基づいてマーケットスタンスを解決する。
 // オーバーライドが有効な場合はそれを優先する。
-func (r *RuleBasedStanceResolver) Resolve(ctx context.Context, indicators entity.IndicatorSet) StanceResult {
-	return r.ResolveAt(ctx, indicators, time.Now())
+func (r *RuleBasedStanceResolver) Resolve(ctx context.Context, indicators entity.IndicatorSet, lastPrice float64) StanceResult {
+	return r.ResolveAt(ctx, indicators, lastPrice, time.Now())
 }
 
 // ResolveAt resolves stance at caller-supplied time (for deterministic backtests).
-func (r *RuleBasedStanceResolver) ResolveAt(ctx context.Context, indicators entity.IndicatorSet, now time.Time) StanceResult {
+func (r *RuleBasedStanceResolver) ResolveAt(ctx context.Context, indicators entity.IndicatorSet, lastPrice float64, now time.Time) StanceResult {
 	if now.IsZero() {
 		now = time.Now()
 	}
 
 	if r.options.DisableOverride {
-		return r.applyRules(indicators, now)
+		return r.applyRules(indicators, lastPrice, now)
 	}
 
 	// オーバーライドチェック
@@ -125,10 +125,10 @@ func (r *RuleBasedStanceResolver) ResolveAt(ctx context.Context, indicators enti
 	}
 
 	// ルールベース判定
-	return r.applyRules(indicators, now)
+	return r.applyRules(indicators, lastPrice, now)
 }
 
-func (r *RuleBasedStanceResolver) applyRules(indicators entity.IndicatorSet, now time.Time) StanceResult {
+func (r *RuleBasedStanceResolver) applyRules(indicators entity.IndicatorSet, lastPrice float64, now time.Time) StanceResult {
 	// 1. インジケータ不足チェック
 	if indicators.SMA20 == nil || indicators.SMA50 == nil || indicators.RSI14 == nil {
 		return StanceResult{
@@ -143,7 +143,7 @@ func (r *RuleBasedStanceResolver) applyRules(indicators entity.IndicatorSet, now
 	sma50 := *indicators.SMA50
 	rsi := *indicators.RSI14
 
-	// 2. RSI極端値 → CONTRARIAN
+	// 2. RSI極端値 → CONTRARIAN（最優先）
 	if rsi < 25 {
 		return StanceResult{
 			Stance:    entity.MarketStanceContrarian,
@@ -161,9 +161,39 @@ func (r *RuleBasedStanceResolver) applyRules(indicators entity.IndicatorSet, now
 		}
 	}
 
-	// 3. SMA収束 → HOLD
+	// 3. RecentSqueeze → BREAKOUT or HOLD
+	if indicators.RecentSqueeze != nil && *indicators.RecentSqueeze {
+		if indicators.BBUpper != nil && indicators.BBLower != nil && indicators.VolumeRatio != nil {
+			volRatio := *indicators.VolumeRatio
+			if lastPrice > *indicators.BBUpper && volRatio >= 1.5 {
+				return StanceResult{
+					Stance:    entity.MarketStanceBreakout,
+					Reasoning: "BB breakout upward with volume confirmation",
+					Source:    "rule-based",
+					UpdatedAt: now.Unix(),
+				}
+			}
+			if lastPrice < *indicators.BBLower && volRatio >= 1.5 {
+				return StanceResult{
+					Stance:    entity.MarketStanceBreakout,
+					Reasoning: "BB breakout downward with volume confirmation",
+					Source:    "rule-based",
+					UpdatedAt: now.Unix(),
+				}
+			}
+		}
+		// スクイーズ中だがブレイクアウト未発生
+		return StanceResult{
+			Stance:    entity.MarketStanceHold,
+			Reasoning: "BB squeeze without breakout",
+			Source:    "rule-based",
+			UpdatedAt: now.Unix(),
+		}
+	}
+
+	// 4. SMA収束 → HOLD
 	divergence := math.Abs(sma20-sma50) / sma50
-	if divergence < 0.001 { // 0.1%
+	if divergence < 0.001 {
 		return StanceResult{
 			Stance:    entity.MarketStanceHold,
 			Reasoning: "SMA converged",
@@ -172,7 +202,7 @@ func (r *RuleBasedStanceResolver) applyRules(indicators entity.IndicatorSet, now
 		}
 	}
 
-	// 4. それ以外 → TREND_FOLLOW
+	// 5. それ以外 → TREND_FOLLOW
 	reasoning := "SMA uptrend"
 	if sma20 < sma50 {
 		reasoning = "SMA downtrend"

--- a/backend/internal/usecase/stance_test.go
+++ b/backend/internal/usecase/stance_test.go
@@ -12,13 +12,15 @@ import (
 
 func ptr(f float64) *float64 { return &f }
 
+func boolPtr(b bool) *bool { return &b }
+
 func TestRuleBasedStanceResolver_RSIBelow25_Contrarian(t *testing.T) {
 	resolver := NewRuleBasedStanceResolver(nil)
 	result := resolver.Resolve(context.Background(), entity.IndicatorSet{
 		SMA20: ptr(5100000),
 		SMA50: ptr(5000000),
 		RSI14: ptr(20.0),
-	})
+	}, 0)
 	if result.Stance != entity.MarketStanceContrarian {
 		t.Fatalf("expected CONTRARIAN, got %s", result.Stance)
 	}
@@ -33,7 +35,7 @@ func TestRuleBasedStanceResolver_RSIAbove75_Contrarian(t *testing.T) {
 		SMA20: ptr(5100000),
 		SMA50: ptr(5000000),
 		RSI14: ptr(80.0),
-	})
+	}, 0)
 	if result.Stance != entity.MarketStanceContrarian {
 		t.Fatalf("expected CONTRARIAN, got %s", result.Stance)
 	}
@@ -46,7 +48,7 @@ func TestRuleBasedStanceResolver_SMAConverged_Hold(t *testing.T) {
 		SMA20: ptr(5000000),
 		SMA50: ptr(5000400),
 		RSI14: ptr(50.0),
-	})
+	}, 0)
 	if result.Stance != entity.MarketStanceHold {
 		t.Fatalf("expected HOLD for converged SMA, got %s", result.Stance)
 	}
@@ -59,7 +61,7 @@ func TestRuleBasedStanceResolver_SMAUptrend_TrendFollow(t *testing.T) {
 		SMA20: ptr(5100000),
 		SMA50: ptr(5000000),
 		RSI14: ptr(50.0),
-	})
+	}, 0)
 	if result.Stance != entity.MarketStanceTrendFollow {
 		t.Fatalf("expected TREND_FOLLOW for uptrend, got %s", result.Stance)
 	}
@@ -72,7 +74,7 @@ func TestRuleBasedStanceResolver_SMADowntrend_TrendFollow(t *testing.T) {
 		SMA20: ptr(4900000),
 		SMA50: ptr(5000000),
 		RSI14: ptr(50.0),
-	})
+	}, 0)
 	if result.Stance != entity.MarketStanceTrendFollow {
 		t.Fatalf("expected TREND_FOLLOW for downtrend, got %s", result.Stance)
 	}
@@ -80,7 +82,7 @@ func TestRuleBasedStanceResolver_SMADowntrend_TrendFollow(t *testing.T) {
 
 func TestRuleBasedStanceResolver_NoIndicators_Hold(t *testing.T) {
 	resolver := NewRuleBasedStanceResolver(nil)
-	result := resolver.Resolve(context.Background(), entity.IndicatorSet{})
+	result := resolver.Resolve(context.Background(), entity.IndicatorSet{}, 0)
 	if result.Stance != entity.MarketStanceHold {
 		t.Fatalf("expected HOLD for no indicators, got %s", result.Stance)
 	}
@@ -98,7 +100,7 @@ func TestRuleBasedStanceResolver_OverrideTakesPriority(t *testing.T) {
 		SMA20: ptr(5100000),
 		SMA50: ptr(5000000),
 		RSI14: ptr(50.0),
-	})
+	}, 0)
 	if result.Stance != entity.MarketStanceContrarian {
 		t.Fatalf("expected CONTRARIAN from override, got %s", result.Stance)
 	}
@@ -127,7 +129,7 @@ func TestRuleBasedStanceResolver_ExpiredOverrideFallsBack(t *testing.T) {
 		SMA20: ptr(5100000),
 		SMA50: ptr(5000000),
 		RSI14: ptr(50.0),
-	})
+	}, 0)
 	if result.Stance != entity.MarketStanceTrendFollow {
 		t.Fatalf("expected TREND_FOLLOW after expired override, got %s", result.Stance)
 	}
@@ -145,7 +147,7 @@ func TestRuleBasedStanceResolver_ClearOverride(t *testing.T) {
 		SMA20: ptr(5100000),
 		SMA50: ptr(5000000),
 		RSI14: ptr(50.0),
-	})
+	}, 0)
 	if result.Stance != entity.MarketStanceTrendFollow {
 		t.Fatalf("expected TREND_FOLLOW after clearing override, got %s", result.Stance)
 	}
@@ -164,7 +166,7 @@ func TestRuleBasedStanceResolver_RSIExactly25_NotContrarian(t *testing.T) {
 		SMA20: ptr(5100000),
 		SMA50: ptr(5000000),
 		RSI14: ptr(25.0),
-	})
+	}, 0)
 	if result.Stance == entity.MarketStanceContrarian {
 		t.Fatalf("RSI=25.0 should NOT be CONTRARIAN, got %s", result.Stance)
 	}
@@ -176,7 +178,7 @@ func TestRuleBasedStanceResolver_RSIExactly75_NotContrarian(t *testing.T) {
 		SMA20: ptr(5100000),
 		SMA50: ptr(5000000),
 		RSI14: ptr(75.0),
-	})
+	}, 0)
 	if result.Stance == entity.MarketStanceContrarian {
 		t.Fatalf("RSI=75.0 should NOT be CONTRARIAN, got %s", result.Stance)
 	}
@@ -188,7 +190,7 @@ func TestRuleBasedStanceResolver_RSI24_9_Contrarian(t *testing.T) {
 		SMA20: ptr(5100000),
 		SMA50: ptr(5000000),
 		RSI14: ptr(24.9),
-	})
+	}, 0)
 	if result.Stance != entity.MarketStanceContrarian {
 		t.Fatalf("RSI=24.9 should be CONTRARIAN, got %s", result.Stance)
 	}
@@ -200,7 +202,7 @@ func TestRuleBasedStanceResolver_RSI75_1_Contrarian(t *testing.T) {
 		SMA20: ptr(5100000),
 		SMA50: ptr(5000000),
 		RSI14: ptr(75.1),
-	})
+	}, 0)
 	if result.Stance != entity.MarketStanceContrarian {
 		t.Fatalf("RSI=75.1 should be CONTRARIAN, got %s", result.Stance)
 	}
@@ -274,7 +276,7 @@ func TestRuleBasedStanceResolver_RestoresFromRepo(t *testing.T) {
 		SMA20: ptr(5100000),
 		SMA50: ptr(5000000),
 		RSI14: ptr(50.0),
-	})
+	}, 0)
 	if result.Stance != entity.MarketStanceContrarian {
 		t.Fatalf("expected CONTRARIAN from restored override, got %s", result.Stance)
 	}
@@ -317,7 +319,7 @@ func TestRuleBasedStanceResolver_ExpiredOverrideOnRestore_AutoDeleted(t *testing
 		SMA20: ptr(5100000),
 		SMA50: ptr(5000000),
 		RSI14: ptr(50.0),
-	})
+	}, 0)
 	if result.Source != "rule-based" {
 		t.Fatalf("expected rule-based after expired override cleanup, got %s", result.Source)
 	}
@@ -385,7 +387,7 @@ func TestRuleBasedStanceResolver_ResolveAt_UsesInjectedTimeForExpiry(t *testing.
 		SMA20: ptr(5100000),
 		SMA50: ptr(5000000),
 		RSI14: ptr(50.0),
-	}, time.Now().Add(1*time.Minute))
+	}, 0, time.Now().Add(1*time.Minute))
 	if early.Source != "override" {
 		t.Fatalf("expected override before expiry, got %s", early.Source)
 	}
@@ -394,7 +396,7 @@ func TestRuleBasedStanceResolver_ResolveAt_UsesInjectedTimeForExpiry(t *testing.
 		SMA20: ptr(5100000),
 		SMA50: ptr(5000000),
 		RSI14: ptr(50.0),
-	}, time.Now().Add(3*time.Minute))
+	}, 0, time.Now().Add(3*time.Minute))
 	if late.Source != "rule-based" {
 		t.Fatalf("expected rule-based after expiry, got %s", late.Source)
 	}
@@ -410,11 +412,120 @@ func TestRuleBasedStanceResolverWithOptions_DisableOverride(t *testing.T) {
 		SMA20: ptr(5100000),
 		SMA50: ptr(5000000),
 		RSI14: ptr(50.0),
-	})
+	}, 0)
 	if result.Source != "rule-based" {
 		t.Fatalf("expected rule-based when override disabled, got %s", result.Source)
 	}
 	if resolver.GetOverride() != nil {
 		t.Fatal("expected no active override when override disabled")
+	}
+}
+
+// --- BREAKOUT tests ---
+
+func TestRuleBasedStanceResolver_Breakout_UpwardWithVolume(t *testing.T) {
+	resolver := NewRuleBasedStanceResolver(nil)
+	// RecentSqueeze=true, price > BBUpper, VolumeRatio >= 1.5
+	result := resolver.Resolve(context.Background(), entity.IndicatorSet{
+		SMA20:         ptr(5000000),
+		SMA50:         ptr(4900000),
+		RSI14:         ptr(55.0),
+		BBUpper:       ptr(5100000),
+		BBLower:       ptr(4900000),
+		BBBandwidth:   ptr(0.015),
+		VolumeRatio:   ptr(2.0),
+		RecentSqueeze: boolPtr(true),
+	}, 5200000)
+	if result.Stance != entity.MarketStanceBreakout {
+		t.Fatalf("expected BREAKOUT for upward breakout with volume, got %s", result.Stance)
+	}
+}
+
+func TestRuleBasedStanceResolver_Breakout_DownwardWithVolume(t *testing.T) {
+	resolver := NewRuleBasedStanceResolver(nil)
+	result := resolver.Resolve(context.Background(), entity.IndicatorSet{
+		SMA20:         ptr(5000000),
+		SMA50:         ptr(5100000),
+		RSI14:         ptr(45.0),
+		BBUpper:       ptr(5100000),
+		BBLower:       ptr(4900000),
+		BBBandwidth:   ptr(0.015),
+		VolumeRatio:   ptr(1.8),
+		RecentSqueeze: boolPtr(true),
+	}, 4800000)
+	if result.Stance != entity.MarketStanceBreakout {
+		t.Fatalf("expected BREAKOUT for downward breakout with volume, got %s", result.Stance)
+	}
+}
+
+func TestRuleBasedStanceResolver_Squeeze_NoBreakout_Hold(t *testing.T) {
+	resolver := NewRuleBasedStanceResolver(nil)
+	// RecentSqueeze=true, but price is between bands → HOLD
+	result := resolver.Resolve(context.Background(), entity.IndicatorSet{
+		SMA20:         ptr(5000000),
+		SMA50:         ptr(5000400),
+		RSI14:         ptr(50.0),
+		BBUpper:       ptr(5100000),
+		BBLower:       ptr(4900000),
+		BBBandwidth:   ptr(0.01),
+		VolumeRatio:   ptr(2.0),
+		RecentSqueeze: boolPtr(true),
+	}, 5050000)
+	if result.Stance != entity.MarketStanceHold {
+		t.Fatalf("expected HOLD for squeeze without breakout, got %s", result.Stance)
+	}
+}
+
+func TestRuleBasedStanceResolver_Breakout_LowVolume_Hold(t *testing.T) {
+	resolver := NewRuleBasedStanceResolver(nil)
+	// Price > BBUpper + RecentSqueeze, but VolumeRatio < 1.5 → HOLD
+	result := resolver.Resolve(context.Background(), entity.IndicatorSet{
+		SMA20:         ptr(5000000),
+		SMA50:         ptr(5000400),
+		RSI14:         ptr(50.0),
+		BBUpper:       ptr(5100000),
+		BBLower:       ptr(4900000),
+		BBBandwidth:   ptr(0.01),
+		VolumeRatio:   ptr(1.0),
+		RecentSqueeze: boolPtr(true),
+	}, 5200000)
+	if result.Stance != entity.MarketStanceHold {
+		t.Fatalf("expected HOLD for breakout without volume confirmation, got %s", result.Stance)
+	}
+}
+
+func TestRuleBasedStanceResolver_Breakout_NoRecentSqueeze_TrendFollow(t *testing.T) {
+	resolver := NewRuleBasedStanceResolver(nil)
+	// Price > BBUpper + high volume, but RecentSqueeze=false → not a breakout
+	result := resolver.Resolve(context.Background(), entity.IndicatorSet{
+		SMA20:         ptr(5100000),
+		SMA50:         ptr(5000000),
+		RSI14:         ptr(55.0),
+		BBUpper:       ptr(5100000),
+		BBLower:       ptr(4900000),
+		BBBandwidth:   ptr(0.05),
+		VolumeRatio:   ptr(2.0),
+		RecentSqueeze: boolPtr(false),
+	}, 5200000)
+	if result.Stance != entity.MarketStanceTrendFollow {
+		t.Fatalf("expected TREND_FOLLOW without recent squeeze, got %s", result.Stance)
+	}
+}
+
+func TestRuleBasedStanceResolver_RSI_Contrarian_OverridesBreakout(t *testing.T) {
+	resolver := NewRuleBasedStanceResolver(nil)
+	// RSI < 25 takes priority over breakout conditions
+	result := resolver.Resolve(context.Background(), entity.IndicatorSet{
+		SMA20:         ptr(5000000),
+		SMA50:         ptr(4900000),
+		RSI14:         ptr(20.0),
+		BBUpper:       ptr(5100000),
+		BBLower:       ptr(4900000),
+		BBBandwidth:   ptr(0.01),
+		VolumeRatio:   ptr(2.0),
+		RecentSqueeze: boolPtr(true),
+	}, 5200000)
+	if result.Stance != entity.MarketStanceContrarian {
+		t.Fatalf("expected CONTRARIAN to override BREAKOUT when RSI extreme, got %s", result.Stance)
 	}
 }

--- a/backend/internal/usecase/strategy.go
+++ b/backend/internal/usecase/strategy.go
@@ -41,7 +41,7 @@ func (e *StrategyEngine) EvaluateWithHigherTFAt(
 		return signal, err
 	}
 
-	result := e.resolveAt(ctx, indicators, now)
+	result := e.resolveAt(ctx, indicators, lastPrice, now)
 
 	// Volatility filter: squeeze detection for trend-follow signals
 	// BBBandwidth < 0.02 (2%) indicates very low volatility / consolidation
@@ -121,7 +121,7 @@ func (e *StrategyEngine) EvaluateAt(ctx context.Context, indicators entity.Indic
 		}, nil
 	}
 
-	result := e.resolveAt(ctx, indicators, now)
+	result := e.resolveAt(ctx, indicators, lastPrice, now)
 
 	sma20 := *indicators.SMA20
 	sma50 := *indicators.SMA50
@@ -142,8 +142,8 @@ func (e *StrategyEngine) EvaluateAt(ctx context.Context, indicators entity.Indic
 	}
 }
 
-func (e *StrategyEngine) resolveAt(ctx context.Context, indicators entity.IndicatorSet, now time.Time) StanceResult {
-	return e.stanceResolver.ResolveAt(ctx, indicators, now)
+func (e *StrategyEngine) resolveAt(ctx context.Context, indicators entity.IndicatorSet, lastPrice float64, now time.Time) StanceResult {
+	return e.stanceResolver.ResolveAt(ctx, indicators, lastPrice, now)
 }
 
 func (e *StrategyEngine) evaluateTrendFollow(symbolID int64, sma20, sma50, rsi float64, ema12, ema26, histogram *float64, nowUnix int64) *entity.Signal {

--- a/backend/internal/usecase/strategy.go
+++ b/backend/internal/usecase/strategy.go
@@ -43,13 +43,12 @@ func (e *StrategyEngine) EvaluateWithHigherTFAt(
 
 	result := e.resolveAt(ctx, indicators, lastPrice, now)
 
-	// Volatility filter: squeeze detection for trend-follow signals
-	// BBBandwidth < 0.02 (2%) indicates very low volatility / consolidation
-	if result.Stance == entity.MarketStanceTrendFollow && indicators.BBBandwidth != nil && *indicators.BBBandwidth < 0.02 {
+	// Low volume filter: reject all signals when volume is extremely low
+	if indicators.VolumeRatio != nil && *indicators.VolumeRatio < 0.3 {
 		return &entity.Signal{
 			SymbolID:  indicators.SymbolID,
 			Action:    entity.SignalActionHold,
-			Reason:    "volatility filter: Bollinger squeeze, trend signal unreliable",
+			Reason:    "volume filter: volume ratio too low, signal unreliable",
 			Timestamp: signal.Timestamp,
 		}, nil
 	}
@@ -57,10 +56,8 @@ func (e *StrategyEngine) EvaluateWithHigherTFAt(
 	// BB position can boost/penalize confidence for contrarian
 	if result.Stance == entity.MarketStanceContrarian && indicators.BBLower != nil && indicators.BBUpper != nil {
 		if signal.Action == entity.SignalActionBuy && lastPrice <= *indicators.BBLower {
-			// Price at/below lower band: extra confidence for buy
 			signal.Confidence = math.Min(signal.Confidence+0.1, 1.0)
 		} else if signal.Action == entity.SignalActionSell && lastPrice >= *indicators.BBUpper {
-			// Price at/above upper band: extra confidence for sell
 			signal.Confidence = math.Min(signal.Confidence+0.1, 1.0)
 		}
 	}
@@ -69,8 +66,8 @@ func (e *StrategyEngine) EvaluateWithHigherTFAt(
 		return signal, nil
 	}
 
-	// Contrarian signals are intentionally counter-trend; don't filter by higher TF
-	if result.Stance == entity.MarketStanceContrarian {
+	// Contrarian and Breakout signals are intentionally allowed against higher TF
+	if result.Stance == entity.MarketStanceContrarian || result.Stance == entity.MarketStanceBreakout {
 		return signal, nil
 	}
 
@@ -132,6 +129,8 @@ func (e *StrategyEngine) EvaluateAt(ctx context.Context, indicators entity.Indic
 		return e.evaluateTrendFollow(indicators.SymbolID, sma20, sma50, rsi, indicators.EMA12, indicators.EMA26, indicators.Histogram, nowUnix), nil
 	case entity.MarketStanceContrarian:
 		return e.evaluateContrarian(indicators.SymbolID, rsi, indicators.Histogram, nowUnix), nil
+	case entity.MarketStanceBreakout:
+		return e.evaluateBreakout(indicators.SymbolID, lastPrice, indicators.BBUpper, indicators.BBLower, indicators.BBMiddle, indicators.VolumeRatio, indicators.Histogram, nowUnix), nil
 	default:
 		return &entity.Signal{
 			SymbolID:  indicators.SymbolID,
@@ -336,4 +335,88 @@ func contrarianConfidence(rsi float64, histogram *float64, isBuy bool) float64 {
 	}
 
 	return rsiExtreme*0.6 + macdNotAgainst*0.4
+}
+
+func (e *StrategyEngine) evaluateBreakout(symbolID int64, lastPrice float64, bbUpper, bbLower, bbMiddle, volumeRatio, histogram *float64, nowUnix int64) *entity.Signal {
+	if bbUpper == nil || bbLower == nil || bbMiddle == nil || volumeRatio == nil {
+		return &entity.Signal{
+			SymbolID:  symbolID,
+			Action:    entity.SignalActionHold,
+			Reason:    "breakout: insufficient BB/volume data",
+			Timestamp: nowUnix,
+		}
+	}
+
+	if lastPrice > *bbUpper && *volumeRatio >= 1.5 {
+		// MACD histogram confirmation
+		if histogram != nil && *histogram < 0 {
+			return &entity.Signal{
+				SymbolID:  symbolID,
+				Action:    entity.SignalActionHold,
+				Reason:    "breakout: MACD histogram negative, skipping buy",
+				Timestamp: nowUnix,
+			}
+		}
+		return &entity.Signal{
+			SymbolID:   symbolID,
+			Action:     entity.SignalActionBuy,
+			Confidence: breakoutConfidence(lastPrice, *bbUpper, *bbMiddle, *volumeRatio, histogram, true),
+			Reason:     "breakout: price above BB upper with volume confirmation",
+			Timestamp:  nowUnix,
+		}
+	}
+
+	if lastPrice < *bbLower && *volumeRatio >= 1.5 {
+		if histogram != nil && *histogram > 0 {
+			return &entity.Signal{
+				SymbolID:  symbolID,
+				Action:    entity.SignalActionHold,
+				Reason:    "breakout: MACD histogram positive, skipping sell",
+				Timestamp: nowUnix,
+			}
+		}
+		return &entity.Signal{
+			SymbolID:   symbolID,
+			Action:     entity.SignalActionSell,
+			Confidence: breakoutConfidence(lastPrice, *bbLower, *bbMiddle, *volumeRatio, histogram, false),
+			Reason:     "breakout: price below BB lower with volume confirmation",
+			Timestamp:  nowUnix,
+		}
+	}
+
+	return &entity.Signal{
+		SymbolID:  symbolID,
+		Action:    entity.SignalActionHold,
+		Reason:    "breakout: no clear breakout signal",
+		Timestamp: nowUnix,
+	}
+}
+
+// breakoutConfidence computes a 0.0–1.0 confidence score for breakout signals.
+// Factors: volume strength (40%), breakout depth (30%), MACD confirmation (30%).
+func breakoutConfidence(lastPrice, bandEdge, bbMiddle, volumeRatio float64, histogram *float64, isBuy bool) float64 {
+	// Volume strength: (VolumeRatio - 1.0) / 2.0, capped at 1.0
+	volStrength := math.Min((volumeRatio-1.0)/2.0, 1.0)
+	if volStrength < 0 {
+		volStrength = 0
+	}
+
+	// Breakout depth: distance from band edge normalized by BBMiddle
+	var depth float64
+	if bbMiddle > 0 {
+		if isBuy {
+			depth = (lastPrice - bandEdge) / bbMiddle
+		} else {
+			depth = (bandEdge - lastPrice) / bbMiddle
+		}
+	}
+	depth = math.Max(0, math.Min(depth*50, 1.0)) // 2% deviation = 1.0
+
+	// MACD confirmation
+	macdConfirm := 0.5
+	if histogram != nil {
+		macdConfirm = math.Min(math.Abs(*histogram)/10, 1.0)
+	}
+
+	return volStrength*0.4 + depth*0.3 + macdConfirm*0.3
 }

--- a/backend/internal/usecase/strategy_test.go
+++ b/backend/internal/usecase/strategy_test.go
@@ -668,8 +668,9 @@ func TestStrategyEngine_MTF_ContrarianNotFiltered(t *testing.T) {
 	}
 }
 
-func TestStrategyEngine_VolatilityFilter_SqueezeBlocksTrendFollow(t *testing.T) {
-	// BB bandwidth < 0.02 during trend follow → HOLD
+func TestStrategyEngine_SqueezeNowHandledByStance(t *testing.T) {
+	// BB squeeze filtering moved to StanceResolver; strategy.go no longer filters by BBBandwidth.
+	// When StanceResolver returns TREND_FOLLOW, strategy should evaluate normally regardless of BBBandwidth.
 	resolver := &mockStanceResolver{
 		result: StanceResult{Stance: entity.MarketStanceTrendFollow, Reasoning: "uptrend", Source: "rule-based", UpdatedAt: time.Now().Unix()},
 	}
@@ -681,17 +682,15 @@ func TestStrategyEngine_VolatilityFilter_SqueezeBlocksTrendFollow(t *testing.T) 
 		SMA50:       ptr(5000000.0),
 		RSI14:       ptr(55.0),
 		Histogram:   ptr(3.0),
-		BBBandwidth: ptr(0.015), // squeeze
+		BBBandwidth: ptr(0.015), // squeeze - but no longer filtered here
 	}
 	signal, err := engine.EvaluateWithHigherTF(context.Background(), indicators, nil, 5100000)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if signal.Action != entity.SignalActionHold {
-		t.Fatalf("expected HOLD during BB squeeze, got %s", signal.Action)
-	}
-	if signal.Reason != "volatility filter: Bollinger squeeze, trend signal unreliable" {
-		t.Fatalf("unexpected reason: %s", signal.Reason)
+	// Squeeze filtering is now in StanceResolver, so TREND_FOLLOW should still produce a signal
+	if signal.Action == entity.SignalActionHold {
+		t.Fatalf("expected non-HOLD since squeeze filter moved to StanceResolver, got HOLD: %s", signal.Reason)
 	}
 }
 
@@ -835,5 +834,182 @@ func TestStrategyEngine_EvaluateWithHigherTFAt_UsesInjectedTimestampForMTFHold(t
 	}
 	if signal.Timestamp != at.Unix() {
 		t.Fatalf("expected timestamp %d, got %d", at.Unix(), signal.Timestamp)
+	}
+}
+
+func TestStrategyEngine_Breakout_BuySignal(t *testing.T) {
+	resolver := &mockStanceResolver{
+		result: StanceResult{
+			Stance:    entity.MarketStanceBreakout,
+			Reasoning: "BB breakout upward with volume confirmation",
+			Source:    "rule-based",
+			UpdatedAt: time.Now().Unix(),
+		},
+	}
+	engine := NewStrategyEngine(resolver)
+
+	indicators := entity.IndicatorSet{
+		SymbolID:    7,
+		SMA20:       ptr(5000000),
+		SMA50:       ptr(4900000),
+		RSI14:       ptr(55.0),
+		BBUpper:     ptr(5100000),
+		BBMiddle:    ptr(5000000),
+		BBLower:     ptr(4900000),
+		VolumeRatio: ptr(2.0),
+		Histogram:   ptr(5.0),
+	}
+	signal, err := engine.Evaluate(context.Background(), indicators, 5200000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if signal.Action != entity.SignalActionBuy {
+		t.Fatalf("expected BUY for upward breakout, got %s", signal.Action)
+	}
+	if signal.Confidence <= 0 {
+		t.Fatal("expected positive confidence")
+	}
+}
+
+func TestStrategyEngine_Breakout_SellSignal(t *testing.T) {
+	resolver := &mockStanceResolver{
+		result: StanceResult{
+			Stance:    entity.MarketStanceBreakout,
+			Reasoning: "BB breakout downward with volume confirmation",
+			Source:    "rule-based",
+			UpdatedAt: time.Now().Unix(),
+		},
+	}
+	engine := NewStrategyEngine(resolver)
+
+	indicators := entity.IndicatorSet{
+		SymbolID:    7,
+		SMA20:       ptr(5000000),
+		SMA50:       ptr(5100000),
+		RSI14:       ptr(45.0),
+		BBUpper:     ptr(5100000),
+		BBMiddle:    ptr(5000000),
+		BBLower:     ptr(4900000),
+		VolumeRatio: ptr(1.8),
+		Histogram:   ptr(-5.0),
+	}
+	signal, err := engine.Evaluate(context.Background(), indicators, 4800000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if signal.Action != entity.SignalActionSell {
+		t.Fatalf("expected SELL for downward breakout, got %s", signal.Action)
+	}
+}
+
+func TestStrategyEngine_Breakout_HoldWhenMACDAgainst(t *testing.T) {
+	resolver := &mockStanceResolver{
+		result: StanceResult{
+			Stance:    entity.MarketStanceBreakout,
+			Reasoning: "BB breakout upward",
+			Source:    "rule-based",
+			UpdatedAt: time.Now().Unix(),
+		},
+	}
+	engine := NewStrategyEngine(resolver)
+
+	indicators := entity.IndicatorSet{
+		SymbolID:    7,
+		SMA20:       ptr(5000000),
+		SMA50:       ptr(4900000),
+		RSI14:       ptr(55.0),
+		BBUpper:     ptr(5100000),
+		BBMiddle:    ptr(5000000),
+		BBLower:     ptr(4900000),
+		VolumeRatio: ptr(2.0),
+		Histogram:   ptr(-5.0), // MACD against buy
+	}
+	signal, err := engine.Evaluate(context.Background(), indicators, 5200000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if signal.Action != entity.SignalActionHold {
+		t.Fatalf("expected HOLD when MACD against breakout buy, got %s", signal.Action)
+	}
+}
+
+func TestStrategyEngine_Breakout_MissingBBData_Hold(t *testing.T) {
+	resolver := &mockStanceResolver{
+		result: StanceResult{
+			Stance:    entity.MarketStanceBreakout,
+			Reasoning: "BB breakout",
+			Source:    "rule-based",
+			UpdatedAt: time.Now().Unix(),
+		},
+	}
+	engine := NewStrategyEngine(resolver)
+
+	indicators := entity.IndicatorSet{
+		SymbolID: 7,
+		SMA20:    ptr(5000000),
+		SMA50:    ptr(4900000),
+		RSI14:    ptr(55.0),
+		// BB fields nil
+	}
+	signal, err := engine.Evaluate(context.Background(), indicators, 5200000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if signal.Action != entity.SignalActionHold {
+		t.Fatalf("expected HOLD when BB data missing for breakout, got %s", signal.Action)
+	}
+}
+
+func TestStrategyEngine_LowVolume_FiltersSignal(t *testing.T) {
+	resolver := &mockStanceResolver{
+		result: StanceResult{
+			Stance:    entity.MarketStanceTrendFollow,
+			Reasoning: "uptrend",
+			Source:    "rule-based",
+			UpdatedAt: time.Now().Unix(),
+		},
+	}
+	engine := NewStrategyEngine(resolver)
+
+	indicators := entity.IndicatorSet{
+		SymbolID:    7,
+		SMA20:       ptr(5100000),
+		SMA50:       ptr(5000000),
+		RSI14:       ptr(55.0),
+		VolumeRatio: ptr(0.2), // Very low volume
+	}
+	signal, err := engine.EvaluateWithHigherTF(context.Background(), indicators, nil, 5100000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if signal.Action != entity.SignalActionHold {
+		t.Fatalf("expected HOLD for low volume, got %s", signal.Action)
+	}
+}
+
+func TestStrategyEngine_LowVolume_NilRatio_NoFilter(t *testing.T) {
+	resolver := &mockStanceResolver{
+		result: StanceResult{
+			Stance:    entity.MarketStanceTrendFollow,
+			Reasoning: "uptrend",
+			Source:    "rule-based",
+			UpdatedAt: time.Now().Unix(),
+		},
+	}
+	engine := NewStrategyEngine(resolver)
+
+	indicators := entity.IndicatorSet{
+		SymbolID: 7,
+		SMA20:    ptr(5100000),
+		SMA50:    ptr(5000000),
+		RSI14:    ptr(55.0),
+		// VolumeRatio nil → フィルターは適用されない
+	}
+	signal, err := engine.EvaluateWithHigherTF(context.Background(), indicators, nil, 5100000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if signal.Action != entity.SignalActionBuy {
+		t.Fatalf("expected BUY when VolumeRatio is nil (no filter), got %s", signal.Action)
 	}
 }

--- a/backend/internal/usecase/strategy_test.go
+++ b/backend/internal/usecase/strategy_test.go
@@ -12,11 +12,11 @@ type mockStanceResolver struct {
 	result StanceResult
 }
 
-func (m *mockStanceResolver) Resolve(ctx context.Context, indicators entity.IndicatorSet) StanceResult {
+func (m *mockStanceResolver) Resolve(ctx context.Context, indicators entity.IndicatorSet, lastPrice float64) StanceResult {
 	return m.result
 }
 
-func (m *mockStanceResolver) ResolveAt(ctx context.Context, indicators entity.IndicatorSet, now time.Time) StanceResult {
+func (m *mockStanceResolver) ResolveAt(ctx context.Context, indicators entity.IndicatorSet, lastPrice float64, now time.Time) StanceResult {
 	return m.result
 }
 

--- a/docs/design/2026-04-15-breakout-volume-strategy-design.md
+++ b/docs/design/2026-04-15-breakout-volume-strategy-design.md
@@ -1,7 +1,7 @@
 # ボリンジャーバンド・ブレイクアウト戦略 + 出来高分析 設計書
 
 **日付:** 2026-04-15
-**ステータス:** 承認済み
+**ステータス:** 承認済み（レビュー反映 v2）
 
 ## Goal
 
@@ -62,29 +62,50 @@ VolumeRatio  *float64 `json:"volumeRatio"`  // 最新出来高 / VolumeSMA20
 
 ### 新しいルール（BREAKOUT 追加）
 
+BREAKOUT 判定は「現在スクイーズ中」ではなく「直近でスクイーズが発生していた」状態からのブレイクアウトを検出する。これにより、スクイーズ中のバンド突破だけでなく、スクイーズ解消直後（帯域拡大が始まった瞬間）のブレイクアウトも捕捉できる。
+
+**「最近のスクイーズ」の定義:** `RecentSqueeze` は IndicatorCalculator が計算する bool 値で、直近5本のキャンドルのうち少なくとも1本で BBBandwidth < 0.02 だった場合に true となる。
+
 ```
-1. RSI < 25 or RSI > 75                              → CONTRARIAN（変更なし）
-2. BBBandwidth < 0.02（スクイーズ中）:
-   a. lastPrice > BBUpper かつ VolumeRatio ≥ 1.5      → BREAKOUT
-   b. lastPrice < BBLower かつ VolumeRatio ≥ 1.5      → BREAKOUT
-   c. それ以外                                        → HOLD（変更なし）
-3. SMA20 ≈ SMA50（乖離 < 0.1%）                      → HOLD（変更なし）
-4. それ以外                                           → TREND_FOLLOW（変更なし）
+1. RSI < 25 or RSI > 75                                         → CONTRARIAN（変更なし）
+2. RecentSqueeze == true:
+   a. lastPrice > BBUpper かつ VolumeRatio ≥ 1.5                 → BREAKOUT
+   b. lastPrice < BBLower かつ VolumeRatio ≥ 1.5                 → BREAKOUT
+   c. それ以外（スクイーズ中だがブレイクアウト未発生）              → HOLD（変更なし）
+3. SMA20 ≈ SMA50（乖離 < 0.1%）                                 → HOLD（変更なし）
+4. それ以外                                                      → TREND_FOLLOW（変更なし）
 ```
+
+### IndicatorSet への追加フィールド（RecentSqueeze 用）
+
+```go
+RecentSqueeze *bool `json:"recentSqueeze"` // 直近5本以内に BBBandwidth < 0.02 だったか
+```
+
+これは `IndicatorCalculator.Calculate()` で計算する。直近5本分の BBBandwidth を求め、いずれかが閾値以下なら true。
 
 ### シグネチャ変更
 
-`ResolveAt` に `lastPrice float64` パラメータを追加する。BB ブレイクアウト判定に現在価格が必要なため。
+`StanceResolver` インターフェースと `RuleBasedStanceResolver` の両メソッドに `lastPrice float64` パラメータを追加する。
 
 ```go
-// Before
+// StanceResolver interface — Before
+Resolve(ctx context.Context, indicators entity.IndicatorSet) StanceResult
 ResolveAt(ctx context.Context, indicators entity.IndicatorSet, now time.Time) StanceResult
 
-// After
+// StanceResolver interface — After
+Resolve(ctx context.Context, indicators entity.IndicatorSet, lastPrice float64) StanceResult
 ResolveAt(ctx context.Context, indicators entity.IndicatorSet, lastPrice float64, now time.Time) StanceResult
 ```
 
-呼び出し元（strategy.go, pipeline, backtest handler）を修正する。
+### 呼び出し元の修正
+
+| 呼び出し元 | 対応 |
+|---|---|
+| `usecase/strategy.go` の `resolveAt` | `lastPrice` を引数に追加して渡す（既にパラメータとして持っている） |
+| `interfaces/api/handler/strategy.go` の `GetStrategy` | 現在 `Resolve(ctx, emptyIndicators)` で呼んでおり、価格情報なし。`lastPrice: 0` を渡す（BREAKOUT 判定には BB/Volume が必要なので、価格 0 + 指標 nil の組み合わせでは BREAKOUT にならない） |
+| `strategy_test.go` の `mockStanceResolver` | `Resolve`/`ResolveAt` のシグネチャを更新（`lastPrice` を受け取るが無視） |
+| `stance_test.go` | 既存テストの `Resolve` 呼び出しに `lastPrice: 0` を追加（BB フィールドが nil なので挙動は変わらない） |
 
 ---
 
@@ -125,9 +146,9 @@ ResolveAt(ctx context.Context, indicators entity.IndicatorSet, lastPrice float64
 
 1. EvaluateAt でシグナル生成（HOLD ならここで return）
 2. **低出来高フィルター** ← 新規
-3. BB スクイーズフィルター（TREND_FOLLOW のみ）→ Stance Resolver 側に移動するため削除
+3. BB スクイーズフィルター（TREND_FOLLOW のみ）→ Stance Resolver 側に移動するため **削除**
 4. BB position による Contrarian confidence ブースト（変更なし）
-5. MTF フィルター（変更なし）
+5. **MTF フィルター — BREAKOUT は例外扱い**（後述）
 
 ### BB スクイーズフィルターの責務移動
 
@@ -137,31 +158,64 @@ ResolveAt(ctx context.Context, indicators entity.IndicatorSet, lastPrice float64
 - Strategy Engine はシグナル生成に専念すべき
 - Stance Resolver がスクイーズ + ブレイクアウト判定を一箇所で行う方が整合性が高い
 
+### MTF フィルターと BREAKOUT の関係
+
+BREAKOUT は CONTRARIAN と同様に MTF フィルターの **例外扱い** とする。理由:
+
+- ブレイクアウトは強いモメンタム転換であり、上位足のトレンドに逆行するブレイクアウトこそがトレンド転換の初動
+- MTF でブロックすると、BREAKOUT Stance の存在意義が大幅に削がれる
+- CONTRARIAN が既に例外扱いされている前例がある
+
+具体的には、`EvaluateWithHigherTFAt` の MTF フィルター部分で：
+```go
+// Contrarian and Breakout signals are intentionally allowed against higher TF
+if result.Stance == entity.MarketStanceContrarian || result.Stance == entity.MarketStanceBreakout {
+    return signal, nil
+}
+```
+
 ---
 
 ## 5. 変更ファイル一覧
 
+### コア変更
+
 | ファイル | 変更内容 |
 |---|---|
-| `entity/indicator.go` | `VolumeSMA20`, `VolumeRatio` フィールド追加 |
+| `entity/indicator.go` | `VolumeSMA20`, `VolumeRatio`, `RecentSqueeze` フィールド追加 |
 | `entity/strategy.go` | `MarketStanceBreakout` 定数追加 |
 | `infrastructure/indicator/volume.go` | **新規** — `VolumeSMA`, `VolumeRatio` 計算関数 |
 | `infrastructure/indicator/volume_test.go` | **新規** — Volume インジケーターのテスト |
-| `usecase/indicator.go` | Volume インジケーター計算を追加 |
-| `usecase/stance.go` | BREAKOUT 判定ルール追加、`ResolveAt` に `lastPrice` パラメータ追加 |
-| `usecase/strategy.go` | `evaluateBreakout` + `breakoutConfidence` 追加、低出来高フィルター追加、BB スクイーズフィルター削除 |
-| `usecase/stance_test.go` | BREAKOUT Stance のテスト |
-| `usecase/strategy_test.go` | BREAKOUT シグナル + 低出来高フィルターのテスト |
+| `usecase/indicator.go` | Volume インジケーター計算 + RecentSqueeze 計算を追加 |
+| `usecase/stance.go` | `StanceResolver` インターフェース + `RuleBasedStanceResolver` に `lastPrice` 追加、BREAKOUT 判定ルール追加 |
+| `usecase/strategy.go` | `evaluateBreakout` + `breakoutConfidence` 追加、低出来高フィルター追加、BB スクイーズフィルター削除、MTF の BREAKOUT 例外追加 |
 
-### 呼び出し元の修正（ResolveAt シグネチャ変更に伴う）
+### テスト
+
+| ファイル | 変更内容 |
+|---|---|
+| `infrastructure/indicator/volume_test.go` | **新規** — VolumeSMA / VolumeRatio のユニットテスト |
+| `usecase/stance_test.go` | BREAKOUT Stance テスト追加 + 既存テストの `Resolve` 呼び出しに `lastPrice` 追加 |
+| `usecase/strategy_test.go` | BREAKOUT シグナルテスト + 低出来高フィルターテスト + `mockStanceResolver` のシグネチャ更新 |
+
+### 呼び出し元の修正（シグネチャ変更に伴う）
 
 | ファイル | 変更内容 |
 |---|---|
 | `usecase/strategy.go` | `resolveAt` に `lastPrice` を渡す |
-| `usecase/backtest/handler.go` | バックテストからの `ResolveAt` 呼び出しに `lastPrice` を渡す（呼んでいる場合） |
+| `interfaces/api/handler/strategy.go` | `Resolve` に `lastPrice: 0` を渡す + `SetStrategy` のバリデーションに `BREAKOUT` を追加 |
+| `interfaces/api/handler/handler_test.go` | SetStrategy のバリデーションテスト更新（BREAKOUT を有効な値として追加） |
+
+### バックテスト対応
+
+| ファイル | 変更内容 |
+|---|---|
+| `usecase/backtest/handler.go` | 指標計算に Volume 指標（VolumeSMA20, VolumeRatio, RecentSqueeze）を追加。BREAKOUT Stance でのシグナル生成が実運用と同等に動作するようにする |
+| `usecase/backtest/handler_test.go` | バックテストでの BREAKOUT シグナル生成テスト |
 
 ### 既存ロジックへの影響
 
 - 既存の TREND_FOLLOW / CONTRARIAN の判定ロジック自体は変更なし
-- BB スクイーズフィルターの責務が strategy.go → stance.go に移動（動作は同等）
-- `ResolveAt` のシグネチャ変更は破壊的だが、呼び出し元は限定的
+- BB スクイーズフィルターの責務が strategy.go → stance.go に移動（TREND_FOLLOW に対する動作は同等）
+- `StanceResolver` インターフェースのシグネチャ変更は破壊的だが、実装は `RuleBasedStanceResolver` のみ、呼び出し元も限定的
+- MTF フィルターに BREAKOUT 例外を追加（CONTRARIAN の既存パターンと統一）

--- a/docs/design/2026-04-15-breakout-volume-strategy-design.md
+++ b/docs/design/2026-04-15-breakout-volume-strategy-design.md
@@ -1,0 +1,167 @@
+# ボリンジャーバンド・ブレイクアウト戦略 + 出来高分析 設計書
+
+**日付:** 2026-04-15
+**ステータス:** 承認済み
+
+## Goal
+
+BB スクイーズ後のブレイクアウトを出来高で確認し、自動売買シグナルを生成する新 Stance `BREAKOUT` を追加する。
+併せて出来高インジケーターを全 Stance 共通のフィルターとして活用する。
+
+## Background
+
+- 現在のシステムは BB スクイーズ（BBBandwidth < 2%）を検出して HOLD にしているが、スクイーズ後のブレイクアウトは最も利益の出るエントリーポイントであり、見逃している
+- 暗号資産は出来高を伴うブレイクアウトが明確に出やすい市場特性がある
+- Candle/Ticker に Volume フィールドが既に存在するが、インジケーター計算に未使用
+
+## Architecture
+
+### Approach: 新 Stance `BREAKOUT` + 出来高フィルター
+
+- BB スクイーズ → ブレイクアウト（バンド突破 + 出来高急増）を検出する4つ目の Stance を追加
+- 出来高は Volume SMA（20期間）との比率でインジケーター化し、ブレイクアウトの確認条件 + 全 Stance 共通のフィルターとして二重活用
+- Stance として独立させることで、既存の TREND_FOLLOW / CONTRARIAN のロジックに影響しない
+
+### 不採用案
+
+- **B. 既存 Stance の拡張のみ**: TREND_FOLLOW が複雑になりすぎる。スクイーズ→ブレイクアウトは独立したパターンであり、無理に既存 Stance に押し込む形になる
+- **C. 出来高インジケーターだけ追加**: 自動売買の改善にはつながらない
+
+---
+
+## 1. インジケーター追加
+
+### 新規インジケーター
+
+| インジケーター | 計算方法 | 用途 |
+|---|---|---|
+| `VolumeSMA20` | 直近20本の出来高の単純移動平均 | 出来高の基準値 |
+| `VolumeRatio` | 最新出来高 / VolumeSMA20 | 出来高の相対的な増減（1.0 = 平均、2.0 = 平均の2倍） |
+
+### IndicatorSet への追加フィールド
+
+```go
+VolumeSMA20  *float64 `json:"volumeSma20"`  // 出来高20期間SMA
+VolumeRatio  *float64 `json:"volumeRatio"`  // 最新出来高 / VolumeSMA20
+```
+
+### 計算
+
+既存の `IndicatorCalculator.Calculate()` に追記。キャンドルの `Volume` データは既に取得済みなので、`volumes` スライスを作って SMA を計算する。VolumeRatio は VolumeSMA20 が 0 の場合は nil を返す（ゼロ除算回避）。
+
+---
+
+## 2. Stance Resolver の変更
+
+### 現在のルール
+
+1. RSI < 25 → CONTRARIAN
+2. RSI > 75 → CONTRARIAN
+3. SMA20 ≈ SMA50（乖離 < 0.1%）→ HOLD
+4. それ以外 → TREND_FOLLOW
+
+### 新しいルール（BREAKOUT 追加）
+
+```
+1. RSI < 25 or RSI > 75                              → CONTRARIAN（変更なし）
+2. BBBandwidth < 0.02（スクイーズ中）:
+   a. lastPrice > BBUpper かつ VolumeRatio ≥ 1.5      → BREAKOUT
+   b. lastPrice < BBLower かつ VolumeRatio ≥ 1.5      → BREAKOUT
+   c. それ以外                                        → HOLD（変更なし）
+3. SMA20 ≈ SMA50（乖離 < 0.1%）                      → HOLD（変更なし）
+4. それ以外                                           → TREND_FOLLOW（変更なし）
+```
+
+### シグネチャ変更
+
+`ResolveAt` に `lastPrice float64` パラメータを追加する。BB ブレイクアウト判定に現在価格が必要なため。
+
+```go
+// Before
+ResolveAt(ctx context.Context, indicators entity.IndicatorSet, now time.Time) StanceResult
+
+// After
+ResolveAt(ctx context.Context, indicators entity.IndicatorSet, lastPrice float64, now time.Time) StanceResult
+```
+
+呼び出し元（strategy.go, pipeline, backtest handler）を修正する。
+
+---
+
+## 3. BREAKOUT 戦略ロジック
+
+### evaluateBreakout の判定
+
+| 条件 | アクション |
+|---|---|
+| lastPrice > BBUpper かつ VolumeRatio ≥ 1.5 | **BUY**（上方ブレイクアウト） |
+| lastPrice < BBLower かつ VolumeRatio ≥ 1.5 | **SELL**（下方ブレイクアウト） |
+| それ以外 | **HOLD** |
+
+### MACD フィルター（既存パターンと統一）
+
+- BUY 時に histogram < 0 → HOLD（モメンタムが逆方向）
+- SELL 時に histogram > 0 → HOLD
+
+### Confidence スコアリング（breakoutConfidence）
+
+| 要素 | ウェイト | 計算 |
+|---|---|---|
+| 出来高の強さ | 40% | `min((VolumeRatio - 1.0) / 2.0, 1.0)` — 出来高が平均の3倍以上で最大 |
+| ブレイクアウトの深さ | 30% | バンドからの乖離率 — BBUpper/BBLower からの距離を BBMiddle で正規化 |
+| MACD 確認 | 30% | `min(abs(histogram) / 10, 1.0)` — ヒストグラムの強さ |
+
+---
+
+## 4. 出来高フィルター（全 Stance 共通）
+
+`EvaluateWithHigherTF` の既存フィルターチェーン（BB スクイーズ、MTF フィルター）に追加:
+
+- **VolumeRatio < 0.3**（平均の30%未満）の場合、全 Stance のシグナルを HOLD に変換
+- 理由: 出来高が極端に少ない時間帯のシグナルは信頼性が低い
+- BREAKOUT は Stance Resolver 段階で VolumeRatio ≥ 1.5 を要求しているので、このフィルターに引っかかることはない
+
+### フィルター適用順序（EvaluateWithHigherTF 内）
+
+1. EvaluateAt でシグナル生成（HOLD ならここで return）
+2. **低出来高フィルター** ← 新規
+3. BB スクイーズフィルター（TREND_FOLLOW のみ）→ Stance Resolver 側に移動するため削除
+4. BB position による Contrarian confidence ブースト（変更なし）
+5. MTF フィルター（変更なし）
+
+### BB スクイーズフィルターの責務移動
+
+現在 `EvaluateWithHigherTF` 内にある BB スクイーズ検出（BBBandwidth < 0.02 → HOLD）は、Stance Resolver に移動する。理由:
+
+- スクイーズ中の判定は Stance レベルの関心事（HOLD vs BREAKOUT）
+- Strategy Engine はシグナル生成に専念すべき
+- Stance Resolver がスクイーズ + ブレイクアウト判定を一箇所で行う方が整合性が高い
+
+---
+
+## 5. 変更ファイル一覧
+
+| ファイル | 変更内容 |
+|---|---|
+| `entity/indicator.go` | `VolumeSMA20`, `VolumeRatio` フィールド追加 |
+| `entity/strategy.go` | `MarketStanceBreakout` 定数追加 |
+| `infrastructure/indicator/volume.go` | **新規** — `VolumeSMA`, `VolumeRatio` 計算関数 |
+| `infrastructure/indicator/volume_test.go` | **新規** — Volume インジケーターのテスト |
+| `usecase/indicator.go` | Volume インジケーター計算を追加 |
+| `usecase/stance.go` | BREAKOUT 判定ルール追加、`ResolveAt` に `lastPrice` パラメータ追加 |
+| `usecase/strategy.go` | `evaluateBreakout` + `breakoutConfidence` 追加、低出来高フィルター追加、BB スクイーズフィルター削除 |
+| `usecase/stance_test.go` | BREAKOUT Stance のテスト |
+| `usecase/strategy_test.go` | BREAKOUT シグナル + 低出来高フィルターのテスト |
+
+### 呼び出し元の修正（ResolveAt シグネチャ変更に伴う）
+
+| ファイル | 変更内容 |
+|---|---|
+| `usecase/strategy.go` | `resolveAt` に `lastPrice` を渡す |
+| `usecase/backtest/handler.go` | バックテストからの `ResolveAt` 呼び出しに `lastPrice` を渡す（呼んでいる場合） |
+
+### 既存ロジックへの影響
+
+- 既存の TREND_FOLLOW / CONTRARIAN の判定ロジック自体は変更なし
+- BB スクイーズフィルターの責務が strategy.go → stance.go に移動（動作は同等）
+- `ResolveAt` のシグネチャ変更は破壊的だが、呼び出し元は限定的

--- a/docs/superpowers/plans/2026-04-15-breakout-volume-strategy.md
+++ b/docs/superpowers/plans/2026-04-15-breakout-volume-strategy.md
@@ -1,0 +1,1088 @@
+# Breakout + Volume Strategy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** BB スクイーズ後のブレイクアウトを出来高で確認する新 Stance `BREAKOUT` と、全 Stance 共通の低出来高フィルターを追加する。
+
+**Architecture:** (1) Volume インジケーター計算関数を追加、(2) IndicatorSet に Volume + RecentSqueeze フィールドを追加、(3) StanceResolver に BREAKOUT 判定を追加（`lastPrice` パラメータ追加）、(4) StrategyEngine に evaluateBreakout + 低出来高フィルターを追加、(5) API handler + バックテストを対応。各タスクは TDD で進める。
+
+**Tech Stack:** Go 1.25, existing indicator/entity/usecase packages
+
+**Design Doc:** `docs/design/2026-04-15-breakout-volume-strategy-design.md`
+
+---
+
+## File Structure
+
+### 新規ファイル
+- `backend/internal/infrastructure/indicator/volume.go` — VolumeSMA / VolumeRatio 計算関数
+- `backend/internal/infrastructure/indicator/volume_test.go` — テスト
+
+### 変更ファイル
+- `backend/internal/domain/entity/indicator.go` — VolumeSMA20, VolumeRatio, RecentSqueeze フィールド追加
+- `backend/internal/domain/entity/strategy.go` — MarketStanceBreakout 定数追加
+- `backend/internal/usecase/indicator.go` — Volume + RecentSqueeze 計算追加
+- `backend/internal/usecase/stance.go` — StanceResolver インターフェース + applyRules に BREAKOUT 追加
+- `backend/internal/usecase/stance_test.go` — BREAKOUT テスト + 既存テストのシグネチャ更新
+- `backend/internal/usecase/strategy.go` — evaluateBreakout, 低出来高フィルター, BB スクイーズフィルター削除, MTF 例外
+- `backend/internal/usecase/strategy_test.go` — mockStanceResolver 更新 + BREAKOUT テスト + フィルターテスト
+- `backend/internal/interfaces/api/handler/strategy.go` — Resolve に lastPrice 追加, BREAKOUT バリデーション
+- `backend/internal/interfaces/api/handler/handler_test.go` — BREAKOUT バリデーションテスト
+- `backend/internal/usecase/backtest/handler.go` — calculateIndicatorSet に Volume + RecentSqueeze 追加
+
+---
+
+## Task 1: Volume インジケーター計算関数
+
+**Files:**
+- Create: `backend/internal/infrastructure/indicator/volume.go`
+- Create: `backend/internal/infrastructure/indicator/volume_test.go`
+
+- [ ] **Step 1: volume_test.go にテスト作成**
+
+```go
+// backend/internal/infrastructure/indicator/volume_test.go
+package indicator
+
+import (
+	"math"
+	"testing"
+)
+
+func TestVolumeSMA_InsufficientData(t *testing.T) {
+	result := VolumeSMA([]float64{100, 200}, 20)
+	if !math.IsNaN(result) {
+		t.Fatalf("expected NaN for insufficient data, got %f", result)
+	}
+}
+
+func TestVolumeSMA_ExactPeriod(t *testing.T) {
+	volumes := make([]float64, 20)
+	for i := range volumes {
+		volumes[i] = 100.0
+	}
+	result := VolumeSMA(volumes, 20)
+	if result != 100.0 {
+		t.Fatalf("expected 100.0, got %f", result)
+	}
+}
+
+func TestVolumeSMA_UsesLastNPeriod(t *testing.T) {
+	// 30 candles, last 20 are all 200, first 10 are all 100
+	volumes := make([]float64, 30)
+	for i := range volumes {
+		if i < 10 {
+			volumes[i] = 100.0
+		} else {
+			volumes[i] = 200.0
+		}
+	}
+	result := VolumeSMA(volumes, 20)
+	if result != 200.0 {
+		t.Fatalf("expected 200.0, got %f", result)
+	}
+}
+
+func TestVolumeRatio_Normal(t *testing.T) {
+	// Current volume = 300, SMA = 100 → ratio = 3.0
+	result := VolumeRatio(300, 100)
+	if result != 3.0 {
+		t.Fatalf("expected 3.0, got %f", result)
+	}
+}
+
+func TestVolumeRatio_ZeroSMA(t *testing.T) {
+	result := VolumeRatio(300, 0)
+	if !math.IsNaN(result) {
+		t.Fatalf("expected NaN for zero SMA, got %f", result)
+	}
+}
+
+func TestVolumeRatio_ZeroVolume(t *testing.T) {
+	result := VolumeRatio(0, 100)
+	if result != 0.0 {
+		t.Fatalf("expected 0.0, got %f", result)
+	}
+}
+```
+
+- [ ] **Step 2: テストが FAIL することを確認**
+
+Run: `cd backend && go test ./internal/infrastructure/indicator/ -run "TestVolumeSMA|TestVolumeRatio" -v`
+Expected: compilation error（VolumeSMA / VolumeRatio が未定義）
+
+- [ ] **Step 3: volume.go を実装**
+
+```go
+// backend/internal/infrastructure/indicator/volume.go
+package indicator
+
+import "math"
+
+// VolumeSMA computes the simple moving average of volume over the last `period` candles.
+// Returns NaN if len(volumes) < period.
+func VolumeSMA(volumes []float64, period int) float64 {
+	if len(volumes) < period {
+		return math.NaN()
+	}
+	sum := 0.0
+	for _, v := range volumes[len(volumes)-period:] {
+		sum += v
+	}
+	return sum / float64(period)
+}
+
+// VolumeRatio computes currentVolume / sma.
+// Returns NaN if sma is zero.
+func VolumeRatio(currentVolume, sma float64) float64 {
+	if sma == 0 {
+		return math.NaN()
+	}
+	return currentVolume / sma
+}
+```
+
+- [ ] **Step 4: テスト PASS を確認**
+
+Run: `cd backend && go test ./internal/infrastructure/indicator/ -run "TestVolumeSMA|TestVolumeRatio" -v`
+Expected: ALL PASS
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add backend/internal/infrastructure/indicator/volume.go backend/internal/infrastructure/indicator/volume_test.go
+git commit -m "feat(indicator): add VolumeSMA and VolumeRatio calculation functions"
+```
+
+---
+
+## Task 2: IndicatorSet + MarketStance エンティティ拡張
+
+**Files:**
+- Modify: `backend/internal/domain/entity/indicator.go`
+- Modify: `backend/internal/domain/entity/strategy.go`
+
+- [ ] **Step 1: IndicatorSet にフィールド追加**
+
+`backend/internal/domain/entity/indicator.go` の `ATR14` フィールドの後に追加:
+
+```go
+	VolumeSMA20   *float64 `json:"volumeSma20"`   // 出来高20期間SMA
+	VolumeRatio   *float64 `json:"volumeRatio"`   // 最新出来高 / VolumeSMA20
+	RecentSqueeze *bool    `json:"recentSqueeze"` // 直近5本以内に BBBandwidth < 0.02
+```
+
+- [ ] **Step 2: MarketStanceBreakout 定数追加**
+
+`backend/internal/domain/entity/strategy.go` の `MarketStanceHold` の後に追加:
+
+```go
+	MarketStanceBreakout MarketStance = "BREAKOUT"
+```
+
+- [ ] **Step 3: ビルド確認**
+
+Run: `cd backend && go build ./...`
+Expected: エラーなし
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add backend/internal/domain/entity/indicator.go backend/internal/domain/entity/strategy.go
+git commit -m "feat(entity): add Volume/RecentSqueeze fields and BREAKOUT stance"
+```
+
+---
+
+## Task 3: IndicatorCalculator に Volume + RecentSqueeze 計算を追加
+
+**Files:**
+- Modify: `backend/internal/usecase/indicator.go`
+- Modify: `backend/internal/usecase/backtest/handler.go`
+
+- [ ] **Step 1: usecase/indicator.go に Volume 計算を追加**
+
+`backend/internal/usecase/indicator.go` の `Calculate` 関数内、`result.ATR14 = ...` の後に追加:
+
+```go
+	// Volume indicators
+	volumes := make([]float64, n)
+	for i, cd := range candles {
+		volumes[n-1-i] = cd.Volume
+	}
+	volSMA := indicator.VolumeSMA(volumes, 20)
+	result.VolumeSMA20 = toPtr(volSMA)
+	if !math.IsNaN(volSMA) && volSMA > 0 && n > 0 {
+		vr := indicator.VolumeRatio(volumes[n-1], volSMA)
+		result.VolumeRatio = toPtr(vr)
+	}
+
+	// RecentSqueeze: check if any of the last 5 candles had BBBandwidth < 0.02
+	if n >= 20 {
+		recentSqueeze := false
+		lookback := 5
+		if lookback > n-19 {
+			lookback = n - 19
+		}
+		for i := 0; i < lookback; i++ {
+			offset := n - 1 - i
+			windowPrices := prices[:offset+1]
+			_, _, _, bw := indicator.BollingerBands(windowPrices, 20, 2.0)
+			if !math.IsNaN(bw) && bw < 0.02 {
+				recentSqueeze = true
+				break
+			}
+		}
+		result.RecentSqueeze = &recentSqueeze
+	}
+```
+
+- [ ] **Step 2: backtest/handler.go の calculateIndicatorSet にも同様に追加**
+
+`backend/internal/usecase/backtest/handler.go` の `calculateIndicatorSet` 関数内、`result.ATR14 = ...` の後に追加:
+
+```go
+	// Volume indicators
+	volumes := make([]float64, n)
+	for i, c := range candles {
+		volumes[i] = c.Volume
+	}
+	volSMA := indicator.VolumeSMA(volumes, 20)
+	result.VolumeSMA20 = floatToPtr(volSMA)
+	if !math.IsNaN(volSMA) && volSMA > 0 && n > 0 {
+		vr := indicator.VolumeRatio(volumes[n-1], volSMA)
+		result.VolumeRatio = floatToPtr(vr)
+	}
+
+	// RecentSqueeze: check if any of the last 5 candles had BBBandwidth < 0.02
+	if n >= 20 {
+		recentSqueeze := false
+		lookback := 5
+		if lookback > n-19 {
+			lookback = n - 19
+		}
+		for i := 0; i < lookback; i++ {
+			offset := n - 1 - i
+			windowCloses := closes[:offset+1]
+			_, _, _, bw := indicator.BollingerBands(windowCloses, 20, 2.0)
+			if !math.IsNaN(bw) && bw < 0.02 {
+				recentSqueeze = true
+				break
+			}
+		}
+		result.RecentSqueeze = &recentSqueeze
+	}
+```
+
+- [ ] **Step 3: ビルド確認**
+
+Run: `cd backend && go build ./...`
+Expected: エラーなし
+
+- [ ] **Step 4: 全テスト PASS 確認**
+
+Run: `cd backend && go test ./... -count=1`
+Expected: ALL PASS
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add backend/internal/usecase/indicator.go backend/internal/usecase/backtest/handler.go
+git commit -m "feat(indicator): compute Volume and RecentSqueeze in IndicatorCalculator and backtest"
+```
+
+---
+
+## Task 4: StanceResolver に BREAKOUT 判定と lastPrice パラメータ追加
+
+**Files:**
+- Modify: `backend/internal/usecase/stance.go`
+- Modify: `backend/internal/usecase/stance_test.go`
+
+- [ ] **Step 1: stance_test.go に BREAKOUT テストを追加**
+
+`backend/internal/usecase/stance_test.go` の末尾に追加:
+
+```go
+func boolPtr(b bool) *bool { return &b }
+
+func TestRuleBasedStanceResolver_Breakout_UpwardWithVolume(t *testing.T) {
+	resolver := NewRuleBasedStanceResolver(nil)
+	// RecentSqueeze=true, price > BBUpper, VolumeRatio >= 1.5
+	result := resolver.Resolve(context.Background(), entity.IndicatorSet{
+		SMA20:         ptr(5000000),
+		SMA50:         ptr(4900000),
+		RSI14:         ptr(55.0),
+		BBUpper:       ptr(5100000),
+		BBLower:       ptr(4900000),
+		BBBandwidth:   ptr(0.015),
+		VolumeRatio:   ptr(2.0),
+		RecentSqueeze: boolPtr(true),
+	}, 5200000)
+	if result.Stance != entity.MarketStanceBreakout {
+		t.Fatalf("expected BREAKOUT for upward breakout with volume, got %s", result.Stance)
+	}
+}
+
+func TestRuleBasedStanceResolver_Breakout_DownwardWithVolume(t *testing.T) {
+	resolver := NewRuleBasedStanceResolver(nil)
+	result := resolver.Resolve(context.Background(), entity.IndicatorSet{
+		SMA20:         ptr(5000000),
+		SMA50:         ptr(5100000),
+		RSI14:         ptr(45.0),
+		BBUpper:       ptr(5100000),
+		BBLower:       ptr(4900000),
+		BBBandwidth:   ptr(0.015),
+		VolumeRatio:   ptr(1.8),
+		RecentSqueeze: boolPtr(true),
+	}, 4800000)
+	if result.Stance != entity.MarketStanceBreakout {
+		t.Fatalf("expected BREAKOUT for downward breakout with volume, got %s", result.Stance)
+	}
+}
+
+func TestRuleBasedStanceResolver_Squeeze_NoBreakout_Hold(t *testing.T) {
+	resolver := NewRuleBasedStanceResolver(nil)
+	// RecentSqueeze=true, but price is between bands → HOLD
+	result := resolver.Resolve(context.Background(), entity.IndicatorSet{
+		SMA20:         ptr(5000000),
+		SMA50:         ptr(5000400),
+		RSI14:         ptr(50.0),
+		BBUpper:       ptr(5100000),
+		BBLower:       ptr(4900000),
+		BBBandwidth:   ptr(0.01),
+		VolumeRatio:   ptr(2.0),
+		RecentSqueeze: boolPtr(true),
+	}, 5050000)
+	if result.Stance != entity.MarketStanceHold {
+		t.Fatalf("expected HOLD for squeeze without breakout, got %s", result.Stance)
+	}
+}
+
+func TestRuleBasedStanceResolver_Breakout_LowVolume_Hold(t *testing.T) {
+	resolver := NewRuleBasedStanceResolver(nil)
+	// Price > BBUpper + RecentSqueeze, but VolumeRatio < 1.5 → HOLD
+	result := resolver.Resolve(context.Background(), entity.IndicatorSet{
+		SMA20:         ptr(5000000),
+		SMA50:         ptr(5000400),
+		RSI14:         ptr(50.0),
+		BBUpper:       ptr(5100000),
+		BBLower:       ptr(4900000),
+		BBBandwidth:   ptr(0.01),
+		VolumeRatio:   ptr(1.0),
+		RecentSqueeze: boolPtr(true),
+	}, 5200000)
+	if result.Stance != entity.MarketStanceHold {
+		t.Fatalf("expected HOLD for breakout without volume confirmation, got %s", result.Stance)
+	}
+}
+
+func TestRuleBasedStanceResolver_Breakout_NoRecentSqueeze_TrendFollow(t *testing.T) {
+	resolver := NewRuleBasedStanceResolver(nil)
+	// Price > BBUpper + high volume, but RecentSqueeze=false → not a breakout
+	result := resolver.Resolve(context.Background(), entity.IndicatorSet{
+		SMA20:         ptr(5100000),
+		SMA50:         ptr(5000000),
+		RSI14:         ptr(55.0),
+		BBUpper:       ptr(5100000),
+		BBLower:       ptr(4900000),
+		BBBandwidth:   ptr(0.05),
+		VolumeRatio:   ptr(2.0),
+		RecentSqueeze: boolPtr(false),
+	}, 5200000)
+	if result.Stance != entity.MarketStanceTrendFollow {
+		t.Fatalf("expected TREND_FOLLOW without recent squeeze, got %s", result.Stance)
+	}
+}
+
+func TestRuleBasedStanceResolver_RSI_Contrarian_OverridesBreakout(t *testing.T) {
+	resolver := NewRuleBasedStanceResolver(nil)
+	// RSI < 25 takes priority over breakout conditions
+	result := resolver.Resolve(context.Background(), entity.IndicatorSet{
+		SMA20:         ptr(5000000),
+		SMA50:         ptr(4900000),
+		RSI14:         ptr(20.0),
+		BBUpper:       ptr(5100000),
+		BBLower:       ptr(4900000),
+		BBBandwidth:   ptr(0.01),
+		VolumeRatio:   ptr(2.0),
+		RecentSqueeze: boolPtr(true),
+	}, 5200000)
+	if result.Stance != entity.MarketStanceContrarian {
+		t.Fatalf("expected CONTRARIAN to override BREAKOUT when RSI extreme, got %s", result.Stance)
+	}
+}
+```
+
+- [ ] **Step 2: テストが FAIL することを確認**
+
+Run: `cd backend && go test ./internal/usecase/ -run "TestRuleBasedStanceResolver_Breakout|TestRuleBasedStanceResolver_Squeeze|TestRuleBasedStanceResolver_RSI_Contrarian_Overrides" -v`
+Expected: compilation error（`Resolve` のシグネチャが変わっている）
+
+- [ ] **Step 3: StanceResolver インターフェースと RuleBasedStanceResolver を更新**
+
+`backend/internal/usecase/stance.go` を修正:
+
+**インターフェース変更（24-27行）:**
+
+```go
+// StanceResolver はマーケットスタンスを解決するインターフェース。
+type StanceResolver interface {
+	Resolve(ctx context.Context, indicators entity.IndicatorSet, lastPrice float64) StanceResult
+	ResolveAt(ctx context.Context, indicators entity.IndicatorSet, lastPrice float64, now time.Time) StanceResult
+}
+```
+
+**Resolve メソッド変更（93-95行）:**
+
+```go
+func (r *RuleBasedStanceResolver) Resolve(ctx context.Context, indicators entity.IndicatorSet, lastPrice float64) StanceResult {
+	return r.ResolveAt(ctx, indicators, lastPrice, time.Now())
+}
+```
+
+**ResolveAt メソッド変更（98行）:**
+
+```go
+func (r *RuleBasedStanceResolver) ResolveAt(ctx context.Context, indicators entity.IndicatorSet, lastPrice float64, now time.Time) StanceResult {
+```
+
+`applyRules` の呼び出し元を修正（104, 128行）:
+
+```go
+	return r.applyRules(indicators, lastPrice, now)
+```
+
+**applyRules を更新（131行〜）:**
+
+```go
+func (r *RuleBasedStanceResolver) applyRules(indicators entity.IndicatorSet, lastPrice float64, now time.Time) StanceResult {
+	// 1. インジケータ不足チェック
+	if indicators.SMA20 == nil || indicators.SMA50 == nil || indicators.RSI14 == nil {
+		return StanceResult{
+			Stance:    entity.MarketStanceHold,
+			Reasoning: "insufficient indicator data",
+			Source:    "rule-based",
+			UpdatedAt: now.Unix(),
+		}
+	}
+
+	sma20 := *indicators.SMA20
+	sma50 := *indicators.SMA50
+	rsi := *indicators.RSI14
+
+	// 2. RSI極端値 → CONTRARIAN（最優先）
+	if rsi < 25 {
+		return StanceResult{
+			Stance:    entity.MarketStanceContrarian,
+			Reasoning: "RSI oversold",
+			Source:    "rule-based",
+			UpdatedAt: now.Unix(),
+		}
+	}
+	if rsi > 75 {
+		return StanceResult{
+			Stance:    entity.MarketStanceContrarian,
+			Reasoning: "RSI overbought",
+			Source:    "rule-based",
+			UpdatedAt: now.Unix(),
+		}
+	}
+
+	// 3. RecentSqueeze → BREAKOUT or HOLD
+	if indicators.RecentSqueeze != nil && *indicators.RecentSqueeze {
+		if indicators.BBUpper != nil && indicators.BBLower != nil && indicators.VolumeRatio != nil {
+			volRatio := *indicators.VolumeRatio
+			if lastPrice > *indicators.BBUpper && volRatio >= 1.5 {
+				return StanceResult{
+					Stance:    entity.MarketStanceBreakout,
+					Reasoning: "BB breakout upward with volume confirmation",
+					Source:    "rule-based",
+					UpdatedAt: now.Unix(),
+				}
+			}
+			if lastPrice < *indicators.BBLower && volRatio >= 1.5 {
+				return StanceResult{
+					Stance:    entity.MarketStanceBreakout,
+					Reasoning: "BB breakout downward with volume confirmation",
+					Source:    "rule-based",
+					UpdatedAt: now.Unix(),
+				}
+			}
+		}
+		// スクイーズ中だがブレイクアウト未発生
+		return StanceResult{
+			Stance:    entity.MarketStanceHold,
+			Reasoning: "BB squeeze without breakout",
+			Source:    "rule-based",
+			UpdatedAt: now.Unix(),
+		}
+	}
+
+	// 4. SMA収束 → HOLD
+	divergence := math.Abs(sma20-sma50) / sma50
+	if divergence < 0.001 {
+		return StanceResult{
+			Stance:    entity.MarketStanceHold,
+			Reasoning: "SMA converged",
+			Source:    "rule-based",
+			UpdatedAt: now.Unix(),
+		}
+	}
+
+	// 5. それ以外 → TREND_FOLLOW
+	reasoning := "SMA uptrend"
+	if sma20 < sma50 {
+		reasoning = "SMA downtrend"
+	}
+	return StanceResult{
+		Stance:    entity.MarketStanceTrendFollow,
+		Reasoning: reasoning,
+		Source:    "rule-based",
+		UpdatedAt: now.Unix(),
+	}
+}
+```
+
+- [ ] **Step 4: 既存 stance_test.go の Resolve 呼び出しに lastPrice を追加**
+
+既存のすべての `resolver.Resolve(context.Background(), entity.IndicatorSet{...})` 呼び出しに第3引数 `0` を追加する。既存テストは BB フィールドが nil なので BREAKOUT にはならない。
+
+例（各テストすべて同様に変更）:
+
+```go
+// Before:
+result := resolver.Resolve(context.Background(), entity.IndicatorSet{...})
+// After:
+result := resolver.Resolve(context.Background(), entity.IndicatorSet{...}, 0)
+```
+
+同様に `resolver.ResolveAt(ctx, indicators, now)` → `resolver.ResolveAt(ctx, indicators, 0, now)` に変更。
+
+- [ ] **Step 5: テスト PASS を確認**
+
+Run: `cd backend && go test ./internal/usecase/ -run TestRuleBasedStanceResolver -v`
+Expected: ALL PASS（既存 + 新規）
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add backend/internal/usecase/stance.go backend/internal/usecase/stance_test.go
+git commit -m "feat(stance): add BREAKOUT detection with RecentSqueeze + volume confirmation"
+```
+
+---
+
+## Task 5: StrategyEngine に evaluateBreakout + フィルター追加
+
+**Files:**
+- Modify: `backend/internal/usecase/strategy.go`
+- Modify: `backend/internal/usecase/strategy_test.go`
+
+- [ ] **Step 1: strategy_test.go の mockStanceResolver シグネチャを更新**
+
+`backend/internal/usecase/strategy_test.go` の `mockStanceResolver` を更新:
+
+```go
+func (m *mockStanceResolver) Resolve(ctx context.Context, indicators entity.IndicatorSet, lastPrice float64) StanceResult {
+	return m.result
+}
+
+func (m *mockStanceResolver) ResolveAt(ctx context.Context, indicators entity.IndicatorSet, lastPrice float64, now time.Time) StanceResult {
+	return m.result
+}
+```
+
+- [ ] **Step 2: BREAKOUT テストを追加**
+
+`backend/internal/usecase/strategy_test.go` の末尾に追加:
+
+```go
+func TestStrategyEngine_Breakout_BuySignal(t *testing.T) {
+	resolver := &mockStanceResolver{
+		result: StanceResult{
+			Stance:    entity.MarketStanceBreakout,
+			Reasoning: "BB breakout upward with volume confirmation",
+			Source:    "rule-based",
+			UpdatedAt: time.Now().Unix(),
+		},
+	}
+	engine := NewStrategyEngine(resolver)
+
+	indicators := entity.IndicatorSet{
+		SymbolID:    7,
+		SMA20:       ptr(5000000),
+		SMA50:       ptr(4900000),
+		RSI14:       ptr(55.0),
+		BBUpper:     ptr(5100000),
+		BBMiddle:    ptr(5000000),
+		BBLower:     ptr(4900000),
+		VolumeRatio: ptr(2.0),
+		Histogram:   ptr(5.0),
+	}
+	signal, err := engine.Evaluate(context.Background(), indicators, 5200000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if signal.Action != entity.SignalActionBuy {
+		t.Fatalf("expected BUY for upward breakout, got %s", signal.Action)
+	}
+	if signal.Confidence <= 0 {
+		t.Fatal("expected positive confidence")
+	}
+}
+
+func TestStrategyEngine_Breakout_SellSignal(t *testing.T) {
+	resolver := &mockStanceResolver{
+		result: StanceResult{
+			Stance:    entity.MarketStanceBreakout,
+			Reasoning: "BB breakout downward with volume confirmation",
+			Source:    "rule-based",
+			UpdatedAt: time.Now().Unix(),
+		},
+	}
+	engine := NewStrategyEngine(resolver)
+
+	indicators := entity.IndicatorSet{
+		SymbolID:    7,
+		SMA20:       ptr(5000000),
+		SMA50:       ptr(5100000),
+		RSI14:       ptr(45.0),
+		BBUpper:     ptr(5100000),
+		BBMiddle:    ptr(5000000),
+		BBLower:     ptr(4900000),
+		VolumeRatio: ptr(1.8),
+		Histogram:   ptr(-5.0),
+	}
+	signal, err := engine.Evaluate(context.Background(), indicators, 4800000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if signal.Action != entity.SignalActionSell {
+		t.Fatalf("expected SELL for downward breakout, got %s", signal.Action)
+	}
+}
+
+func TestStrategyEngine_Breakout_HoldWhenMACDAgainst(t *testing.T) {
+	resolver := &mockStanceResolver{
+		result: StanceResult{
+			Stance:    entity.MarketStanceBreakout,
+			Reasoning: "BB breakout upward",
+			Source:    "rule-based",
+			UpdatedAt: time.Now().Unix(),
+		},
+	}
+	engine := NewStrategyEngine(resolver)
+
+	indicators := entity.IndicatorSet{
+		SymbolID:    7,
+		SMA20:       ptr(5000000),
+		SMA50:       ptr(4900000),
+		RSI14:       ptr(55.0),
+		BBUpper:     ptr(5100000),
+		BBMiddle:    ptr(5000000),
+		BBLower:     ptr(4900000),
+		VolumeRatio: ptr(2.0),
+		Histogram:   ptr(-5.0), // MACD against buy
+	}
+	signal, err := engine.Evaluate(context.Background(), indicators, 5200000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if signal.Action != entity.SignalActionHold {
+		t.Fatalf("expected HOLD when MACD against breakout buy, got %s", signal.Action)
+	}
+}
+
+func TestStrategyEngine_Breakout_MissingBBData_Hold(t *testing.T) {
+	resolver := &mockStanceResolver{
+		result: StanceResult{
+			Stance:    entity.MarketStanceBreakout,
+			Reasoning: "BB breakout",
+			Source:    "rule-based",
+			UpdatedAt: time.Now().Unix(),
+		},
+	}
+	engine := NewStrategyEngine(resolver)
+
+	indicators := entity.IndicatorSet{
+		SymbolID: 7,
+		SMA20:    ptr(5000000),
+		SMA50:    ptr(4900000),
+		RSI14:    ptr(55.0),
+		// BB fields nil
+	}
+	signal, err := engine.Evaluate(context.Background(), indicators, 5200000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if signal.Action != entity.SignalActionHold {
+		t.Fatalf("expected HOLD when BB data missing for breakout, got %s", signal.Action)
+	}
+}
+
+func TestStrategyEngine_LowVolume_FiltersSignal(t *testing.T) {
+	resolver := &mockStanceResolver{
+		result: StanceResult{
+			Stance:    entity.MarketStanceTrendFollow,
+			Reasoning: "uptrend",
+			Source:    "rule-based",
+			UpdatedAt: time.Now().Unix(),
+		},
+	}
+	engine := NewStrategyEngine(resolver)
+
+	indicators := entity.IndicatorSet{
+		SymbolID:    7,
+		SMA20:       ptr(5100000),
+		SMA50:       ptr(5000000),
+		RSI14:       ptr(55.0),
+		VolumeRatio: ptr(0.2), // Very low volume
+	}
+	signal, err := engine.EvaluateWithHigherTF(context.Background(), indicators, nil, 5100000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if signal.Action != entity.SignalActionHold {
+		t.Fatalf("expected HOLD for low volume, got %s", signal.Action)
+	}
+}
+
+func TestStrategyEngine_LowVolume_NilRatio_NoFilter(t *testing.T) {
+	resolver := &mockStanceResolver{
+		result: StanceResult{
+			Stance:    entity.MarketStanceTrendFollow,
+			Reasoning: "uptrend",
+			Source:    "rule-based",
+			UpdatedAt: time.Now().Unix(),
+		},
+	}
+	engine := NewStrategyEngine(resolver)
+
+	indicators := entity.IndicatorSet{
+		SymbolID: 7,
+		SMA20:    ptr(5100000),
+		SMA50:    ptr(5000000),
+		RSI14:    ptr(55.0),
+		// VolumeRatio nil → フィルターは適用されない
+	}
+	signal, err := engine.EvaluateWithHigherTF(context.Background(), indicators, nil, 5100000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if signal.Action != entity.SignalActionBuy {
+		t.Fatalf("expected BUY when VolumeRatio is nil (no filter), got %s", signal.Action)
+	}
+}
+```
+
+- [ ] **Step 3: テストが FAIL することを確認**
+
+Run: `cd backend && go test ./internal/usecase/ -run "TestStrategyEngine_Breakout|TestStrategyEngine_LowVolume" -v`
+Expected: FAIL（evaluateBreakout が未定義、mockStanceResolver のシグネチャ不一致）
+
+- [ ] **Step 4: strategy.go の resolveAt を更新**
+
+`backend/internal/usecase/strategy.go` の `resolveAt` メソッド（145-147行）を変更:
+
+```go
+func (e *StrategyEngine) resolveAt(ctx context.Context, indicators entity.IndicatorSet, lastPrice float64, now time.Time) StanceResult {
+	return e.stanceResolver.ResolveAt(ctx, indicators, lastPrice, now)
+}
+```
+
+- [ ] **Step 5: EvaluateAt の resolveAt 呼び出しを更新**
+
+`EvaluateAt`（108行付近）と `EvaluateWithHigherTFAt`（39行付近）内の `resolveAt` 呼び出しを更新:
+
+```go
+// EvaluateAt 内（124行付近）:
+result := e.resolveAt(ctx, indicators, lastPrice, now)
+
+// EvaluateWithHigherTFAt 内（44行付近）:
+result := e.resolveAt(ctx, indicators, lastPrice, now)
+```
+
+- [ ] **Step 6: EvaluateAt に BREAKOUT case を追加**
+
+`EvaluateAt` の switch 文（130行付近）に追加:
+
+```go
+	case entity.MarketStanceBreakout:
+		return e.evaluateBreakout(indicators.SymbolID, lastPrice, indicators.BBUpper, indicators.BBLower, indicators.BBMiddle, indicators.VolumeRatio, indicators.Histogram, nowUnix), nil
+```
+
+- [ ] **Step 7: evaluateBreakout と breakoutConfidence を実装**
+
+`backend/internal/usecase/strategy.go` の `contrarianConfidence` の後に追加:
+
+```go
+func (e *StrategyEngine) evaluateBreakout(symbolID int64, lastPrice float64, bbUpper, bbLower, bbMiddle, volumeRatio, histogram *float64, nowUnix int64) *entity.Signal {
+	if bbUpper == nil || bbLower == nil || bbMiddle == nil || volumeRatio == nil {
+		return &entity.Signal{
+			SymbolID:  symbolID,
+			Action:    entity.SignalActionHold,
+			Reason:    "breakout: insufficient BB/volume data",
+			Timestamp: nowUnix,
+		}
+	}
+
+	if lastPrice > *bbUpper && *volumeRatio >= 1.5 {
+		// MACD histogram confirmation
+		if histogram != nil && *histogram < 0 {
+			return &entity.Signal{
+				SymbolID:  symbolID,
+				Action:    entity.SignalActionHold,
+				Reason:    "breakout: MACD histogram negative, skipping buy",
+				Timestamp: nowUnix,
+			}
+		}
+		return &entity.Signal{
+			SymbolID:   symbolID,
+			Action:     entity.SignalActionBuy,
+			Confidence: breakoutConfidence(lastPrice, *bbUpper, *bbMiddle, *volumeRatio, histogram, true),
+			Reason:     "breakout: price above BB upper with volume confirmation",
+			Timestamp:  nowUnix,
+		}
+	}
+
+	if lastPrice < *bbLower && *volumeRatio >= 1.5 {
+		if histogram != nil && *histogram > 0 {
+			return &entity.Signal{
+				SymbolID:  symbolID,
+				Action:    entity.SignalActionHold,
+				Reason:    "breakout: MACD histogram positive, skipping sell",
+				Timestamp: nowUnix,
+			}
+		}
+		return &entity.Signal{
+			SymbolID:   symbolID,
+			Action:     entity.SignalActionSell,
+			Confidence: breakoutConfidence(lastPrice, *bbLower, *bbMiddle, *volumeRatio, histogram, false),
+			Reason:     "breakout: price below BB lower with volume confirmation",
+			Timestamp:  nowUnix,
+		}
+	}
+
+	return &entity.Signal{
+		SymbolID:  symbolID,
+		Action:    entity.SignalActionHold,
+		Reason:    "breakout: no clear breakout signal",
+		Timestamp: nowUnix,
+	}
+}
+
+// breakoutConfidence computes a 0.0–1.0 confidence score for breakout signals.
+// Factors: volume strength (40%), breakout depth (30%), MACD confirmation (30%).
+func breakoutConfidence(lastPrice, bandEdge, bbMiddle, volumeRatio float64, histogram *float64, isBuy bool) float64 {
+	// Volume strength: (VolumeRatio - 1.0) / 2.0, capped at 1.0
+	volStrength := math.Min((volumeRatio-1.0)/2.0, 1.0)
+	if volStrength < 0 {
+		volStrength = 0
+	}
+
+	// Breakout depth: distance from band edge normalized by BBMiddle
+	var depth float64
+	if bbMiddle > 0 {
+		if isBuy {
+			depth = (lastPrice - bandEdge) / bbMiddle
+		} else {
+			depth = (bandEdge - lastPrice) / bbMiddle
+		}
+	}
+	depth = math.Max(0, math.Min(depth*50, 1.0)) // 2% deviation = 1.0
+
+	// MACD confirmation
+	macdConfirm := 0.5
+	if histogram != nil {
+		macdConfirm = math.Min(math.Abs(*histogram)/10, 1.0)
+	}
+
+	return volStrength*0.4 + depth*0.3 + macdConfirm*0.3
+}
+```
+
+- [ ] **Step 8: EvaluateWithHigherTFAt に低出来高フィルター + BB スクイーズフィルター削除 + MTF BREAKOUT 例外を追加**
+
+`backend/internal/usecase/strategy.go` の `EvaluateWithHigherTFAt` を更新:
+
+BB スクイーズフィルター（48-55行付近）を削除し、低出来高フィルターと MTF BREAKOUT 例外を追加:
+
+```go
+func (e *StrategyEngine) EvaluateWithHigherTFAt(
+	ctx context.Context,
+	indicators entity.IndicatorSet,
+	higherTF *entity.IndicatorSet,
+	lastPrice float64,
+	now time.Time,
+) (*entity.Signal, error) {
+	signal, err := e.EvaluateAt(ctx, indicators, lastPrice, now)
+	if err != nil || signal.Action == entity.SignalActionHold {
+		return signal, err
+	}
+
+	result := e.resolveAt(ctx, indicators, lastPrice, now)
+
+	// Low volume filter: reject all signals when volume is extremely low
+	if indicators.VolumeRatio != nil && *indicators.VolumeRatio < 0.3 {
+		return &entity.Signal{
+			SymbolID:  indicators.SymbolID,
+			Action:    entity.SignalActionHold,
+			Reason:    "volume filter: volume ratio too low, signal unreliable",
+			Timestamp: signal.Timestamp,
+		}, nil
+	}
+
+	// BB position can boost/penalize confidence for contrarian
+	if result.Stance == entity.MarketStanceContrarian && indicators.BBLower != nil && indicators.BBUpper != nil {
+		if signal.Action == entity.SignalActionBuy && lastPrice <= *indicators.BBLower {
+			signal.Confidence = math.Min(signal.Confidence+0.1, 1.0)
+		} else if signal.Action == entity.SignalActionSell && lastPrice >= *indicators.BBUpper {
+			signal.Confidence = math.Min(signal.Confidence+0.1, 1.0)
+		}
+	}
+
+	if higherTF == nil || higherTF.SMA20 == nil || higherTF.SMA50 == nil {
+		return signal, nil
+	}
+
+	// Contrarian and Breakout signals are intentionally allowed against higher TF
+	if result.Stance == entity.MarketStanceContrarian || result.Stance == entity.MarketStanceBreakout {
+		return signal, nil
+	}
+
+	higherUptrend := *higherTF.SMA20 > *higherTF.SMA50
+
+	if signal.Action == entity.SignalActionBuy && !higherUptrend {
+		return &entity.Signal{
+			SymbolID:  indicators.SymbolID,
+			Action:    entity.SignalActionHold,
+			Reason:    "MTF filter: higher timeframe downtrend blocks buy",
+			Timestamp: signal.Timestamp,
+		}, nil
+	}
+	if signal.Action == entity.SignalActionSell && higherUptrend {
+		return &entity.Signal{
+			SymbolID:  indicators.SymbolID,
+			Action:    entity.SignalActionHold,
+			Reason:    "MTF filter: higher timeframe uptrend blocks sell",
+			Timestamp: signal.Timestamp,
+		}, nil
+	}
+
+	signal.Confidence = math.Min(signal.Confidence+0.1, 1.0)
+	return signal, nil
+}
+```
+
+- [ ] **Step 9: 全テスト PASS を確認**
+
+Run: `cd backend && go test ./internal/usecase/ -v -run "TestStrategy"`
+Expected: ALL PASS（既存 + 新規）
+
+- [ ] **Step 10: 全体テスト PASS を確認**
+
+Run: `cd backend && go test ./... -count=1`
+Expected: ALL PASS
+
+- [ ] **Step 11: コミット**
+
+```bash
+git add backend/internal/usecase/strategy.go backend/internal/usecase/strategy_test.go
+git commit -m "feat(strategy): add BREAKOUT evaluation, low-volume filter, and MTF breakout exception"
+```
+
+---
+
+## Task 6: API handler の更新
+
+**Files:**
+- Modify: `backend/internal/interfaces/api/handler/strategy.go`
+- Modify: `backend/internal/interfaces/api/handler/handler_test.go`
+
+- [ ] **Step 1: strategy.go の Resolve 呼び出しに lastPrice 追加**
+
+`backend/internal/interfaces/api/handler/strategy.go` の `GetStrategy`（20-24行）を更新:
+
+```go
+func (h *StrategyHandler) GetStrategy(c *gin.Context) {
+	indicators := entity.IndicatorSet{}
+	result := h.stanceResolver.Resolve(c.Request.Context(), indicators, 0)
+	c.JSON(http.StatusOK, result)
+}
+```
+
+- [ ] **Step 2: SetStrategy の BREAKOUT バリデーション追加**
+
+`SetStrategy` のバリデーション（40-41行）を更新:
+
+```go
+	if stance != entity.MarketStanceTrendFollow && stance != entity.MarketStanceContrarian && stance != entity.MarketStanceHold && stance != entity.MarketStanceBreakout {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "stance must be TREND_FOLLOW, CONTRARIAN, HOLD, or BREAKOUT"})
+		return
+	}
+```
+
+- [ ] **Step 3: handler_test.go のバリデーションテスト更新を確認**
+
+既存のテストで BREAKOUT が invalid として扱われていないか確認。もし `TestSetStrategy_InvalidStance` のようなテストで BREAKOUT をテストしている場合は更新が必要。
+
+Run: `cd backend && go test ./internal/interfaces/api/handler/ -v -run TestStrategy`
+
+- [ ] **Step 4: ビルド + テスト PASS 確認**
+
+Run: `cd backend && go build ./... && go test ./... -count=1`
+Expected: ALL PASS
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add backend/internal/interfaces/api/handler/strategy.go backend/internal/interfaces/api/handler/handler_test.go
+git commit -m "feat(api): update strategy handler for BREAKOUT stance and lastPrice parameter"
+```
+
+---
+
+## Task 7: 全体テスト + PR 作成
+
+**Files:** なし（テスト実行のみ）
+
+- [ ] **Step 1: Backend テスト**
+
+Run: `cd backend && go test ./... -race -count=1`
+Expected: ALL PASS
+
+- [ ] **Step 2: Frontend テスト**
+
+Run: `cd frontend && pnpm test`
+Expected: ALL PASS（Frontend に変更なし）
+
+- [ ] **Step 3: Docker ビルド確認**
+
+Run: `docker compose up --build -d && docker compose logs backend --tail=20`
+Expected: backend が正常起動
+
+- [ ] **Step 4: コミット → PR**
+
+```bash
+git push -u origin improve/breakout-volume-strategy
+gh pr create --base main --title "feat(strategy): add BB breakout stance with volume confirmation" --body "$(cat <<'EOF'
+## Summary
+- 新 Stance `BREAKOUT`: BB スクイーズ後のブレイクアウトを出来高で確認してシグナル生成
+- Volume インジケーター追加: VolumeSMA20, VolumeRatio, RecentSqueeze
+- 低出来高フィルター: VolumeRatio < 0.3 で全 Stance のシグナルを抑制
+- BREAKOUT は MTF フィルターの例外扱い（CONTRARIAN と同様）
+- BB スクイーズフィルターの責務を strategy.go → stance.go に移動
+
+## Design Doc
+docs/design/2026-04-15-breakout-volume-strategy-design.md
+
+## Test plan
+- [ ] `go test ./... -race -count=1` — 全テスト PASS
+- [ ] `pnpm test` — Frontend テスト PASS
+- [ ] Docker ビルド + 起動確認
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```


### PR DESCRIPTION
## Summary
- 新 Stance `BREAKOUT`: BB スクイーズ後のブレイクアウトを出来高で確認してシグナル生成
- Volume インジケーター追加: VolumeSMA20, VolumeRatio, RecentSqueeze
- 低出来高フィルター: VolumeRatio < 0.3 で全 Stance のシグナルを抑制
- BREAKOUT は MTF フィルターの例外扱い（CONTRARIAN と同様）
- BB スクイーズフィルターの責務を strategy.go → stance.go に移動

## Design Doc
docs/design/2026-04-15-breakout-volume-strategy-design.md

## Test plan
- [x] `go test ./... -race -count=1` — 全テスト PASS
- [x] `pnpm test` — Frontend テスト PASS (21/21)
- [ ] Docker ビルド + 起動確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)