### PR TITLE
feat(backtest): PDCA migrations + BiweeklyWinRate (PDCA Task 4)

### DIFF
--- a/backend/internal/domain/entity/backtest.go
+++ b/backend/internal/domain/entity/backtest.go
@@ -32,6 +32,12 @@ type BacktestSummary struct {
 	AvgHoldSeconds     int64   `json:"avgHoldSeconds"`
 	TotalCarryingCost  float64 `json:"totalCarryingCost"`
 	TotalSpreadCost    float64 `json:"totalSpreadCost"`
+	// BiweeklyWinRate is the mean of 14-day sliding-window win rates across the
+	// backtest period, expressed on a 0-100 scale (matches WinRate scale).
+	// Windows with fewer than 3 closed trades are penalized to 0 (not skipped);
+	// if the coverage ratio (windows with >=3 trades / total windows) is below 50%,
+	// the overall value is reported as 0 to signal low reliability.
+	BiweeklyWinRate float64 `json:"biweeklyWinRate"`
 }
 
 // BacktestTradeRecord is a closed trade record produced by the simulator.
@@ -59,4 +65,15 @@ type BacktestResult struct {
 	Config    BacktestConfig        `json:"config"`
 	Summary   BacktestSummary       `json:"summary"`
 	Trades    []BacktestTradeRecord `json:"trades,omitempty"`
+
+	// PDCA metadata. Introduced by the PDCA strategy optimizer (see design doc §5).
+	// ProfileName identifies the StrategyProfile that produced this run (empty for legacy rows).
+	ProfileName string `json:"profileName"`
+	// PDCACycleID links this run to a PDCA cycle document/ID (empty when unassigned).
+	PDCACycleID string `json:"pdcaCycleId,omitempty"`
+	// Hypothesis records the experimenter's hypothesis for this run.
+	Hypothesis string `json:"hypothesis,omitempty"`
+	// ParentResultID points to the previous run in a comparison chain.
+	// nil means "root node" (no parent).
+	ParentResultID *string `json:"parentResultId,omitempty"`
 }

--- a/backend/internal/infrastructure/backtest/result_repository.go
+++ b/backend/internal/infrastructure/backtest/result_repository.go
@@ -9,6 +9,22 @@ import (
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/repository"
 )
 
+// resultColumns は backtest_results テーブルの全カラムを列挙した共通定義。
+// INSERT/SELECT の双方でこの定数を参照することで列リストの重複を排除する。
+//
+// 不変条件: このカラム順序は scanResultRow の Scan 引数順序および Save の
+// INSERT バインド引数順序と完全に一致していなければならない。変更時は両方を
+// 必ず同時に更新すること。
+const resultColumns = `id, created_at, symbol, symbol_id, primary_interval, higher_tf_interval,
+	from_ts, to_ts, initial_balance, final_balance, total_return, total_trades,
+	win_trades, loss_trades, win_rate, profit_factor, max_drawdown, max_drawdown_balance,
+	sharpe_ratio, avg_hold_seconds, total_carrying_cost, total_spread_cost,
+	profile_name, pdca_cycle_id, hypothesis, parent_result_id, biweekly_win_rate`
+
+// resultColumnPlaceholders は resultColumns と同じ個数 (27) の INSERT プレースホルダ。
+// resultColumns のカラム数を変更した場合はここも必ず同期させること。
+const resultColumnPlaceholders = `?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?`
+
 type ResultRepository struct {
 	db *sql.DB
 }
@@ -29,15 +45,7 @@ func (r *ResultRepository) Save(ctx context.Context, result entity.BacktestResul
 		parentID = sql.NullString{String: *result.ParentResultID, Valid: true}
 	}
 
