### PR TITLE
feat(backtest): list filter query params + PDCA 列 & 絞り込み UI (PDCA Task 7)

### DIFF
--- a/backend/internal/interfaces/api/handler/backtest.go
+++ b/backend/internal/interfaces/api/handler/backtest.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"net/http"
 	"strconv"
 	"strings"
@@ -327,10 +328,47 @@ func (h *BacktestHandler) ListResults(c *gin.Context) {
 		return
 	}
 
-	results, err := h.repo.List(c.Request.Context(), repository.BacktestResultFilter{
-		Limit:  limit,
-		Offset: offset,
-	})
+	filter := repository.BacktestResultFilter{
+		Limit:       limit,
+		Offset:      offset,
+		ProfileName: c.Query("profileName"),
+		PDCACycleID: c.Query("pdcaCycleId"),
+	}
+
+	// parentResultId: per spec §5.3 `(nil = フィルタなし)`. An empty string is a
+	// legitimate filter value at the repository layer, but it has no useful
+	// semantics as a real parent_result_id (domain values are UUIDs), so we
+	// fold empty into "no filter" at the HTTP layer. This keeps the query
+	// string ergonomic — callers can safely default `parentResultId=` to
+	// disable the filter without having to strip the param from the URL.
+	if v, present := c.GetQuery("parentResultId"); present && v != "" {
+		filter.ParentResultID = &v
+	}
+
+	// hasParent: accept only "true"/"false" (idiomatic strconv.ParseBool,
+	// aligns with JS booleans). Any other non-empty value is a 400.
+	if v, present := c.GetQuery("hasParent"); present {
+		parsed, err := strconv.ParseBool(v)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "hasParent must be true or false"})
+			return
+		}
+		filter.HasParent = &parsed
+	}
+
+	// Precedence: when both parentResultId and hasParent are provided, the
+	// specific ID wins. Drop HasParent at the handler layer so the repository
+	// layer sees a single intent. Duplicating the rule here keeps the two
+	// layers internally consistent and surfaces a debug log for observability.
+	if filter.ParentResultID != nil && filter.HasParent != nil {
+		slog.Debug("backtest list filter: parentResultId takes precedence over hasParent",
+			"parentResultId", *filter.ParentResultID,
+			"droppedHasParent", *filter.HasParent,
+		)
+		filter.HasParent = nil
+	}
+
+	results, err := h.repo.List(c.Request.Context(), filter)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return

--- a/backend/internal/interfaces/api/handler/backtest_test.go
+++ b/backend/internal/interfaces/api/handler/backtest_test.go
@@ -32,13 +32,17 @@ type mockBacktestResultRepo struct {
 	// to assert that PDCA metadata (profileName, parentResultId, etc.) is
 	// attached to the persisted entity.
 	saved *entity.BacktestResult
+	// lastFilter records the last filter passed to List so handler tests can
+	// assert query-parameter plumbing without exercising the SQL layer.
+	lastFilter *repository.BacktestResultFilter
 }
 
 func (m *mockBacktestResultRepo) Save(_ context.Context, r entity.BacktestResult) error {
 	m.saved = &r
 	return m.saveErr
 }
