### PR TITLE
feat(strategy): introduce Strategy port, Registry, and DefaultStrategy wrapper (PDCA Task 1)

### DIFF
--- a/backend/cmd/event_pipeline.go
+++ b/backend/cmd/event_pipeline.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/port"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/repository"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/infrastructure/live"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase"
@@ -30,7 +31,7 @@ type EventDrivenPipeline struct {
 
 	// Existing dependencies (injected at construction)
 	riskMgr          *usecase.RiskManager
-	strategyEngine   *usecase.StrategyEngine
+	strategy         port.Strategy
 	marketDataSvc    *usecase.MarketDataService
 	orderClient      repository.OrderClient
 	symbolFetcher    repository.SymbolFetcher
@@ -66,7 +67,7 @@ func NewEventDrivenPipeline(
 	orderClient repository.OrderClient,
 	symbolFetcher repository.SymbolFetcher,
 	marketDataSvc *usecase.MarketDataService,
-	strategyEngine *usecase.StrategyEngine,
+	strategy port.Strategy,
 	riskMgr *usecase.RiskManager,
 	tradeHistoryRepo repository.TradeHistoryRepository,
 	riskStateRepo repository.RiskStateRepository,
@@ -81,7 +82,7 @@ func NewEventDrivenPipeline(
 		orderClient:       orderClient,
 		symbolFetcher:     symbolFetcher,
 		marketDataSvc:     marketDataSvc,
-		strategyEngine:    strategyEngine,
+		strategy:          strategy,
 		riskMgr:           riskMgr,
 		tradeHistoryRepo:  tradeHistoryRepo,
 		riskStateRepo:     riskStateRepo,
@@ -252,7 +253,7 @@ func (p *EventDrivenPipeline) snapshot() eventSnapshot {
 // feeds them through LiveSource to produce events, and dispatches them
 // through the EventEngine handler chain.
 func (p *EventDrivenPipeline) runEventLoop(ctx context.Context, snap eventSnapshot) {
-	if p.marketDataSvc == nil || p.strategyEngine == nil || p.orderClient == nil || p.riskMgr == nil {
+	if p.marketDataSvc == nil || p.strategy == nil || p.orderClient == nil || p.riskMgr == nil {
 		<-ctx.Done()
 		return
 	}
@@ -285,7 +286,7 @@ func (p *EventDrivenPipeline) runEventLoop(ctx context.Context, snap eventSnapsh
 	bus.Register(entity.EventTypeCandle, 10, indicatorHandler)
 
 	// StrategyHandler: signal generation from indicators (priority 20).
-	strategyHandler := &backtest.StrategyHandler{Engine: p.strategyEngine}
+	strategyHandler := &backtest.StrategyHandler{Strategy: p.strategy}
 	bus.Register(entity.EventTypeIndicator, 20, strategyHandler)
 
 	// RiskHandler: risk gating for signals (priority 30).

--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -59,12 +59,12 @@ func main() {
 	backtestResultRepo := backtestinfra.NewResultRepository(db)
 	stanceResolver := usecase.NewRuleBasedStanceResolver(stanceOverrideRepo)
 	strategyEngine := usecase.NewStrategyEngine(stanceResolver)
+	// The StrategyRegistry lives in the strategy package and is exercised by
+	// its own unit tests. It is intentionally not wired here yet because no
+	// downstream code consumes it; leaving dead infrastructure at the
+	// composition root would be misleading. It will be wired in the PR that
+	// introduces CLI/API strategy-profile selection.
 	defaultStrategy := strategyuc.NewDefaultStrategy(strategyEngine)
-	strategyRegistry := strategyuc.NewStrategyRegistry()
-	if err := strategyRegistry.Register(defaultStrategy.Name(), defaultStrategy); err != nil {
-		slog.Error("failed to register default strategy", "error", err)
-		os.Exit(1)
-	}
 	backtestRunner := backtestuc.NewBacktestRunner()
 	riskMgr := usecase.NewRiskManager(entity.RiskConfig{
 		MaxPositionAmount:     cfg.Risk.MaxPositionAmount,

--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/interfaces/api"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase"
 	backtestuc "github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/backtest"
+	strategyuc "github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/strategy"
 )
 
 func main() {
@@ -58,6 +59,12 @@ func main() {
 	backtestResultRepo := backtestinfra.NewResultRepository(db)
 	stanceResolver := usecase.NewRuleBasedStanceResolver(stanceOverrideRepo)
 	strategyEngine := usecase.NewStrategyEngine(stanceResolver)
+	defaultStrategy := strategyuc.NewDefaultStrategy(strategyEngine)
+	strategyRegistry := strategyuc.NewStrategyRegistry()
+	if err := strategyRegistry.Register(defaultStrategy.Name(), defaultStrategy); err != nil {
+		slog.Error("failed to register default strategy", "error", err)
+		os.Exit(1)
+	}
 	backtestRunner := backtestuc.NewBacktestRunner()
 	riskMgr := usecase.NewRiskManager(entity.RiskConfig{
 		MaxPositionAmount:     cfg.Risk.MaxPositionAmount,
@@ -94,7 +101,7 @@ func main() {
 		restClient,
 		restClient, // SymbolFetcher
 		marketDataSvc,
-		strategyEngine,
+		defaultStrategy,
 		riskMgr,
 		tradeHistoryRepo,
 		riskStateRepo,

--- a/backend/cmd/pipeline.go
+++ b/backend/cmd/pipeline.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/port"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/repository"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase"
 )
@@ -58,7 +59,7 @@ type TradingPipeline struct {
 	symbolFetcher    repository.SymbolFetcher
 	marketDataSvc    *usecase.MarketDataService
 	indicatorCalc    *usecase.IndicatorCalculator
-	strategyEngine   *usecase.StrategyEngine
+	strategy         port.Strategy
 	orderExecutor    *usecase.OrderExecutor
 	riskMgr          *usecase.RiskManager
 	tradeHistoryRepo repository.TradeHistoryRepository
@@ -105,7 +106,7 @@ func NewTradingPipeline(
 	symbolFetcher repository.SymbolFetcher,
 	marketDataSvc *usecase.MarketDataService,
 	indicatorCalc *usecase.IndicatorCalculator,
-	strategyEngine *usecase.StrategyEngine,
+	strategy port.Strategy,
 	orderExecutor *usecase.OrderExecutor,
 	riskMgr *usecase.RiskManager,
 	tradeHistoryRepo repository.TradeHistoryRepository,
@@ -121,7 +122,7 @@ func NewTradingPipeline(
 		symbolFetcher:     symbolFetcher,
 		marketDataSvc:     marketDataSvc,
 		indicatorCalc:     indicatorCalc,
-		strategyEngine:    strategyEngine,
+		strategy:          strategy,
 		orderExecutor:     orderExecutor,
 		riskMgr:           riskMgr,
 		tradeHistoryRepo:  tradeHistoryRepo,
@@ -280,7 +281,7 @@ func (p *TradingPipeline) SwitchSymbol(symbolID int64, tradeAmount float64, onSw
 // runTradingLoop は一定間隔で指標計算→戦略判定→注文実行を行う。
 func (p *TradingPipeline) runTradingLoop(ctx context.Context) {
 	// テスト時に依存が nil の場合は評価ループを回さない（ロック挙動のみ検証する用途）
-	if p.marketDataSvc == nil || p.indicatorCalc == nil || p.strategyEngine == nil || p.restClient == nil || p.orderExecutor == nil {
+	if p.marketDataSvc == nil || p.indicatorCalc == nil || p.strategy == nil || p.restClient == nil || p.orderExecutor == nil {
 		<-ctx.Done()
 		return
 	}
@@ -330,7 +331,7 @@ func (p *TradingPipeline) evaluate(ctx context.Context) {
 	}
 
 	// 3. 戦略判定（マルチタイムフレーム分析付き）
-	signal, err := p.strategyEngine.EvaluateWithHigherTF(ctx, *indicators, higherTF, latestTicker.Last)
+	signal, err := p.strategy.Evaluate(ctx, indicators, higherTF, latestTicker.Last, time.Now())
 	if err != nil {
 		slog.Warn("pipeline: failed to evaluate strategy", "error", err)
 		return

--- a/backend/internal/domain/port/strategy.go
+++ b/backend/internal/domain/port/strategy.go
@@ -1,0 +1,42 @@
+// Package port defines inbound/outbound ports (interfaces) used to decouple the
+// domain/usecase layers from concrete implementations. Ports live in the domain
+// layer so that dependencies point inward (infrastructure depends on port, not
+// the other way around).
+package port
+
+import (
+	"context"
+	"time"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+)
+
+// Strategy is the abstract port for a trading strategy. Implementations turn a
+// snapshot of technical indicators into a trading Signal.
+//
+// Semantics of Evaluate's indicators argument:
+//   - indicators is a pointer by convention so implementations can distinguish
+//     "no indicators available" (nil) from "indicators present but incomplete".
+//   - Callers MUST pass a non-nil *entity.IndicatorSet when they have
+//     calculated a snapshot. A nil argument signals "no data" and the
+//     implementation is expected to return an error rather than a HOLD signal,
+//     because "no signal" and "no input" are different conditions.
+//   - higherTF may be nil: it denotes an optional multi-timeframe indicator
+//     snapshot that the strategy may use to filter or confirm the primary
+//     signal.
+//   - now is the evaluation timestamp used by the strategy to stamp the
+//     resulting Signal. Using an explicit time (rather than time.Now()) keeps
+//     backtests deterministic.
+type Strategy interface {
+	Evaluate(
+		ctx context.Context,
+		indicators *entity.IndicatorSet,
+		higherTF *entity.IndicatorSet,
+		lastPrice float64,
+		now time.Time,
+	) (*entity.Signal, error)
+
+	// Name returns a stable identifier for the strategy (e.g. "default").
+	// Used by registries and logging.
+	Name() string
+}

--- a/backend/internal/usecase/backtest/handler.go
+++ b/backend/internal/usecase/backtest/handler.go
@@ -2,6 +2,7 @@ package backtest
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"strconv"
@@ -14,6 +15,12 @@ import (
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/eventengine"
 )
+
+// ErrBacktestStrategyMissing is returned by StrategyHandler.Handle when the
+// handler was constructed with a nil port.Strategy. Callers should use
+// NewStrategyHandler so this path is only reachable through struct-literal
+// construction that bypasses the constructor.
+var ErrBacktestStrategyMissing = errors.New("backtest: strategy handler has no strategy")
 
 // TickGeneratorHandler creates deterministic synthetic in-bar ticks from primary candles.
 type TickGeneratorHandler struct {
@@ -167,8 +174,22 @@ func (h *IndicatorHandler) Handle(_ context.Context, event entity.Event) ([]enti
 // It depends on the port.Strategy abstraction so the concrete implementation
 // (DefaultStrategy wrapping StrategyEngine today, a ConfigurableStrategy later)
 // can be swapped at the composition root without touching the handler chain.
+//
+// Construct via NewStrategyHandler to guarantee a non-nil strategy. The
+// Handle method keeps a sentinel check as defense-in-depth for struct-literal
+// construction that bypasses the constructor.
 type StrategyHandler struct {
 	Strategy port.Strategy
+}
+
+// NewStrategyHandler returns a StrategyHandler that delegates to s. It panics
+// if s is nil — the non-nil strategy is a composition-root invariant, so a nil
+// argument represents a programmer error that should fail loudly at startup.
+func NewStrategyHandler(s port.Strategy) *StrategyHandler {
+	if s == nil {
+		panic("backtest: NewStrategyHandler strategy must not be nil")
+	}
+	return &StrategyHandler{Strategy: s}
 }
 
 func (h *StrategyHandler) Handle(ctx context.Context, event entity.Event) ([]entity.Event, error) {
@@ -177,7 +198,7 @@ func (h *StrategyHandler) Handle(ctx context.Context, event entity.Event) ([]ent
 		return nil, nil
 	}
 	if h.Strategy == nil {
-		return nil, fmt.Errorf("strategy is nil")
+		return nil, ErrBacktestStrategyMissing
 	}
 
 	indicators := indicatorEvent.Primary

--- a/backend/internal/usecase/backtest/handler.go
+++ b/backend/internal/usecase/backtest/handler.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/port"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/infrastructure/indicator"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/eventengine"
@@ -162,9 +163,12 @@ func (h *IndicatorHandler) Handle(_ context.Context, event entity.Event) ([]enti
 	return nil, nil
 }
 
-// StrategyHandler converts IndicatorEvent to SignalEvent using StrategyEngine.
+// StrategyHandler converts IndicatorEvent to SignalEvent using a Strategy.
+// It depends on the port.Strategy abstraction so the concrete implementation
+// (DefaultStrategy wrapping StrategyEngine today, a ConfigurableStrategy later)
+// can be swapped at the composition root without touching the handler chain.
 type StrategyHandler struct {
-	Engine *usecase.StrategyEngine
+	Strategy port.Strategy
 }
 
 func (h *StrategyHandler) Handle(ctx context.Context, event entity.Event) ([]entity.Event, error) {
@@ -172,13 +176,14 @@ func (h *StrategyHandler) Handle(ctx context.Context, event entity.Event) ([]ent
 	if !ok {
 		return nil, nil
 	}
-	if h.Engine == nil {
-		return nil, fmt.Errorf("strategy engine is nil")
+	if h.Strategy == nil {
+		return nil, fmt.Errorf("strategy is nil")
 	}
 
-	signal, err := h.Engine.EvaluateWithHigherTFAt(
+	indicators := indicatorEvent.Primary
+	signal, err := h.Strategy.Evaluate(
 		ctx,
-		indicatorEvent.Primary,
+		&indicators,
 		indicatorEvent.HigherTF,
 		indicatorEvent.LastPrice,
 		time.UnixMilli(indicatorEvent.Timestamp),

--- a/backend/internal/usecase/backtest/handler_test.go
+++ b/backend/internal/usecase/backtest/handler_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/eventengine"
+	strategyuc "github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/strategy"
 )
 
 func TestIndicatorHandler_NoFutureHigherTFLeak(t *testing.T) {
@@ -64,7 +65,7 @@ func TestIndicatorHandler_NoFutureHigherTFLeak(t *testing.T) {
 func TestStrategyHandler_UsesIndicatorTimestamp(t *testing.T) {
 	resolver := usecase.NewRuleBasedStanceResolver(nil)
 	engine := usecase.NewStrategyEngine(resolver)
-	handler := &StrategyHandler{Engine: engine}
+	handler := &StrategyHandler{Strategy: strategyuc.NewDefaultStrategy(engine)}
 
 	ts := time.Date(2026, 4, 14, 12, 0, 0, 0, time.UTC).UnixMilli()
 	events, err := handler.Handle(context.Background(), entity.IndicatorEvent{

--- a/backend/internal/usecase/backtest/handler_test.go
+++ b/backend/internal/usecase/backtest/handler_test.go
@@ -65,7 +65,7 @@ func TestIndicatorHandler_NoFutureHigherTFLeak(t *testing.T) {
 func TestStrategyHandler_UsesIndicatorTimestamp(t *testing.T) {
 	resolver := usecase.NewRuleBasedStanceResolver(nil)
 	engine := usecase.NewStrategyEngine(resolver)
-	handler := &StrategyHandler{Strategy: strategyuc.NewDefaultStrategy(engine)}
+	handler := NewStrategyHandler(strategyuc.NewDefaultStrategy(engine))
 
 	ts := time.Date(2026, 4, 14, 12, 0, 0, 0, time.UTC).UnixMilli()
 	events, err := handler.Handle(context.Background(), entity.IndicatorEvent{

--- a/backend/internal/usecase/backtest/runner.go
+++ b/backend/internal/usecase/backtest/runner.go
@@ -11,6 +11,7 @@ import (
 	infra "github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/infrastructure/backtest"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/eventengine"
+	strategyuc "github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/strategy"
 )
 
 type RunInput struct {
@@ -61,6 +62,7 @@ func (r *BacktestRunner) Run(ctx context.Context, input RunInput) (*entity.Backt
 		DisablePersistence: true,
 	})
 	strategyEngine := usecase.NewStrategyEngine(stanceResolver)
+	defaultStrategy := strategyuc.NewDefaultStrategy(strategyEngine)
 	riskMgr := usecase.NewRiskManager(riskCfg)
 
 	sim := infra.NewSimExecutor(infra.SimConfig{
@@ -79,7 +81,7 @@ func (r *BacktestRunner) Run(ctx context.Context, input RunInput) (*entity.Backt
 		riskCfg.TakeProfitPercent,
 	)
 	indicatorHandler := NewIndicatorHandler(input.Config.PrimaryInterval, input.Config.HigherTFInterval, 500)
-	strategyHandler := &StrategyHandler{Engine: strategyEngine}
+	strategyHandler := &StrategyHandler{Strategy: defaultStrategy}
 	riskHandler := &RiskHandler{
 		RiskManager: riskMgr,
 		TradeAmount: input.TradeAmount,

--- a/backend/internal/usecase/backtest/runner.go
+++ b/backend/internal/usecase/backtest/runner.go
@@ -81,7 +81,7 @@ func (r *BacktestRunner) Run(ctx context.Context, input RunInput) (*entity.Backt
 		riskCfg.TakeProfitPercent,
 	)
 	indicatorHandler := NewIndicatorHandler(input.Config.PrimaryInterval, input.Config.HigherTFInterval, 500)
-	strategyHandler := &StrategyHandler{Strategy: defaultStrategy}
+	strategyHandler := NewStrategyHandler(defaultStrategy)
 	riskHandler := &RiskHandler{
 		RiskManager: riskMgr,
 		TradeAmount: input.TradeAmount,

--- a/backend/internal/usecase/strategy/default_strategy.go
+++ b/backend/internal/usecase/strategy/default_strategy.go
@@ -1,0 +1,67 @@
+// Package strategy hosts the pluggable trading-strategy abstraction: the
+// DefaultStrategy (wrapper around the classic StrategyEngine) and the
+// StrategyRegistry that lets composition roots look strategies up by name.
+package strategy
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/port"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase"
+)
+
+// DefaultStrategyName is the registration name of the built-in strategy.
+const DefaultStrategyName = "default"
+
+// ErrIndicatorsRequired is returned by Evaluate when the caller passes a nil
+// indicators argument. The port's contract is that callers must supply a
+// snapshot (possibly with missing fields), so nil is treated as a programmer
+// error rather than silently downgrading to HOLD.
+var ErrIndicatorsRequired = errors.New("strategy: indicators required")
+
+// DefaultStrategy adapts the existing *usecase.StrategyEngine to the
+// port.Strategy interface. It is the production strategy and satisfies
+// port.Strategy.
+//
+// The wrapper keeps runtime behaviour identical to calling
+// StrategyEngine.EvaluateWithHigherTFAt directly.
+type DefaultStrategy struct {
+	engine *usecase.StrategyEngine
+}
+
+// NewDefaultStrategy wraps a StrategyEngine so it can be consumed as a
+// port.Strategy. engine must not be nil.
+func NewDefaultStrategy(engine *usecase.StrategyEngine) *DefaultStrategy {
+	return &DefaultStrategy{engine: engine}
+}
+
+// Evaluate implements port.Strategy by delegating to the underlying
+// StrategyEngine. It converts the pointer-based port signature to the
+// by-value signature used by StrategyEngine. Nil indicators result in
+// ErrIndicatorsRequired.
+func (s *DefaultStrategy) Evaluate(
+	ctx context.Context,
+	indicators *entity.IndicatorSet,
+	higherTF *entity.IndicatorSet,
+	lastPrice float64,
+	now time.Time,
+) (*entity.Signal, error) {
+	if s == nil || s.engine == nil {
+		return nil, errors.New("strategy: default strategy is not initialised")
+	}
+	if indicators == nil {
+		return nil, ErrIndicatorsRequired
+	}
+	return s.engine.EvaluateWithHigherTFAt(ctx, *indicators, higherTF, lastPrice, now)
+}
+
+// Name returns the stable identifier used to register this strategy.
+func (s *DefaultStrategy) Name() string {
+	return DefaultStrategyName
+}
+
+// Compile-time guarantee that DefaultStrategy satisfies port.Strategy.
+var _ port.Strategy = (*DefaultStrategy)(nil)

--- a/backend/internal/usecase/strategy/default_strategy.go
+++ b/backend/internal/usecase/strategy/default_strategy.go
@@ -33,8 +33,13 @@ type DefaultStrategy struct {
 }
 
 // NewDefaultStrategy wraps a StrategyEngine so it can be consumed as a
-// port.Strategy. engine must not be nil.
+// port.Strategy. engine must not be nil; passing nil panics because a nil
+// engine represents a composition-root programmer error that should fail
+// loudly at startup rather than surface as a runtime error later.
 func NewDefaultStrategy(engine *usecase.StrategyEngine) *DefaultStrategy {
+	if engine == nil {
+		panic("strategy: NewDefaultStrategy engine must not be nil")
+	}
 	return &DefaultStrategy{engine: engine}
 }
 
@@ -42,6 +47,10 @@ func NewDefaultStrategy(engine *usecase.StrategyEngine) *DefaultStrategy {
 // StrategyEngine. It converts the pointer-based port signature to the
 // by-value signature used by StrategyEngine. Nil indicators result in
 // ErrIndicatorsRequired.
+//
+// The receiver and engine are construction-time invariants enforced by
+// NewDefaultStrategy, so Evaluate only validates the caller-supplied
+// indicators argument.
 func (s *DefaultStrategy) Evaluate(
 	ctx context.Context,
 	indicators *entity.IndicatorSet,
@@ -49,9 +58,6 @@ func (s *DefaultStrategy) Evaluate(
 	lastPrice float64,
 	now time.Time,
 ) (*entity.Signal, error) {
-	if s == nil || s.engine == nil {
-		return nil, errors.New("strategy: default strategy is not initialised")
-	}
 	if indicators == nil {
 		return nil, ErrIndicatorsRequired
 	}

--- a/backend/internal/usecase/strategy/default_strategy_test.go
+++ b/backend/internal/usecase/strategy/default_strategy_test.go
@@ -143,14 +143,15 @@ func TestDefaultStrategy_Evaluate_NilIndicators(t *testing.T) {
 	}
 }
 
-func TestDefaultStrategy_Evaluate_NilEngine(t *testing.T) {
-	s := NewDefaultStrategy(nil)
-	indicators := entity.IndicatorSet{SymbolID: 1}
-	signal, err := s.Evaluate(context.Background(), &indicators, nil, 0, time.Now())
-	if err == nil {
-		t.Fatal("expected error when wrapping a nil engine, got nil")
-	}
-	if signal != nil {
-		t.Errorf("expected nil signal on error, got %+v", signal)
-	}
+// TestDefaultStrategy_NewDefaultStrategy_NilEnginePanics asserts that passing
+// a nil engine to the constructor panics. The non-nil engine invariant is
+// enforced at construction time so Evaluate can rely on it without redundant
+// defensive checks.
+func TestDefaultStrategy_NewDefaultStrategy_NilEnginePanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic when constructing DefaultStrategy with nil engine, got none")
+		}
+	}()
+	_ = NewDefaultStrategy(nil)
 }

--- a/backend/internal/usecase/strategy/default_strategy_test.go
+++ b/backend/internal/usecase/strategy/default_strategy_test.go
@@ -1,0 +1,156 @@
+package strategy
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase"
+)
+
+// stubStanceResolver returns a fixed StanceResult for every call. It mirrors
+// the pattern used by the existing usecase.mockStanceResolver but lives in the
+// strategy package so we can instantiate a real *usecase.StrategyEngine
+// without touching unexported internals.
+type stubStanceResolver struct {
+	result usecase.StanceResult
+}
+
+func (s *stubStanceResolver) Resolve(
+	ctx context.Context,
+	indicators entity.IndicatorSet,
+	lastPrice float64,
+) usecase.StanceResult {
+	return s.result
+}
+
+func (s *stubStanceResolver) ResolveAt(
+	ctx context.Context,
+	indicators entity.IndicatorSet,
+	lastPrice float64,
+	now time.Time,
+) usecase.StanceResult {
+	return s.result
+}
+
+func floatPtr(v float64) *float64 { return &v }
+
+func TestDefaultStrategy_Name(t *testing.T) {
+	engine := usecase.NewStrategyEngine(&stubStanceResolver{})
+	s := NewDefaultStrategy(engine)
+	if got := s.Name(); got != DefaultStrategyName {
+		t.Errorf("Name() = %q, want %q", got, DefaultStrategyName)
+	}
+}
+
+// TestDefaultStrategy_Evaluate_DelegatesToEngine verifies that the wrapper
+// produces the same Signal as the underlying StrategyEngine for identical
+// inputs. This guarantees behavioural equivalence between calling
+// StrategyEngine.EvaluateWithHigherTFAt directly and via the port.
+func TestDefaultStrategy_Evaluate_DelegatesToEngine(t *testing.T) {
+	resolver := &stubStanceResolver{
+		result: usecase.StanceResult{
+			Stance:    entity.MarketStanceTrendFollow,
+			Reasoning: "uptrend",
+			Source:    "rule-based",
+		},
+	}
+	engine := usecase.NewStrategyEngine(resolver)
+	wrapped := NewDefaultStrategy(engine)
+
+	// Minimal indicator set that drives StrategyEngine into a BUY decision
+	// under TREND_FOLLOW: SMA20 > SMA50, RSI < 70, EMA aligned with SMA.
+	indicators := entity.IndicatorSet{
+		SymbolID: 7,
+		SMA20:    floatPtr(5_100_000),
+		SMA50:    floatPtr(5_000_000),
+		EMA12:    floatPtr(5_100_000),
+		EMA26:    floatPtr(5_000_000),
+		RSI14:    floatPtr(55),
+	}
+	lastPrice := 5_100_000.0
+	now := time.Unix(1_700_000_000, 0)
+
+	direct, err := engine.EvaluateWithHigherTFAt(
+		context.Background(),
+		indicators,
+		nil,
+		lastPrice,
+		now,
+	)
+	if err != nil {
+		t.Fatalf("engine direct call failed: %v", err)
+	}
+
+	viaPort, err := wrapped.Evaluate(
+		context.Background(),
+		&indicators,
+		nil,
+		lastPrice,
+		now,
+	)
+	if err != nil {
+		t.Fatalf("wrapped Evaluate failed: %v", err)
+	}
+
+	if viaPort == nil || direct == nil {
+		t.Fatalf("expected non-nil signals, got direct=%v viaPort=%v", direct, viaPort)
+	}
+	if viaPort.Action != direct.Action {
+		t.Errorf("Action mismatch: direct=%s wrapped=%s", direct.Action, viaPort.Action)
+	}
+	if viaPort.SymbolID != direct.SymbolID {
+		t.Errorf("SymbolID mismatch: direct=%d wrapped=%d", direct.SymbolID, viaPort.SymbolID)
+	}
+	if viaPort.Reason != direct.Reason {
+		t.Errorf("Reason mismatch: direct=%q wrapped=%q", direct.Reason, viaPort.Reason)
+	}
+	if viaPort.Confidence != direct.Confidence {
+		t.Errorf("Confidence mismatch: direct=%v wrapped=%v", direct.Confidence, viaPort.Confidence)
+	}
+	if viaPort.Timestamp != direct.Timestamp {
+		t.Errorf("Timestamp mismatch: direct=%d wrapped=%d", direct.Timestamp, viaPort.Timestamp)
+	}
+	// Sanity: our fabricated TREND_FOLLOW inputs should produce a BUY so we
+	// know the test actually exercised the engine and didn't just match a
+	// trivial HOLD.
+	if viaPort.Action != entity.SignalActionBuy {
+		t.Fatalf("expected BUY signal, got %s (reason=%q)", viaPort.Action, viaPort.Reason)
+	}
+}
+
+func TestDefaultStrategy_Evaluate_NilIndicators(t *testing.T) {
+	engine := usecase.NewStrategyEngine(&stubStanceResolver{})
+	s := NewDefaultStrategy(engine)
+
+	signal, err := s.Evaluate(
+		context.Background(),
+		nil, // nil indicators
+		nil,
+		0,
+		time.Now(),
+	)
+	if err == nil {
+		t.Fatal("expected error for nil indicators, got nil")
+	}
+	if !errors.Is(err, ErrIndicatorsRequired) {
+		t.Errorf("expected ErrIndicatorsRequired, got %v", err)
+	}
+	if signal != nil {
+		t.Errorf("expected nil signal on error, got %+v", signal)
+	}
+}
+
+func TestDefaultStrategy_Evaluate_NilEngine(t *testing.T) {
+	s := NewDefaultStrategy(nil)
+	indicators := entity.IndicatorSet{SymbolID: 1}
+	signal, err := s.Evaluate(context.Background(), &indicators, nil, 0, time.Now())
+	if err == nil {
+		t.Fatal("expected error when wrapping a nil engine, got nil")
+	}
+	if signal != nil {
+		t.Errorf("expected nil signal on error, got %+v", signal)
+	}
+}

--- a/backend/internal/usecase/strategy/registry.go
+++ b/backend/internal/usecase/strategy/registry.go
@@ -1,0 +1,89 @@
+package strategy
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"sync"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/port"
+)
+
+// Registry errors.
+var (
+	// ErrStrategyNameEmpty is returned when Register is called with an empty
+	// name.
+	ErrStrategyNameEmpty = errors.New("strategy: name must not be empty")
+
+	// ErrStrategyNil is returned when Register is called with a nil
+	// port.Strategy.
+	ErrStrategyNil = errors.New("strategy: strategy must not be nil")
+
+	// ErrStrategyAlreadyRegistered is returned when Register is called with a
+	// name that is already present in the registry.
+	ErrStrategyAlreadyRegistered = errors.New("strategy: name already registered")
+
+	// ErrStrategyNotFound is returned when Get cannot find a strategy by the
+	// given name.
+	ErrStrategyNotFound = errors.New("strategy: not found")
+)
+
+// StrategyRegistry is a goroutine-safe lookup for port.Strategy implementations
+// keyed by stable name. Composition roots construct the registry once at
+// startup and hand out a *StrategyRegistry to callers that need to resolve
+// strategies dynamically (e.g. a future profile loader or CLI flag).
+type StrategyRegistry struct {
+	mu         sync.RWMutex
+	strategies map[string]port.Strategy
+}
+
+// NewStrategyRegistry returns an empty, ready-to-use registry.
+func NewStrategyRegistry() *StrategyRegistry {
+	return &StrategyRegistry{
+		strategies: make(map[string]port.Strategy),
+	}
+}
+
+// Register stores s under name. Returns ErrStrategyNameEmpty for empty names,
+// ErrStrategyNil if s is nil, and ErrStrategyAlreadyRegistered if name has
+// already been registered.
+func (r *StrategyRegistry) Register(name string, s port.Strategy) error {
+	if name == "" {
+		return ErrStrategyNameEmpty
+	}
+	if s == nil {
+		return ErrStrategyNil
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.strategies[name]; exists {
+		return fmt.Errorf("%w: %q", ErrStrategyAlreadyRegistered, name)
+	}
+	r.strategies[name] = s
+	return nil
+}
+
+// Get returns the strategy registered under name, or ErrStrategyNotFound.
+func (r *StrategyRegistry) Get(name string) (port.Strategy, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	s, ok := r.strategies[name]
+	if !ok {
+		return nil, fmt.Errorf("%w: %q", ErrStrategyNotFound, name)
+	}
+	return s, nil
+}
+
+// List returns all registered strategy names in lexicographic order. The
+// returned slice is a copy safe for the caller to mutate.
+func (r *StrategyRegistry) List() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	names := make([]string, 0, len(r.strategies))
+	for name := range r.strategies {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/backend/internal/usecase/strategy/registry_test.go
+++ b/backend/internal/usecase/strategy/registry_test.go
@@ -1,0 +1,204 @@
+package strategy
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/port"
+)
+
+// stubStrategy is a minimal port.Strategy implementation for registry tests.
+// It does not touch any indicator math – the registry is a pure lookup.
+type stubStrategy struct {
+	name string
+}
+
+func (s *stubStrategy) Evaluate(
+	ctx context.Context,
+	indicators *entity.IndicatorSet,
+	higherTF *entity.IndicatorSet,
+	lastPrice float64,
+	now time.Time,
+) (*entity.Signal, error) {
+	return &entity.Signal{Action: entity.SignalActionHold}, nil
+}
+
+func (s *stubStrategy) Name() string { return s.name }
+
+func TestStrategyRegistry_RegisterGetList_HappyPath(t *testing.T) {
+	r := NewStrategyRegistry()
+
+	// Registered intentionally out of lexicographic order to verify List sorts.
+	entries := []*stubStrategy{
+		{name: "default"},
+		{name: "aggressive"},
+		{name: "passive"},
+	}
+	for _, s := range entries {
+		if err := r.Register(s.name, s); err != nil {
+			t.Fatalf("Register(%q) returned unexpected error: %v", s.name, err)
+		}
+	}
+
+	// Get each one back by name.
+	for _, s := range entries {
+		got, err := r.Get(s.name)
+		if err != nil {
+			t.Fatalf("Get(%q) returned error: %v", s.name, err)
+		}
+		if got.Name() != s.name {
+			t.Errorf("Get(%q) returned strategy with Name()=%q", s.name, got.Name())
+		}
+	}
+
+	want := []string{"aggressive", "default", "passive"}
+	if got := r.List(); !reflect.DeepEqual(got, want) {
+		t.Errorf("List() = %v, want sorted %v", got, want)
+	}
+}
+
+func TestStrategyRegistry_Register_DuplicateName(t *testing.T) {
+	r := NewStrategyRegistry()
+	if err := r.Register("default", &stubStrategy{name: "default"}); err != nil {
+		t.Fatalf("first Register failed: %v", err)
+	}
+	err := r.Register("default", &stubStrategy{name: "default"})
+	if err == nil {
+		t.Fatal("expected error registering duplicate name, got nil")
+	}
+	if !errors.Is(err, ErrStrategyAlreadyRegistered) {
+		t.Errorf("expected ErrStrategyAlreadyRegistered, got %v", err)
+	}
+}
+
+func TestStrategyRegistry_Register_EmptyName(t *testing.T) {
+	r := NewStrategyRegistry()
+	err := r.Register("", &stubStrategy{name: ""})
+	if err == nil {
+		t.Fatal("expected error for empty name, got nil")
+	}
+	if !errors.Is(err, ErrStrategyNameEmpty) {
+		t.Errorf("expected ErrStrategyNameEmpty, got %v", err)
+	}
+}
+
+func TestStrategyRegistry_Register_NilStrategy(t *testing.T) {
+	r := NewStrategyRegistry()
+	err := r.Register("default", nil)
+	if err == nil {
+		t.Fatal("expected error for nil strategy, got nil")
+	}
+	if !errors.Is(err, ErrStrategyNil) {
+		t.Errorf("expected ErrStrategyNil, got %v", err)
+	}
+}
+
+func TestStrategyRegistry_Get_Unknown(t *testing.T) {
+	r := NewStrategyRegistry()
+	_, err := r.Get("does-not-exist")
+	if err == nil {
+		t.Fatal("expected error for unknown name, got nil")
+	}
+	if !errors.Is(err, ErrStrategyNotFound) {
+		t.Errorf("expected ErrStrategyNotFound, got %v", err)
+	}
+}
+
+func TestStrategyRegistry_List_Empty(t *testing.T) {
+	r := NewStrategyRegistry()
+	if got := r.List(); len(got) != 0 {
+		t.Errorf("expected empty slice from empty registry, got %v", got)
+	}
+}
+
+// TestStrategyRegistry_ConcurrentAccess exercises Register / Get / List under
+// concurrent goroutines. Combined with `go test -race`, this verifies that
+// the sync.RWMutex protects the internal map.
+func TestStrategyRegistry_ConcurrentAccess(t *testing.T) {
+	r := NewStrategyRegistry()
+
+	const numWorkers = 32
+	const perWorker = 20
+
+	var wg sync.WaitGroup
+
+	// Writers: each goroutine registers its own unique names.
+	for w := 0; w < numWorkers; w++ {
+		wg.Add(1)
+		go func(worker int) {
+			defer wg.Done()
+			for i := 0; i < perWorker; i++ {
+				name := stratName(worker, i)
+				_ = r.Register(name, &stubStrategy{name: name})
+			}
+		}(w)
+	}
+
+	// Readers: concurrently call Get / List while writers are registering.
+	for w := 0; w < numWorkers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < perWorker; i++ {
+				_, _ = r.Get("default")
+				_ = r.List()
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// Post-condition: every written name should be retrievable exactly once.
+	got := r.List()
+	wantCount := numWorkers * perWorker
+	if len(got) != wantCount {
+		t.Fatalf("expected %d registered strategies, got %d", wantCount, len(got))
+	}
+
+	var (
+		lookupErrs int
+		s          port.Strategy
+		err        error
+	)
+	for _, name := range got {
+		s, err = r.Get(name)
+		if err != nil || s == nil {
+			lookupErrs++
+		}
+	}
+	if lookupErrs != 0 {
+		t.Errorf("%d concurrent lookups failed", lookupErrs)
+	}
+}
+
+func stratName(worker, idx int) string {
+	// Compact deterministic names that sort stably.
+	return "w" + itoa(worker) + "-" + itoa(idx)
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	i := len(buf)
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}

--- a/backend/internal/usecase/strategy/registry_test.go
+++ b/backend/internal/usecase/strategy/registry_test.go
@@ -3,6 +3,7 @@ package strategy
 import (
 	"context"
 	"errors"
+	"fmt"
 	"reflect"
 	"sync"
 	"testing"
@@ -178,27 +179,5 @@ func TestStrategyRegistry_ConcurrentAccess(t *testing.T) {
 
 func stratName(worker, idx int) string {
 	// Compact deterministic names that sort stably.
-	return "w" + itoa(worker) + "-" + itoa(idx)
-}
-
-func itoa(n int) string {
-	if n == 0 {
-		return "0"
-	}
-	var buf [20]byte
-	i := len(buf)
-	neg := n < 0
-	if neg {
-		n = -n
-	}
-	for n > 0 {
-		i--
-		buf[i] = byte('0' + n%10)
-		n /= 10
-	}
-	if neg {
-		i--
-		buf[i] = '-'
-	}
-	return string(buf[i:])
+	return fmt.Sprintf("w%02d-%02d", worker, idx)
 }

--- a/docs/superpowers/specs/2026-04-16-pdca-strategy-optimizer-design.md
+++ b/docs/superpowers/specs/2026-04-16-pdca-strategy-optimizer-design.md
@@ -310,6 +310,7 @@ backtestPDCAColumns := []struct {
     {"pdca_cycle_id", "pdca_cycle_id TEXT NOT NULL DEFAULT ''"},
     {"hypothesis", "hypothesis TEXT NOT NULL DEFAULT ''"},
     {"parent_result_id", "parent_result_id TEXT NOT NULL DEFAULT ''"},
+    {"biweekly_win_rate", "biweekly_win_rate REAL NOT NULL DEFAULT 0"},
 }
 for _, col := range backtestPDCAColumns {
     if err := addColumnIfNotExists(db, "backtest_results", col.name, col.def); err != nil {
@@ -329,7 +330,13 @@ CREATE INDEX IF NOT EXISTS idx_backtest_results_parent
 CREATE INDEX IF NOT EXISTS idx_backtest_results_profile
     ON backtest_results(profile_name)
     WHERE profile_name != '';
+
+CREATE INDEX IF NOT EXISTS idx_backtest_results_pdca_cycle
+    ON backtest_results(pdca_cycle_id)
+    WHERE pdca_cycle_id != '';
 ```
+
+`biweekly_win_rate` カラムは `BacktestSummary` の新フィールドに対応し、Repository の INSERT/SELECT で永続化する。
 
 ### 5.2 API レスポンス拡張
 
@@ -431,14 +438,20 @@ type PDCAEvaluation struct {
 
 バックテスト期間をタイムスタンプベースで2週間 (14日) のウィンドウに分割し、1日ずつスライドする。
 各ウィンドウ内のクローズ済みトレードから勝率を算出し、全ウィンドウの平均を取る。
-トレード数が0のウィンドウはスキップする。
+
+**最低トレード数制約:** 各ウィンドウ内のトレード数が3件未満の場合はそのウィンドウの勝率を0%として扱う（スキップではなくペナルティ）。
+これにより低頻度売買戦略が見かけ上高い勝率を得ることを防ぐ。
+
+**カバレッジ率制約:** トレードが3件以上あるウィンドウの割合（カバレッジ率）が50%未満の場合、BiweeklyWinRate 自体を信頼不可として 0 を返す。
 
 ```
 期間: 2024-01-01 ～ 2024-12-31
-Window 1: 01/01 - 01/14 → 勝率 75%
-Window 2: 01/02 - 01/15 → 勝率 80%
+Window 1: 01/01 - 01/14 → 5件, 勝率 75%  ✓
+Window 2: 01/02 - 01/15 → 1件, 勝率 0%   (3件未満ペナルティ)
+Window 3: 01/03 - 01/16 → 4件, 勝率 80%  ✓
 ...
-BiweeklyWinRate = avg(全ウィンドウ)
+カバレッジ率 = 有効ウィンドウ数 / 全ウィンドウ数
+BiweeklyWinRate = カバレッジ率 ≥ 50% ? avg(全ウィンドウ) : 0
 ```
 
 ### 7.3 BacktestSummary への追加フィールド
@@ -480,10 +493,32 @@ go run ./cmd/backtest optimize \
 
 ```
 POST /api/v1/backtest/run
-  + profilePath: string (プロファイルJSONのパス)
+  + profileName: string (プロファイル名。profiles/<profileName>.json として解決)
   + pdcaCycleId: string (PDCAサイクルID、オプション)
   + hypothesis: string (仮説テキスト、オプション)
   + parentResultId: string (比較元の結果ID、オプション)
+```
+
+### 8.3 プロファイルパスのバリデーション
+
+API 経由の `profileName` はファイル名のみ（拡張子なし）を受け付け、サーバー側で `profiles/<name>.json` に解決する。
+CLI の `--profile` も同様に `profiles/` 配下に限定する。
+
+```go
+// パストラバーサル防止
+func resolveProfilePath(name string) (string, error) {
+    // 英数字、ハイフン、アンダースコアのみ許可
+    if !regexp.MustCompile(`^[a-zA-Z0-9_-]+$`).MatchString(name) {
+        return "", fmt.Errorf("invalid profile name: %s", name)
+    }
+    path := filepath.Join("profiles", name+".json")
+    // 念のため Clean 後に profiles/ プレフィックスを検証
+    cleaned := filepath.Clean(path)
+    if !strings.HasPrefix(cleaned, "profiles/") {
+        return "", fmt.Errorf("profile path traversal detected: %s", name)
+    }
+    return cleaned, nil
+}
 ```
 
 ---

--- a/docs/superpowers/specs/2026-04-16-pdca-strategy-optimizer-design.md
+++ b/docs/superpowers/specs/2026-04-16-pdca-strategy-optimizer-design.md
@@ -143,7 +143,7 @@ type StrategyProfile struct {
     Indicators  IndicatorConfig     `json:"indicators"`
     StanceRules StanceRulesConfig   `json:"stance_rules"`
     SignalRules SignalRulesConfig    `json:"signal_rules"`
-    Risk        StrategyRiskConfig  `json:"risk"`
+    Risk        StrategyRiskConfig  `json:"strategy_risk"`
     HTFFilter   HTFFilterConfig     `json:"htf_filter"`
 }
 
@@ -199,6 +199,14 @@ type HTFFilterConfig struct {
     BlockCounterTrend bool    `json:"block_counter_trend"`
     AlignmentBoost    float64 `json:"alignment_boost"`
 }
+
+type StrategyRiskConfig struct {
+    StopLossPercent      float64 `json:"stop_loss_percent"`
+    TakeProfitPercent    float64 `json:"take_profit_percent"`
+    StopLossATRMultiplier float64 `json:"stop_loss_atr_multiplier"`
+    MaxPositionAmount    float64 `json:"max_position_amount"`
+    MaxDailyLoss         float64 `json:"max_daily_loss"`
+}
 ```
 
 ---
@@ -222,10 +230,11 @@ Do:
   3. go run ./cmd/backtest run --profile profiles/experiment_... を実行
 
 Check:
-  1. 結果を前回と比較
-     - MaxDD ≤ 20% (必須制約)
-     - 2週間区間勝率 → 80%目標
-     - Total Return 改善
+  1. 結果を前回と比較 (目的関数で評価)
+     - [必須制約] MaxDD ≤ 20% — 超過した場合は即 reject
+     - [主目的] Total Return 最大化
+     - [副目的] 2週間スライド勝率 → 80%目標
+     - [参考] Sharpe Ratio, ProfitFactor
 
 Act:
   1. 改善 → 採用、次の仮説へ
@@ -288,13 +297,38 @@ docs/pdca/
 
 ### 5.1 DBスキーマ追加
 
-既存の `backtest_results` テーブルに以下のカラムを追加:
+既存の `backtest_results` テーブルに以下のカラムを追加する。
+現行の `addColumnIfNotExists` 補助関数（`database/migrations.go`）を使い、冪等に実行する。
+
+```go
+// migrations.go の RunMigrations 末尾に追加
+backtestPDCAColumns := []struct {
+    name string
+    def  string
+}{
+    {"profile_name", "profile_name TEXT NOT NULL DEFAULT ''"},
+    {"pdca_cycle_id", "pdca_cycle_id TEXT NOT NULL DEFAULT ''"},
+    {"hypothesis", "hypothesis TEXT NOT NULL DEFAULT ''"},
+    {"parent_result_id", "parent_result_id TEXT NOT NULL DEFAULT ''"},
+}
+for _, col := range backtestPDCAColumns {
+    if err := addColumnIfNotExists(db, "backtest_results", col.name, col.def); err != nil {
+        return fmt.Errorf("backtest_results alter: %w", err)
+    }
+}
+```
+
+`parent_result_id` にはインデックスを作成し、系譜追跡のクエリ性能を確保する。
+SQLite では FK 制約の実効性が限定的なため、アプリケーション層で参照整合性を検証する。
 
 ```sql
-ALTER TABLE backtest_results ADD COLUMN profile_name TEXT DEFAULT '';
-ALTER TABLE backtest_results ADD COLUMN pdca_cycle_id TEXT DEFAULT '';
-ALTER TABLE backtest_results ADD COLUMN hypothesis TEXT DEFAULT '';
-ALTER TABLE backtest_results ADD COLUMN parent_result_id TEXT DEFAULT '';
+CREATE INDEX IF NOT EXISTS idx_backtest_results_parent
+    ON backtest_results(parent_result_id)
+    WHERE parent_result_id != '';
+
+CREATE INDEX IF NOT EXISTS idx_backtest_results_profile
+    ON backtest_results(profile_name)
+    WHERE profile_name != '';
 ```
 
 ### 5.2 API レスポンス拡張
@@ -311,11 +345,32 @@ type BacktestResult struct {
 }
 ```
 
-### 5.3 フロントエンド一覧表示
+### 5.3 一覧 API のフィルタ拡張
+
+既存の `BacktestResultFilter` (現在は `Limit`/`Offset` のみ) にフィルタパラメータを追加する。
+
+```go
+// domain/repository/backtest_result.go
+type BacktestResultFilter struct {
+    Limit          int
+    Offset         int
+    ProfileName    string // 完全一致フィルタ (空文字 = フィルタなし)
+    PDCACycleID    string // 完全一致フィルタ
+    ParentResultID string // 系譜追跡用
+}
+```
+
+```
+GET /api/v1/backtest/results?limit=20&offset=0&profileName=ltc_aggressive_v3&pdcaCycleId=2026-04-16_cycle01
+```
+
+Repository 実装では追加カラムを `WHERE` 句に動的追加する。
+
+### 5.4 フロントエンド一覧表示
 
 バックテスト一覧にプロファイル名・PDCAサイクル番号を表示:
 
-- プロファイル名でフィルタ可能
+- プロファイル名でフィルタ可能 (ドロップダウン)
 - PDCAサイクルの結果は改善チェーン (parent_result_id) で系譜を辿れる
 - 実験結果と手動実行を視覚的に区別 (アイコン or バッジ)
 
@@ -344,11 +399,70 @@ PDCA Level 3 で新しいインジケーターを追加する際の変更箇所:
 
 ---
 
-## 7. CLI 拡張
+## 7. 評価関数 (目的関数)
 
-### 7.1 `--profile` フラグ追加
+### 7.1 PDCA用複合スコア
+
+現行の Optimizer は Sharpe Ratio 単一でソートしているが、PDCA では以下の複合評価を適用する。
+
+```go
+// PDCAの評価ロジック (Claude Code セッション内で判定)
+// 実装としては reporter.go の BacktestSummary に 2週間勝率フィールドを追加し、
+// CLI出力に含める。最終判定は Claude Code が行う。
+
+type PDCAEvaluation struct {
+    // 必須制約 — 1つでも違反したら reject
+    MaxDDConstraint     float64 // ≤ 0.20 (20%)
+
+    // 主目的 — 高いほど良い
+    TotalReturn         float64
+
+    // 副目的 — 高いほど良い (目標 0.80)
+    BiweeklyWinRate     float64 // 2週間スライドウィンドウ勝率の平均
+
+    // 参考指標
+    SharpeRatio         float64
+    ProfitFactor        float64
+    WinRate             float64
+}
+```
+
+### 7.2 2週間スライド勝率の計算
+
+バックテスト期間をタイムスタンプベースで2週間 (14日) のウィンドウに分割し、1日ずつスライドする。
+各ウィンドウ内のクローズ済みトレードから勝率を算出し、全ウィンドウの平均を取る。
+トレード数が0のウィンドウはスキップする。
+
+```
+期間: 2024-01-01 ～ 2024-12-31
+Window 1: 01/01 - 01/14 → 勝率 75%
+Window 2: 01/02 - 01/15 → 勝率 80%
+...
+BiweeklyWinRate = avg(全ウィンドウ)
+```
+
+### 7.3 BacktestSummary への追加フィールド
+
+```go
+type BacktestSummary struct {
+    // ... 既存フィールド
+    BiweeklyWinRate float64 // 2週間スライド勝率の平均
+}
+```
+
+---
+
+## 8. CLI 拡張
+
+### 8.1 `--profile` フラグ追加
+
+CLI および API でのパスは `backend/` ディレクトリからの相対パスとして解決する。
+これは既存の `--data` フラグ（例: `data/candles_*.csv`）と同じ規約に従う。
 
 ```bash
+# 実行ディレクトリ: backend/
+cd backend
+
 # プロファイル指定でバックテスト実行
 go run ./cmd/backtest run \
   --profile profiles/experiment_2026-04-16_01.json \
@@ -362,7 +476,7 @@ go run ./cmd/backtest optimize \
   ...
 ```
 
-### 7.2 API 拡張
+### 8.2 API 拡張
 
 ```
 POST /api/v1/backtest/run
@@ -374,7 +488,7 @@ POST /api/v1/backtest/run
 
 ---
 
-## 8. スコープ
+## 9. スコープ
 
 ### 今回実装するもの
 
@@ -388,6 +502,7 @@ POST /api/v1/backtest/run
 - バックテスト一覧画面にプロファイル名・PDCAサイクル情報の表示
 - production.json (現行パラメータの外出し)
 - docs/pdca/ 記録フォーマット
+- BiweeklyWinRate (2週間スライド勝率) の算出ロジック + BacktestSummary への追加
 
 ### 今回実装しないもの
 

--- a/docs/superpowers/specs/2026-04-16-pdca-strategy-optimizer-design.md
+++ b/docs/superpowers/specs/2026-04-16-pdca-strategy-optimizer-design.md
@@ -227,7 +227,13 @@ Plan:
 Do:
   1. profiles/experiment_*.json を生成
   2. (Level 3の場合) indicator/*.go を追加・修正
-  3. go run ./cmd/backtest run --profile profiles/experiment_... を実行
+  3. バックテスト実行:
+     go run ./cmd/backtest run \
+       --profile experiment_2026-04-16_01 \
+       --data data/candles_LTC_JPY_PT15M.csv \
+       --data-htf data/candles_LTC_JPY_PT1H.csv
+     ※ --data/--data-htf は常に必須。プロファイルは戦略パラメータのみを持ち、
+       データソースと期間はCLI引数で指定する（再現性のためPDCA記録にも残す）。
 
 Check:
   1. 結果を前回と比較 (目的関数で評価)
@@ -321,7 +327,14 @@ for _, col := range backtestPDCAColumns {
 
 `parent_result_id` にはインデックスと自己参照 FK 制約を設定する。
 本プロジェクトは `PRAGMA foreign_keys=ON`（`sqlite.go:31`）を有効化しているため、FK が実効的に機能する。
-ただし `parent_result_id` は空文字（ルートノード）を許容するため、FK は空文字でない場合のみ適用される（SQLite では NULL の FK は無視されるため、空文字ではなく NULL をデフォルトとする）。
+`parent_result_id` のルートノード（親なし）は NULL で表現する。SQLite では NULL の FK 参照はチェックをスキップする。
+
+**`parent_result_id` の整合性ルール（アプリケーション層）:**
+
+- **存在チェック:** 非 NULL の場合、`backtest_results` に該当IDが存在すること（FK で担保）
+- **自己参照禁止:** 自身の result_id と同一の値を拒否する（保存前に検証、HTTP 422 を返す）
+- **別プロファイル参照:** 許可する。異なるプロファイル間の比較チェーンは有効なユースケース（例: production → experiment_v1 の系譜）
+- **エラーレスポンス:** parent_result_id が不正な場合は HTTP 422 Unprocessable Entity を返し、理由を含める
 
 ```sql
 CREATE INDEX IF NOT EXISTS idx_backtest_results_parent
@@ -483,22 +496,50 @@ go run ./cmd/backtest run \
   --data data/candles_LTC_JPY_PT15M.csv \
   --data-htf data/candles_LTC_JPY_PT1H.csv
 
-# プロファイル指定で最適化
+# プロファイルをベースに最適化（プロファイルの値を起点としてパラメータ探索）
 go run ./cmd/backtest optimize \
-  --profile production \
+  --profile experiment_2026-04-16_01 \
   --param "stop_loss_percent=1:10:1" \
   ...
 ```
 
 ### 8.2 API 拡張
 
+`POST /api/v1/backtest/run` の完全リクエストスキーマ:
+
+```jsonc
+{
+  // --- データソース (必須: 既存と同じ) ---
+  "data": "data/candles_LTC_JPY_PT15M.csv",       // required
+  "dataHtf": "data/candles_LTC_JPY_PT1H.csv",     // optional
+  "from": "2024-01-01",                             // optional (省略時: CSV先頭)
+  "to": "2024-12-31",                               // optional (省略時: CSV末尾)
+
+  // --- 戦略プロファイル (optional, 新規追加) ---
+  "profileName": "experiment_2026-04-16_01",        // optional: profiles/<name>.json を読み込み
+
+  // --- 個別パラメータ (optional, 既存と同じ) ---
+  // profileName と同時指定された場合、個別パラメータがプロファイルの値をオーバーライドする
+  "initialBalance": 100000,
+  "tradeAmount": 0.1,
+  "stopLossPercent": 5,
+  "takeProfitPercent": 10,
+  "spread": 0.1,
+  "carryingCost": 0.04,
+  "slippage": 0.05,
+  "maxPositionAmount": 100000,
+  "maxDailyLoss": 50000,
+  "maxConsecutiveLosses": 0,
+  "cooldownMinutes": 0,
+
+  // --- PDCAメタデータ (optional, 新規追加) ---
+  "pdcaCycleId": "2026-04-16_cycle01",             // optional
+  "hypothesis": "RSI閾値を15/85に変更",             // optional
+  "parentResultId": "01HXYZ..."                     // optional: 既存結果IDのみ許可
+}
 ```
-POST /api/v1/backtest/run
-  + profileName: string (プロファイル名。profiles/<profileName>.json として解決)
-  + pdcaCycleId: string (PDCAサイクルID、オプション)
-  + hypothesis: string (仮説テキスト、オプション)
-  + parentResultId: string (比較元の結果ID、オプション)
-```
+
+**優先順位ルール:** `profileName` が指定された場合、プロファイルの値をベースとし、同時に指定された個別パラメータでオーバーライドする。`profileName` が未指定の場合は従来通り個別パラメータのみで動作する。
 
 ### 8.3 プロファイルパスのバリデーション
 

--- a/docs/superpowers/specs/2026-04-16-pdca-strategy-optimizer-design.md
+++ b/docs/superpowers/specs/2026-04-16-pdca-strategy-optimizer-design.md
@@ -309,7 +309,7 @@ backtestPDCAColumns := []struct {
     {"profile_name", "profile_name TEXT NOT NULL DEFAULT ''"},
     {"pdca_cycle_id", "pdca_cycle_id TEXT NOT NULL DEFAULT ''"},
     {"hypothesis", "hypothesis TEXT NOT NULL DEFAULT ''"},
-    {"parent_result_id", "parent_result_id TEXT NOT NULL DEFAULT ''"},
+    {"parent_result_id", "parent_result_id TEXT DEFAULT NULL REFERENCES backtest_results(id)"},
     {"biweekly_win_rate", "biweekly_win_rate REAL NOT NULL DEFAULT 0"},
 }
 for _, col := range backtestPDCAColumns {
@@ -319,13 +319,14 @@ for _, col := range backtestPDCAColumns {
 }
 ```
 
-`parent_result_id` にはインデックスを作成し、系譜追跡のクエリ性能を確保する。
-SQLite では FK 制約の実効性が限定的なため、アプリケーション層で参照整合性を検証する。
+`parent_result_id` にはインデックスと自己参照 FK 制約を設定する。
+本プロジェクトは `PRAGMA foreign_keys=ON`（`sqlite.go:31`）を有効化しているため、FK が実効的に機能する。
+ただし `parent_result_id` は空文字（ルートノード）を許容するため、FK は空文字でない場合のみ適用される（SQLite では NULL の FK は無視されるため、空文字ではなく NULL をデフォルトとする）。
 
 ```sql
 CREATE INDEX IF NOT EXISTS idx_backtest_results_parent
     ON backtest_results(parent_result_id)
-    WHERE parent_result_id != '';
+    WHERE parent_result_id IS NOT NULL;
 
 CREATE INDEX IF NOT EXISTS idx_backtest_results_profile
     ON backtest_results(profile_name)
@@ -348,7 +349,7 @@ type BacktestResult struct {
     ProfileName    string `json:"profileName"`
     PDCACycleID    string `json:"pdcaCycleId,omitempty"`
     Hypothesis     string `json:"hypothesis,omitempty"`
-    ParentResultID string `json:"parentResultId,omitempty"`
+    ParentResultID *string `json:"parentResultId,omitempty"` // NULL = ルートノード
 }
 ```
 
@@ -469,8 +470,8 @@ type BacktestSummary struct {
 
 ### 8.1 `--profile` フラグ追加
 
-CLI および API でのパスは `backend/` ディレクトリからの相対パスとして解決する。
-これは既存の `--data` フラグ（例: `data/candles_*.csv`）と同じ規約に従う。
+CLI・API ともにプロファイルは **名前のみ（拡張子なし）** で指定する。
+サーバー/CLI 側で `profiles/<name>.json` に解決する（8.3 のバリデーション参照）。
 
 ```bash
 # 実行ディレクトリ: backend/
@@ -478,13 +479,13 @@ cd backend
 
 # プロファイル指定でバックテスト実行
 go run ./cmd/backtest run \
-  --profile profiles/experiment_2026-04-16_01.json \
+  --profile experiment_2026-04-16_01 \
   --data data/candles_LTC_JPY_PT15M.csv \
   --data-htf data/candles_LTC_JPY_PT1H.csv
 
 # プロファイル指定で最適化
 go run ./cmd/backtest optimize \
-  --profile profiles/base.json \
+  --profile production \
   --param "stop_loss_percent=1:10:1" \
   ...
 ```

--- a/docs/superpowers/specs/2026-04-16-pdca-strategy-optimizer-design.md
+++ b/docs/superpowers/specs/2026-04-16-pdca-strategy-optimizer-design.md
@@ -264,6 +264,12 @@ Act:
 ```markdown
 # PDCA Cycle NN — YYYY-MM-DD
 
+## 実行条件
+- データ: data/candles_LTC_JPY_PT15M.csv
+- HTFデータ: data/candles_LTC_JPY_PT1H.csv
+- 期間: YYYY-MM-DD ～ YYYY-MM-DD
+- 実行コマンド: (再現用の完全なコマンドを記載)
+
 ## 仮説
 (何をどう変えるか、なぜ改善すると考えるか)
 
@@ -497,8 +503,11 @@ go run ./cmd/backtest run \
   --data-htf data/candles_LTC_JPY_PT1H.csv
 
 # プロファイルをベースに最適化（プロファイルの値を起点としてパラメータ探索）
+# --data は必須、--data-htf / --from / --to はオプション（run と同じ規約）
 go run ./cmd/backtest optimize \
   --profile experiment_2026-04-16_01 \
+  --data data/candles_LTC_JPY_PT15M.csv \
+  --data-htf data/candles_LTC_JPY_PT1H.csv \
   --param "stop_loss_percent=1:10:1" \
   ...
 ```
@@ -580,6 +589,18 @@ func resolveProfilePath(name string) (string, error) {
 - production.json (現行パラメータの外出し)
 - docs/pdca/ 記録フォーマット
 - BiweeklyWinRate (2週間スライド勝率) の算出ロジック + BacktestSummary への追加
+
+### 必須テスト
+
+| 対象 | テストケース | 種別 |
+|---|---|---|
+| マイグレーション | 新カラム追加が冪等に実行できること（2回実行してエラーなし） | 統合テスト |
+| resolveProfilePath | 正常名、空文字、`..` 含み、絶対パス、特殊文字を拒否 | 単体テスト |
+| parent_result_id | 自己参照で 422、存在しないIDで FK エラー、NULL で正常保存 | 統合テスト |
+| profileName + 個別パラメータ | 個別パラメータがプロファイル値をオーバーライドすること | 単体テスト |
+| BiweeklyWinRate | 3件未満ペナルティ、カバレッジ50%未満で0、正常算出 | 単体テスト |
+| ConfigurableStrategy | プロファイルから生成した戦略が DefaultStrategy と同一入力で動作すること | 単体テスト |
+| API /backtest/results フィルタ | profileName / pdcaCycleId でフィルタ結果が正しいこと | 統合テスト |
 
 ### 今回実装しないもの
 

--- a/docs/superpowers/specs/2026-04-16-pdca-strategy-optimizer-design.md
+++ b/docs/superpowers/specs/2026-04-16-pdca-strategy-optimizer-design.md
@@ -1,0 +1,397 @@
+# PDCA Strategy Optimizer — 設計書
+
+**日付:** 2026-04-16
+**対象通貨:** LTC/JPY 固定
+**目的:** バックテストを自動化し、PDCAサイクルでパラメータ調整→ロジック組み替え→新指標追加を段階的に行い、最適な戦略を発見する
+
+---
+
+## 1. 概要
+
+### 1.1 目標
+
+- MaxDrawdown 20%以下の制約のもとで Total Return を最大化する
+- 2週間区間での勝率80%を目標とする（バックテスト期間を2週間ウィンドウでスライドし、各ウィンドウの勝率を算出、その平均値で評価）
+- 本番運用の戦略とは独立して実験的な戦略を試行できるようにする
+- うまくいった戦略を手動承認で本番に昇格させる
+
+### 1.2 方針まとめ
+
+| 項目 | 決定 |
+|---|---|
+| 通貨 | LTC/JPY 固定 |
+| チューニング範囲 | パラメータ → ロジック組み替え → 新指標追加（全レベル） |
+| AI自律度 | 半自律（コード変更+バックテスト自動、本番反映は手動承認） |
+| 実行トリガー | 手動起動（Claude Codeセッション内） |
+| 評価基準 | MaxDD上限付きリターン最大化 + 2週間勝率80%目標 |
+| AI実装方式 | Claude Codeセッション内で完結 |
+
+---
+
+## 2. 戦略プラグインアーキテクチャ
+
+### 2.1 Strategy Interface
+
+現在の `StrategyEngine` と `RuleBasedStanceResolver` をinterfaceの背後に配置し、複数の戦略実装を切り替え可能にする。
+
+```go
+// domain/port/strategy.go
+type Strategy interface {
+    Evaluate(ctx context.Context, indicators *entity.IndicatorSet, higherTF *entity.IndicatorSet, lastPrice float64, now time.Time) (*entity.Signal, error)
+    Name() string
+}
+```
+
+### 2.2 実装
+
+- **DefaultStrategy** — 現行の StrategyEngine + RuleBasedStanceResolver をラップ。本番デフォルト。
+- **ConfigurableStrategy** — StrategyProfile (JSON) からパラメータと条件を構築。バックテスト実験用。
+
+### 2.3 Registry
+
+```go
+// usecase/strategy/registry.go
+type StrategyRegistry struct {
+    strategies map[string]Strategy
+}
+
+func (r *StrategyRegistry) Register(name string, s Strategy)
+func (r *StrategyRegistry) Get(name string) (Strategy, error)
+func (r *StrategyRegistry) List() []string
+```
+
+---
+
+## 3. StrategyProfile 構造
+
+バックテストに渡す設定ファイル。戦略の全パラメータを宣言的に定義する。
+
+### 3.1 ファイル配置
+
+```
+backend/profiles/
+├── production.json              ← 本番用
+└── experiment_*.json            ← PDCA実験用
+```
+
+### 3.2 JSON構造
+
+```json
+{
+  "name": "ltc_aggressive_v3",
+  "description": "LTC向け攻めの短期戦略",
+  "indicators": {
+    "sma_short": 10,
+    "sma_long": 30,
+    "rsi_period": 14,
+    "macd_fast": 12,
+    "macd_slow": 26,
+    "macd_signal": 9,
+    "bb_period": 20,
+    "bb_multiplier": 2.0,
+    "atr_period": 14
+  },
+  "stance_rules": {
+    "rsi_oversold": 20,
+    "rsi_overbought": 80,
+    "sma_convergence_threshold": 0.001,
+    "bb_squeeze_lookback": 5,
+    "breakout_volume_ratio": 1.5
+  },
+  "signal_rules": {
+    "trend_follow": {
+      "enabled": true,
+      "require_macd_confirm": true,
+      "require_ema_cross": true,
+      "rsi_buy_max": 70,
+      "rsi_sell_min": 30
+    },
+    "contrarian": {
+      "enabled": true,
+      "rsi_entry": 30,
+      "rsi_exit": 70,
+      "macd_histogram_limit": 10
+    },
+    "breakout": {
+      "enabled": true,
+      "volume_ratio_min": 1.5,
+      "require_macd_confirm": true
+    }
+  },
+  "strategy_risk": {
+    "stop_loss_percent": 5,
+    "take_profit_percent": 10,
+    "stop_loss_atr_multiplier": 0,
+    "max_position_amount": 100000,
+    "max_daily_loss": 50000
+  },
+  "htf_filter": {
+    "enabled": true,
+    "block_counter_trend": true,
+    "alignment_boost": 0.1
+  }
+}
+```
+
+### 3.3 Go構造体
+
+```go
+// domain/entity/strategy_config.go
+type StrategyProfile struct {
+    Name        string              `json:"name"`
+    Description string              `json:"description"`
+    Indicators  IndicatorConfig     `json:"indicators"`
+    StanceRules StanceRulesConfig   `json:"stance_rules"`
+    SignalRules SignalRulesConfig    `json:"signal_rules"`
+    Risk        StrategyRiskConfig  `json:"risk"`
+    HTFFilter   HTFFilterConfig     `json:"htf_filter"`
+}
+
+type IndicatorConfig struct {
+    SMAShort     int     `json:"sma_short"`
+    SMALong      int     `json:"sma_long"`
+    RSIPeriod    int     `json:"rsi_period"`
+    MACDFast     int     `json:"macd_fast"`
+    MACDSlow     int     `json:"macd_slow"`
+    MACDSignal   int     `json:"macd_signal"`
+    BBPeriod     int     `json:"bb_period"`
+    BBMultiplier float64 `json:"bb_multiplier"`
+    ATRPeriod    int     `json:"atr_period"`
+}
+
+type StanceRulesConfig struct {
+    RSIOversold              float64 `json:"rsi_oversold"`
+    RSIOverbought            float64 `json:"rsi_overbought"`
+    SMAConvergenceThreshold  float64 `json:"sma_convergence_threshold"`
+    BBSqueezeLookback        int     `json:"bb_squeeze_lookback"`
+    BreakoutVolumeRatio      float64 `json:"breakout_volume_ratio"`
+}
+
+type TrendFollowConfig struct {
+    Enabled            bool    `json:"enabled"`
+    RequireMACDConfirm bool    `json:"require_macd_confirm"`
+    RequireEMACross    bool    `json:"require_ema_cross"`
+    RSIBuyMax          float64 `json:"rsi_buy_max"`
+    RSISellMin         float64 `json:"rsi_sell_min"`
+}
+
+type ContrarianConfig struct {
+    Enabled            bool    `json:"enabled"`
+    RSIEntry           float64 `json:"rsi_entry"`
+    RSIExit            float64 `json:"rsi_exit"`
+    MACDHistogramLimit float64 `json:"macd_histogram_limit"`
+}
+
+type BreakoutConfig struct {
+    Enabled            bool    `json:"enabled"`
+    VolumeRatioMin     float64 `json:"volume_ratio_min"`
+    RequireMACDConfirm bool    `json:"require_macd_confirm"`
+}
+
+type SignalRulesConfig struct {
+    TrendFollow TrendFollowConfig `json:"trend_follow"`
+    Contrarian  ContrarianConfig  `json:"contrarian"`
+    Breakout    BreakoutConfig    `json:"breakout"`
+}
+
+type HTFFilterConfig struct {
+    Enabled           bool    `json:"enabled"`
+    BlockCounterTrend bool    `json:"block_counter_trend"`
+    AlignmentBoost    float64 `json:"alignment_boost"`
+}
+```
+
+---
+
+## 4. PDCAサイクル
+
+### 4.1 実行フロー
+
+```
+あなた: 「LTCの戦略を最適化して」
+
+Plan:
+  1. production.json を読む
+  2. docs/pdca/ の過去履歴を読む
+  3. 直近バックテスト結果を分析
+  4. 改善仮説を立てる
+
+Do:
+  1. profiles/experiment_*.json を生成
+  2. (Level 3の場合) indicator/*.go を追加・修正
+  3. go run ./cmd/backtest run --profile profiles/experiment_... を実行
+
+Check:
+  1. 結果を前回と比較
+     - MaxDD ≤ 20% (必須制約)
+     - 2週間区間勝率 → 80%目標
+     - Total Return 改善
+
+Act:
+  1. 改善 → 採用、次の仮説へ
+  2. 悪化 → ロールバック
+  3. docs/pdca/YYYY-MM-DD_cycleNN.md に記録
+  4. あなたに報告 →「次のサイクル回しますか？」
+```
+
+### 4.2 段階的エスカレーション
+
+| サイクル | レベル | 内容 | 例 |
+|---|---|---|---|
+| 1〜3 | Level 1: パラメータ | 数値の調整 | RSI閾値、SMA期間、SL/TP% |
+| 4〜6 | Level 2: 条件組替 | ロジック構造の変更 | MACD確認を外す、BB Squeeze厳格化 |
+| 7〜 | Level 3: 新指標 | Goコード追加 | ADX、Stochastics、Ichimoku等 |
+
+頭打ちになったら次のレベルに上がる。
+
+### 4.3 PDCA記録フォーマット
+
+```markdown
+# PDCA Cycle NN — YYYY-MM-DD
+
+## 仮説
+(何をどう変えるか、なぜ改善すると考えるか)
+
+## 変更内容
+- プロファイル: profiles/experiment_YYYY-MM-DD_NN.json
+- 変更パラメータ一覧
+
+## 結果
+| 指標 | before | after | 判定 |
+|---|---|---|---|
+| Total Return | | | |
+| MaxDD | | | |
+| 2週間勝率 | | | |
+| Sharpe Ratio | | | |
+| WinRate | | | |
+| ProfitFactor | | | |
+
+## 判定
+(採用 / ロールバック / 部分改善)
+
+## 学び
+(次のサイクルに活かす知見)
+```
+
+### 4.4 ファイル配置
+
+```
+docs/pdca/
+├── 2026-04-16_cycle01.md
+├── 2026-04-16_cycle02.md
+└── ...
+```
+
+---
+
+## 5. バックテスト結果の統合
+
+### 5.1 DBスキーマ追加
+
+既存の `backtest_results` テーブルに以下のカラムを追加:
+
+```sql
+ALTER TABLE backtest_results ADD COLUMN profile_name TEXT DEFAULT '';
+ALTER TABLE backtest_results ADD COLUMN pdca_cycle_id TEXT DEFAULT '';
+ALTER TABLE backtest_results ADD COLUMN hypothesis TEXT DEFAULT '';
+ALTER TABLE backtest_results ADD COLUMN parent_result_id TEXT DEFAULT '';
+```
+
+### 5.2 API レスポンス拡張
+
+`BacktestResult` に以下のフィールドを追加:
+
+```go
+type BacktestResult struct {
+    // ... 既存フィールド
+    ProfileName    string `json:"profileName"`
+    PDCACycleID    string `json:"pdcaCycleId,omitempty"`
+    Hypothesis     string `json:"hypothesis,omitempty"`
+    ParentResultID string `json:"parentResultId,omitempty"`
+}
+```
+
+### 5.3 フロントエンド一覧表示
+
+バックテスト一覧にプロファイル名・PDCAサイクル番号を表示:
+
+- プロファイル名でフィルタ可能
+- PDCAサイクルの結果は改善チェーン (parent_result_id) で系譜を辿れる
+- 実験結果と手動実行を視覚的に区別 (アイコン or バッジ)
+
+---
+
+## 6. 新指標追加の拡張ポイント
+
+PDCA Level 3 で新しいインジケーターを追加する際の変更箇所:
+
+```
+1. infrastructure/indicator/<name>.go    — 計算ロジック
+2. domain/entity/indicator.go            — IndicatorSet にフィールド追加
+3. usecase/strategy/configurable_strategy.go — シグナル条件で参照
+```
+
+### 6.1 追加候補指標
+
+| 指標 | 用途 | 現状 | 追加難易度 |
+|---|---|---|---|
+| Stochastics | オーバーシュート検知 | フロントのみ | 低 |
+| Ichimoku | 雲・転換線でトレンド判定 | フロントのみ | 中 |
+| ADX | トレンド強度フィルター | なし | 低 |
+| Williams %R | オーバーシュート検知 | なし | 低 |
+| OBV | 出来高トレンド確認 | なし | 低 |
+| VWAP | 日中の価格重心 | なし | 中 |
+
+---
+
+## 7. CLI 拡張
+
+### 7.1 `--profile` フラグ追加
+
+```bash
+# プロファイル指定でバックテスト実行
+go run ./cmd/backtest run \
+  --profile profiles/experiment_2026-04-16_01.json \
+  --data data/candles_LTC_JPY_PT15M.csv \
+  --data-htf data/candles_LTC_JPY_PT1H.csv
+
+# プロファイル指定で最適化
+go run ./cmd/backtest optimize \
+  --profile profiles/base.json \
+  --param "stop_loss_percent=1:10:1" \
+  ...
+```
+
+### 7.2 API 拡張
+
+```
+POST /api/v1/backtest/run
+  + profilePath: string (プロファイルJSONのパス)
+  + pdcaCycleId: string (PDCAサイクルID、オプション)
+  + hypothesis: string (仮説テキスト、オプション)
+  + parentResultId: string (比較元の結果ID、オプション)
+```
+
+---
+
+## 8. スコープ
+
+### 今回実装するもの
+
+- Strategy interface + StrategyRegistry
+- StrategyProfile (JSON) 構造体 + パース
+- ConfigurableStrategy (プロファイル駆動の戦略)
+- DefaultStrategy (現行ロジックのラップ)
+- backtest_results への PDCAメタデータカラム追加
+- CLI `--profile` フラグ対応
+- API リクエスト/レスポンスの拡張
+- バックテスト一覧画面にプロファイル名・PDCAサイクル情報の表示
+- production.json (現行パラメータの外出し)
+- docs/pdca/ 記録フォーマット
+
+### 今回実装しないもの
+
+- フロントの「本番昇格」ボタン (手動でJSONコピー)
+- 新指標の実装 (PDCA Level 3 で都度追加)
+- 自動実行トリガー (cron等)
+- 複数通貨対応 (LTC/JPY固定)


### PR DESCRIPTION
## Summary

PDCA Strategy Optimizer 設計書 (docs/superpowers/specs/2026-04-16-pdca-strategy-optimizer-design.md) §2.1–2.3 に対応する最初の PR。

- `port.Strategy` インターフェースを追加 (`backend/internal/domain/port/strategy.go`)
- `StrategyRegistry` を新設 (`backend/internal/usecase/strategy/registry.go`) — 並行安全、`List()` はソート済み
- 既存の `*usecase.StrategyEngine` を `DefaultStrategy` でラップ (`backend/internal/usecase/strategy/default_strategy.go`)
- ライブ/バックテスト両パイプラインの呼び出し箇所を `port.Strategy` 経由に差し替え
- コンポジションルート(`cmd/main.go`, `backtest/runner.go`)では `DefaultStrategy` をワイヤし、**ランタイム挙動は維持**

後続 PR で ConfigurableStrategy・プロファイル駆動・CLI/API 拡張を積んでいく予定 (Stacked PR)。

## Test plan

- [x] `cd backend && go build ./...`
- [x] `cd backend && go vet ./...`
- [x] `cd backend && go test ./... -race -count=1` — 全パッケージ PASS
- [x] `StrategyRegistry`: Register/Get/List (sorted) / duplicate name / empty name / nil strategy / concurrent access (32 goroutines × 20 ops)
- [x] `DefaultStrategy`: StrategyEngine との委譲等価性、nil indicators → `ErrIndicatorsRequired`、`NewDefaultStrategy(nil)` → panic、`Name() == "default"`
- [x] バックテスト既存テスト (`handler_test.go`) は新しい `NewStrategyHandler` を経由して引き続き PASS

## Scope

- **含む**: port 定義、Registry、DefaultStrategy、最小ワイヤリング変更
- **含まない**: ConfigurableStrategy、StrategyProfile、DB/CLI/API 拡張 — いずれも後続タスクで実装

🤖 Generated with [Claude Code](https://claude.com/claude-code)