### PR TITLE
feat: バックテスト実行画面で通貨ペア選択とCSV期間自動入力に対応

### DIFF
--- a/backend/internal/interfaces/api/handler/backtest.go
+++ b/backend/internal/interfaces/api/handler/backtest.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -210,6 +211,45 @@ func (h *BacktestHandler) GetResult(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusOK, result)
+}
+
+func (h *BacktestHandler) CSVMeta(c *gin.Context) {
+	dataPath := strings.TrimSpace(c.Query("data"))
+	if dataPath == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "data query is required"})
+		return
+	}
+
+	file, err := csvinfra.LoadCandles(dataPath)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "failed to load csv: " + err.Error()})
+		return
+	}
+	if len(file.Candles) == 0 {
+		c.JSON(http.StatusNotFound, gin.H{"error": "csv has no candles"})
+		return
+	}
+
+	fromTs := file.Candles[0].Time
+	toTs := file.Candles[0].Time
+	for _, candle := range file.Candles[1:] {
+		if candle.Time < fromTs {
+			fromTs = candle.Time
+		}
+		if candle.Time > toTs {
+			toTs = candle.Time
+		}
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"data":          dataPath,
+		"symbol":        file.Symbol,
+		"symbolId":      file.SymbolID,
+		"interval":      file.Interval,
+		"rowCount":      len(file.Candles),
+		"fromTimestamp": fromTs,
+		"toTimestamp":   toTs,
+	})
 }
 
 func parseBacktestDateStart(v string) (int64, error) {

--- a/backend/internal/interfaces/api/handler/backtest_test.go
+++ b/backend/internal/interfaces/api/handler/backtest_test.go
@@ -71,6 +71,65 @@ func TestBacktestHandler_ListResults_InvalidSort(t *testing.T) {
 	}
 }
 