-func (m *mockBacktestResultRepo) List(_ context.Context, _ repository.BacktestResultFilter) ([]entity.BacktestResult, error) {
+func (m *mockBacktestResultRepo) List(_ context.Context, f repository.BacktestResultFilter) ([]entity.BacktestResult, error) {
+	m.lastFilter = &f
 	return m.listResults, nil
 }
 func (m *mockBacktestResultRepo) FindByID(_ context.Context, _ string) (*entity.BacktestResult, error) {
@@ -798,5 +802,135 @@ func TestBacktestHandler_Run_PDCAMetadataPersisted(t *testing.T) {
 	}
 	if stored.Hypothesis != "tighter stop reduces drawdown" {
 		t.Errorf("Hypothesis = %q, want %q", stored.Hypothesis, "tighter stop reduces drawdown")
+	}
+}
+
+// --- Task 7: ListResults query-parameter filters ---
+
+// listWithQuery invokes the ListResults handler with the given query string
+// against a mock repo so we can assert the BacktestResultFilter it received.
+func listWithQuery(t *testing.T, query string) (*httptest.ResponseRecorder, *mockBacktestResultRepo) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	repo := &mockBacktestResultRepo{}
+	h := NewBacktestHandler(bt.NewBacktestRunner(), repo)
+	router := gin.New()
+	router.GET("/api/v1/backtest/results", h.ListResults)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/backtest/results"+query, nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w, repo
+}
+
+func TestBacktestHandler_ListResults_FilterProfileName(t *testing.T) {
+	w, repo := listWithQuery(t, "?profileName=foo")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if repo.lastFilter == nil {
+		t.Fatal("expected List to receive a filter")
+	}
+	if repo.lastFilter.ProfileName != "foo" {
+		t.Errorf("ProfileName = %q, want %q", repo.lastFilter.ProfileName, "foo")
+	}
+}
+
+func TestBacktestHandler_ListResults_FilterPDCACycleID(t *testing.T) {
+	w, repo := listWithQuery(t, "?pdcaCycleId=cycle-1")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if repo.lastFilter.PDCACycleID != "cycle-1" {
+		t.Errorf("PDCACycleID = %q, want %q", repo.lastFilter.PDCACycleID, "cycle-1")
+	}
+}
+
+func TestBacktestHandler_ListResults_FilterHasParentTrue(t *testing.T) {
+	w, repo := listWithQuery(t, "?hasParent=true")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if repo.lastFilter.HasParent == nil || *repo.lastFilter.HasParent != true {
+		t.Errorf("HasParent = %v, want true", repo.lastFilter.HasParent)
+	}
+}
+
+func TestBacktestHandler_ListResults_FilterHasParentFalse(t *testing.T) {
+	w, repo := listWithQuery(t, "?hasParent=false")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if repo.lastFilter.HasParent == nil || *repo.lastFilter.HasParent != false {
+		t.Errorf("HasParent = %v, want false", repo.lastFilter.HasParent)
+	}
+}
+
+func TestBacktestHandler_ListResults_FilterHasParentInvalid_400(t *testing.T) {
+	w, _ := listWithQuery(t, "?hasParent=yes")
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid hasParent, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestBacktestHandler_ListResults_FilterParentResultID(t *testing.T) {
+	w, repo := listWithQuery(t, "?parentResultId=p-123")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if repo.lastFilter.ParentResultID == nil || *repo.lastFilter.ParentResultID != "p-123" {
+		t.Errorf("ParentResultID = %v, want &\"p-123\"", repo.lastFilter.ParentResultID)
+	}
+}
+
+func TestBacktestHandler_ListResults_FilterParentResultIDEmpty_NoFilter(t *testing.T) {
+	// Spec §5.3: empty string is a legitimate filter value at the repo layer,
+	// but the handler treats `?parentResultId=` as "no filter" (see handler
+	// comment for rationale). We verify the handler drops the filter.
+	w, repo := listWithQuery(t, "?parentResultId=")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if repo.lastFilter.ParentResultID != nil {
+		t.Errorf("ParentResultID = %v, want nil (empty string folds into no-filter)", repo.lastFilter.ParentResultID)
+	}
+}
+
+func TestBacktestHandler_ListResults_FilterCombined(t *testing.T) {
+	w, repo := listWithQuery(t, "?profileName=foo&hasParent=false")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if repo.lastFilter.ProfileName != "foo" {
+		t.Errorf("ProfileName = %q, want %q", repo.lastFilter.ProfileName, "foo")
+	}
+	if repo.lastFilter.HasParent == nil || *repo.lastFilter.HasParent != false {
+		t.Errorf("HasParent = %v, want false", repo.lastFilter.HasParent)
+	}
+}
+
+func TestBacktestHandler_ListResults_PrecedenceParentResultIDOverHasParent(t *testing.T) {
+	// Per repository doc and spec §5.3: when both are set, ParentResultID wins.
+	// Handler enforces the precedence before calling into the repo so the two
+	// layers agree. Assert HasParent is dropped.
+	w, repo := listWithQuery(t, "?parentResultId=p-1&hasParent=true")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if repo.lastFilter.ParentResultID == nil || *repo.lastFilter.ParentResultID != "p-1" {
+		t.Errorf("ParentResultID = %v, want &\"p-1\"", repo.lastFilter.ParentResultID)
+	}
+	if repo.lastFilter.HasParent != nil {
+		t.Errorf("HasParent = %v, want nil (parentResultId takes precedence)", repo.lastFilter.HasParent)
+	}
+}
+
+func TestBacktestHandler_ListResults_NoFilters(t *testing.T) {
+	w, repo := listWithQuery(t, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if repo.lastFilter.ProfileName != "" || repo.lastFilter.PDCACycleID != "" ||
+		repo.lastFilter.ParentResultID != nil || repo.lastFilter.HasParent != nil {
+		t.Errorf("expected all filters zero, got %+v", repo.lastFilter)
 	}
 }

--- a/frontend/src/hooks/__tests__/useBacktest.test.tsx
+++ b/frontend/src/hooks/__tests__/useBacktest.test.tsx
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
+import { useBacktestResults } from '../useBacktest'
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+  }
+}
+
+function lastFetchURL(): string {
+  const mock = vi.mocked(fetch)
+  const last = mock.mock.calls[mock.mock.calls.length - 1]?.[0]
+  if (typeof last !== 'string') {
+    throw new Error('fetch was not called with a string URL')
+  }
+  return last
+}
+
+beforeEach(() => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ results: [] }),
+    } as Response),
+  )
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('useBacktestResults', () => {
+  it('fetches with default limit/offset and no filter params', async () => {
+    const { result } = renderHook(() => useBacktestResults(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const url = lastFetchURL()
+    expect(url).toContain('/backtest/results?')
+    expect(url).toContain('limit=20')
+    expect(url).toContain('offset=0')
+    expect(url).not.toContain('profileName')
+    expect(url).not.toContain('pdcaCycleId')
+    expect(url).not.toContain('hasParent')
+    expect(url).not.toContain('parentResultId')
+  })
+
+  it('serialises profileName into the query string', async () => {
+    const { result } = renderHook(
+      () => useBacktestResults({ profileName: 'production' }),
+      { wrapper: createWrapper() },
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(lastFetchURL()).toContain('profileName=production')
+  })
+
+  it('serialises hasParent=false as a literal `false` string', async () => {
+    const { result } = renderHook(
+      () => useBacktestResults({ hasParent: false }),
+      { wrapper: createWrapper() },
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(lastFetchURL()).toContain('hasParent=false')
+  })
+
+  it('serialises hasParent=true as a literal `true` string', async () => {
+    const { result } = renderHook(
+      () => useBacktestResults({ hasParent: true }),
+      { wrapper: createWrapper() },
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(lastFetchURL()).toContain('hasParent=true')
+  })
+
+  it('skips undefined and empty-string filter values', async () => {
+    const { result } = renderHook(
+      () =>
+        useBacktestResults({
+          profileName: '',
+          pdcaCycleId: undefined,
+          parentResultId: '',
+        }),
+      { wrapper: createWrapper() },
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const url = lastFetchURL()
+    expect(url).not.toContain('profileName=')
+    expect(url).not.toContain('pdcaCycleId=')
+    expect(url).not.toContain('parentResultId=')
+  })
+
+  it('URL-encodes filter values via URLSearchParams', async () => {
+    // Use a value that requires escaping to prove we're not concatenating.
+    const { result } = renderHook(
+      () => useBacktestResults({ profileName: 'prod&dev' }),
+      { wrapper: createWrapper() },
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const url = lastFetchURL()
+    // URLSearchParams encodes `&` inside a value as `%26`.
+    expect(url).toContain('profileName=prod%26dev')
+  })
+})

--- a/frontend/src/hooks/useBacktest.ts
+++ b/frontend/src/hooks/useBacktest.ts
@@ -8,13 +8,46 @@ import {
   type BacktestRunRequest,
 } from '../lib/api'
 
-export function useBacktestResults(limit = 20, offset = 0) {
+// BacktestResultsFilter mirrors the query-parameter plumbing added to
+// `GET /api/v1/backtest/results` (spec §5.3). Each field is optional; a
+// missing or empty value means "no filter" — the hook strips them before
+// building the URL so empty values do not reach the backend.
+export type BacktestResultsFilter = {
+  limit?: number
+  offset?: number
+  profileName?: string
+  pdcaCycleId?: string
+  hasParent?: boolean
+  parentResultId?: string
+}
+
+function buildBacktestResultsURL(filter: BacktestResultsFilter): string {
+  const params = new URLSearchParams()
+  const { limit = 20, offset = 0 } = filter
+  params.set('limit', String(limit))
+  params.set('offset', String(offset))
+  if (filter.profileName !== undefined && filter.profileName !== '') {
+    params.set('profileName', filter.profileName)
+  }
+  if (filter.pdcaCycleId !== undefined && filter.pdcaCycleId !== '') {
+    params.set('pdcaCycleId', filter.pdcaCycleId)
+  }
+  if (filter.parentResultId !== undefined && filter.parentResultId !== '') {
+    params.set('parentResultId', filter.parentResultId)
+  }
+  if (filter.hasParent !== undefined) {
+    params.set('hasParent', filter.hasParent ? 'true' : 'false')
+  }
+  return `/backtest/results?${params.toString()}`
+}
+
+export function useBacktestResults(filter: BacktestResultsFilter = {}) {
+  const url = buildBacktestResultsURL(filter)
   return useQuery({
-    queryKey: ['backtest', 'results', limit, offset],
-    queryFn: () =>
-      fetchApi<BacktestResultListResponse>(
-        `/backtest/results?limit=${limit}&offset=${offset}`,
-      ),
+    // Include the full filter object in the key so distinct filter
+    // combinations get their own cache entry and refetch on change.
+    queryKey: ['backtest', 'results', filter] as const,
+    queryFn: () => fetchApi<BacktestResultListResponse>(url),
     staleTime: 30_000,
   })
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -231,6 +231,15 @@ export type BacktestResult = {
     totalSpreadCost: number
   }
   trades?: BacktestTrade[]
+  // PDCA metadata — introduced by spec §5. Optional on the wire because:
+  //   - profileName / pdcaCycleId / hypothesis use Go's `omitempty` tag so
+  //     empty strings may be dropped from the JSON payload for legacy rows.
+  //   - parentResultId is `*string` in Go with `omitempty`, so the field is
+  //     absent entirely for root runs; present as null is also tolerated.
+  profileName?: string
+  pdcaCycleId?: string
+  hypothesis?: string
+  parentResultId?: string | null
 }
 
 export type BacktestResultListResponse = {

--- a/frontend/src/routes/backtest.tsx
+++ b/frontend/src/routes/backtest.tsx
@@ -53,6 +53,16 @@ const defaultRunForm: BacktestRunForm = {
 const fallbackBacktestPairs = ['BTC_JPY', 'LTC_JPY'] as const
 const TRADE_TABLE_COLUMN_COUNT = 11
 
+// Parent-relation filter for the list view. Kept as a const tuple so the
+// runtime guard in the <select> onChange handler stays in sync with the
+// `HasParentFilter` type below.
+const PARENT_FILTER_VALUES = ['all', 'only', 'root'] as const
+type HasParentFilter = (typeof PARENT_FILTER_VALUES)[number]
+
+function isHasParentFilter(value: string): value is HasParentFilter {
+  return (PARENT_FILTER_VALUES as readonly string[]).includes(value)
+}
+
 function buildAutoCSVPaths(currencyPair: string) {
   return {
     primary: `data/candles_${currencyPair}_PT15M.csv`,
@@ -155,7 +165,7 @@ function BacktestPage() {
   // list to just the children of that parent ID. Clearing it returns to the
   // default view.
   const [profileFilter, setProfileFilter] = useState('')
-  const [hasParentFilter, setHasParentFilter] = useState<'all' | 'only' | 'root'>('all')
+  const [hasParentFilter, setHasParentFilter] = useState<HasParentFilter>('all')
   const [parentFilter, setParentFilter] = useState('')
   const { data, isLoading, isError } = useBacktestResults({
     profileName: profileFilter || undefined,
@@ -455,9 +465,12 @@ function BacktestPage() {
             </span>
             <select
               value={hasParentFilter}
-              onChange={(event) =>
-                setHasParentFilter(event.target.value as 'all' | 'only' | 'root')
-              }
+              onChange={(event) => {
+                const value = event.target.value
+                if (isHasParentFilter(value)) {
+                  setHasParentFilter(value)
+                }
+              }}
               className="w-[220px] rounded-2xl border border-white/10 bg-white/6 px-4 py-2 text-sm text-white outline-none transition focus:border-cyan-200"
             >
               <option value="all" className="bg-bg-card text-white">すべて</option>
@@ -486,7 +499,9 @@ function BacktestPage() {
           <p className="mt-4 text-sm text-text-secondary">読み込み中...</p>
         ) : results.length === 0 ? (
           <p className="mt-4 text-sm text-text-secondary">
-            バックテスト結果がありません。
+            {profileFilter !== '' || parentFilter !== '' || hasParentFilter !== 'all'
+              ? 'フィルタに一致する結果がありません。'
+              : 'バックテスト結果がありません。'}
           </p>
         ) : (
           <div className="mt-4 overflow-x-auto">
@@ -495,7 +510,7 @@ function BacktestPage() {
                 <tr className="border-b border-white/8 text-left text-xs uppercase tracking-wider text-text-secondary">
                   <th className="px-3 py-2">ID</th>
                   <th className="px-3 py-2">プロファイル</th>
-                  <th className="px-3 py-2">PDCA</th>
+                  <th className="px-3 py-2">PDCA Cycle</th>
                   <th className="px-3 py-2">Symbol</th>
                   <th className="px-3 py-2">期間</th>
                   <th className="px-3 py-2 text-right">Total Return</th>
@@ -591,7 +606,7 @@ function ResultRow({ result, selected, onSelect, onNavigateParent }: ResultRowPr
   // a small Tailwind pill. Empty profileName collapses to an em-dash so the
   // table stays visually aligned.
   const isPDCA = (result.profileName ?? '') !== ''
-  const parentId = result.parentResultId ?? null
+  const parentId = result.parentResultId ?? undefined
 
   return (
     <tr

--- a/frontend/src/routes/backtest.tsx
+++ b/frontend/src/routes/backtest.tsx
@@ -148,7 +148,25 @@ function BacktestPage() {
   const [runForm, setRunForm] = useState<BacktestRunForm>(defaultRunForm)
   const [runValidationError, setRunValidationError] = useState('')
   const runBacktest = useRunBacktest()
-  const { data, isLoading, isError } = useBacktestResults()
+  // List filter state. `profileFilter === ''` means "すべて" (no filter).
+  // `hasParentFilter === 'only'` means only PDCA-continuation rows (親あり);
+  // `'root'` means only root runs (親なし); `'all'` applies neither.
+  // `parentFilter` is set by clicking a lineage link on a row; it filters the
+  // list to just the children of that parent ID. Clearing it returns to the
+  // default view.
+  const [profileFilter, setProfileFilter] = useState('')
+  const [hasParentFilter, setHasParentFilter] = useState<'all' | 'only' | 'root'>('all')
+  const [parentFilter, setParentFilter] = useState('')
+  const { data, isLoading, isError } = useBacktestResults({
+    profileName: profileFilter || undefined,
+    hasParent:
+      hasParentFilter === 'only'
+        ? true
+        : hasParentFilter === 'root'
+          ? false
+          : undefined,
+    parentResultId: parentFilter || undefined,
+  })
   const { data: detail, isLoading: detailLoading } = useBacktestResult(selectedId)
   const {
     data: csvMeta,
@@ -157,6 +175,19 @@ function BacktestPage() {
   } = useBacktestCSVMeta(runForm.data)
 
   const results = data?.results ?? []
+
+  // Distinct profile names from the currently-loaded rows, for the filter
+  // dropdown. We keep the currently-selected profile in the list even when
+  // it is filtered out by `hasParent` to avoid dropping the selection on
+  // render.
+  const profileOptions = useMemo(() => {
+    const set = new Set<string>()
+    for (const r of results) {
+      if (r.profileName && r.profileName !== '') set.add(r.profileName)
+    }
+    if (profileFilter !== '') set.add(profileFilter)
+    return Array.from(set).sort()
+  }, [results, profileFilter])
 
   useEffect(() => {
     if (pairOptions.length === 0) return
@@ -398,6 +429,59 @@ function BacktestPage() {
         <p className="text-xs uppercase tracking-[0.28em] text-text-secondary">Results</p>
         <h2 className="mt-2 text-xl font-semibold text-white">バックテスト一覧</h2>
 
+        {/* Filter controls (spec §5.4) */}
+        <div className="mt-4 flex flex-wrap items-end gap-3">
+          <label className="block">
+            <span className="mb-2 block text-xs uppercase tracking-[0.2em] text-text-secondary">
+              プロファイル
+            </span>
+            <select
+              value={profileFilter}
+              onChange={(event) => setProfileFilter(event.target.value)}
+              className="w-[220px] rounded-2xl border border-white/10 bg-white/6 px-4 py-2 text-sm text-white outline-none transition focus:border-cyan-200"
+            >
+              <option value="" className="bg-bg-card text-white">すべて</option>
+              {profileOptions.map((name) => (
+                <option key={name} value={name} className="bg-bg-card text-white">
+                  {name}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="block">
+            <span className="mb-2 block text-xs uppercase tracking-[0.2em] text-text-secondary">
+              親子関係
+            </span>
+            <select
+              value={hasParentFilter}
+              onChange={(event) =>
+                setHasParentFilter(event.target.value as 'all' | 'only' | 'root')
+              }
+              className="w-[220px] rounded-2xl border border-white/10 bg-white/6 px-4 py-2 text-sm text-white outline-none transition focus:border-cyan-200"
+            >
+              <option value="all" className="bg-bg-card text-white">すべて</option>
+              <option value="only" className="bg-bg-card text-white">親あり (PDCA継続)</option>
+              <option value="root" className="bg-bg-card text-white">親なし (ルート)</option>
+            </select>
+          </label>
+
+          {parentFilter !== '' && (
+            <div className="flex items-center gap-2 rounded-full border border-cyan-200/40 bg-cyan-200/10 px-3 py-1.5 text-xs text-cyan-100">
+              <span className="font-medium">親フィルタ:</span>
+              <span className="font-mono">{parentFilter.slice(0, 8)}</span>
+              <button
+                type="button"
+                onClick={() => setParentFilter('')}
+                className="ml-1 rounded-full px-1.5 text-cyan-200 transition hover:bg-cyan-200/20"
+                aria-label="親フィルタを解除"
+              >
+                ×
+              </button>
+            </div>
+          )}
+        </div>
+
         {isLoading ? (
           <p className="mt-4 text-sm text-text-secondary">読み込み中...</p>
         ) : results.length === 0 ? (
@@ -406,10 +490,12 @@ function BacktestPage() {
           </p>
         ) : (
           <div className="mt-4 overflow-x-auto">
-            <table className="w-full min-w-[800px] text-sm">
+            <table className="w-full min-w-[960px] text-sm">
               <thead>
                 <tr className="border-b border-white/8 text-left text-xs uppercase tracking-wider text-text-secondary">
                   <th className="px-3 py-2">ID</th>
+                  <th className="px-3 py-2">プロファイル</th>
+                  <th className="px-3 py-2">PDCA</th>
                   <th className="px-3 py-2">Symbol</th>
                   <th className="px-3 py-2">期間</th>
                   <th className="px-3 py-2 text-right">Total Return</th>
@@ -417,6 +503,7 @@ function BacktestPage() {
                   <th className="px-3 py-2 text-right">Sharpe</th>
                   <th className="px-3 py-2 text-right">Max DD</th>
                   <th className="px-3 py-2 text-right">Trades</th>
+                  <th className="px-3 py-2">親</th>
                   <th className="px-3 py-2">作成日</th>
                 </tr>
               </thead>
@@ -427,6 +514,7 @@ function BacktestPage() {
                     result={r}
                     selected={r.id === selectedId}
                     onSelect={() => setSelectedId(r.id === selectedId ? '' : r.id)}
+                    onNavigateParent={(parentId) => setParentFilter(parentId)}
                   />
                 ))}
               </tbody>
@@ -491,13 +579,19 @@ type ResultRowProps = {
   result: BacktestResult
   selected: boolean
   onSelect: () => void
+  onNavigateParent: (parentId: string) => void
 }
 
-function ResultRow({ result, selected, onSelect }: ResultRowProps) {
+function ResultRow({ result, selected, onSelect, onNavigateParent }: ResultRowProps) {
   const { config, summary } = result
   const periodFrom = new Date(config.fromTimestamp).toLocaleDateString('ja-JP')
   const periodTo = new Date(config.toTimestamp).toLocaleDateString('ja-JP')
   const created = new Date(result.createdAt * 1000).toLocaleDateString('ja-JP')
+  // Distinguish PDCA-driven runs (have a profileName) from manual runs with
+  // a small Tailwind pill. Empty profileName collapses to an em-dash so the
+  // table stays visually aligned.
+  const isPDCA = (result.profileName ?? '') !== ''
+  const parentId = result.parentResultId ?? null
 
   return (
     <tr
@@ -507,7 +601,24 @@ function ResultRow({ result, selected, onSelect }: ResultRowProps) {
       }`}
     >
       <td className="px-3 py-2.5 font-mono text-xs text-text-secondary">
-        {result.id.slice(0, 8)}
+        <div className="flex items-center gap-2">
+          <span>{result.id.slice(0, 8)}</span>
+          {isPDCA ? (
+            <span className="rounded-full bg-cyan-200/15 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-cyan-200">
+              PDCA
+            </span>
+          ) : (
+            <span className="rounded-full bg-white/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-text-secondary">
+              manual
+            </span>
+          )}
+        </div>
+      </td>
+      <td className="px-3 py-2.5 text-white">
+        {result.profileName && result.profileName !== '' ? result.profileName : '—'}
+      </td>
+      <td className="px-3 py-2.5 font-mono text-xs text-text-secondary">
+        {result.pdcaCycleId && result.pdcaCycleId !== '' ? result.pdcaCycleId : '—'}
       </td>
       <td className="px-3 py-2.5 text-white">{config.symbol}</td>
       <td className="px-3 py-2.5 text-text-secondary">
@@ -526,6 +637,24 @@ function ResultRow({ result, selected, onSelect }: ResultRowProps) {
         {formatPercent(summary.maxDrawdown)}
       </td>
       <td className="px-3 py-2.5 text-right text-white">{summary.totalTrades}</td>
+      <td className="px-3 py-2.5 font-mono text-xs">
+        {parentId && parentId !== '' ? (
+          <button
+            type="button"
+            onClick={(event) => {
+              // Prevent the row click (which toggles selectedId) from firing.
+              event.stopPropagation()
+              onNavigateParent(parentId)
+            }}
+            className="text-cyan-200 underline-offset-2 transition hover:underline"
+            aria-label={`親 ${parentId} でフィルタ`}
+          >
+            {parentId.slice(0, 8)}
+          </button>
+        ) : (
+          <span className="text-text-secondary">—</span>
+        )}
+      </td>
       <td className="px-3 py-2.5 text-text-secondary">{created}</td>
     </tr>
   )


### PR DESCRIPTION
## Summary

PDCA 設計書 §5.3 / §5.4 に対応する PR（Task 6 にスタック）。

### Backend
- `GET /backtest/results` にクエリパラメータ `profileName` / `pdcaCycleId` / `parentResultId` / `hasParent` を追加
- 空文字列は「フィルタなし」として扱う（§5.3 準拠）
- `hasParent` は `true`/`false` のみ許容、それ以外 → 400
- `parentResultId` 非空 + `hasParent` 指定時は `parentResultId` を優先し `hasParent` を無視（repository precedence と一致、`slog.Debug` でログ出力）

### Frontend
- `BacktestResult` 型に `profileName` / `pdcaCycleId` / `hypothesis` / `parentResultId` (nullable) を追加
- `useBacktestResults` を filter オブジェクト引数に変更
  - `URLSearchParams` で安全に URL 構築
  - 未定義 / 空文字列はスキップ
  - `hasParent: false` は `undefined` と区別される
  - queryKey に filter を含める（キャッシュ分離 + TanStack Query v5 の hashKey が undefined を正規化）
- 一覧 UI (`routes/backtest.tsx`):
  - 追加カラム: プロファイル / PDCA Cycle / 親
  - ID 列横に `PDCA`/`manual` ピル（`profileName` の有無で区別）
  - 上部にプロファイル `<select>` と「親子関係」`<select>`（すべて / 親あり / ルートのみ）— 値は `const` タプルでタイプセーフにガード
  - 親 ID クリックで `parentResultId` フィルタを適用（フルナビではなく状態更新）、能動的なフィルタ適用状態は dismissible pill で可視化
  - フィルタ適用中で結果 0 件の場合は「フィルタに一致する結果がありません。」を表示

## Test plan

- [x] Backend: `go test ./... -race -count=1` — 全 PASS（ハンドラ 10 ケース追加: 各フィルタ、combined、precedence、invalid hasParent → 400）
- [x] Frontend: `pnpm test` — 27/27 PASS（`useBacktest` 6 ケース追加: default / profileName / hasParent true・false / skip empty / URL encoding）
- [x] `npx tsc --noEmit`: **本 PR で新規 TS エラーはゼロ**（既存 4 件は未修正）

## Stacked PR

チェーン: #96 (Task 1) ← #97 (Task 2) ← #98 (Task 4) ← #99 (Task 3) ← #100 (Task 5) ← #101 (Task 6) ← **本PR** (Task 7)

## Follow-ups (別 PR で対応)

- プロファイル候補を全件取得する専用 API（現状は現ページの結果から distinct 抽出のため、25 件目以降のプロファイルはドロップダウンに出ない UX 課題）
- `hypothesis` の詳細表示（型は追加済み、UI に未露出 — PDCA 詳細パネル実装時に）

🤖 Generated with [Claude Code](https://claude.com/claude-code)