-	_, err = tx.ExecContext(ctx, `
-		INSERT INTO backtest_results (
-			id, created_at, symbol, symbol_id, primary_interval, higher_tf_interval,
-			from_ts, to_ts, initial_balance, final_balance, total_return, total_trades,
-			win_trades, loss_trades, win_rate, profit_factor, max_drawdown, max_drawdown_balance,
-			sharpe_ratio, avg_hold_seconds, total_carrying_cost, total_spread_cost,
-			profile_name, pdca_cycle_id, hypothesis, parent_result_id, biweekly_win_rate
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-	`,
+	_, err = tx.ExecContext(ctx, `INSERT INTO backtest_results (`+resultColumns+`) VALUES (`+resultColumnPlaceholders+`)`,
 		result.ID,
 		result.CreatedAt,
 		result.Config.Symbol,
@@ -120,17 +128,9 @@ func (r *ResultRepository) List(ctx context.Context, filter repository.BacktestR
 		offset = 0
 	}
 
-	rows, err := r.db.QueryContext(ctx, `
-		SELECT
-			id, created_at, symbol, symbol_id, primary_interval, higher_tf_interval,
-			from_ts, to_ts, initial_balance, final_balance, total_return, total_trades,
-			win_trades, loss_trades, win_rate, profit_factor, max_drawdown, max_drawdown_balance,
-			sharpe_ratio, avg_hold_seconds, total_carrying_cost, total_spread_cost,
-			profile_name, pdca_cycle_id, hypothesis, parent_result_id, biweekly_win_rate
-		FROM backtest_results
+	rows, err := r.db.QueryContext(ctx, `SELECT `+resultColumns+` FROM backtest_results
 		ORDER BY created_at DESC, id DESC
-		LIMIT ? OFFSET ?
-	`, limit, offset)
+		LIMIT ? OFFSET ?`, limit, offset)
 	if err != nil {
 		return nil, fmt.Errorf("list backtest results: %w", err)
 	}
@@ -151,16 +151,7 @@ func (r *ResultRepository) List(ctx context.Context, filter repository.BacktestR
 }
 
 func (r *ResultRepository) FindByID(ctx context.Context, id string) (*entity.BacktestResult, error) {
-	row := r.db.QueryRowContext(ctx, `
-		SELECT
-			id, created_at, symbol, symbol_id, primary_interval, higher_tf_interval,
-			from_ts, to_ts, initial_balance, final_balance, total_return, total_trades,
-			win_trades, loss_trades, win_rate, profit_factor, max_drawdown, max_drawdown_balance,
-			sharpe_ratio, avg_hold_seconds, total_carrying_cost, total_spread_cost,
-			profile_name, pdca_cycle_id, hypothesis, parent_result_id, biweekly_win_rate
-		FROM backtest_results
-		WHERE id = ?
-	`, id)
+	row := r.db.QueryRowContext(ctx, `SELECT `+resultColumns+` FROM backtest_results WHERE id = ?`, id)
 
 	var result entity.BacktestResult
 	if err := scanResultRow(row, &result); err != nil {

--- a/backend/internal/infrastructure/backtest/result_repository.go
+++ b/backend/internal/infrastructure/backtest/result_repository.go
@@ -24,13 +24,19 @@ func (r *ResultRepository) Save(ctx context.Context, result entity.BacktestResul
 	}
 	defer tx.Rollback()
 
+	parentID := sql.NullString{}
+	if result.ParentResultID != nil {
+		parentID = sql.NullString{String: *result.ParentResultID, Valid: true}
+	}
+
 	_, err = tx.ExecContext(ctx, `
 		INSERT INTO backtest_results (
 			id, created_at, symbol, symbol_id, primary_interval, higher_tf_interval,
 			from_ts, to_ts, initial_balance, final_balance, total_return, total_trades,
 			win_trades, loss_trades, win_rate, profit_factor, max_drawdown, max_drawdown_balance,
-			sharpe_ratio, avg_hold_seconds, total_carrying_cost, total_spread_cost
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			sharpe_ratio, avg_hold_seconds, total_carrying_cost, total_spread_cost,
+			profile_name, pdca_cycle_id, hypothesis, parent_result_id, biweekly_win_rate
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`,
 		result.ID,
 		result.CreatedAt,
@@ -54,6 +60,11 @@ func (r *ResultRepository) Save(ctx context.Context, result entity.BacktestResul
 		result.Summary.AvgHoldSeconds,
 		result.Summary.TotalCarryingCost,
 		result.Summary.TotalSpreadCost,
+		result.ProfileName,
+		result.PDCACycleID,
+		result.Hypothesis,
+		parentID,
+		result.Summary.BiweeklyWinRate,
 	)
 	if err != nil {
 		return fmt.Errorf("insert backtest result: %w", err)
@@ -114,7 +125,8 @@ func (r *ResultRepository) List(ctx context.Context, filter repository.BacktestR
 			id, created_at, symbol, symbol_id, primary_interval, higher_tf_interval,
 			from_ts, to_ts, initial_balance, final_balance, total_return, total_trades,
 			win_trades, loss_trades, win_rate, profit_factor, max_drawdown, max_drawdown_balance,
-			sharpe_ratio, avg_hold_seconds, total_carrying_cost, total_spread_cost
+			sharpe_ratio, avg_hold_seconds, total_carrying_cost, total_spread_cost,
+			profile_name, pdca_cycle_id, hypothesis, parent_result_id, biweekly_win_rate
 		FROM backtest_results
 		ORDER BY created_at DESC, id DESC
 		LIMIT ? OFFSET ?
@@ -144,7 +156,8 @@ func (r *ResultRepository) FindByID(ctx context.Context, id string) (*entity.Bac
 			id, created_at, symbol, symbol_id, primary_interval, higher_tf_interval,
 			from_ts, to_ts, initial_balance, final_balance, total_return, total_trades,
 			win_trades, loss_trades, win_rate, profit_factor, max_drawdown, max_drawdown_balance,
-			sharpe_ratio, avg_hold_seconds, total_carrying_cost, total_spread_cost
+			sharpe_ratio, avg_hold_seconds, total_carrying_cost, total_spread_cost,
+			profile_name, pdca_cycle_id, hypothesis, parent_result_id, biweekly_win_rate
 		FROM backtest_results
 		WHERE id = ?
 	`, id)
@@ -225,6 +238,7 @@ type rowScanner interface {
 }
 
 func scanResultRow(scanner rowScanner, result *entity.BacktestResult) error {
+	var parentID sql.NullString
 	err := scanner.Scan(
 		&result.ID,
 		&result.CreatedAt,
@@ -248,9 +262,20 @@ func scanResultRow(scanner rowScanner, result *entity.BacktestResult) error {
 		&result.Summary.AvgHoldSeconds,
 		&result.Summary.TotalCarryingCost,
 		&result.Summary.TotalSpreadCost,
+		&result.ProfileName,
+		&result.PDCACycleID,
+		&result.Hypothesis,
+		&parentID,
+		&result.Summary.BiweeklyWinRate,
 	)
 	if err != nil {
 		return err
+	}
+	if parentID.Valid {
+		v := parentID.String
+		result.ParentResultID = &v
+	} else {
+		result.ParentResultID = nil
 	}
 	result.Summary.PeriodFrom = result.Config.FromTimestamp
 	result.Summary.PeriodTo = result.Config.ToTimestamp

--- a/backend/internal/infrastructure/backtest/result_repository_test.go
+++ b/backend/internal/infrastructure/backtest/result_repository_test.go
@@ -105,3 +105,138 @@ func TestResultRepository_SaveListFindDelete(t *testing.T) {
 		t.Fatalf("expected 1 deleted row, got %d", deleted)
 	}
 }
+
+func TestResultRepository_PDCAFieldsRoundTrip(t *testing.T) {
+	tmp := t.TempDir()
+	db, err := database.NewDB(filepath.Join(tmp, "test.db"))
+	if err != nil {
+		t.Fatalf("new db: %v", err)
+	}
+	defer db.Close()
+	if err := database.RunMigrations(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	repo := NewResultRepository(db)
+	now := time.Now().Unix()
+
+	parentID := "bt-parent-01"
+	parentResult := entity.BacktestResult{
+		ID:        parentID,
+		CreatedAt: now,
+		Config: entity.BacktestConfig{
+			Symbol:          "BTC_JPY",
+			SymbolID:        7,
+			PrimaryInterval: "PT15M",
+			FromTimestamp:   1000,
+			ToTimestamp:     2000,
+		},
+		Summary: entity.BacktestSummary{
+			InitialBalance:  100000,
+			FinalBalance:    110000,
+			WinRate:         100,
+			BiweeklyWinRate: 72.5,
+		},
+		ProfileName: "production_v1",
+		PDCACycleID: "2026-04-16_cycle01",
+		Hypothesis:  "baseline before tuning",
+		// ParentResultID: nil (root)
+	}
+	if err := repo.Save(context.Background(), parentResult); err != nil {
+		t.Fatalf("save parent: %v", err)
+	}
+
+	childID := "bt-child-01"
+	pid := parentID
+	childResult := entity.BacktestResult{
+		ID:        childID,
+		CreatedAt: now + 1,
+		Config: entity.BacktestConfig{
+			Symbol:          "BTC_JPY",
+			SymbolID:        7,
+			PrimaryInterval: "PT15M",
+			FromTimestamp:   3000,
+			ToTimestamp:     4000,
+		},
+		Summary: entity.BacktestSummary{
+			InitialBalance:  100000,
+			FinalBalance:    120000,
+			WinRate:         80,
+			BiweeklyWinRate: 81.25,
+		},
+		ProfileName:    "experiment_v1",
+		PDCACycleID:    "2026-04-16_cycle02",
+		Hypothesis:     "ATR stop helps",
+		ParentResultID: &pid,
+	}
+	if err := repo.Save(context.Background(), childResult); err != nil {
+		t.Fatalf("save child: %v", err)
+	}
+
+	// List returns both rows with PDCA fields intact.
+	list, err := repo.List(context.Background(), repository.BacktestResultFilter{Limit: 10, Offset: 0})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(list) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(list))
+	}
+	byID := map[string]entity.BacktestResult{}
+	for _, r := range list {
+		byID[r.ID] = r
+	}
+	gotParent, ok := byID[parentID]
+	if !ok {
+		t.Fatalf("parent result missing from list")
+	}
+	if gotParent.ProfileName != "production_v1" ||
+		gotParent.PDCACycleID != "2026-04-16_cycle01" ||
+		gotParent.Hypothesis != "baseline before tuning" {
+		t.Fatalf("parent PDCA metadata mismatch: %+v", gotParent)
+	}
+	if gotParent.ParentResultID != nil {
+		t.Fatalf("parent ParentResultID expected nil, got %v", *gotParent.ParentResultID)
+	}
+	if gotParent.Summary.BiweeklyWinRate != 72.5 {
+		t.Fatalf("parent biweekly win rate mismatch: %v", gotParent.Summary.BiweeklyWinRate)
+	}
+
+	gotChild, ok := byID[childID]
+	if !ok {
+		t.Fatalf("child result missing from list")
+	}
+	if gotChild.ParentResultID == nil {
+		t.Fatalf("child ParentResultID expected non-nil")
+	}
+	if *gotChild.ParentResultID != parentID {
+		t.Fatalf("child ParentResultID expected %q, got %q", parentID, *gotChild.ParentResultID)
+	}
+	if gotChild.Summary.BiweeklyWinRate != 81.25 {
+		t.Fatalf("child biweekly win rate mismatch: %v", gotChild.Summary.BiweeklyWinRate)
+	}
+
+	// FindByID returns the PDCA fields.
+	found, err := repo.FindByID(context.Background(), childID)
+	if err != nil {
+		t.Fatalf("find child: %v", err)
+	}
+	if found == nil || found.ParentResultID == nil || *found.ParentResultID != parentID {
+		t.Fatalf("find child PDCA mismatch: %+v", found)
+	}
+
+	// FK ON DELETE SET NULL: deleting the parent should null out the child's ParentResultID.
+	// DeleteOlderThan deletes through the same sql.DB where PRAGMA foreign_keys=ON was set
+	// by database.NewDB, so the trigger fires here.
+	if _, err := db.ExecContext(context.Background(), "DELETE FROM backtest_results WHERE id = ?", parentID); err != nil {
+		t.Fatalf("delete parent: %v", err)
+	}
+	afterDelete, err := repo.FindByID(context.Background(), childID)
+	if err != nil {
+		t.Fatalf("find child after parent delete: %v", err)
+	}
+	if afterDelete == nil {
+		t.Fatalf("child should still exist after parent delete")
+	}
+	if afterDelete.ParentResultID != nil {
+		t.Fatalf("expected child ParentResultID to be nil after parent delete, got %q", *afterDelete.ParentResultID)
+	}
+}

--- a/backend/internal/infrastructure/database/migrations.go
+++ b/backend/internal/infrastructure/database/migrations.go
@@ -209,5 +209,44 @@ func RunMigrations(db *sql.DB) error {
 		return fmt.Errorf("create idx_client_orders_status: %w", err)
 	}
 
+	// PDCA メタデータを backtest_results に追加する。
+	// `parent_result_id` はルートノード=NULL のため、`ALTER TABLE ADD COLUMN ... REFERENCES` を
+	// 既存行に対して冪等に実行できる (nullable かつ default NULL)。
+	// `ON DELETE SET NULL` で親削除時に子を再ルート化し、履歴を保持する。
+	backtestPDCAColumns := []struct {
+		name string
+		def  string
+	}{
+		{"profile_name", "profile_name TEXT NOT NULL DEFAULT ''"},
+		{"pdca_cycle_id", "pdca_cycle_id TEXT NOT NULL DEFAULT ''"},
+		{"hypothesis", "hypothesis TEXT NOT NULL DEFAULT ''"},
+		{"parent_result_id", "parent_result_id TEXT DEFAULT NULL REFERENCES backtest_results(id) ON DELETE SET NULL"},
+		{"biweekly_win_rate", "biweekly_win_rate REAL NOT NULL DEFAULT 0"},
+	}
+	for _, col := range backtestPDCAColumns {
+		if err := addColumnIfNotExists(db, "backtest_results", col.name, col.def); err != nil {
+			return fmt.Errorf("backtest_results alter: %w", err)
+		}
+	}
+
+	// PDCA 関連カラムの検索を高速化する部分インデックス。NULL/空文字列を除外して
+	// インデックスサイズを抑える (大半の既存行は空文字列/NULL)。
+	pdcaIndexes := []string{
+		`CREATE INDEX IF NOT EXISTS idx_backtest_results_parent
+			ON backtest_results(parent_result_id)
+			WHERE parent_result_id IS NOT NULL`,
+		`CREATE INDEX IF NOT EXISTS idx_backtest_results_profile
+			ON backtest_results(profile_name)
+			WHERE profile_name != ''`,
+		`CREATE INDEX IF NOT EXISTS idx_backtest_results_pdca_cycle
+			ON backtest_results(pdca_cycle_id)
+			WHERE pdca_cycle_id != ''`,
+	}
+	for _, stmt := range pdcaIndexes {
+		if _, err := db.Exec(stmt); err != nil {
+			return fmt.Errorf("create pdca index: %w", err)
+		}
+	}
+
 	return nil
 }

--- a/backend/internal/infrastructure/database/migrations_test.go
+++ b/backend/internal/infrastructure/database/migrations_test.go
@@ -58,3 +58,89 @@ func TestRunMigrations_Idempotent(t *testing.T) {
 		t.Fatalf("second migration failed: %v", err)
 	}
 }
+
+func TestRunMigrations_PDCABacktestResultsColumnsAndIndexes(t *testing.T) {
+	tmpDir := t.TempDir()
+	db, err := NewDB(filepath.Join(tmpDir, "test.db"))
+	if err != nil {
+		t.Fatalf("failed to create db: %v", err)
+	}
+	defer db.Close()
+
+	if err := RunMigrations(db); err != nil {
+		t.Fatalf("first migration failed: %v", err)
+	}
+	// 2 度実行しても壊れないことを確認 (冪等性)。
+	if err := RunMigrations(db); err != nil {
+		t.Fatalf("second migration failed: %v", err)
+	}
+
+	// 新カラムの存在を PRAGMA table_info で確認。
+	wantColumns := map[string]bool{
+		"profile_name":      false,
+		"pdca_cycle_id":     false,
+		"hypothesis":        false,
+		"parent_result_id":  false,
+		"biweekly_win_rate": false,
+	}
+	rows, err := db.Query("PRAGMA table_info(backtest_results)")
+	if err != nil {
+		t.Fatalf("pragma table_info: %v", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var (
+			cid     int
+			name    string
+			ctype   string
+			notnull int
+			dflt    interface{}
+			pk      int
+		)
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk); err != nil {
+			t.Fatalf("scan table_info: %v", err)
+		}
+		if _, ok := wantColumns[name]; ok {
+			wantColumns[name] = true
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate table_info: %v", err)
+	}
+	for col, seen := range wantColumns {
+		if !seen {
+			t.Errorf("expected column %q in backtest_results", col)
+		}
+	}
+
+	// インデックスの存在確認。
+	wantIndexes := map[string]bool{
+		"idx_backtest_results_parent":     false,
+		"idx_backtest_results_profile":    false,
+		"idx_backtest_results_pdca_cycle": false,
+	}
+	idxRows, err := db.Query(
+		"SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='backtest_results'",
+	)
+	if err != nil {
+		t.Fatalf("query indexes: %v", err)
+	}
+	defer idxRows.Close()
+	for idxRows.Next() {
+		var name string
+		if err := idxRows.Scan(&name); err != nil {
+			t.Fatalf("scan index name: %v", err)
+		}
+		if _, ok := wantIndexes[name]; ok {
+			wantIndexes[name] = true
+		}
+	}
+	if err := idxRows.Err(); err != nil {
+		t.Fatalf("iterate indexes: %v", err)
+	}
+	for idx, seen := range wantIndexes {
+		if !seen {
+			t.Errorf("expected index %q to exist", idx)
+		}
+	}
+}

--- a/backend/internal/usecase/backtest/biweekly.go
+++ b/backend/internal/usecase/backtest/biweekly.go
@@ -1,0 +1,90 @@
+package backtest
+
+import (
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+)
+
+// biweeklyWindowMillis は 14 日間ウィンドウを表すミリ秒数。
+const biweeklyWindowMillis int64 = 14 * 24 * 60 * 60 * 1000
+
+// biweeklyStepMillis はウィンドウを 1 日ずつスライドするための刻み幅 (ミリ秒)。
+const biweeklyStepMillis int64 = 24 * 60 * 60 * 1000
+
+// biweeklyMinTrades は 1 ウィンドウを「有効」と判定する最小トレード数。
+// これ未満の場合、ウィンドウ勝率は 0 として扱われる (ペナルティ)。
+const biweeklyMinTrades = 3
+
+// biweeklyCoverageFloor は全ウィンドウに対する有効ウィンドウの最低割合。
+// これを下回る場合、BiweeklyWinRate 全体を 0 として信頼不可と判定する。
+const biweeklyCoverageFloor = 0.5
+
+// ComputeBiweeklyWinRate は 14 日スライディングウィンドウ (1 日刻み) で
+// 勝率を算出し、全ウィンドウの平均を返す (0-100 スケール)。
+//
+// `trades` はバックテストが吐き出したクローズ済みトレード列を想定しており、
+// `BacktestTradeRecord.ExitTime` をクローズタイムスタンプとして使用する。
+// トレードのタイムスタンプと periodFrom/periodTo は同一単位 (本プロジェクトでは
+// ミリ秒) で指定する必要がある。
+//
+// アルゴリズム (spec §7.2 に準拠):
+//
+//   - ウィンドウ境界は半開区間 [windowStart, windowEnd)。
+//   - 各ウィンドウ内のトレード数が 3 件未満 → そのウィンドウの勝率を 0 とする
+//     (スキップせずペナルティとして平均の分母には残す)。
+//   - 各ウィンドウ内のトレード数が 3 件以上 → win / total * 100 を勝率とする。
+//     勝ちの定義は `SummaryReporter.BuildSummary` と揃えており PnL >= 0 を勝ちとする。
+//   - カバレッジ率 = (>=3 件ウィンドウ数) / (全ウィンドウ数)。
+//     カバレッジ率 < 50% の場合は全体として信頼不可と判定し 0 を返す。
+//   - 条件を満たせば全ウィンドウ勝率 (ペナルティ 0 を含む) の単純平均を返す。
+//
+// エッジケース:
+//   - `trades` が空 → 0。
+//   - 期間 (periodTo - periodFrom) が 14 日未満 → ウィンドウが 1 つも作れないため 0。
+//   - periodTo <= periodFrom → 0。
+func ComputeBiweeklyWinRate(trades []entity.BacktestTradeRecord, periodFrom, periodTo int64) float64 {
+	if len(trades) == 0 {
+		return 0
+	}
+	if periodTo <= periodFrom {
+		return 0
+	}
+	if periodTo-periodFrom < biweeklyWindowMillis {
+		return 0
+	}
+
+	var (
+		totalWindows   int
+		coveredWindows int
+		rateSum        float64
+	)
+	for windowStart := periodFrom; windowStart+biweeklyWindowMillis <= periodTo; windowStart += biweeklyStepMillis {
+		windowEnd := windowStart + biweeklyWindowMillis
+		totalWindows++
+
+		var total, wins int
+		for _, tr := range trades {
+			if tr.ExitTime >= windowStart && tr.ExitTime < windowEnd {
+				total++
+				if tr.PnL >= 0 {
+					wins++
+				}
+			}
+		}
+
+		if total < biweeklyMinTrades {
+			// ペナルティ: 勝率 0 としてそのまま和に加える (加算なし)。
+			continue
+		}
+		coveredWindows++
+		rateSum += float64(wins) * 100.0 / float64(total)
+	}
+
+	if totalWindows == 0 {
+		return 0
+	}
+	coverage := float64(coveredWindows) / float64(totalWindows)
+	if coverage < biweeklyCoverageFloor {
+		return 0
+	}
+	return rateSum / float64(totalWindows)
+}

--- a/backend/internal/usecase/backtest/biweekly_test.go
+++ b/backend/internal/usecase/backtest/biweekly_test.go
@@ -8,8 +8,7 @@ import (
 )
 
 const (
-	dayMillis  int64 = 24 * 60 * 60 * 1000
-	weekMillis       = 7 * dayMillis
+	dayMillis int64 = 24 * 60 * 60 * 1000
 )
 
 // makeTrade は ExitTime と PnL だけ指定可能な簡易ファクトリ。
@@ -92,10 +91,12 @@ func TestComputeBiweeklyWinRate_Mix2Wins1Loss(t *testing.T) {
 
 func TestComputeBiweeklyWinRate_SparseCoverageBelowFloor(t *testing.T) {
 	// 期間 30 日 → ウィンドウ 17 個 (start = 0..16 day)。
-	// 先頭 3 日間に全勝 3 件のみ配置 → [0,14)/[1,15)/[2,15)/[3,16) あたりだけ有効。
-	// 有効ウィンドウ数を計算: トレードは day2, day3 に配置。
-	// windowStart=s のウィンドウが有効なのは s<=2 かつ s+14>3 つまり s>-11 → s in {0,1,2}。
-	// カバレッジ = 3/17 < 0.5 → 0 を返すべき。
+	// トレードは day1, day2, day3 に全勝 3 件のみ配置。
+	// windowStart=s のウィンドウ [s, s+14) に 3 件全てが入って有効 (>=3件) となる条件:
+	//   day1 が入る → s <= 1
+	//   day3 が入る → s+14 > 3 (常に真)
+	// 従って有効ウィンドウは s in {0,1} の 2 つ。
+	// カバレッジ = 2/17 ≈ 0.118 < 0.5 → 0 を返すべき。
 	trades := []entity.BacktestTradeRecord{
 		makeTrade(1*dayMillis, 10),
 		makeTrade(2*dayMillis, 10),

--- a/backend/internal/usecase/backtest/biweekly_test.go
+++ b/backend/internal/usecase/backtest/biweekly_test.go
@@ -1,0 +1,154 @@
+package backtest
+
+import (
+	"math"
+	"testing"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+)
+
+const (
+	dayMillis  int64 = 24 * 60 * 60 * 1000
+	weekMillis       = 7 * dayMillis
+)
+
+// makeTrade は ExitTime と PnL だけ指定可能な簡易ファクトリ。
+func makeTrade(exitTime int64, pnl float64) entity.BacktestTradeRecord {
+	return entity.BacktestTradeRecord{
+		ExitTime: exitTime,
+		PnL:      pnl,
+	}
+}
+
+func TestComputeBiweeklyWinRate_EmptyTrades(t *testing.T) {
+	got := ComputeBiweeklyWinRate(nil, 0, 20*dayMillis)
+	if got != 0 {
+		t.Fatalf("expected 0 for empty trades, got %v", got)
+	}
+}
+
+func TestComputeBiweeklyWinRate_PeriodShorterThanWindow(t *testing.T) {
+	trades := []entity.BacktestTradeRecord{
+		makeTrade(1*dayMillis, 100),
+		makeTrade(2*dayMillis, 100),
+		makeTrade(3*dayMillis, 100),
+	}
+	// 期間が 13 日 < 14 日なのでウィンドウ不成立 → 0。
+	got := ComputeBiweeklyWinRate(trades, 0, 13*dayMillis)
+	if got != 0 {
+		t.Fatalf("expected 0 for period < 14 days, got %v", got)
+	}
+}
+
+func TestComputeBiweeklyWinRate_PeriodInverted(t *testing.T) {
+	trades := []entity.BacktestTradeRecord{makeTrade(1*dayMillis, 100)}
+	got := ComputeBiweeklyWinRate(trades, 100*dayMillis, 50*dayMillis)
+	if got != 0 {
+		t.Fatalf("expected 0 for inverted period, got %v", got)
+	}
+}
+
+func TestComputeBiweeklyWinRate_SingleWindow100PercentWin(t *testing.T) {
+	// 期間 = 14 日ちょうど → ウィンドウ 1 つ。
+	// 3 件以上・全勝 → 100。
+	trades := []entity.BacktestTradeRecord{
+		makeTrade(1*dayMillis, 10),
+		makeTrade(5*dayMillis, 20),
+		makeTrade(10*dayMillis, 30),
+	}
+	got := ComputeBiweeklyWinRate(trades, 0, 14*dayMillis)
+	if math.Abs(got-100) > 1e-9 {
+		t.Fatalf("expected 100, got %v", got)
+	}
+}
+
+func TestComputeBiweeklyWinRate_AllWindowsZeroWins(t *testing.T) {
+	// 期間 16 日 → ウィンドウ 3 つ (start=0,1,2 day)。
+	// 各ウィンドウ ([0,14)/[1,15)/[2,16)) に全滅トレードを 3 件以上入れる。
+	var trades []entity.BacktestTradeRecord
+	// day 3, 5, 7, 9, 11, 13 にトレードを配置 → 3 つのウィンドウ全てに >= 3 件入る。
+	for _, d := range []int64{3, 5, 7, 9, 11, 13} {
+		trades = append(trades, makeTrade(d*dayMillis, -5))
+	}
+	got := ComputeBiweeklyWinRate(trades, 0, 16*dayMillis)
+	if math.Abs(got) > 1e-9 {
+		t.Fatalf("expected 0 for all losses, got %v", got)
+	}
+}
+
+func TestComputeBiweeklyWinRate_Mix2Wins1Loss(t *testing.T) {
+	// 期間 14 日 → ウィンドウ 1 つ。2 勝 1 敗 → 200/3 ≈ 66.666...
+	trades := []entity.BacktestTradeRecord{
+		makeTrade(2*dayMillis, 10),
+		makeTrade(5*dayMillis, 10),
+		makeTrade(9*dayMillis, -5),
+	}
+	got := ComputeBiweeklyWinRate(trades, 0, 14*dayMillis)
+	want := 200.0 / 3.0
+	if math.Abs(got-want) > 1e-6 {
+		t.Fatalf("expected ~%v, got %v", want, got)
+	}
+}
+
+func TestComputeBiweeklyWinRate_SparseCoverageBelowFloor(t *testing.T) {
+	// 期間 30 日 → ウィンドウ 17 個 (start = 0..16 day)。
+	// 先頭 3 日間に全勝 3 件のみ配置 → [0,14)/[1,15)/[2,15)/[3,16) あたりだけ有効。
+	// 有効ウィンドウ数を計算: トレードは day2, day3 に配置。
+	// windowStart=s のウィンドウが有効なのは s<=2 かつ s+14>3 つまり s>-11 → s in {0,1,2}。
+	// カバレッジ = 3/17 < 0.5 → 0 を返すべき。
+	trades := []entity.BacktestTradeRecord{
+		makeTrade(1*dayMillis, 10),
+		makeTrade(2*dayMillis, 10),
+		makeTrade(3*dayMillis, 10),
+	}
+	got := ComputeBiweeklyWinRate(trades, 0, 30*dayMillis)
+	if got != 0 {
+		t.Fatalf("expected 0 for coverage < 50%%, got %v", got)
+	}
+}
+
+func TestComputeBiweeklyWinRate_SparseCoverageAtFloorAveragesWithPenaltyZeros(t *testing.T) {
+	// 期間 15 日 → ウィンドウ 2 つ: [0,14) と [1,15)。
+	// Window 1: 3 件全勝 (rate=100), Window 2: 1 件のみ (ペナルティ rate=0)。
+	// カバレッジ = 1/2 = 0.5 → 閾値以上。
+	// 平均 = (100 + 0) / 2 = 50。
+	trades := []entity.BacktestTradeRecord{
+		// window1 のみ: ExitTime < 1 day。3 件全勝。
+		makeTrade(0*dayMillis+1, 10),
+		makeTrade(0*dayMillis+2, 10),
+		makeTrade(0*dayMillis+3, 10),
+		// 両ウィンドウに入る境界上でない 1 件。
+		// 14*day は window1 の end と一致 → window1 に入らず、window2 ([1d,15d)) に入る。
+		makeTrade(14*dayMillis, 10),
+	}
+	// window1 のトレード (day0 + 1ms..3ms) は window2 ([1d,15d)) には含まれない。
+	// window2 にはさらに 14d のトレード 1 件だけ → ペナルティ。
+	got := ComputeBiweeklyWinRate(trades, 0, 15*dayMillis)
+	if math.Abs(got-50) > 1e-9 {
+		t.Fatalf("expected 50 (avg of 100 and penalty 0), got %v", got)
+	}
+}
+
+func TestComputeBiweeklyWinRate_OffByOneWindowBoundary(t *testing.T) {
+	// ウィンドウは半開区間 [start, end)。
+	// 期間 15 日 → ウィンドウ 2 つ: window1=[0,14d), window2=[1d,15d)。
+	// 境界ちょうど 14d のトレードは window1 に含まれず window2 のみに含まれる。
+	// window1 (3 件全勝) / window2 (3 件, うち 14d 境界 1 件が負け → 2 勝 1 敗 = 66.67)
+	trades := []entity.BacktestTradeRecord{
+		// window1 のみ (ExitTime in [0, 14d))
+		makeTrade(2*dayMillis, 10),
+		makeTrade(5*dayMillis, 10),
+		makeTrade(12*dayMillis, 10),
+		// window2 にだけ入るトレード (ExitTime in [1d, 15d) だが [0,14d) にも入りうる)
+		makeTrade(13*dayMillis+dayMillis/2, 10), // window1 と window2 両方に入る (12.5d, 13.5d で [0,14d) と [1d,15d) に含まれる)
+		// 境界ちょうど: 14d は window1 に NOT 含まれ、window2 に含まれる (負け)
+		makeTrade(14*dayMillis, -5),
+	}
+	// window1 ([0, 14d)) のトレード: day2, day5, day12, day13.5 → 4 件全勝 → rate 100
+	// window2 ([1d, 15d)) のトレード: day2, day5, day12, day13.5, day14 → 5 件中 4 勝 1 敗 → 80
+	// カバレッジ = 2/2 = 1.0 → 平均 = (100 + 80)/2 = 90
+	got := ComputeBiweeklyWinRate(trades, 0, 15*dayMillis)
+	if math.Abs(got-90) > 1e-9 {
+		t.Fatalf("expected 90, got %v", got)
+	}
+}

--- a/backend/internal/usecase/backtest/reporter.go
+++ b/backend/internal/usecase/backtest/reporter.go
@@ -64,6 +64,7 @@ func (r *SummaryReporter) BuildSummary(
 
 	maxDDRatio, maxDDBalance := calcMaxDrawdown(equityPoints)
 	sharpe := calcSharpe(equityPoints)
+	biweekly := ComputeBiweeklyWinRate(trades, config.FromTimestamp, config.ToTimestamp)
 
 	return entity.BacktestSummary{
 		PeriodFrom:         config.FromTimestamp,
@@ -82,6 +83,7 @@ func (r *SummaryReporter) BuildSummary(
 		AvgHoldSeconds:     avgHold,
 		TotalCarryingCost:  carryingCost,
 		TotalSpreadCost:    spreadCost,
+		BiweeklyWinRate:    biweekly,
 	}
 }
 


### PR DESCRIPTION
## Summary

PDCA Strategy Optimizer 設計書 §5.1 / §5.2 / §7.2 / §7.3 に対応する PR（Task 2 にスタック）。

### DB
- `backtest_results` に 5 カラム追加（既存 `addColumnIfNotExists` で冪等）:
  - `profile_name`, `pdca_cycle_id`, `hypothesis` (TEXT NOT NULL DEFAULT '')
  - `parent_result_id` (TEXT, `REFERENCES backtest_results(id) ON DELETE SET NULL`)
  - `biweekly_win_rate` (REAL NOT NULL DEFAULT 0)
- Partial index 3 本: parent / profile / pdca_cycle

### Entity
- `BacktestResult` に `ProfileName`/`PDCACycleID`/`Hypothesis`/`ParentResultID *string` を追加
- `BacktestSummary` に `BiweeklyWinRate` (0-100 スケール) を追加

### Logic
- `usecase/backtest/biweekly.go` — `ComputeBiweeklyWinRate(trades, periodFrom, periodTo)`:
  - 14日ウィンドウ / 1日スライド (ms単位)
  - 3件未満ペナルティ（ウィンドウ値を 0 とするが分母に残す）
  - カバレッジ < 50% なら全体 0 を返す
- `SummaryReporter` が生成する `BacktestSummary` に自動で含まれる

### Repository
- INSERT/SELECT で 5 カラム往復。`parent_result_id` は `sql.NullString` 経由で nil ↔ NULL を維持
- カラムリストを定数 `resultColumns`/`resultColumnPlaceholders` に集約し drift を防止
- FK SET NULL: 親削除で子の `parent_result_id` が自動 NULL 化（PRAGMA foreign_keys=ON 下で担保）

## Test plan

- [x] `go test ./... -race -count=1` 全 PASS
- [x] マイグレーション: `RunMigrations` 2 回実行でエラーなし、PRAGMA / sqlite_master でカラム・インデックス存在確認
- [x] BiweeklyWinRate 9 ケース: empty / 期間14日未満 / 反転期間 / 100% / 0% / 2勝1敗 / カバレッジ下限未満 / カバレッジ下限越えペナルティ混在 / ウィンドウ境界
- [x] Repository: 5 新カラム往復、`ParentResultID=nil` 往復、FK SET NULL 検証

## Stacked PR

Base: `feat/pdca-strategy-profile` (PR #97)。
チェーン: #96 (Task 1) ← #97 (Task 2) ← **本PR** (Task 4)

## Scope

- **含まない**: フィルタ拡張・自己参照バリデーション (Task 5)、API/CLI/フロント (Task 6/7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)