### PR TITLE
feat(strategy): ConfigurableStrategy driven by StrategyProfile + production.json (PDCA Task 3)

### DIFF
--- a/backend/internal/usecase/stance.go
+++ b/backend/internal/usecase/stance.go
@@ -33,12 +33,63 @@ type stanceOverride struct {
 	ExpiresAt time.Time
 }
 
-// RuleBasedStanceResolverOptions controls override behavior.
+// RuleBasedStanceResolverOptions controls override behavior and the
+// rule-based classification thresholds. Zero-valued numeric thresholds are
+// replaced with the legacy defaults by applyStanceResolverDefaults so
+// existing callers (which construct the options without thresholds) keep
+// producing bit-identical stances.
 type RuleBasedStanceResolverOptions struct {
 	// DisableOverride forces resolver to always use rule-based result.
 	DisableOverride bool
 	// DisablePersistence prevents loading/saving/deleting override records.
 	DisablePersistence bool
+
+	// Rule thresholds (see applyStanceResolverDefaults for defaults).
+	RSIOversold             float64 // RSI below which → CONTRARIAN; default 25
+	RSIOverbought           float64 // RSI above which → CONTRARIAN; default 75
+	SMAConvergenceThreshold float64 // |sma20-sma50|/sma50 below which → HOLD; default 0.001
+	BreakoutVolumeRatio     float64 // volume ratio for BREAKOUT stance; default 1.5
+
+	// defaulted tracks whether applyStanceResolverDefaults has already been
+	// called so we don't re-apply defaults to explicitly-zero inputs.
+	defaulted bool
+}
+
+// defaultStanceResolverOptions returns the legacy hard-coded configuration
+// preserved exactly as it was before profile-driven overrides were threaded
+// through the resolver.
+func defaultStanceResolverOptions() RuleBasedStanceResolverOptions {
+	return RuleBasedStanceResolverOptions{
+		RSIOversold:             25,
+		RSIOverbought:           75,
+		SMAConvergenceThreshold: 0.001,
+		BreakoutVolumeRatio:     1.5,
+		defaulted:               true,
+	}
+}
+
+// applyStanceResolverDefaults fills zero-valued numeric fields with legacy
+// constants, leaving the DisableOverride / DisablePersistence booleans
+// untouched (those are genuine boolean flags, not thresholds).
+func (o RuleBasedStanceResolverOptions) applyStanceResolverDefaults() RuleBasedStanceResolverOptions {
+	if o.defaulted {
+		return o
+	}
+	d := defaultStanceResolverOptions()
+	if o.RSIOversold == 0 {
+		o.RSIOversold = d.RSIOversold
+	}
+	if o.RSIOverbought == 0 {
+		o.RSIOverbought = d.RSIOverbought
+	}
+	if o.SMAConvergenceThreshold == 0 {
+		o.SMAConvergenceThreshold = d.SMAConvergenceThreshold
+	}
+	if o.BreakoutVolumeRatio == 0 {
+		o.BreakoutVolumeRatio = d.BreakoutVolumeRatio
+	}
+	o.defaulted = true
+	return o
 }
 
 // RuleBasedStanceResolver はルールベースでマーケットスタンスを解決する。
@@ -56,6 +107,9 @@ func NewRuleBasedStanceResolver(repo repository.StanceOverrideRepository) *RuleB
 }
 
 // NewRuleBasedStanceResolverWithOptions creates resolver with explicit options.
