### PR TITLE
feat(backtest): parent-integrity enforcement + filter fields (PDCA Task 5)

### DIFF
--- a/backend/internal/domain/repository/backtest_result.go
+++ b/backend/internal/domain/repository/backtest_result.go
@@ -7,9 +7,28 @@ import (
 )
 
 // BacktestResultFilter defines query options for listing persisted results.
+//
+// String filters (ProfileName, PDCACycleID) are inclusive exact-match filters;
+// an empty string means "no filter". Pointer filters (ParentResultID, HasParent)
+// treat nil as "no filter".
+//
+// If both ParentResultID and HasParent are supplied, ParentResultID takes
+// precedence and HasParent is ignored (see design doc §5.3).
 type BacktestResultFilter struct {
 	Limit  int
 	Offset int
+
+	// ProfileName filters by exact ProfileName match when non-empty.
+	ProfileName string
+	// PDCACycleID filters by exact PDCACycleID match when non-empty.
+	PDCACycleID string
+	// ParentResultID filters rows where parent_result_id equals *ParentResultID
+	// when non-nil. An empty-string pointer value is a legitimate filter value
+	// (not treated as "no filter").
+	ParentResultID *string
+	// HasParent filters rows by parent_result_id IS [NOT] NULL when non-nil.
+	// Ignored if ParentResultID is also non-nil.
+	HasParent *bool
 }
 
 // BacktestResultRepository persists backtest summaries and trade logs.

--- a/backend/internal/domain/repository/errors.go
+++ b/backend/internal/domain/repository/errors.go
@@ -1,0 +1,15 @@
+package repository
+
+import "errors"
+
+// ErrParentResultSelfReference is returned by BacktestResultRepository.Save
+// when the result's ParentResultID references its own ID.
+//
+// Use errors.Is to detect this error even after wrapping with fmt.Errorf("%w: ...").
+var ErrParentResultSelfReference = errors.New("backtest_result: parent_result_id cannot equal id")
+
+// ErrParentResultNotFound is returned by BacktestResultRepository.Save
+// when the result's ParentResultID points to a row that does not exist.
+//
+// Use errors.Is to detect this error even after wrapping with fmt.Errorf("%w: ...").
+var ErrParentResultNotFound = errors.New("backtest_result: parent_result_id does not reference an existing row")

--- a/backend/internal/domain/repository/errors.go
+++ b/backend/internal/domain/repository/errors.go
@@ -5,11 +5,11 @@ import "errors"
 // ErrParentResultSelfReference is returned by BacktestResultRepository.Save
 // when the result's ParentResultID references its own ID.
 //
-// Use errors.Is to detect this error even after wrapping with fmt.Errorf("%w: ...").
+// Use errors.Is to detect this error even after wrapping with fmt.Errorf("...: %w", err).
 var ErrParentResultSelfReference = errors.New("backtest_result: parent_result_id cannot equal id")
 
 // ErrParentResultNotFound is returned by BacktestResultRepository.Save
 // when the result's ParentResultID points to a row that does not exist.
 //
-// Use errors.Is to detect this error even after wrapping with fmt.Errorf("%w: ...").
+// Use errors.Is to detect this error even after wrapping with fmt.Errorf("...: %w", err).
 var ErrParentResultNotFound = errors.New("backtest_result: parent_result_id does not reference an existing row")

--- a/backend/internal/infrastructure/backtest/result_repository.go
+++ b/backend/internal/infrastructure/backtest/result_repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/repository"
@@ -39,6 +40,22 @@ func (r *ResultRepository) Save(ctx context.Context, result entity.BacktestResul
 		return fmt.Errorf("begin tx: %w", err)
 	}
 	defer tx.Rollback()
