### PR TITLE
feat: バックテスト取引一覧に TanStack Virtual を導入

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     "@tanstack/react-router-devtools": "latest",
     "@tanstack/react-router-ssr-query": "latest",
     "@tanstack/react-start": "latest",
+    "@tanstack/react-virtual": "^3.13.23",
     "@tanstack/router-plugin": "^1.132.0",
     "lightweight-charts": "^5.1.0",
     "lucide-react": "^0.545.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@tanstack/react-start':
         specifier: latest
         version: 1.167.16(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
+      '@tanstack/react-virtual':
+        specifier: ^3.13.23
+        version: 3.13.23(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@tanstack/router-plugin':
         specifier: ^1.132.0
         version: 1.167.12(@tanstack/react-router@1.168.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
@@ -817,6 +820,12 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  '@tanstack/react-virtual@3.13.23':
+    resolution: {integrity: sha512-XnMRnHQ23piOVj2bzJqHrRrLg4r+F86fuBcwteKfbIjJrtGxb4z7tIvPVAe4B+4UVwo9G4Giuz5fmapcrnZ0OQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   '@tanstack/router-core@1.168.9':
     resolution: {integrity: sha512-18oeEwEDyXOIuO1VBP9ACaK7tYHZUjynGDCoUh/5c/BNhia9vCJCp9O0LfhZXOorDc/PmLSgvmweFhVmIxF10g==}
     engines: {node: '>=20.19'}
@@ -895,6 +904,9 @@ packages:
 
   '@tanstack/store@0.9.3':
     resolution: {integrity: sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==}
+
+  '@tanstack/virtual-core@3.13.23':
+    resolution: {integrity: sha512-zSz2Z2HNyLjCplANTDyl3BcdQJc2k1+yyFoKhNRmCr7V7dY8o8q5m8uFTI1/Pg1kL+Hgrz6u3Xo6eFUB7l66cg==}
 
   '@tanstack/virtual-file-routes@1.161.7':
     resolution: {integrity: sha512-olW33+Cn+bsCsZKPwEGhlkqS6w3M2slFv11JIobdnCFKMLG97oAI2kWKdx5/zsywTL8flpnoIgaZZPlQTFYhdQ==}
@@ -2538,6 +2550,12 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
       use-sync-external-store: 1.6.0(react@19.2.4)
 
+  '@tanstack/react-virtual@3.13.23(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@tanstack/virtual-core': 3.13.23
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
   '@tanstack/router-core@1.168.9':
     dependencies:
       '@tanstack/history': 1.161.6
@@ -2663,6 +2681,8 @@ snapshots:
       '@tanstack/router-core': 1.168.9
 
   '@tanstack/store@0.9.3': {}
+
+  '@tanstack/virtual-core@3.13.23': {}
 
   '@tanstack/virtual-file-routes@1.161.7': {}
 

--- a/frontend/src/routes/backtest.tsx
+++ b/frontend/src/routes/backtest.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useMemo, useState, type FormEvent } from 'react'
+import { useEffect, useMemo, useRef, useState, type FormEvent } from 'react'
 import { createFileRoute } from '@tanstack/react-router'
+import { useVirtualizer } from '@tanstack/react-virtual'
 import { AppFrame } from '../components/AppFrame'
 import {
   useBacktestCSVMeta,
@@ -50,6 +51,7 @@ const defaultRunForm: BacktestRunForm = {
 }
 
 const fallbackBacktestPairs = ['BTC_JPY', 'LTC_JPY'] as const
+const TRADE_TABLE_COLUMN_COUNT = 11
 
 function buildAutoCSVPaths(currencyPair: string) {
   return {
@@ -630,32 +632,67 @@ function DetailPanel({ result }: { result: BacktestResult }) {
           <h3 className="mt-2 text-lg font-semibold text-white">
             取引一覧 ({result.trades.length} 件)
           </h3>
-          <div className="mt-3 overflow-x-auto">
-            <table className="w-full min-w-[900px] text-sm">
-              <thead>
-                <tr className="border-b border-white/8 text-left text-xs uppercase tracking-wider text-text-secondary">
-                  <th className="px-3 py-2">#</th>
-                  <th className="px-3 py-2">Side</th>
-                  <th className="px-3 py-2">Entry</th>
-                  <th className="px-3 py-2">Exit</th>
-                  <th className="px-3 py-2 text-right">Entry Price</th>
-                  <th className="px-3 py-2 text-right">Exit Price</th>
-                  <th className="px-3 py-2 text-right">Amount</th>
-                  <th className="px-3 py-2 text-right">PnL</th>
-                  <th className="px-3 py-2 text-right">PnL %</th>
-                  <th className="px-3 py-2">Entry Reason</th>
-                  <th className="px-3 py-2">Exit Reason</th>
-                </tr>
-              </thead>
-              <tbody>
-                {result.trades.map((t) => (
-                  <TradeRow key={t.tradeId} trade={t} />
-                ))}
-              </tbody>
-            </table>
-          </div>
+          <VirtualizedTradesTable trades={result.trades} />
         </div>
       )}
+    </div>
+  )
+}
+
+/* ------------------------------------------------------------------ */
+/* Trades table                                                        */
+/* ------------------------------------------------------------------ */
+
+function VirtualizedTradesTable({ trades }: { trades: BacktestTrade[] }) {
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const rowVirtualizer = useVirtualizer({
+    count: trades.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => 42,
+    overscan: 15,
+  })
+
+  const virtualRows = rowVirtualizer.getVirtualItems()
+  const paddingTop = virtualRows.length > 0 ? virtualRows[0].start : 0
+  const paddingBottom = virtualRows.length > 0
+    ? rowVirtualizer.getTotalSize() - virtualRows[virtualRows.length - 1].end
+    : 0
+
+  return (
+    <div ref={scrollRef} className="mt-3 max-h-[560px] overflow-auto">
+      <table className="w-full min-w-[900px] text-sm">
+        <thead className="sticky top-0 z-10 bg-bg-card/95 backdrop-blur">
+          <tr className="border-b border-white/8 text-left text-xs uppercase tracking-wider text-text-secondary">
+            <th className="px-3 py-2">#</th>
+            <th className="px-3 py-2">Side</th>
+            <th className="px-3 py-2">Entry</th>
+            <th className="px-3 py-2">Exit</th>
+            <th className="px-3 py-2 text-right">Entry Price</th>
+            <th className="px-3 py-2 text-right">Exit Price</th>
+            <th className="px-3 py-2 text-right">Amount</th>
+            <th className="px-3 py-2 text-right">PnL</th>
+            <th className="px-3 py-2 text-right">PnL %</th>
+            <th className="px-3 py-2">Entry Reason</th>
+            <th className="px-3 py-2">Exit Reason</th>
+          </tr>
+        </thead>
+        <tbody>
+          {paddingTop > 0 && (
+            <tr aria-hidden="true">
+              <td colSpan={TRADE_TABLE_COLUMN_COUNT} style={{ height: `${paddingTop}px` }} />
+            </tr>
+          )}
+          {virtualRows.map((virtualRow) => {
+            const trade = trades[virtualRow.index]
+            return <TradeRow key={`${trade.tradeId}-${virtualRow.index}`} trade={trade} />
+          })}
+          {paddingBottom > 0 && (
+            <tr aria-hidden="true">
+              <td colSpan={TRADE_TABLE_COLUMN_COUNT} style={{ height: `${paddingBottom}px` }} />
+            </tr>
+          )}
+        </tbody>
+      </table>
     </div>
   )
 }


### PR DESCRIPTION
## 概要
バックテスト詳細の取引一覧（大量件数）を `@tanstack/react-virtual` で仮想化し、描画コストを削減しました。

## 変更内容
- `@tanstack/react-virtual` を依存追加
- `frontend/src/routes/backtest.tsx` の取引一覧テーブルを `VirtualizedTradesTable` に置換
- `tbody` の全件 `map` を廃止し、可視範囲 + overscan のみ描画
- テーブルヘッダーを `sticky` 化

## 確認
- `pnpm build`（frontend）
- `pnpm test`（frontend）
- `docker compose up --build -d` 後、取引一覧画面で表示確認（import 解決エラー解消済み）