+// Zero-valued numeric threshold fields are backfilled with legacy defaults so
+// existing callers that only set DisableOverride / DisablePersistence continue
+// to work unchanged.
 func NewRuleBasedStanceResolverWithOptions(repo repository.StanceOverrideRepository, options RuleBasedStanceResolverOptions) *RuleBasedStanceResolver {
 	if options.DisablePersistence {
 		repo = nil
@@ -63,7 +117,7 @@ func NewRuleBasedStanceResolverWithOptions(repo repository.StanceOverrideReposit
 
 	r := &RuleBasedStanceResolver{
 		repo:    repo,
-		options: options,
+		options: options.applyStanceResolverDefaults(),
 	}
 	if repo != nil && !options.DisableOverride {
 		record, err := repo.Load(context.Background())
@@ -144,7 +198,7 @@ func (r *RuleBasedStanceResolver) applyRules(indicators entity.IndicatorSet, las
 	rsi := *indicators.RSI14
 
 	// 2. RSI極端値 → CONTRARIAN（最優先）
-	if rsi < 25 {
+	if rsi < r.options.RSIOversold {
 		return StanceResult{
 			Stance:    entity.MarketStanceContrarian,
 			Reasoning: "RSI oversold",
@@ -152,7 +206,7 @@ func (r *RuleBasedStanceResolver) applyRules(indicators entity.IndicatorSet, las
 			UpdatedAt: now.Unix(),
 		}
 	}
-	if rsi > 75 {
+	if rsi > r.options.RSIOverbought {
 		return StanceResult{
 			Stance:    entity.MarketStanceContrarian,
 			Reasoning: "RSI overbought",
@@ -165,7 +219,7 @@ func (r *RuleBasedStanceResolver) applyRules(indicators entity.IndicatorSet, las
 	if indicators.RecentSqueeze != nil && *indicators.RecentSqueeze {
 		if indicators.BBUpper != nil && indicators.BBLower != nil && indicators.VolumeRatio != nil {
 			volRatio := *indicators.VolumeRatio
-			if lastPrice > *indicators.BBUpper && volRatio >= 1.5 {
+			if lastPrice > *indicators.BBUpper && volRatio >= r.options.BreakoutVolumeRatio {
 				return StanceResult{
 					Stance:    entity.MarketStanceBreakout,
 					Reasoning: "BB breakout upward with volume confirmation",
@@ -173,7 +227,7 @@ func (r *RuleBasedStanceResolver) applyRules(indicators entity.IndicatorSet, las
 					UpdatedAt: now.Unix(),
 				}
 			}
-			if lastPrice < *indicators.BBLower && volRatio >= 1.5 {
+			if lastPrice < *indicators.BBLower && volRatio >= r.options.BreakoutVolumeRatio {
 				return StanceResult{
 					Stance:    entity.MarketStanceBreakout,
 					Reasoning: "BB breakout downward with volume confirmation",
@@ -193,7 +247,7 @@ func (r *RuleBasedStanceResolver) applyRules(indicators entity.IndicatorSet, las
 
 	// 4. SMA収束 → HOLD
 	divergence := math.Abs(sma20-sma50) / sma50
-	if divergence < 0.001 {
+	if divergence < r.options.SMAConvergenceThreshold {
 		return StanceResult{
 			Stance:    entity.MarketStanceHold,
 			Reasoning: "SMA converged",

--- a/backend/internal/usecase/strategy.go
+++ b/backend/internal/usecase/strategy.go
@@ -9,18 +9,31 @@ import (
 )
 
 // StrategyEngineOptions parameterizes the thresholds and feature toggles used
-// by StrategyEngine. Zero values are replaced with production defaults by
-// applyDefaults, so callers can construct a partially-populated options struct
-// and still get sensible behaviour — but production code paths that create
-// StrategyEngine via NewStrategyEngine inherit every default implicitly.
+// by StrategyEngine.
 //
-// Boolean feature toggles (EnableTrendFollow / EnableContrarian /
-// EnableBreakout / HTFEnabled / HTFBlockCounterTrend / RequireMACDConfirm /
-// RequireEMACross / BreakoutRequireMACDConfirm) default to true because the
-// current hard-coded StrategyEngine behaviour applies each of those gates.
-// They are expressed as plain bools rather than *bool because the defaulting
-// code explicitly flips them to true when they arrive as false AND the struct
-// is otherwise empty — see applyDefaults.
+// Defaulting rules (see applyDefaults):
+//   - Numeric threshold fields (RSIBuyMax, RSISellMin, ContrarianRSIEntry,
+//     ContrarianRSIExit, MACDHistogramLimit, BreakoutVolumeRatio,
+//     HTFAlignmentBoost) are backfilled with the legacy production constants
+//     when they arrive as zero.
+//   - Boolean toggles (EnableTrendFollow / EnableContrarian / EnableBreakout /
+//     HTFEnabled / HTFBlockCounterTrend / RequireMACDConfirm / RequireEMACross
+//     / BreakoutRequireMACDConfirm) are NOT defaulted — they are taken
+//     as-supplied so callers can opt out of each gate explicitly.
+//
+// Constructing StrategyEngineOptions safely:
+//   - Call defaultStrategyEngineOptions() to get the legacy-preserving
+//     starting point (all bools true, all numerics at production values) and
+//     override only the fields you want to change.
+//   - Or populate every field you care about explicitly, including every
+//     boolean toggle that your profile intends to enable.
+//
+// Passing a bare StrategyEngineOptions{} to NewStrategyEngineWithOptions
+// yields all-false booleans, which effectively disables signal generation
+// (every stance branch hits its EnableX==false guard and returns HOLD). This
+// is intentional: profile-driven configurations that want, for example,
+// EnableTrendFollow=false simply omit it, and nothing flips it back on behind
+// the caller's back.
 type StrategyEngineOptions struct {
 	// Trend-follow thresholds
 	RSIBuyMax          float64 // RSI ceiling for TREND_FOLLOW buy; default 70
@@ -340,7 +353,7 @@ func (e *StrategyEngine) evaluateTrendFollow(symbolID int64, sma20, sma50, rsi f
 		return &entity.Signal{
 			SymbolID:   symbolID,
 			Action:     entity.SignalActionBuy,
-			Confidence: trendFollowConfidence(sma20, sma50, rsi, ema12, ema26, histogram, true),
+			Confidence: e.trendFollowConfidence(sma20, sma50, rsi, ema12, ema26, histogram, true),
 			Reason:     reason,
 			Timestamp:  nowUnix,
 		}
@@ -365,7 +378,7 @@ func (e *StrategyEngine) evaluateTrendFollow(symbolID int64, sma20, sma50, rsi f
 		return &entity.Signal{
 			SymbolID:   symbolID,
 			Action:     entity.SignalActionSell,
-			Confidence: trendFollowConfidence(sma20, sma50, rsi, ema12, ema26, histogram, false),
+			Confidence: e.trendFollowConfidence(sma20, sma50, rsi, ema12, ema26, histogram, false),
 			Reason:     reason,
 			Timestamp:  nowUnix,
 		}
@@ -380,7 +393,13 @@ func (e *StrategyEngine) evaluateTrendFollow(symbolID int64, sma20, sma50, rsi f
 
 // trendFollowConfidence computes a 0.0–1.0 confidence score for trend-follow signals.
 // Factors: EMA/SMA divergence (30%), SMA trend strength (15%), RSI headroom (25%), MACD (30%).
-func trendFollowConfidence(sma20, sma50, rsi float64, ema12, ema26, histogram *float64, isBuy bool) float64 {
+//
+// RSI headroom is measured against the configured RSIBuyMax / RSISellMin
+// thresholds so that profile overrides (e.g. RSIBuyMax=60) feed through to
+// confidence as well as gating. The width (RSIBuyMax - RSISellMin) is used as
+// the denominator; under default thresholds (70, 30) this preserves the
+// legacy 40-wide band exactly.
+func (e *StrategyEngine) trendFollowConfidence(sma20, sma50, rsi float64, ema12, ema26, histogram *float64, isBuy bool) float64 {
 	// EMA divergence: how strongly the EMA cross is established
 	emaDivergence := 0.5
 	if ema12 != nil && ema26 != nil && *ema26 != 0 {
@@ -390,12 +409,17 @@ func trendFollowConfidence(sma20, sma50, rsi float64, ema12, ema26, histogram *f
 	// SMA trend strength (capped at 2%)
 	smaDivergence := math.Min(math.Abs(sma20-sma50)/sma50*100, 2.0) / 2.0
 
-	// RSI headroom: distance from the overbought/oversold boundary
+	// RSI headroom: distance from the overbought/oversold boundary, scaled by
+	// the configured RSI band width. Guard against a zero/negative band (which
+	// would be a misconfiguration) by falling back to 0.0 headroom.
+	rsiBand := e.options.RSIBuyMax - e.options.RSISellMin
 	var rsiRoom float64
-	if isBuy {
-		rsiRoom = (70 - rsi) / 40
-	} else {
-		rsiRoom = (rsi - 30) / 40
+	if rsiBand > 0 {
+		if isBuy {
+			rsiRoom = (e.options.RSIBuyMax - rsi) / rsiBand
+		} else {
+			rsiRoom = (rsi - e.options.RSISellMin) / rsiBand
+		}
 	}
 	rsiRoom = math.Max(0, math.Min(1, rsiRoom))
 
@@ -427,7 +451,7 @@ func (e *StrategyEngine) evaluateContrarian(symbolID int64, rsi float64, histogr
 		return &entity.Signal{
 			SymbolID:   symbolID,
 			Action:     entity.SignalActionBuy,
-			Confidence: contrarianConfidence(rsi, histogram, true),
+			Confidence: e.contrarianConfidence(rsi, histogram, true),
 			Reason:     reason,
 			Timestamp:  nowUnix,
 		}
@@ -449,7 +473,7 @@ func (e *StrategyEngine) evaluateContrarian(symbolID int64, rsi float64, histogr
 		return &entity.Signal{
 			SymbolID:   symbolID,
 			Action:     entity.SignalActionSell,
-			Confidence: contrarianConfidence(rsi, histogram, false),
+			Confidence: e.contrarianConfidence(rsi, histogram, false),
 			Reason:     reason,
 			Timestamp:  nowUnix,
 		}
@@ -464,13 +488,27 @@ func (e *StrategyEngine) evaluateContrarian(symbolID int64, rsi float64, histogr
 
 // contrarianConfidence computes a 0.0–1.0 confidence score for contrarian signals.
 // Factors: RSI extremity (60%), MACD not-against (40%).
-func contrarianConfidence(rsi float64, histogram *float64, isBuy bool) float64 {
-	// RSI extremity: how deep into oversold/overbought territory
+//
+// RSI extremity uses the configured ContrarianRSIEntry / ContrarianRSIExit
+// thresholds so profile overrides affect confidence. The denominators are
+// sized to preserve legacy behaviour under default thresholds (entry=30,
+// exit=70): buy-side = ContrarianRSIEntry (i.e. 30), sell-side =
+// 100 − ContrarianRSIExit (i.e. 30).
+func (e *StrategyEngine) contrarianConfidence(rsi float64, histogram *float64, isBuy bool) float64 {
+	// RSI extremity: how deep into oversold/overbought territory. Guard
+	// against degenerate thresholds (entry<=0 or exit>=100) that would make
+	// the denominator non-positive.
 	var rsiExtreme float64
 	if isBuy {
-		rsiExtreme = (30 - rsi) / 30 // 0→1.0, 30→0.0
+		denom := e.options.ContrarianRSIEntry
+		if denom > 0 {
+			rsiExtreme = (e.options.ContrarianRSIEntry - rsi) / denom
+		}
 	} else {
-		rsiExtreme = (rsi - 70) / 30 // 100→1.0, 70→0.0
+		denom := 100.0 - e.options.ContrarianRSIExit
+		if denom > 0 {
+			rsiExtreme = (rsi - e.options.ContrarianRSIExit) / denom
+		}
 	}
 	rsiExtreme = math.Max(0, math.Min(1, rsiExtreme))
 

--- a/backend/internal/usecase/strategy.go
+++ b/backend/internal/usecase/strategy.go
@@ -8,14 +8,126 @@ import (
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
 )
 
+// StrategyEngineOptions parameterizes the thresholds and feature toggles used
+// by StrategyEngine. Zero values are replaced with production defaults by
+// applyDefaults, so callers can construct a partially-populated options struct
+// and still get sensible behaviour — but production code paths that create
+// StrategyEngine via NewStrategyEngine inherit every default implicitly.
+//
+// Boolean feature toggles (EnableTrendFollow / EnableContrarian /
+// EnableBreakout / HTFEnabled / HTFBlockCounterTrend / RequireMACDConfirm /
+// RequireEMACross / BreakoutRequireMACDConfirm) default to true because the
+// current hard-coded StrategyEngine behaviour applies each of those gates.
+// They are expressed as plain bools rather than *bool because the defaulting
+// code explicitly flips them to true when they arrive as false AND the struct
+// is otherwise empty — see applyDefaults.
+type StrategyEngineOptions struct {
+	// Trend-follow thresholds
+	RSIBuyMax          float64 // RSI ceiling for TREND_FOLLOW buy; default 70
+	RSISellMin         float64 // RSI floor for TREND_FOLLOW sell; default 30
+	RequireMACDConfirm bool    // if true, histogram sign gates trend-follow signals; default true
+	RequireEMACross    bool    // if true, use EMA-based cross with SMA alignment; default true
+
+	// Contrarian thresholds
+	ContrarianRSIEntry float64 // RSI below which contrarian BUYs; default 30
+	ContrarianRSIExit  float64 // RSI above which contrarian SELLs; default 70
+	MACDHistogramLimit float64 // |histogram| above which contrarian is suppressed; default 10
+
+	// Breakout thresholds
+	BreakoutVolumeRatio        float64 // volume ratio required for breakout; default 1.5
+	BreakoutRequireMACDConfirm bool    // if true, histogram sign gates breakout signals; default true
+
+	// HTF filter
+	HTFEnabled           bool    // if false, skip the HTF filter entirely; default true
+	HTFBlockCounterTrend bool    // if true, block signals against higher-TF trend; default true
+	HTFAlignmentBoost    float64 // confidence boost when HTF aligns; default 0.1
+
+	// Stance-level feature toggles
+	EnableTrendFollow bool // if false, TREND_FOLLOW stance yields HOLD; default true
+	EnableContrarian  bool // if false, CONTRARIAN stance yields HOLD; default true
+	EnableBreakout    bool // if false, BREAKOUT stance yields HOLD; default true
+
+	// defaulted tracks whether applyDefaults has already been called so we
+	// don't flip booleans to true twice (e.g. on a caller that explicitly
+	// wants them false).
+	defaulted bool
+}
+
+// defaultStrategyEngineOptions returns the legacy hard-coded configuration
+// preserved exactly as it was before profile-driven overrides were threaded
+// through the engine.
+func defaultStrategyEngineOptions() StrategyEngineOptions {
+	return StrategyEngineOptions{
+		RSIBuyMax:                  70,
+		RSISellMin:                 30,
+		RequireMACDConfirm:         true,
+		RequireEMACross:            true,
+		ContrarianRSIEntry:         30,
+		ContrarianRSIExit:          70,
+		MACDHistogramLimit:         10,
+		BreakoutVolumeRatio:        1.5,
+		BreakoutRequireMACDConfirm: true,
+		HTFEnabled:                 true,
+		HTFBlockCounterTrend:       true,
+		HTFAlignmentBoost:          0.1,
+		EnableTrendFollow:          true,
+		EnableContrarian:           true,
+		EnableBreakout:             true,
+		defaulted:                  true,
+	}
+}
+
+// applyDefaults fills zero-valued numeric fields with legacy constants. It
+// does NOT touch boolean toggles: callers that explicitly want a gate
+// disabled must pass the bool they want, and callers that want defaults
+// should use defaultStrategyEngineOptions() as the starting point.
+func (o StrategyEngineOptions) applyDefaults() StrategyEngineOptions {
+	if o.defaulted {
+		return o
+	}
+	d := defaultStrategyEngineOptions()
+	if o.RSIBuyMax == 0 {
+		o.RSIBuyMax = d.RSIBuyMax
+	}
+	if o.RSISellMin == 0 {
+		o.RSISellMin = d.RSISellMin
+	}
+	if o.ContrarianRSIEntry == 0 {
+		o.ContrarianRSIEntry = d.ContrarianRSIEntry
+	}
+	if o.ContrarianRSIExit == 0 {
+		o.ContrarianRSIExit = d.ContrarianRSIExit
+	}
+	if o.MACDHistogramLimit == 0 {
+		o.MACDHistogramLimit = d.MACDHistogramLimit
+	}
+	if o.BreakoutVolumeRatio == 0 {
+		o.BreakoutVolumeRatio = d.BreakoutVolumeRatio
+	}
+	if o.HTFAlignmentBoost == 0 {
+		o.HTFAlignmentBoost = d.HTFAlignmentBoost
+	}
+	o.defaulted = true
+	return o
+}
+
 // StrategyEngine はテクニカル指標とスタンスリゾルバの戦略方針を統合して売買シグナルを生成する。
 type StrategyEngine struct {
 	stanceResolver StanceResolver
+	options        StrategyEngineOptions
 }
 
 func NewStrategyEngine(stanceResolver StanceResolver) *StrategyEngine {
+	return NewStrategyEngineWithOptions(stanceResolver, defaultStrategyEngineOptions())
+}
+
+// NewStrategyEngineWithOptions builds a StrategyEngine driven by explicit
+// options. Zero-valued numeric fields are backfilled with legacy defaults;
+// boolean toggles are taken as-is (see applyDefaults for the split).
+func NewStrategyEngineWithOptions(stanceResolver StanceResolver, options StrategyEngineOptions) *StrategyEngine {
 	return &StrategyEngine{
 		stanceResolver: stanceResolver,
+		options:        options.applyDefaults(),
 	}
 }
 
@@ -62,7 +174,7 @@ func (e *StrategyEngine) EvaluateWithHigherTFAt(
 		}
 	}
 
-	if higherTF == nil || higherTF.SMA20 == nil || higherTF.SMA50 == nil {
+	if !e.options.HTFEnabled || higherTF == nil || higherTF.SMA20 == nil || higherTF.SMA50 == nil {
 		return signal, nil
 	}
 
@@ -73,25 +185,33 @@ func (e *StrategyEngine) EvaluateWithHigherTFAt(
 
 	higherUptrend := *higherTF.SMA20 > *higherTF.SMA50
 
-	if signal.Action == entity.SignalActionBuy && !higherUptrend {
-		return &entity.Signal{
-			SymbolID:  indicators.SymbolID,
-			Action:    entity.SignalActionHold,
-			Reason:    "MTF filter: higher timeframe downtrend blocks buy",
-			Timestamp: signal.Timestamp,
-		}, nil
-	}
-	if signal.Action == entity.SignalActionSell && higherUptrend {
-		return &entity.Signal{
-			SymbolID:  indicators.SymbolID,
-			Action:    entity.SignalActionHold,
-			Reason:    "MTF filter: higher timeframe uptrend blocks sell",
-			Timestamp: signal.Timestamp,
-		}, nil
+	if e.options.HTFBlockCounterTrend {
+		if signal.Action == entity.SignalActionBuy && !higherUptrend {
+			return &entity.Signal{
+				SymbolID:  indicators.SymbolID,
+				Action:    entity.SignalActionHold,
+				Reason:    "MTF filter: higher timeframe downtrend blocks buy",
+				Timestamp: signal.Timestamp,
+			}, nil
+		}
+		if signal.Action == entity.SignalActionSell && higherUptrend {
+			return &entity.Signal{
+				SymbolID:  indicators.SymbolID,
+				Action:    entity.SignalActionHold,
+				Reason:    "MTF filter: higher timeframe uptrend blocks sell",
+				Timestamp: signal.Timestamp,
+			}, nil
+		}
 	}
 
-	// Signal aligns with higher TF: boost confidence by 10% (capped at 1.0)
-	signal.Confidence = math.Min(signal.Confidence+0.1, 1.0)
+	// Signal aligns with higher TF: boost confidence by HTFAlignmentBoost
+	// (capped at 1.0). Boost only applies when the signal direction matches
+	// the higher-timeframe trend direction.
+	aligned := (signal.Action == entity.SignalActionBuy && higherUptrend) ||
+		(signal.Action == entity.SignalActionSell && !higherUptrend)
+	if aligned {
+		signal.Confidence = math.Min(signal.Confidence+e.options.HTFAlignmentBoost, 1.0)
+	}
 	return signal, nil
 }
 
@@ -126,10 +246,34 @@ func (e *StrategyEngine) EvaluateAt(ctx context.Context, indicators entity.Indic
 
 	switch result.Stance {
 	case entity.MarketStanceTrendFollow:
+		if !e.options.EnableTrendFollow {
+			return &entity.Signal{
+				SymbolID:  indicators.SymbolID,
+				Action:    entity.SignalActionHold,
+				Reason:    "trend follow: disabled by profile",
+				Timestamp: nowUnix,
+			}, nil
+		}
 		return e.evaluateTrendFollow(indicators.SymbolID, sma20, sma50, rsi, indicators.EMA12, indicators.EMA26, indicators.Histogram, nowUnix), nil
 	case entity.MarketStanceContrarian:
+		if !e.options.EnableContrarian {
+			return &entity.Signal{
+				SymbolID:  indicators.SymbolID,
+				Action:    entity.SignalActionHold,
+				Reason:    "contrarian: disabled by profile",
+				Timestamp: nowUnix,
+			}, nil
+		}
 		return e.evaluateContrarian(indicators.SymbolID, rsi, indicators.Histogram, nowUnix), nil
 	case entity.MarketStanceBreakout:
+		if !e.options.EnableBreakout {
+			return &entity.Signal{
+				SymbolID:  indicators.SymbolID,
+				Action:    entity.SignalActionHold,
+				Reason:    "breakout: disabled by profile",
+				Timestamp: nowUnix,
+			}, nil
+		}
 		return e.evaluateBreakout(indicators.SymbolID, lastPrice, indicators.BBUpper, indicators.BBLower, indicators.BBMiddle, indicators.VolumeRatio, indicators.Histogram, nowUnix), nil
 	default:
 		return &entity.Signal{
@@ -147,11 +291,13 @@ func (e *StrategyEngine) resolveAt(ctx context.Context, indicators entity.Indica
 
 func (e *StrategyEngine) evaluateTrendFollow(symbolID int64, sma20, sma50, rsi float64, ema12, ema26, histogram *float64, nowUnix int64) *entity.Signal {
 
-	// Primary signal: EMA12/26 crossover (faster than SMA cross)
-	// Fallback to SMA20/50 when EMA is unavailable
+	// Primary signal: EMA12/26 crossover (faster than SMA cross), controlled
+	// by the RequireEMACross option. When disabled, we skip EMA entirely and
+	// only look at SMA20/50. When enabled but EMA is unavailable, we fall
+	// back to SMA — matches the original behaviour.
 	var fastAboveSlow bool
 	var fastBelowSlow bool
-	useEMA := ema12 != nil && ema26 != nil
+	useEMA := e.options.RequireEMACross && ema12 != nil && ema26 != nil
 
 	if useEMA {
 		fastAboveSlow = *ema12 > *ema26
@@ -174,9 +320,9 @@ func (e *StrategyEngine) evaluateTrendFollow(symbolID int64, sma20, sma50, rsi f
 		}
 	}
 
-	if fastAboveSlow && rsi < 70 {
+	if fastAboveSlow && rsi < e.options.RSIBuyMax {
 		// MACD histogram confirmation: skip buy if momentum is negative
-		if histogram != nil && *histogram < 0 {
+		if e.options.RequireMACDConfirm && histogram != nil && *histogram < 0 {
 			return &entity.Signal{
 				SymbolID:  symbolID,
 				Action:    entity.SignalActionHold,
@@ -199,9 +345,9 @@ func (e *StrategyEngine) evaluateTrendFollow(symbolID int64, sma20, sma50, rsi f
 			Timestamp:  nowUnix,
 		}
 	}
-	if fastBelowSlow && rsi > 30 {
+	if fastBelowSlow && rsi > e.options.RSISellMin {
 		// MACD histogram confirmation: skip sell if momentum is positive
-		if histogram != nil && *histogram > 0 {
+		if e.options.RequireMACDConfirm && histogram != nil && *histogram > 0 {
 			return &entity.Signal{
 				SymbolID:  symbolID,
 				Action:    entity.SignalActionHold,
@@ -264,9 +410,9 @@ func trendFollowConfidence(sma20, sma50, rsi float64, ema12, ema26, histogram *f
 
 func (e *StrategyEngine) evaluateContrarian(symbolID int64, rsi float64, histogram *float64, nowUnix int64) *entity.Signal {
 
-	if rsi < 30 {
+	if rsi < e.options.ContrarianRSIEntry {
 		// Skip contrarian buy if MACD momentum is still strongly negative
-		if histogram != nil && *histogram < -10 {
+		if histogram != nil && *histogram < -e.options.MACDHistogramLimit {
 			return &entity.Signal{
 				SymbolID:  symbolID,
 				Action:    entity.SignalActionHold,
@@ -286,9 +432,9 @@ func (e *StrategyEngine) evaluateContrarian(symbolID int64, rsi float64, histogr
 			Timestamp:  nowUnix,
 		}
 	}
-	if rsi > 70 {
+	if rsi > e.options.ContrarianRSIExit {
 		// Skip contrarian sell if MACD momentum is still strongly positive
-		if histogram != nil && *histogram > 10 {
+		if histogram != nil && *histogram > e.options.MACDHistogramLimit {
 			return &entity.Signal{
 				SymbolID:  symbolID,
 				Action:    entity.SignalActionHold,
@@ -347,9 +493,9 @@ func (e *StrategyEngine) evaluateBreakout(symbolID int64, lastPrice float64, bbU
 		}
 	}
 
-	if lastPrice > *bbUpper && *volumeRatio >= 1.5 {
+	if lastPrice > *bbUpper && *volumeRatio >= e.options.BreakoutVolumeRatio {
 		// MACD histogram confirmation
-		if histogram != nil && *histogram < 0 {
+		if e.options.BreakoutRequireMACDConfirm && histogram != nil && *histogram < 0 {
 			return &entity.Signal{
 				SymbolID:  symbolID,
 				Action:    entity.SignalActionHold,
@@ -366,8 +512,8 @@ func (e *StrategyEngine) evaluateBreakout(symbolID int64, lastPrice float64, bbU
 		}
 	}
 
-	if lastPrice < *bbLower && *volumeRatio >= 1.5 {
-		if histogram != nil && *histogram > 0 {
+	if lastPrice < *bbLower && *volumeRatio >= e.options.BreakoutVolumeRatio {
+		if e.options.BreakoutRequireMACDConfirm && histogram != nil && *histogram > 0 {
 			return &entity.Signal{
 				SymbolID:  symbolID,
 				Action:    entity.SignalActionHold,

--- a/backend/internal/usecase/strategy/configurable_strategy.go
+++ b/backend/internal/usecase/strategy/configurable_strategy.go
@@ -1,0 +1,113 @@
+package strategy
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/port"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase"
+)
+
+// ConfigurableStrategy is a port.Strategy driven by a StrategyProfile. It
+// wires a profile into a RuleBasedStanceResolver + StrategyEngine pair so the
+// existing signal pipeline is reused, while the thresholds and feature
+// toggles are sourced from the profile rather than the hard-coded defaults.
+//
+// Scope note: indicator *periods* (from IndicatorConfig) are informational at
+// this layer — the live pipeline computes IndicatorSet with fixed periods
+// upstream, so periods are not applied by this struct. Stance and signal
+// thresholds, however, are fully profile-driven.
+type ConfigurableStrategy struct {
+	profile *entity.StrategyProfile
+	engine  *usecase.StrategyEngine
+}
+
+// NewConfigurableStrategy builds a ConfigurableStrategy from the supplied
+// profile. The profile is validated up-front; invalid profiles fail
+// construction rather than surfacing later as confusing signal behaviour.
+//
+// breakout_volume_ratio appears in both StanceRulesConfig and
+// SignalRulesConfig; they govern different code paths (stance classification
+// vs. signal generation) and are intentionally wired separately.
+func NewConfigurableStrategy(profile *entity.StrategyProfile) (*ConfigurableStrategy, error) {
+	if profile == nil {
+		return nil, fmt.Errorf("strategy: profile must not be nil")
+	}
+	if err := profile.Validate(); err != nil {
+		return nil, fmt.Errorf("strategy: invalid profile: %w", err)
+	}
+
+	// Stateless stance resolver: DisableOverride + DisablePersistence both
+	// true so the strategy is deterministic for backtests and does not touch
+	// the override repository.
+	resolverOpts := usecase.RuleBasedStanceResolverOptions{
+		DisableOverride:         true,
+		DisablePersistence:      true,
+		RSIOversold:             profile.StanceRules.RSIOversold,
+		RSIOverbought:           profile.StanceRules.RSIOverbought,
+		SMAConvergenceThreshold: profile.StanceRules.SMAConvergenceThreshold,
+		// StanceRules.BreakoutVolumeRatio drives the BREAKOUT *stance*
+		// decision; SignalRules.Breakout.VolumeRatioMin drives the breakout
+		// *signal* threshold below. They are separate values by design.
+		BreakoutVolumeRatio: profile.StanceRules.BreakoutVolumeRatio,
+	}
+	resolver := usecase.NewRuleBasedStanceResolverWithOptions(nil, resolverOpts)
+
+	engineOpts := usecase.StrategyEngineOptions{
+		// Trend-follow
+		EnableTrendFollow:  profile.SignalRules.TrendFollow.Enabled,
+		RSIBuyMax:          profile.SignalRules.TrendFollow.RSIBuyMax,
+		RSISellMin:         profile.SignalRules.TrendFollow.RSISellMin,
+		RequireMACDConfirm: profile.SignalRules.TrendFollow.RequireMACDConfirm,
+		RequireEMACross:    profile.SignalRules.TrendFollow.RequireEMACross,
+
+		// Contrarian
+		EnableContrarian:   profile.SignalRules.Contrarian.Enabled,
+		ContrarianRSIEntry: profile.SignalRules.Contrarian.RSIEntry,
+		ContrarianRSIExit:  profile.SignalRules.Contrarian.RSIExit,
+		MACDHistogramLimit: profile.SignalRules.Contrarian.MACDHistogramLimit,
+
+		// Breakout
+		EnableBreakout:             profile.SignalRules.Breakout.Enabled,
+		BreakoutVolumeRatio:        profile.SignalRules.Breakout.VolumeRatioMin,
+		BreakoutRequireMACDConfirm: profile.SignalRules.Breakout.RequireMACDConfirm,
+
+		// HTF filter
+		HTFEnabled:           profile.HTFFilter.Enabled,
+		HTFBlockCounterTrend: profile.HTFFilter.BlockCounterTrend,
+		HTFAlignmentBoost:    profile.HTFFilter.AlignmentBoost,
+	}
+	engine := usecase.NewStrategyEngineWithOptions(resolver, engineOpts)
+
+	return &ConfigurableStrategy{
+		profile: profile,
+		engine:  engine,
+	}, nil
+}
+
+// Evaluate implements port.Strategy by delegating to the underlying
+// StrategyEngine. Nil indicators yield ErrIndicatorsRequired to mirror
+// DefaultStrategy's contract.
+func (s *ConfigurableStrategy) Evaluate(
+	ctx context.Context,
+	indicators *entity.IndicatorSet,
+	higherTF *entity.IndicatorSet,
+	lastPrice float64,
+	now time.Time,
+) (*entity.Signal, error) {
+	if indicators == nil {
+		return nil, ErrIndicatorsRequired
+	}
+	return s.engine.EvaluateWithHigherTFAt(ctx, *indicators, higherTF, lastPrice, now)
+}
+
+// Name returns the profile's name. Registries key strategies by Name(), so
+// loading two profiles with the same name is a caller error.
+func (s *ConfigurableStrategy) Name() string {
+	return s.profile.Name
+}
+
+// Compile-time guarantee that ConfigurableStrategy satisfies port.Strategy.
+var _ port.Strategy = (*ConfigurableStrategy)(nil)

--- a/backend/internal/usecase/strategy/configurable_strategy_test.go
+++ b/backend/internal/usecase/strategy/configurable_strategy_test.go
@@ -1,0 +1,313 @@
+package strategy
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/infrastructure/strategyprofile"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase"
+)
+
+// productionProfilePath walks up from this test file to the module root (go.mod)
+// and appends profiles/production.json. We resolve it dynamically so the test
+// works regardless of where `go test` is invoked from.
+func productionProfilePath(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller(0) failed")
+	}
+	dir := filepath.Dir(thisFile)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return filepath.Join(dir, "profiles", "production.json")
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("go.mod not found walking up from test file")
+		}
+		dir = parent
+	}
+}
+
+// productionProfile loads the on-disk production.json via the real loader so
+// the tests cover the same path used by the CLI / API.
+func productionProfile(t *testing.T) *entity.StrategyProfile {
+	t.Helper()
+	path := productionProfilePath(t)
+	baseDir := filepath.Dir(path)
+	loader := strategyprofile.NewLoader(baseDir)
+	profile, err := loader.Load("production")
+	if err != nil {
+		t.Fatalf("load production profile: %v", err)
+	}
+	return profile
+}
+
+func TestConfigurableStrategy_Name(t *testing.T) {
+	profile := productionProfile(t)
+	s, err := NewConfigurableStrategy(profile)
+	if err != nil {
+		t.Fatalf("NewConfigurableStrategy: %v", err)
+	}
+	if got, want := s.Name(), "production"; got != want {
+		t.Errorf("Name() = %q, want %q", got, want)
+	}
+}
+
+func TestConfigurableStrategy_InvalidProfile(t *testing.T) {
+	// Zero value: fails Validate (empty Name, zero periods, etc.).
+	invalid := &entity.StrategyProfile{}
+	s, err := NewConfigurableStrategy(invalid)
+	if err == nil {
+		t.Fatal("expected error for invalid profile, got nil")
+	}
+	if s != nil {
+		t.Errorf("expected nil strategy on error, got %+v", s)
+	}
+
+	// Nil profile is also rejected.
+	s, err = NewConfigurableStrategy(nil)
+	if err == nil {
+		t.Fatal("expected error for nil profile, got nil")
+	}
+	if s != nil {
+		t.Errorf("expected nil strategy on nil-profile error, got %+v", s)
+	}
+}
+
+func TestConfigurableStrategy_NilIndicators(t *testing.T) {
+	profile := productionProfile(t)
+	s, err := NewConfigurableStrategy(profile)
+	if err != nil {
+		t.Fatalf("NewConfigurableStrategy: %v", err)
+	}
+	signal, err := s.Evaluate(context.Background(), nil, nil, 0, time.Now())
+	if err == nil {
+		t.Fatal("expected error for nil indicators, got nil")
+	}
+	if !errors.Is(err, ErrIndicatorsRequired) {
+		t.Errorf("expected ErrIndicatorsRequired, got %v", err)
+	}
+	if signal != nil {
+		t.Errorf("expected nil signal on error, got %+v", signal)
+	}
+}
+
+// buildDefaultStrategyFromProfile constructs a DefaultStrategy wired to mirror
+// ConfigurableStrategy(profile) — a fresh stateless RuleBasedStanceResolver
+// with default thresholds and a vanilla StrategyEngine. This is the baseline
+// we assert equivalence against; any divergence means the profile has drifted
+// from the hard-coded defaults (or the options-threading has broken).
+func buildDefaultStrategyFromProfile(t *testing.T) *DefaultStrategy {
+	t.Helper()
+	resolver := usecase.NewRuleBasedStanceResolverWithOptions(nil, usecase.RuleBasedStanceResolverOptions{
+		DisableOverride:    true,
+		DisablePersistence: true,
+	})
+	engine := usecase.NewStrategyEngine(resolver)
+	return NewDefaultStrategy(engine)
+}
+
+// indicatorScenario drives both strategies through the same inputs so we can
+// compare signal output field-for-field.
+type indicatorScenario struct {
+	name       string
+	indicators entity.IndicatorSet
+	higherTF   *entity.IndicatorSet
+	lastPrice  float64
+}
+
+// fpRef returns a pointer to v so scenarios can be expressed inline.
+func fpRef(v float64) *float64 { return &v }
+
+// scenariosForEquivalence exercises multiple signal branches: TREND_FOLLOW
+// buy, CONTRARIAN sell, and a HOLD counter-trend case. All three must match
+// between DefaultStrategy and ConfigurableStrategy(production).
+func scenariosForEquivalence() []indicatorScenario {
+	return []indicatorScenario{
+		{
+			name: "trend-follow buy",
+			indicators: entity.IndicatorSet{
+				SymbolID:    7,
+				SMA20:       fpRef(5_100_000),
+				SMA50:       fpRef(5_000_000),
+				EMA12:       fpRef(5_100_000),
+				EMA26:       fpRef(5_000_000),
+				RSI14:       fpRef(55),
+				Histogram:   fpRef(5),
+				VolumeRatio: fpRef(1.0),
+			},
+			higherTF: &entity.IndicatorSet{
+				SMA20: fpRef(5_100_000),
+				SMA50: fpRef(5_000_000),
+			},
+			lastPrice: 5_100_000,
+		},
+		{
+			name: "contrarian sell (RSI overbought triggers CONTRARIAN stance)",
+			indicators: entity.IndicatorSet{
+				SymbolID:    7,
+				SMA20:       fpRef(5_100_000),
+				SMA50:       fpRef(5_000_000),
+				RSI14:       fpRef(82),
+				Histogram:   fpRef(-2),
+				VolumeRatio: fpRef(1.0),
+				BBUpper:     fpRef(5_200_000),
+				BBLower:     fpRef(5_000_000),
+			},
+			higherTF:  nil,
+			lastPrice: 5_150_000,
+		},
+		{
+			name: "hold: TF buy blocked by higher-TF downtrend",
+			indicators: entity.IndicatorSet{
+				SymbolID:    7,
+				SMA20:       fpRef(5_100_000),
+				SMA50:       fpRef(5_000_000),
+				EMA12:       fpRef(5_100_000),
+				EMA26:       fpRef(5_000_000),
+				RSI14:       fpRef(55),
+				Histogram:   fpRef(5),
+				VolumeRatio: fpRef(1.0),
+			},
+			higherTF: &entity.IndicatorSet{
+				SMA20: fpRef(4_900_000),
+				SMA50: fpRef(5_000_000),
+			},
+			lastPrice: 5_100_000,
+		},
+	}
+}
+
+// TestConfigurableStrategy_EquivalentToDefault is the spec-mandated critical
+// test: production.json must produce signals identical to DefaultStrategy
+// across multiple representative branches.
+func TestConfigurableStrategy_EquivalentToDefault(t *testing.T) {
+	profile := productionProfile(t)
+	configurable, err := NewConfigurableStrategy(profile)
+	if err != nil {
+		t.Fatalf("NewConfigurableStrategy: %v", err)
+	}
+	def := buildDefaultStrategyFromProfile(t)
+
+	now := time.Unix(1_700_000_000, 0)
+	ctx := context.Background()
+
+	for _, sc := range scenariosForEquivalence() {
+		sc := sc
+		t.Run(sc.name, func(t *testing.T) {
+			defSignal, err := def.Evaluate(ctx, &sc.indicators, sc.higherTF, sc.lastPrice, now)
+			if err != nil {
+				t.Fatalf("DefaultStrategy.Evaluate: %v", err)
+			}
+			cfgSignal, err := configurable.Evaluate(ctx, &sc.indicators, sc.higherTF, sc.lastPrice, now)
+			if err != nil {
+				t.Fatalf("ConfigurableStrategy.Evaluate: %v", err)
+			}
+			if defSignal == nil || cfgSignal == nil {
+				t.Fatalf("got nil signal: default=%v configurable=%v", defSignal, cfgSignal)
+			}
+			if defSignal.Action != cfgSignal.Action {
+				t.Errorf("Action mismatch: default=%s configurable=%s", defSignal.Action, cfgSignal.Action)
+			}
+			if defSignal.SymbolID != cfgSignal.SymbolID {
+				t.Errorf("SymbolID mismatch: default=%d configurable=%d", defSignal.SymbolID, cfgSignal.SymbolID)
+			}
+			if defSignal.Reason != cfgSignal.Reason {
+				t.Errorf("Reason mismatch: default=%q configurable=%q", defSignal.Reason, cfgSignal.Reason)
+			}
+			if defSignal.Confidence != cfgSignal.Confidence {
+				t.Errorf("Confidence mismatch: default=%v configurable=%v", defSignal.Confidence, cfgSignal.Confidence)
+			}
+			if defSignal.Timestamp != cfgSignal.Timestamp {
+				t.Errorf("Timestamp mismatch: default=%d configurable=%d", defSignal.Timestamp, cfgSignal.Timestamp)
+			}
+		})
+	}
+}
+
+// TestConfigurableStrategy_DisabledTrendFollow proves the Enabled toggle
+// actually routes through the engine: inputs that would normally produce a
+// TREND_FOLLOW buy yield HOLD once trend_follow.enabled = false.
+func TestConfigurableStrategy_DisabledTrendFollow(t *testing.T) {
+	profile := productionProfile(t)
+	profile.SignalRules.TrendFollow.Enabled = false
+
+	s, err := NewConfigurableStrategy(profile)
+	if err != nil {
+		t.Fatalf("NewConfigurableStrategy: %v", err)
+	}
+
+	// Same inputs as the trend-follow buy scenario above.
+	indicators := entity.IndicatorSet{
+		SymbolID:    7,
+		SMA20:       fpRef(5_100_000),
+		SMA50:       fpRef(5_000_000),
+		EMA12:       fpRef(5_100_000),
+		EMA26:       fpRef(5_000_000),
+		RSI14:       fpRef(55),
+		Histogram:   fpRef(5),
+		VolumeRatio: fpRef(1.0),
+	}
+	signal, err := s.Evaluate(context.Background(), &indicators, nil, 5_100_000, time.Unix(1_700_000_000, 0))
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if signal.Action != entity.SignalActionHold {
+		t.Fatalf("expected HOLD with trend_follow.enabled=false, got %s (reason=%q)", signal.Action, signal.Reason)
+	}
+}
+
+// TestConfigurableStrategy_CustomRSIThresholds verifies a profile-level
+// threshold override actually changes the decision. RSI 65 passes the
+// production RSIBuyMax=70 ceiling but is blocked by a tightened 60 ceiling.
+func TestConfigurableStrategy_CustomRSIThresholds(t *testing.T) {
+	profile := productionProfile(t)
+
+	// Sanity: baseline (production, RSIBuyMax=70) produces a BUY.
+	baseline, err := NewConfigurableStrategy(profile)
+	if err != nil {
+		t.Fatalf("NewConfigurableStrategy baseline: %v", err)
+	}
+
+	indicators := entity.IndicatorSet{
+		SymbolID:    7,
+		SMA20:       fpRef(5_100_000),
+		SMA50:       fpRef(5_000_000),
+		EMA12:       fpRef(5_100_000),
+		EMA26:       fpRef(5_000_000),
+		RSI14:       fpRef(65),
+		Histogram:   fpRef(5),
+		VolumeRatio: fpRef(1.0),
+	}
+	now := time.Unix(1_700_000_000, 0)
+
+	baselineSignal, err := baseline.Evaluate(context.Background(), &indicators, nil, 5_100_000, now)
+	if err != nil {
+		t.Fatalf("baseline Evaluate: %v", err)
+	}
+	if baselineSignal.Action != entity.SignalActionBuy {
+		t.Fatalf("baseline expected BUY (RSI 65 < 70), got %s (reason=%q)", baselineSignal.Action, baselineSignal.Reason)
+	}
+
+	// Tighten: RSI 65 is now above the RSIBuyMax=60 ceiling → HOLD.
+	profile.SignalRules.TrendFollow.RSIBuyMax = 60
+	strict, err := NewConfigurableStrategy(profile)
+	if err != nil {
+		t.Fatalf("NewConfigurableStrategy strict: %v", err)
+	}
+	strictSignal, err := strict.Evaluate(context.Background(), &indicators, nil, 5_100_000, now)
+	if err != nil {
+		t.Fatalf("strict Evaluate: %v", err)
+	}
+	if strictSignal.Action != entity.SignalActionHold {
+		t.Fatalf("strict expected HOLD (RSI 65 > 60), got %s (reason=%q)", strictSignal.Action, strictSignal.Reason)
+	}
+}

--- a/backend/internal/usecase/strategy/configurable_strategy_test.go
+++ b/backend/internal/usecase/strategy/configurable_strategy_test.go
@@ -127,9 +127,12 @@ type indicatorScenario struct {
 // fpRef returns a pointer to v so scenarios can be expressed inline.
 func fpRef(v float64) *float64 { return &v }
 
+// bpRef returns a pointer to v so scenarios can be expressed inline.
+func bpRef(v bool) *bool { return &v }
+
 // scenariosForEquivalence exercises multiple signal branches: TREND_FOLLOW
-// buy, CONTRARIAN sell, and a HOLD counter-trend case. All three must match
-// between DefaultStrategy and ConfigurableStrategy(production).
+// buy, CONTRARIAN sell, BREAKOUT buy, and a HOLD counter-trend case. All four
+// must match between DefaultStrategy and ConfigurableStrategy(production).
 func scenariosForEquivalence() []indicatorScenario {
 	return []indicatorScenario{
 		{
@@ -164,6 +167,30 @@ func scenariosForEquivalence() []indicatorScenario {
 			},
 			higherTF:  nil,
 			lastPrice: 5_150_000,
+		},
+		{
+			// BREAKOUT stance (RecentSqueeze=true, price > BBUpper, VolumeRatio
+			// >= 1.5) must also route identically between the two strategies.
+			// This closes the breakout-volume-ratio dual-path coverage gap
+			// (the threshold appears in both StanceRulesConfig and
+			// SignalRulesConfig and they must stay in sync for production.json).
+			name: "breakout buy (BB squeeze release with volume confirmation)",
+			indicators: entity.IndicatorSet{
+				SymbolID:      7,
+				SMA20:         fpRef(5_050_000),
+				SMA50:         fpRef(5_000_000),
+				EMA12:         fpRef(5_050_000),
+				EMA26:         fpRef(5_000_000),
+				RSI14:         fpRef(55), // neutral: avoids CONTRARIAN override
+				Histogram:     fpRef(5),  // >= 0: survives BreakoutRequireMACDConfirm
+				BBUpper:       fpRef(5_100_000),
+				BBMiddle:      fpRef(5_050_000),
+				BBLower:       fpRef(5_000_000),
+				VolumeRatio:   fpRef(1.6), // >= 1.5 default BreakoutVolumeRatio
+				RecentSqueeze: bpRef(true),
+			},
+			higherTF:  nil,
+			lastPrice: 5_150_000, // strictly above BBUpper
 		},
 		{
 			name: "hold: TF buy blocked by higher-TF downtrend",

--- a/backend/profiles/production.json
+++ b/backend/profiles/production.json
@@ -1,0 +1,54 @@
+{
+  "name": "production",
+  "description": "Production defaults matching current DefaultStrategy behavior",
+  "indicators": {
+    "sma_short": 20,
+    "sma_long": 50,
+    "rsi_period": 14,
+    "macd_fast": 12,
+    "macd_slow": 26,
+    "macd_signal": 9,
+    "bb_period": 20,
+    "bb_multiplier": 2.0,
+    "atr_period": 14
+  },
+  "stance_rules": {
+    "rsi_oversold": 25,
+    "rsi_overbought": 75,
+    "sma_convergence_threshold": 0.001,
+    "bb_squeeze_lookback": 5,
+    "breakout_volume_ratio": 1.5
+  },
+  "signal_rules": {
+    "trend_follow": {
+      "enabled": true,
+      "require_macd_confirm": true,
+      "require_ema_cross": true,
+      "rsi_buy_max": 70,
+      "rsi_sell_min": 30
+    },
+    "contrarian": {
+      "enabled": true,
+      "rsi_entry": 30,
+      "rsi_exit": 70,
+      "macd_histogram_limit": 10
+    },
+    "breakout": {
+      "enabled": true,
+      "volume_ratio_min": 1.5,
+      "require_macd_confirm": true
+    }
+  },
+  "strategy_risk": {
+    "stop_loss_percent": 5,
+    "take_profit_percent": 10,
+    "stop_loss_atr_multiplier": 0,
+    "max_position_amount": 100000,
+    "max_daily_loss": 50000
+  },
+  "htf_filter": {
+    "enabled": true,
+    "block_counter_trend": true,
+    "alignment_boost": 0.1
+  }
+}


### PR DESCRIPTION
## Summary

PDCA 設計書 §2.2 / §9「必須テスト」に対応する PR（Task 4 にスタック）。

### 最小限の refactor
- `StrategyEngineOptions` / `RuleBasedStanceResolverOptions` を拡張しシグナル・スタンス閾値を注入可能化
- 既存 `NewStrategyEngine` / `NewRuleBasedStanceResolver*` はデフォルト充填で **bit-identical** な本番挙動を維持
- Confidence scoring (`trendFollowConfidence`/`contrarianConfidence`) も設定 RSI 閾値を参照するようメソッド化（デフォルト値では既存テスト全 PASS）

### ConfigurableStrategy
- `backend/internal/usecase/strategy/configurable_strategy.go` — `StrategyProfile` から Resolver+Engine を組み立てる
- プロファイルを `Validate()` した後、`SignalRules` / `HTFFilter` → engine options、`StanceRules` → resolver options にマップ
- `port.Strategy` 実装、`Name()` はプロファイル名を返す

### production.json
- `backend/profiles/production.json` — 現行コードのハードコード値と 1:1 対応
- 読み込み時 `DisallowUnknownFields` を通過することを CI / テストで担保

## Test plan

- [x] `go test ./... -race -count=1` 全 PASS（既存テスト含む）
- [x] `TestConfigurableStrategy_EquivalentToDefault` — production.json をロード、DefaultStrategy と **4 シナリオ** (TrendFollow Buy / Contrarian Sell / HTF-blocked HOLD / Breakout Buy) で `Action`/`SymbolID`/`Reason`/`Confidence`/`Timestamp` 完全一致
- [x] `TestConfigurableStrategy_DisabledTrendFollow` / `CustomRSIThresholds` — 設定で挙動が変化することを検証
- [x] 既存 Confidence テスト 3 本 (`TrendFollowStrong/Weak`, `ContrarianStrong`) デフォルト値下で同値

## Behavior preservation

- 既存本番コード (`DefaultStrategy` 経由) は **ゼロ差分**。Engine/Resolver のハードコード値は defaults 充填によって元値に戻る
- HTF alignment boost: `HTFBlockCounterTrend=true`（本番デフォルト）では reach 条件が同じで挙動不変

## Stacked PR

チェーン: #96 (Task 1) ← #97 (Task 2) ← #98 (Task 4) ← **本PR** (Task 3)

## Scope

- **含まない**: indicator period パラメトライズ（IndicatorCalculator の責務）、CLI/API wiring (Task 6)、フロント (Task 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)