+func TestBacktestHandler_CSVMeta_MissingData(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	repo := &mockBacktestResultRepo{}
+	h := NewBacktestHandler(bt.NewBacktestRunner(), repo)
+
+	w := httptestGet(h.CSVMeta, "/backtest/csv-meta", "/backtest/csv-meta")
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestBacktestHandler_CSVMeta_OK(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	repo := &mockBacktestResultRepo{}
+	h := NewBacktestHandler(bt.NewBacktestRunner(), repo)
+
+	tmpDir := t.TempDir()
+	csvPath := writeTempCSV(t, tmpDir, csvinfra.CandleFile{
+		Symbol:   "LTC_JPY",
+		SymbolID: 10,
+		Interval: "PT15M",
+		Candles: []entity.Candle{
+			{Time: 3000, Open: 1, High: 2, Low: 0.5, Close: 1.5, Volume: 1},
+			{Time: 1000, Open: 1, High: 2, Low: 0.5, Close: 1.5, Volume: 1},
+			{Time: 2000, Open: 1, High: 2, Low: 0.5, Close: 1.5, Volume: 1},
+		},
+	})
+
+	w := httptestGet(h.CSVMeta, "/backtest/csv-meta", "/backtest/csv-meta?data="+csvPath)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Data          string `json:"data"`
+		Symbol        string `json:"symbol"`
+		SymbolID      int64  `json:"symbolId"`
+		Interval      string `json:"interval"`
+		RowCount      int    `json:"rowCount"`
+		FromTimestamp int64  `json:"fromTimestamp"`
+		ToTimestamp   int64  `json:"toTimestamp"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal csv meta: %v", err)
+	}
+	if resp.Data != csvPath {
+		t.Fatalf("expected data path %s, got %s", csvPath, resp.Data)
+	}
+	if resp.Symbol != "LTC_JPY" || resp.SymbolID != 10 || resp.Interval != "PT15M" {
+		t.Fatalf("unexpected symbol meta: %+v", resp)
+	}
+	if resp.RowCount != 3 {
+		t.Fatalf("expected rowCount=3, got %d", resp.RowCount)
+	}
+	if resp.FromTimestamp != 1000 || resp.ToTimestamp != 3000 {
+		t.Fatalf("unexpected range: %d..%d", resp.FromTimestamp, resp.ToTimestamp)
+	}
+}
+
 func httptestRequestWithParam(handler gin.HandlerFunc, route, paramKey, paramValue string) *httptest.ResponseRecorder {
 	w := httptest.NewRecorder()
 	r := gin.New()
@@ -311,4 +370,3 @@ func TestBacktestHandler_Integration_RunMissingData(t *testing.T) {
 		t.Fatalf("missing data: expected 400, got %d", runW.Code)
 	}
 }
-

--- a/backend/internal/interfaces/api/router.go
+++ b/backend/internal/interfaces/api/router.go
@@ -129,6 +129,7 @@ func NewRouter(deps Dependencies) *gin.Engine {
 	if deps.BacktestRunner != nil && deps.BacktestResultRepo != nil {
 		backtestHandler := handler.NewBacktestHandler(deps.BacktestRunner, deps.BacktestResultRepo)
 		v1.POST("/backtest/run", backtestHandler.Run)
+		v1.GET("/backtest/csv-meta", backtestHandler.CSVMeta)
 		v1.GET("/backtest/results", backtestHandler.ListResults)
 		v1.GET("/backtest/results/:id", backtestHandler.GetResult)
 	}

--- a/frontend/src/hooks/useBacktest.ts
+++ b/frontend/src/hooks/useBacktest.ts
@@ -1,5 +1,12 @@
-import { useQuery } from '@tanstack/react-query'
-import { fetchApi, type BacktestResult, type BacktestResultListResponse } from '../lib/api'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import {
+  type BacktestCSVMeta,
+  fetchApi,
+  sendApi,
+  type BacktestResult,
+  type BacktestResultListResponse,
+  type BacktestRunRequest,
+} from '../lib/api'
 
 export function useBacktestResults(limit = 20, offset = 0) {
   return useQuery({
@@ -18,5 +25,29 @@ export function useBacktestResult(id: string) {
     queryFn: () => fetchApi<BacktestResult>(`/backtest/results/${id}`),
     enabled: id !== '',
     staleTime: 60_000,
+  })
+}
+
+export function useBacktestCSVMeta(dataPath: string) {
+  const path = dataPath.trim()
+  return useQuery({
+    queryKey: ['backtest', 'csv-meta', path],
+    queryFn: () =>
+      fetchApi<BacktestCSVMeta>(`/backtest/csv-meta?data=${encodeURIComponent(path)}`),
+    enabled: path !== '',
+    staleTime: 60_000,
+  })
+}
+
+export function useRunBacktest() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (request: BacktestRunRequest) =>
+      sendApi<BacktestResult, BacktestRunRequest>('/backtest/run', 'POST', request),
+    onSuccess: (result) => {
+      void queryClient.invalidateQueries({ queryKey: ['backtest', 'results'] })
+      queryClient.setQueryData(['backtest', 'result', result.id], result)
+    },
   })
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -237,6 +237,34 @@ export type BacktestResultListResponse = {
   results: BacktestResult[]
 }
 
+export type BacktestCSVMeta = {
+  data: string
+  symbol: string
+  symbolId: number
+  interval: string
+  rowCount: number
+  fromTimestamp: number
+  toTimestamp: number
+}
+
+export type BacktestRunRequest = {
+  data: string
+  dataHtf?: string
+  from?: string
+  to?: string
+  initialBalance?: number
+  spread?: number
+  carryingCost?: number
+  slippage?: number
+  tradeAmount?: number
+  stopLossPercent?: number
+  takeProfitPercent?: number
+  maxPositionAmount?: number
+  maxDailyLoss?: number
+  maxConsecutiveLosses?: number
+  cooldownMinutes?: number
+}
+
 export async function fetchApi<T>(path: string): Promise<T> {
   const res = await fetch(`${API_BASE}${path}`)
   if (!res.ok) {

--- a/frontend/src/routes/backtest.tsx
+++ b/frontend/src/routes/backtest.tsx
@@ -1,18 +1,219 @@
-import { useState } from 'react'
+import { useEffect, useMemo, useState, type FormEvent } from 'react'
 import { createFileRoute } from '@tanstack/react-router'
 import { AppFrame } from '../components/AppFrame'
-import { useBacktestResults, useBacktestResult } from '../hooks/useBacktest'
+import {
+  useBacktestCSVMeta,
+  useBacktestResults,
+  useBacktestResult,
+  useRunBacktest,
+} from '../hooks/useBacktest'
+import { useSymbols } from '../hooks/useSymbols'
 import { EquityCurveChart } from '../components/EquityCurveChart'
-import type { BacktestResult, BacktestTrade } from '../lib/api'
+import type { BacktestResult, BacktestRunRequest, BacktestTrade } from '../lib/api'
 
 export const Route = createFileRoute('/backtest')({ component: BacktestPage })
 
+type BacktestRunForm = {
+  data: string
+  dataHtf: string
+  from: string
+  to: string
+  initialBalance: string
+  spread: string
+  carryingCost: string
+  slippage: string
+  tradeAmount: string
+  stopLossPercent: string
+  takeProfitPercent: string
+  maxPositionAmount: string
+  maxDailyLoss: string
+  maxConsecutiveLosses: string
+  cooldownMinutes: string
+}
+
+const defaultRunForm: BacktestRunForm = {
+  data: 'data/candles_BTC_JPY_PT15M.csv',
+  dataHtf: 'data/candles_BTC_JPY_PT1H.csv',
+  from: '',
+  to: '',
+  initialBalance: '100000',
+  spread: '0.1',
+  carryingCost: '0.04',
+  slippage: '0',
+  tradeAmount: '0.01',
+  stopLossPercent: '5',
+  takeProfitPercent: '10',
+  maxPositionAmount: '',
+  maxDailyLoss: '',
+  maxConsecutiveLosses: '',
+  cooldownMinutes: '',
+}
+
+const fallbackBacktestPairs = ['BTC_JPY', 'LTC_JPY'] as const
+
+function buildAutoCSVPaths(currencyPair: string) {
+  return {
+    primary: `data/candles_${currencyPair}_PT15M.csv`,
+    higherTF: `data/candles_${currencyPair}_PT1H.csv`,
+  }
+}
+
+function toJSTDateInput(timestamp: number): string {
+  // JST has no DST, so fixed +9h offset is deterministic for date-only conversion.
+  return new Date(timestamp + 9*60*60*1000).toISOString().slice(0, 10)
+}
+
+function parseOptionalNumber(label: string, value: string, integer = false): number | undefined {
+  const trimmed = value.trim()
+  if (trimmed === '') {
+    return undefined
+  }
+  const parsed = Number(trimmed)
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`${label} は数値で入力してください。`)
+  }
+  if (integer && !Number.isInteger(parsed)) {
+    throw new Error(`${label} は整数で入力してください。`)
+  }
+  return parsed
+}
+
+function buildRunRequest(form: BacktestRunForm): BacktestRunRequest {
+  const data = form.data.trim()
+  if (data === '') {
+    throw new Error('Primary CSV(data) は必須です。')
+  }
+
+  const request: BacktestRunRequest = { data }
+  if (form.dataHtf.trim() !== '') request.dataHtf = form.dataHtf.trim()
+  if (form.from.trim() !== '') request.from = form.from.trim()
+  if (form.to.trim() !== '') request.to = form.to.trim()
+
+  const initialBalance = parseOptionalNumber('Initial Balance', form.initialBalance)
+  const spread = parseOptionalNumber('Spread', form.spread)
+  const carryingCost = parseOptionalNumber('Carrying Cost', form.carryingCost)
+  const slippage = parseOptionalNumber('Slippage', form.slippage)
+  const tradeAmount = parseOptionalNumber('Trade Amount', form.tradeAmount)
+  const stopLossPercent = parseOptionalNumber('Stop Loss Percent', form.stopLossPercent)
+  const takeProfitPercent = parseOptionalNumber('Take Profit Percent', form.takeProfitPercent)
+  const maxPositionAmount = parseOptionalNumber('Max Position Amount', form.maxPositionAmount)
+  const maxDailyLoss = parseOptionalNumber('Max Daily Loss', form.maxDailyLoss)
+  const maxConsecutiveLosses = parseOptionalNumber(
+    'Max Consecutive Losses',
+    form.maxConsecutiveLosses,
+    true,
+  )
+  const cooldownMinutes = parseOptionalNumber('Cooldown Minutes', form.cooldownMinutes, true)
+
+  if (initialBalance !== undefined) request.initialBalance = initialBalance
+  if (spread !== undefined) request.spread = spread
+  if (carryingCost !== undefined) request.carryingCost = carryingCost
+  if (slippage !== undefined) request.slippage = slippage
+  if (tradeAmount !== undefined) request.tradeAmount = tradeAmount
+  if (stopLossPercent !== undefined) request.stopLossPercent = stopLossPercent
+  if (takeProfitPercent !== undefined) request.takeProfitPercent = takeProfitPercent
+  if (maxPositionAmount !== undefined) request.maxPositionAmount = maxPositionAmount
+  if (maxDailyLoss !== undefined) request.maxDailyLoss = maxDailyLoss
+  if (maxConsecutiveLosses !== undefined) request.maxConsecutiveLosses = maxConsecutiveLosses
+  if (cooldownMinutes !== undefined) request.cooldownMinutes = cooldownMinutes
+
+  return request
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message
+  }
+  return 'バックテスト実行に失敗しました。'
+}
+
 function BacktestPage() {
+  const { data: symbols } = useSymbols()
+  const pairOptions = useMemo(() => {
+    const values = [...fallbackBacktestPairs]
+    for (const symbol of symbols ?? []) {
+      if (!values.includes(symbol.currencyPair)) {
+        values.push(symbol.currencyPair)
+      }
+    }
+    return values
+  }, [symbols])
+
+  const [selectedPair, setSelectedPair] = useState('BTC_JPY')
+  const autoPaths = useMemo(() => buildAutoCSVPaths(selectedPair), [selectedPair])
+
   const [selectedId, setSelectedId] = useState('')
+  const [runForm, setRunForm] = useState<BacktestRunForm>(defaultRunForm)
+  const [runValidationError, setRunValidationError] = useState('')
+  const runBacktest = useRunBacktest()
   const { data, isLoading, isError } = useBacktestResults()
   const { data: detail, isLoading: detailLoading } = useBacktestResult(selectedId)
+  const {
+    data: csvMeta,
+    isLoading: isCSVMetaLoading,
+    isError: isCSVMetaError,
+  } = useBacktestCSVMeta(runForm.data)
 
   const results = data?.results ?? []
+
+  useEffect(() => {
+    if (pairOptions.length === 0) return
+    if (pairOptions.includes(selectedPair)) return
+    setSelectedPair(pairOptions[0])
+  }, [pairOptions, selectedPair])
+
+  useEffect(() => {
+    setRunForm((current) => {
+      if (
+        current.data === autoPaths.primary &&
+        current.dataHtf === autoPaths.higherTF &&
+        current.from === '' &&
+        current.to === ''
+      ) {
+        return current
+      }
+      return {
+        ...current,
+        data: autoPaths.primary,
+        dataHtf: autoPaths.higherTF,
+        from: '',
+        to: '',
+      }
+    })
+    setRunValidationError('')
+  }, [autoPaths.higherTF, autoPaths.primary])
+
+  useEffect(() => {
+    if (!csvMeta) return
+    setRunForm((current) => ({
+      ...current,
+      from: toJSTDateInput(csvMeta.fromTimestamp),
+      to: toJSTDateInput(csvMeta.toTimestamp),
+    }))
+  }, [csvMeta])
+
+  const setRunField = (key: keyof BacktestRunForm, value: string) => {
+    setRunForm((current) => ({ ...current, [key]: value }))
+  }
+
+  const handleRun = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setRunValidationError('')
+
+    let request: BacktestRunRequest
+    try {
+      request = buildRunRequest(runForm)
+    } catch (error) {
+      setRunValidationError(getErrorMessage(error))
+      return
+    }
+
+    runBacktest.mutate(request, {
+      onSuccess: (result) => {
+        setSelectedId(result.id)
+      },
+    })
+  }
 
   return (
     <AppFrame
@@ -24,6 +225,171 @@ function BacktestPage() {
           バックテスト結果の取得に失敗しました。
         </div>
       )}
+
+      <section className="mb-4 rounded-3xl border border-white/8 bg-bg-card/90 p-5 shadow-[0_12px_40px_rgba(0,0,0,0.22)]">
+        <p className="text-xs uppercase tracking-[0.28em] text-text-secondary">Run</p>
+        <h2 className="mt-2 text-xl font-semibold text-white">バックテスト実行</h2>
+        <p className="mt-2 text-sm text-text-secondary">
+          `data` / `dataHtf` は backend コンテナから参照可能な CSV パスを指定してください。
+        </p>
+        <label className="mt-3 block">
+          <span className="mb-2 block text-sm text-slate-300">通貨ペア</span>
+          <select
+            value={selectedPair}
+            onChange={(event) => setSelectedPair(event.target.value)}
+            className="w-full rounded-2xl border border-white/10 bg-white/6 px-4 py-3 text-white outline-none transition focus:border-cyan-200 sm:w-[320px]"
+          >
+            {pairOptions.map((pair) => (
+              <option key={pair} value={pair} className="bg-bg-card text-white">
+                {pair.replace('_', '/')}
+              </option>
+            ))}
+          </select>
+        </label>
+        <p className="mt-2 text-xs text-text-secondary">
+          選択中の通貨ペア: {selectedPair.replace('_', '/')}（CSVパスと期間は自動反映）
+        </p>
+        {isCSVMetaLoading && (
+          <p className="mt-1 text-xs text-text-secondary">CSV期間を読み込み中...</p>
+        )}
+        {isCSVMetaError && (
+          <p className="mt-1 text-xs text-accent-red">
+            CSV期間の自動取得に失敗しました。CSVパスを確認してください。
+          </p>
+        )}
+
+        <form onSubmit={handleRun} className="mt-4">
+          <div className="grid gap-4 sm:grid-cols-2">
+            <RunField
+              label="Primary CSV (data)"
+              value={runForm.data}
+              onChange={(value) => setRunField('data', value)}
+              placeholder="data/candles_BTC_JPY_PT15M.csv"
+            />
+            <RunField
+              label="Higher TF CSV (dataHtf)"
+              value={runForm.dataHtf}
+              onChange={(value) => setRunField('dataHtf', value)}
+              placeholder="data/candles_BTC_JPY_PT1H.csv"
+            />
+            <RunField
+              label="From (YYYY-MM-DD)"
+              value={runForm.from}
+              onChange={(value) => setRunField('from', value)}
+              type="date"
+            />
+            <RunField
+              label="To (YYYY-MM-DD)"
+              value={runForm.to}
+              onChange={(value) => setRunField('to', value)}
+              type="date"
+            />
+            <RunField
+              label="Initial Balance"
+              value={runForm.initialBalance}
+              onChange={(value) => setRunField('initialBalance', value)}
+              type="number"
+              step="1"
+            />
+            <RunField
+              label="Trade Amount"
+              value={runForm.tradeAmount}
+              onChange={(value) => setRunField('tradeAmount', value)}
+              type="number"
+              step="0.0001"
+            />
+            <RunField
+              label="Spread (%)"
+              value={runForm.spread}
+              onChange={(value) => setRunField('spread', value)}
+              type="number"
+              step="0.0001"
+            />
+            <RunField
+              label="Carrying Cost (% / day)"
+              value={runForm.carryingCost}
+              onChange={(value) => setRunField('carryingCost', value)}
+              type="number"
+              step="0.0001"
+            />
+            <RunField
+              label="Slippage (%)"
+              value={runForm.slippage}
+              onChange={(value) => setRunField('slippage', value)}
+              type="number"
+              step="0.0001"
+            />
+            <RunField
+              label="Stop Loss (%)"
+              value={runForm.stopLossPercent}
+              onChange={(value) => setRunField('stopLossPercent', value)}
+              type="number"
+              step="0.1"
+            />
+            <RunField
+              label="Take Profit (%)"
+              value={runForm.takeProfitPercent}
+              onChange={(value) => setRunField('takeProfitPercent', value)}
+              type="number"
+              step="0.1"
+            />
+            <RunField
+              label="Max Position Amount (optional)"
+              value={runForm.maxPositionAmount}
+              onChange={(value) => setRunField('maxPositionAmount', value)}
+              type="number"
+              step="1"
+            />
+            <RunField
+              label="Max Daily Loss (optional)"
+              value={runForm.maxDailyLoss}
+              onChange={(value) => setRunField('maxDailyLoss', value)}
+              type="number"
+              step="1"
+            />
+            <RunField
+              label="Max Consecutive Losses (optional)"
+              value={runForm.maxConsecutiveLosses}
+              onChange={(value) => setRunField('maxConsecutiveLosses', value)}
+              type="number"
+              step="1"
+            />
+            <RunField
+              label="Cooldown Minutes (optional)"
+              value={runForm.cooldownMinutes}
+              onChange={(value) => setRunField('cooldownMinutes', value)}
+              type="number"
+              step="1"
+            />
+          </div>
+
+          {runValidationError !== '' && (
+            <div className="mt-4 rounded-2xl border border-accent-red/40 bg-accent-red/10 px-4 py-3 text-sm text-accent-red">
+              {runValidationError}
+            </div>
+          )}
+          {runBacktest.isError && (
+            <div className="mt-4 rounded-2xl border border-accent-red/40 bg-accent-red/10 px-4 py-3 text-sm text-accent-red">
+              {getErrorMessage(runBacktest.error)}
+            </div>
+          )}
+          {runBacktest.isSuccess && (
+            <div className="mt-4 rounded-2xl border border-accent-green/40 bg-accent-green/10 px-4 py-3 text-sm text-accent-green">
+              実行完了: {runBacktest.data.id}
+            </div>
+          )}
+
+          <div className="mt-4 flex justify-end">
+            <button
+              type="submit"
+              disabled={runBacktest.isPending}
+              className="rounded-full bg-cyan-200 px-5 py-2 text-sm font-semibold text-slate-950 transition hover:bg-cyan-100 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {runBacktest.isPending ? '実行中...' : 'バックテストを実行'}
+            </button>
+          </div>
+        </form>
+      </section>
 
       {/* Results list */}
       <section className="rounded-3xl border border-white/8 bg-bg-card/90 p-5 shadow-[0_12px_40px_rgba(0,0,0,0.22)]">
@@ -80,6 +446,38 @@ function BacktestPage() {
         </section>
       )}
     </AppFrame>
+  )
+}
+
+type RunFieldProps = {
+  label: string
+  value: string
+  onChange: (value: string) => void
+  placeholder?: string
+  type?: 'text' | 'number' | 'date'
+  step?: string
+}
+
+function RunField({
+  label,
+  value,
+  onChange,
+  placeholder,
+  type = 'text',
+  step,
+}: RunFieldProps) {
+  return (
+    <label className="block">
+      <span className="mb-2 block text-sm text-slate-300">{label}</span>
+      <input
+        type={type}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder={placeholder}
+        step={step}
+        className="w-full rounded-2xl border border-white/10 bg-white/6 px-4 py-3 text-white outline-none transition placeholder:text-slate-500 focus:border-cyan-200"
+      />
+    </label>
   )
 }
 


### PR DESCRIPTION
## 概要
- バックテスト実行フォームに、画面内専用の通貨ペア選択を追加
- 選択した通貨ペアに応じて `data` / `dataHtf` を自動入力
- CSV の最小/最大時刻を取得する API (`GET /api/v1/backtest/csv-meta`) を追加し、`from` / `to` を自動入力

## 変更内容
### Backend
- `GET /api/v1/backtest/csv-meta?data=...` を追加
  - CSV 読み込み
  - 最小/最大 timestamp 算出
  - `rowCount`, `interval`, `symbol` などを返却
- ルーターに `csv-meta` ルートを追加
- ハンドラテストを追加

### Frontend
- `useBacktestCSVMeta` を追加
- Backtest 実行フォームに通貨ペアセレクタを追加（全画面共通の選択状態とは独立）
- 選択ペアに応じて `data/candles_{PAIR}_PT15M.csv`, `data/candles_{PAIR}_PT1H.csv` を自動反映
- `csv-meta` 応答から `from` / `to` を自動反映

## 動作確認
- `go test ./internal/interfaces/api/... -count=1`
- `pnpm test`
- `pnpm build`
- `curl http://localhost:38080/api/v1/backtest/csv-meta?data=data/candles_LTC_JPY_PT15M.csv`