+
+	// Application-layer integrity checks on parent_result_id (design doc §5.1).
+	// Self-reference check happens first so we short-circuit without hitting the DB.
+	if result.ParentResultID != nil {
+		if *result.ParentResultID == result.ID {
+			return fmt.Errorf("save backtest result: %w", repository.ErrParentResultSelfReference)
+		}
+		var exists int
+		err := tx.QueryRowContext(ctx, `SELECT 1 FROM backtest_results WHERE id = ?`, *result.ParentResultID).Scan(&exists)
+		if err != nil {
+			if err == sql.ErrNoRows {
+				return fmt.Errorf("save backtest result: %w", repository.ErrParentResultNotFound)
+			}
+			return fmt.Errorf("check parent existence: %w", err)
+		}
+	}
 
 	parentID := sql.NullString{}
 	if result.ParentResultID != nil {
@@ -128,9 +145,42 @@ func (r *ResultRepository) List(ctx context.Context, filter repository.BacktestR
 		offset = 0
 	}
 
-	rows, err := r.db.QueryContext(ctx, `SELECT `+resultColumns+` FROM backtest_results
+	// Dynamic WHERE construction. Only parameterised placeholders are used;
+	// the static column names are not derived from caller input.
+	var clauses []string
+	var args []any
+
+	if filter.ProfileName != "" {
+		clauses = append(clauses, "profile_name = ?")
+		args = append(args, filter.ProfileName)
+	}
+	if filter.PDCACycleID != "" {
+		clauses = append(clauses, "pdca_cycle_id = ?")
+		args = append(args, filter.PDCACycleID)
+	}
+	// ParentResultID takes precedence over HasParent (design doc §5.3).
+	switch {
+	case filter.ParentResultID != nil:
+		clauses = append(clauses, "parent_result_id = ?")
+		args = append(args, *filter.ParentResultID)
+	case filter.HasParent != nil && *filter.HasParent:
+		clauses = append(clauses, "parent_result_id IS NOT NULL")
+	case filter.HasParent != nil && !*filter.HasParent:
+		clauses = append(clauses, "parent_result_id IS NULL")
+	}
+
+	where := ""
+	if len(clauses) > 0 {
+		where = " WHERE " + strings.Join(clauses, " AND ")
+	}
+
+	args = append(args, limit, offset)
+
+	query := `SELECT ` + resultColumns + ` FROM backtest_results` + where + `
 		ORDER BY created_at DESC, id DESC
-		LIMIT ? OFFSET ?`, limit, offset)
+		LIMIT ? OFFSET ?`
+
+	rows, err := r.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("list backtest results: %w", err)
 	}

--- a/backend/internal/infrastructure/backtest/result_repository.go
+++ b/backend/internal/infrastructure/backtest/result_repository.go
@@ -3,6 +3,7 @@ package backtest
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -50,7 +51,7 @@ func (r *ResultRepository) Save(ctx context.Context, result entity.BacktestResul
 		var exists int
 		err := tx.QueryRowContext(ctx, `SELECT 1 FROM backtest_results WHERE id = ?`, *result.ParentResultID).Scan(&exists)
 		if err != nil {
-			if err == sql.ErrNoRows {
+			if errors.Is(err, sql.ErrNoRows) {
 				return fmt.Errorf("save backtest result: %w", repository.ErrParentResultNotFound)
 			}
 			return fmt.Errorf("check parent existence: %w", err)

--- a/backend/internal/infrastructure/backtest/result_repository_test.go
+++ b/backend/internal/infrastructure/backtest/result_repository_test.go
@@ -2,6 +2,7 @@ package backtest
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"testing"
 	"time"
@@ -239,4 +240,263 @@ func TestResultRepository_PDCAFieldsRoundTrip(t *testing.T) {
 	if afterDelete.ParentResultID != nil {
 		t.Fatalf("expected child ParentResultID to be nil after parent delete, got %q", *afterDelete.ParentResultID)
 	}
+}
+
+// newTestRepo opens a fresh in-memory-backed SQLite DB in a temp directory,
+// runs migrations, and returns a ResultRepository ready for use.
+func newTestRepo(t *testing.T) *ResultRepository {
+	t.Helper()
+	tmp := t.TempDir()
+	db, err := database.NewDB(filepath.Join(tmp, "test.db"))
+	if err != nil {
+		t.Fatalf("new db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := database.RunMigrations(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	return NewResultRepository(db)
+}
+
+// basicResult returns a minimally-populated BacktestResult for persistence tests.
+func basicResult(id string, createdAt int64) entity.BacktestResult {
+	return entity.BacktestResult{
+		ID:        id,
+		CreatedAt: createdAt,
+		Config: entity.BacktestConfig{
+			Symbol:          "BTC_JPY",
+			SymbolID:        7,
+			PrimaryInterval: "PT15M",
+			FromTimestamp:   1000,
+			ToTimestamp:     2000,
+		},
+		Summary: entity.BacktestSummary{
+			InitialBalance: 100000,
+			FinalBalance:   110000,
+			WinRate:        50,
+		},
+	}
+}
+
+func TestResultRepository_SaveSelfReference422(t *testing.T) {
+	repo := newTestRepo(t)
+	id := "bt-self-ref"
+	self := id
+	r := basicResult(id, time.Now().Unix())
+	r.ParentResultID = &self
+
+	err := repo.Save(context.Background(), r)
+	if err == nil {
+		t.Fatal("expected error for self-reference, got nil")
+	}
+	if !errors.Is(err, repository.ErrParentResultSelfReference) {
+		t.Fatalf("expected ErrParentResultSelfReference, got %v", err)
+	}
+}
+
+func TestResultRepository_SaveParentNotFound422(t *testing.T) {
+	repo := newTestRepo(t)
+	missing := "does-not-exist"
+	r := basicResult("bt-orphan", time.Now().Unix())
+	r.ParentResultID = &missing
+
+	err := repo.Save(context.Background(), r)
+	if err == nil {
+		t.Fatal("expected error for missing parent, got nil")
+	}
+	if !errors.Is(err, repository.ErrParentResultNotFound) {
+		t.Fatalf("expected ErrParentResultNotFound, got %v", err)
+	}
+}
+
+func TestResultRepository_SaveValidParent(t *testing.T) {
+	repo := newTestRepo(t)
+	now := time.Now().Unix()
+
+	parent := basicResult("bt-parent", now)
+	if err := repo.Save(context.Background(), parent); err != nil {
+		t.Fatalf("save parent: %v", err)
+	}
+
+	pid := parent.ID
+	child := basicResult("bt-child", now+1)
+	child.ParentResultID = &pid
+	if err := repo.Save(context.Background(), child); err != nil {
+		t.Fatalf("save valid child: %v", err)
+	}
+
+	found, err := repo.FindByID(context.Background(), child.ID)
+	if err != nil {
+		t.Fatalf("find child: %v", err)
+	}
+	if found == nil || found.ParentResultID == nil || *found.ParentResultID != parent.ID {
+		t.Fatalf("expected child.ParentResultID=%q, got %+v", parent.ID, found)
+	}
+}
+
+func TestResultRepository_Filter(t *testing.T) {
+	repo := newTestRepo(t)
+	now := time.Now().Unix()
+	ctx := context.Background()
+
+	// r1: profile=prodA, cycle=c1, no parent.
+	r1 := basicResult("bt-f1", now)
+	r1.ProfileName = "prodA"
+	r1.PDCACycleID = "c1"
+
+	// r2: profile=prodB, cycle=c1, no parent.
+	r2 := basicResult("bt-f2", now+1)
+	r2.ProfileName = "prodB"
+	r2.PDCACycleID = "c1"
+
+	// r3: profile=prodA, cycle=c2, parent=r1.
+	r3 := basicResult("bt-f3", now+2)
+	r3.ProfileName = "prodA"
+	r3.PDCACycleID = "c2"
+	pid1 := r1.ID
+	r3.ParentResultID = &pid1
+
+	// r4: profile=prodB, cycle=c2, parent=r2.
+	r4 := basicResult("bt-f4", now+3)
+	r4.ProfileName = "prodB"
+	r4.PDCACycleID = "c2"
+	pid2 := r2.ID
+	r4.ParentResultID = &pid2
+
+	for _, r := range []entity.BacktestResult{r1, r2, r3, r4} {
+		if err := repo.Save(ctx, r); err != nil {
+			t.Fatalf("save %s: %v", r.ID, err)
+		}
+	}
+
+	collectIDs := func(results []entity.BacktestResult) map[string]struct{} {
+		m := make(map[string]struct{}, len(results))
+		for _, r := range results {
+			m[r.ID] = struct{}{}
+		}
+		return m
+	}
+
+	t.Run("ProfileName", func(t *testing.T) {
+		got, err := repo.List(ctx, repository.BacktestResultFilter{
+			Limit:       10,
+			ProfileName: "prodA",
+		})
+		if err != nil {
+			t.Fatalf("list: %v", err)
+		}
+		ids := collectIDs(got)
+		if len(ids) != 2 {
+			t.Fatalf("expected 2 rows, got %d: %v", len(ids), ids)
+		}
+		if _, ok := ids[r1.ID]; !ok {
+			t.Fatalf("r1 missing from ProfileName=prodA result: %v", ids)
+		}
+		if _, ok := ids[r3.ID]; !ok {
+			t.Fatalf("r3 missing from ProfileName=prodA result: %v", ids)
+		}
+	})
+
+	t.Run("PDCACycleID", func(t *testing.T) {
+		got, err := repo.List(ctx, repository.BacktestResultFilter{
+			Limit:       10,
+			PDCACycleID: "c2",
+		})
+		if err != nil {
+			t.Fatalf("list: %v", err)
+		}
+		ids := collectIDs(got)
+		if len(ids) != 2 {
+			t.Fatalf("expected 2 rows, got %d: %v", len(ids), ids)
+		}
+		if _, ok := ids[r3.ID]; !ok {
+			t.Fatalf("r3 missing from PDCACycleID=c2 result: %v", ids)
+		}
+		if _, ok := ids[r4.ID]; !ok {
+			t.Fatalf("r4 missing from PDCACycleID=c2 result: %v", ids)
+		}
+	})
+
+	t.Run("HasParentTrue", func(t *testing.T) {
+		yes := true
+		got, err := repo.List(ctx, repository.BacktestResultFilter{
+			Limit:     10,
+			HasParent: &yes,
+		})
+		if err != nil {
+			t.Fatalf("list: %v", err)
+		}
+		ids := collectIDs(got)
+		if len(ids) != 2 {
+			t.Fatalf("expected 2 rows (children only), got %d: %v", len(ids), ids)
+		}
+		if _, ok := ids[r3.ID]; !ok {
+			t.Fatalf("r3 missing from HasParent=true: %v", ids)
+		}
+		if _, ok := ids[r4.ID]; !ok {
+			t.Fatalf("r4 missing from HasParent=true: %v", ids)
+		}
+	})
+
+	t.Run("HasParentFalse", func(t *testing.T) {
+		no := false
+		got, err := repo.List(ctx, repository.BacktestResultFilter{
+			Limit:     10,
+			HasParent: &no,
+		})
+		if err != nil {
+			t.Fatalf("list: %v", err)
+		}
+		ids := collectIDs(got)
+		if len(ids) != 2 {
+			t.Fatalf("expected 2 rows (roots only), got %d: %v", len(ids), ids)
+		}
+		if _, ok := ids[r1.ID]; !ok {
+			t.Fatalf("r1 missing from HasParent=false: %v", ids)
+		}
+		if _, ok := ids[r2.ID]; !ok {
+			t.Fatalf("r2 missing from HasParent=false: %v", ids)
+		}
+	})
+
+	t.Run("ParentResultIDExactMatch", func(t *testing.T) {
+		pid := r1.ID
+		got, err := repo.List(ctx, repository.BacktestResultFilter{
+			Limit:          10,
+			ParentResultID: &pid,
+		})
+		if err != nil {
+			t.Fatalf("list: %v", err)
+		}
+		ids := collectIDs(got)
+		if len(ids) != 1 {
+			t.Fatalf("expected 1 row, got %d: %v", len(ids), ids)
+		}
+		if _, ok := ids[r3.ID]; !ok {
+			t.Fatalf("r3 missing from ParentResultID=r1 result: %v", ids)
+		}
+	})
+
+	t.Run("ParentResultIDWinsOverHasParent", func(t *testing.T) {
+		// Spec §5.3: ParentResultID takes precedence over HasParent.
+		// If HasParent=false (which would exclude rows with a parent) were
+		// honored, we'd get zero rows; ParentResultID=r2 must win and return r4.
+		pid := r2.ID
+		no := false
+		got, err := repo.List(ctx, repository.BacktestResultFilter{
+			Limit:          10,
+			ParentResultID: &pid,
+			HasParent:      &no,
+		})
+		if err != nil {
+			t.Fatalf("list: %v", err)
+		}
+		ids := collectIDs(got)
+		if len(ids) != 1 {
+			t.Fatalf("expected 1 row (ParentResultID wins), got %d: %v", len(ids), ids)
+		}
+		if _, ok := ids[r4.ID]; !ok {
+			t.Fatalf("r4 missing from ParentResultID=r2 (HasParent should be ignored): %v", ids)
+		}
+	})
 }

--- a/backend/internal/infrastructure/backtest/result_repository_test.go
+++ b/backend/internal/infrastructure/backtest/result_repository_test.go
@@ -278,7 +278,7 @@ func basicResult(id string, createdAt int64) entity.BacktestResult {
 	}
 }
 
-func TestResultRepository_SaveSelfReference422(t *testing.T) {
+func TestResultRepository_SaveRejectsSelfReference(t *testing.T) {
 	repo := newTestRepo(t)
 	id := "bt-self-ref"
 	self := id
@@ -292,12 +292,22 @@ func TestResultRepository_SaveSelfReference422(t *testing.T) {
 	if !errors.Is(err, repository.ErrParentResultSelfReference) {
 		t.Fatalf("expected ErrParentResultSelfReference, got %v", err)
 	}
+
+	// Rollback integrity: the rejected row must not have been persisted.
+	found, err := repo.FindByID(context.Background(), id)
+	if err != nil {
+		t.Fatalf("find after self-ref rejection: %v", err)
+	}
+	if found != nil {
+		t.Fatalf("expected no row persisted after self-ref rejection, got %+v", found)
+	}
 }
 
-func TestResultRepository_SaveParentNotFound422(t *testing.T) {
+func TestResultRepository_SaveRejectsMissingParent(t *testing.T) {
 	repo := newTestRepo(t)
 	missing := "does-not-exist"
-	r := basicResult("bt-orphan", time.Now().Unix())
+	id := "bt-orphan"
+	r := basicResult(id, time.Now().Unix())
 	r.ParentResultID = &missing
 
 	err := repo.Save(context.Background(), r)
@@ -306,6 +316,15 @@ func TestResultRepository_SaveParentNotFound422(t *testing.T) {
 	}
 	if !errors.Is(err, repository.ErrParentResultNotFound) {
 		t.Fatalf("expected ErrParentResultNotFound, got %v", err)
+	}
+
+	// Rollback integrity: the rejected row must not have been persisted.
+	found, err := repo.FindByID(context.Background(), id)
+	if err != nil {
+		t.Fatalf("find after missing-parent rejection: %v", err)
+	}
+	if found != nil {
+		t.Fatalf("expected no row persisted after missing-parent rejection, got %+v", found)
 	}
 }
 
@@ -474,6 +493,27 @@ func TestResultRepository_Filter(t *testing.T) {
 		}
 		if _, ok := ids[r3.ID]; !ok {
 			t.Fatalf("r3 missing from ParentResultID=r1 result: %v", ids)
+		}
+	})
+
+	t.Run("ProfileNameAndPDCACycleIDCombined", func(t *testing.T) {
+		// AND semantics: only rows matching BOTH ProfileName=prodA and
+		// PDCACycleID=c1 should be returned. r3 matches profile but not cycle;
+		// r2 matches cycle but not profile; only r1 matches both.
+		got, err := repo.List(ctx, repository.BacktestResultFilter{
+			Limit:       10,
+			ProfileName: "prodA",
+			PDCACycleID: "c1",
+		})
+		if err != nil {
+			t.Fatalf("list: %v", err)
+		}
+		ids := collectIDs(got)
+		if len(ids) != 1 {
+			t.Fatalf("expected 1 row (AND match), got %d: %v", len(ids), ids)
+		}
+		if _, ok := ids[r1.ID]; !ok {
+			t.Fatalf("r1 missing from ProfileName=prodA AND PDCACycleID=c1 result: %v", ids)
 		}
 	})
 

--- a/backend/internal/interfaces/api/handler/backtest.go
+++ b/backend/internal/interfaces/api/handler/backtest.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"strconv"
 	"strings"
@@ -150,6 +151,13 @@ func (h *BacktestHandler) Run(c *gin.Context) {
 	}
 
 	if err := h.repo.Save(c.Request.Context(), *result); err != nil {
+		// parent_result_id integrity failures map to 422 so clients can
+		// distinguish them from generic 500 persistence errors.
+		if errors.Is(err, repository.ErrParentResultSelfReference) ||
+			errors.Is(err, repository.ErrParentResultNotFound) {
+			c.JSON(http.StatusUnprocessableEntity, gin.H{"error": err.Error()})
+			return
+		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to save backtest result: " + err.Error()})
 		return
 	}

--- a/backend/internal/interfaces/api/handler/backtest_test.go
+++ b/backend/internal/interfaces/api/handler/backtest_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"math"
 	"net/http"
 	"net/http/httptest"
@@ -24,9 +25,12 @@ import (
 type mockBacktestResultRepo struct {
 	listResults []entity.BacktestResult
 	findResult  *entity.BacktestResult
+	saveErr     error
 }
 
-func (m *mockBacktestResultRepo) Save(_ context.Context, _ entity.BacktestResult) error { return nil }
+func (m *mockBacktestResultRepo) Save(_ context.Context, _ entity.BacktestResult) error {
+	return m.saveErr
+}
 func (m *mockBacktestResultRepo) List(_ context.Context, _ repository.BacktestResultFilter) ([]entity.BacktestResult, error) {
 	return m.listResults, nil
 }
@@ -368,5 +372,77 @@ func TestBacktestHandler_Integration_RunMissingData(t *testing.T) {
 
 	if runW.Code != http.StatusBadRequest {
 		t.Fatalf("missing data: expected 400, got %d", runW.Code)
+	}
+}
+
+// Error mapping tests: verify that parent-integrity sentinel errors surface
+// as HTTP 422, while other persistence errors stay at 500.
+//
+// Note: request-body plumbing for parent_result_id lands in Task 6. Here we
+// simulate the downstream error via a mock repo that returns the sentinel,
+// which is exactly the propagation path from the real repository.
+
+func runBacktestExpectingSaveErr(t *testing.T, saveErr error) *httptest.ResponseRecorder {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	repo := &mockBacktestResultRepo{saveErr: saveErr}
+	h := NewBacktestHandler(bt.NewBacktestRunner(), repo)
+
+	tmpDir := t.TempDir()
+	candles := generateTestCandles(50)
+	csvPath := writeTempCSV(t, tmpDir, csvinfra.CandleFile{
+		Symbol:   "BTC_JPY",
+		SymbolID: 7,
+		Interval: "PT15M",
+		Candles:  candles,
+	})
+
+	router := gin.New()
+	router.POST("/api/v1/backtest/run", h.Run)
+
+	body := `{"data":"` + csvPath + `","initialBalance":100000}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/backtest/run", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w
+}
+
+func TestBacktestHandler_Run_SelfReference_422(t *testing.T) {
+	wrapped := fmt.Errorf("save backtest result: %w", repository.ErrParentResultSelfReference)
+	w := runBacktestExpectingSaveErr(t, wrapped)
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.Error == "" {
+		t.Fatal("expected non-empty error message")
+	}
+}
+
+func TestBacktestHandler_Run_ParentNotFound_422(t *testing.T) {
+	wrapped := fmt.Errorf("save backtest result: %w", repository.ErrParentResultNotFound)
+	w := runBacktestExpectingSaveErr(t, wrapped)
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestBacktestHandler_Run_OtherPersistError_500(t *testing.T) {
+	w := runBacktestExpectingSaveErr(t, fmt.Errorf("some generic storage failure"))
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestBacktestHandler_Run_Happy_200(t *testing.T) {
+	w := runBacktestExpectingSaveErr(t, nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 	}
 }


### PR DESCRIPTION
## Summary

PDCA 設計書 §5.1 / §5.3 に対応する PR（Task 3 にスタック）。

### ドメイン層
- `BacktestResultFilter` に 4 フィルタフィールドを追加（`ProfileName`, `PDCACycleID`, `ParentResultID *string`, `HasParent *bool`）
- ドメインセンチネルエラー `ErrParentResultSelfReference`, `ErrParentResultNotFound` を追加（`errors.Is` で判別可能）

### Repository (Save 時の整合性チェック)
- `ParentResultID == ID` → `ErrParentResultSelfReference`（DB を叩かず即時 reject）
- `ParentResultID` が存在しない ID を指す → `ErrParentResultNotFound`
- 存在チェックと INSERT は同一トランザクション内（原子性担保）
- 失敗時は rollback されて行が書き込まれないことをテストで明示検証

### Repository (List の動的 WHERE)
- 4 フィルタを組み合わせた AND 句。`ParentResultID` 非 nil は `HasParent` より優先
- プレースホルダ経由、カラム名は静的のみ（SQL インジェクション不可）

### API Handler
- `POST /backtest/run` のエラー応答: センチネルエラー → 422、他の永続化エラー → 500
- `errors.Is` ラップチェーンを handler テストで検証

## Test plan

- [x] `go test ./... -race -count=1` — 全 PASS
- [x] Repository: 自己参照 reject + rollback 検証、存在しない親 reject + rollback 検証、有効な親 accept
- [x] Repository フィルタ: ProfileName / PDCACycleID / HasParent true / HasParent false / ParentResultID 一致 / 競合時の precedence / AND 結合
- [x] Handler: 422 (self-ref, parent-not-found) / 500 (generic) / 200 (happy)、422 時のレスポンスボディ shape

## Deferred（仕様書にあるが別 PR）

- HTTP クエリパラメータ経由のフィルタ受け口（`/backtest/results?profileName=...`）→ Task 7 でフロントと同時
- Run リクエストの `profileName` / `pdcaCycleId` / `hypothesis` / `parentResultId` フィールド受け口 → Task 6
- 422 ガードはこの PR では dead code（Task 6 で実際に到達するようになる）

## Stacked PR

チェーン: #96 (Task 1) ← #97 (Task 2) ← #98 (Task 4) ← #99 (Task 3) ← **本PR** (Task 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)