### PR TITLE
feat(strategy): StrategyProfile entity + loader with safe path resolution (PDCA Task 2)

### DIFF
--- a/backend/internal/domain/entity/strategy_config.go
+++ b/backend/internal/domain/entity/strategy_config.go
@@ -99,7 +99,11 @@ type StrategyRiskConfig struct {
 //
 // All violations are collected via errors.Join so the caller sees every
 // problem in one pass.
-func (p *StrategyProfile) Validate() error {
+//
+// Value receiver: Validate() does not mutate the receiver, and a value
+// receiver eliminates the possibility of a nil-pointer panic if a caller
+// ever holds a nil *StrategyProfile.
+func (p StrategyProfile) Validate() error {
 	var errs []error
 
 	if p.Name == "" {
@@ -124,6 +128,9 @@ func (p *StrategyProfile) Validate() error {
 	}
 	if ind.MACDSlow <= 0 {
 		errs = append(errs, fmt.Errorf("indicators.macd_slow must be > 0 (got %d)", ind.MACDSlow))
+	}
+	if ind.MACDFast > 0 && ind.MACDSlow > 0 && ind.MACDFast >= ind.MACDSlow {
+		errs = append(errs, fmt.Errorf("indicators.macd_fast (%d) must be < macd_slow (%d)", ind.MACDFast, ind.MACDSlow))
 	}
 	if ind.MACDSignal <= 0 {
 		errs = append(errs, fmt.Errorf("indicators.macd_signal must be > 0 (got %d)", ind.MACDSignal))

--- a/backend/internal/domain/entity/strategy_config.go
+++ b/backend/internal/domain/entity/strategy_config.go
@@ -1,0 +1,163 @@
+package entity
+
+import (
+	"errors"
+	"fmt"
+)
+
+// StrategyProfile is the declarative configuration file that drives
+// backtest / live strategy parameters. The on-disk JSON shape is documented in
+// docs/superpowers/specs/2026-04-16-pdca-strategy-optimizer-design.md §3.2.
+//
+// Note: the `Risk` struct field is intentionally tagged `strategy_risk`
+// (not `risk`) to match the spec.
+type StrategyProfile struct {
+	Name        string             `json:"name"`
+	Description string             `json:"description"`
+	Indicators  IndicatorConfig    `json:"indicators"`
+	StanceRules StanceRulesConfig  `json:"stance_rules"`
+	SignalRules SignalRulesConfig  `json:"signal_rules"`
+	Risk        StrategyRiskConfig `json:"strategy_risk"`
+	HTFFilter   HTFFilterConfig    `json:"htf_filter"`
+}
+
+// IndicatorConfig declares the lookback periods and shape parameters used when
+// computing technical indicators (SMA / RSI / MACD / BB / ATR).
+type IndicatorConfig struct {
+	SMAShort     int     `json:"sma_short"`
+	SMALong      int     `json:"sma_long"`
+	RSIPeriod    int     `json:"rsi_period"`
+	MACDFast     int     `json:"macd_fast"`
+	MACDSlow     int     `json:"macd_slow"`
+	MACDSignal   int     `json:"macd_signal"`
+	BBPeriod     int     `json:"bb_period"`
+	BBMultiplier float64 `json:"bb_multiplier"`
+	ATRPeriod    int     `json:"atr_period"`
+}
+
+// StanceRulesConfig declares thresholds for rule-based stance classification
+// (TREND_FOLLOW / CONTRARIAN / BREAKOUT / HOLD).
+type StanceRulesConfig struct {
+	RSIOversold             float64 `json:"rsi_oversold"`
+	RSIOverbought           float64 `json:"rsi_overbought"`
+	SMAConvergenceThreshold float64 `json:"sma_convergence_threshold"`
+	BBSqueezeLookback       int     `json:"bb_squeeze_lookback"`
+	BreakoutVolumeRatio     float64 `json:"breakout_volume_ratio"`
+}
+
+// SignalRulesConfig aggregates per-stance entry/exit rule configs.
+type SignalRulesConfig struct {
+	TrendFollow TrendFollowConfig `json:"trend_follow"`
+	Contrarian  ContrarianConfig  `json:"contrarian"`
+	Breakout    BreakoutConfig    `json:"breakout"`
+}
+
+// TrendFollowConfig configures the trend-follow signal generator.
+type TrendFollowConfig struct {
+	Enabled            bool    `json:"enabled"`
+	RequireMACDConfirm bool    `json:"require_macd_confirm"`
+	RequireEMACross    bool    `json:"require_ema_cross"`
+	RSIBuyMax          float64 `json:"rsi_buy_max"`
+	RSISellMin         float64 `json:"rsi_sell_min"`
+}
+
+// ContrarianConfig configures the contrarian signal generator.
+type ContrarianConfig struct {
+	Enabled            bool    `json:"enabled"`
+	RSIEntry           float64 `json:"rsi_entry"`
+	RSIExit            float64 `json:"rsi_exit"`
+	MACDHistogramLimit float64 `json:"macd_histogram_limit"`
+}
+
+// BreakoutConfig configures the breakout signal generator.
+type BreakoutConfig struct {
+	Enabled            bool    `json:"enabled"`
+	VolumeRatioMin     float64 `json:"volume_ratio_min"`
+	RequireMACDConfirm bool    `json:"require_macd_confirm"`
+}
+
+// HTFFilterConfig configures the higher-timeframe trend filter.
+type HTFFilterConfig struct {
+	Enabled           bool    `json:"enabled"`
+	BlockCounterTrend bool    `json:"block_counter_trend"`
+	AlignmentBoost    float64 `json:"alignment_boost"`
+}
+
+// StrategyRiskConfig configures the per-strategy risk envelope (position
+// sizing, stop-loss, take-profit, daily loss cap).
+type StrategyRiskConfig struct {
+	StopLossPercent       float64 `json:"stop_loss_percent"`
+	TakeProfitPercent     float64 `json:"take_profit_percent"`
+	StopLossATRMultiplier float64 `json:"stop_loss_atr_multiplier"`
+	MaxPositionAmount     float64 `json:"max_position_amount"`
+	MaxDailyLoss          float64 `json:"max_daily_loss"`
+}
+
+// Validate reports structural problems in the profile. The goal is to reject
+// garbage (missing name, negative periods, inverted RSI bounds), not to
+// enforce a business policy.
+//
+// All violations are collected via errors.Join so the caller sees every
+// problem in one pass.
+func (p *StrategyProfile) Validate() error {
+	var errs []error
+
+	if p.Name == "" {
+		errs = append(errs, errors.New("name must not be empty"))
+	}
+
+	ind := p.Indicators
+	if ind.SMAShort <= 0 {
+		errs = append(errs, fmt.Errorf("indicators.sma_short must be > 0 (got %d)", ind.SMAShort))
+	}
+	if ind.SMALong <= 0 {
+		errs = append(errs, fmt.Errorf("indicators.sma_long must be > 0 (got %d)", ind.SMALong))
+	}
+	if ind.SMAShort > 0 && ind.SMALong > 0 && ind.SMAShort >= ind.SMALong {
+		errs = append(errs, fmt.Errorf("indicators.sma_short (%d) must be < sma_long (%d)", ind.SMAShort, ind.SMALong))
+	}
+	if ind.RSIPeriod <= 0 {
+		errs = append(errs, fmt.Errorf("indicators.rsi_period must be > 0 (got %d)", ind.RSIPeriod))
+	}
+	if ind.MACDFast <= 0 {
+		errs = append(errs, fmt.Errorf("indicators.macd_fast must be > 0 (got %d)", ind.MACDFast))
+	}
+	if ind.MACDSlow <= 0 {
+		errs = append(errs, fmt.Errorf("indicators.macd_slow must be > 0 (got %d)", ind.MACDSlow))
+	}
+	if ind.MACDSignal <= 0 {
+		errs = append(errs, fmt.Errorf("indicators.macd_signal must be > 0 (got %d)", ind.MACDSignal))
+	}
+	if ind.BBPeriod <= 0 {
+		errs = append(errs, fmt.Errorf("indicators.bb_period must be > 0 (got %d)", ind.BBPeriod))
+	}
+	if ind.ATRPeriod <= 0 {
+		errs = append(errs, fmt.Errorf("indicators.atr_period must be > 0 (got %d)", ind.ATRPeriod))
+	}
+	if ind.BBMultiplier <= 0 {
+		errs = append(errs, fmt.Errorf("indicators.bb_multiplier must be > 0 (got %v)", ind.BBMultiplier))
+	}
+
+	sr := p.StanceRules
+	if sr.RSIOversold <= 0 || sr.RSIOversold >= 100 {
+		errs = append(errs, fmt.Errorf("stance_rules.rsi_oversold must be in (0, 100) (got %v)", sr.RSIOversold))
+	}
+	if sr.RSIOverbought <= 0 || sr.RSIOverbought >= 100 {
+		errs = append(errs, fmt.Errorf("stance_rules.rsi_overbought must be in (0, 100) (got %v)", sr.RSIOverbought))
+	}
+	if sr.RSIOversold > 0 && sr.RSIOverbought > 0 && sr.RSIOversold >= sr.RSIOverbought {
+		errs = append(errs, fmt.Errorf("stance_rules.rsi_oversold (%v) must be < rsi_overbought (%v)", sr.RSIOversold, sr.RSIOverbought))
+	}
+
+	if p.Risk.StopLossPercent < 0 {
+		errs = append(errs, fmt.Errorf("strategy_risk.stop_loss_percent must be >= 0 (got %v)", p.Risk.StopLossPercent))
+	}
+	if p.Risk.TakeProfitPercent < 0 {
+		errs = append(errs, fmt.Errorf("strategy_risk.take_profit_percent must be >= 0 (got %v)", p.Risk.TakeProfitPercent))
+	}
+
+	if len(errs) == 0 {
+		return nil
+	}
+	return fmt.Errorf("invalid strategy profile: %w", errors.Join(errs...))
+}

--- a/backend/internal/domain/entity/strategy_config_test.go
+++ b/backend/internal/domain/entity/strategy_config_test.go
@@ -116,6 +116,14 @@ func TestStrategyProfile_Validate(t *testing.T) {
 			wantErr: "macd_slow",
 		},
 		{
+			name: "macd_fast >= macd_slow",
+			mutate: func(p *StrategyProfile) {
+				p.Indicators.MACDFast = 26
+				p.Indicators.MACDSlow = 26
+			},
+			wantErr: "must be < macd_slow",
+		},
+		{
 			name:    "macd_signal zero",
 			mutate:  func(p *StrategyProfile) { p.Indicators.MACDSignal = 0 },
 			wantErr: "macd_signal",
@@ -171,7 +179,6 @@ func TestStrategyProfile_Validate(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			p := validProfile()

--- a/backend/internal/domain/entity/strategy_config_test.go
+++ b/backend/internal/domain/entity/strategy_config_test.go
@@ -1,0 +1,287 @@
+package entity
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// validProfile returns a profile that passes Validate(). Individual test
+// cases mutate it to exercise failure branches.
+func validProfile() StrategyProfile {
+	return StrategyProfile{
+		Name:        "ltc_aggressive_v3",
+		Description: "LTC向け攻めの短期戦略",
+		Indicators: IndicatorConfig{
+			SMAShort:     10,
+			SMALong:      30,
+			RSIPeriod:    14,
+			MACDFast:     12,
+			MACDSlow:     26,
+			MACDSignal:   9,
+			BBPeriod:     20,
+			BBMultiplier: 2.0,
+			ATRPeriod:    14,
+		},
+		StanceRules: StanceRulesConfig{
+			RSIOversold:             20,
+			RSIOverbought:           80,
+			SMAConvergenceThreshold: 0.001,
+			BBSqueezeLookback:       5,
+			BreakoutVolumeRatio:     1.5,
+		},
+		SignalRules: SignalRulesConfig{
+			TrendFollow: TrendFollowConfig{
+				Enabled:            true,
+				RequireMACDConfirm: true,
+				RequireEMACross:    true,
+				RSIBuyMax:          70,
+				RSISellMin:         30,
+			},
+			Contrarian: ContrarianConfig{
+				Enabled:            true,
+				RSIEntry:           30,
+				RSIExit:            70,
+				MACDHistogramLimit: 10,
+			},
+			Breakout: BreakoutConfig{
+				Enabled:            true,
+				VolumeRatioMin:     1.5,
+				RequireMACDConfirm: true,
+			},
+		},
+		Risk: StrategyRiskConfig{
+			StopLossPercent:       5,
+			TakeProfitPercent:     10,
+			StopLossATRMultiplier: 0,
+			MaxPositionAmount:     100000,
+			MaxDailyLoss:          50000,
+		},
+		HTFFilter: HTFFilterConfig{
+			Enabled:           true,
+			BlockCounterTrend: true,
+			AlignmentBoost:    0.1,
+		},
+	}
+}
+
+func TestStrategyProfile_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*StrategyProfile)
+		wantErr string // substring expected in the joined error; empty means expect nil
+	}{
+		{
+			name:    "happy path",
+			mutate:  func(p *StrategyProfile) {},
+			wantErr: "",
+		},
+		{
+			name:    "empty name",
+			mutate:  func(p *StrategyProfile) { p.Name = "" },
+			wantErr: "name must not be empty",
+		},
+		{
+			name:    "sma_short zero",
+			mutate:  func(p *StrategyProfile) { p.Indicators.SMAShort = 0 },
+			wantErr: "sma_short",
+		},
+		{
+			name:    "sma_long zero",
+			mutate:  func(p *StrategyProfile) { p.Indicators.SMALong = 0 },
+			wantErr: "sma_long",
+		},
+		{
+			name: "sma_short >= sma_long",
+			mutate: func(p *StrategyProfile) {
+				p.Indicators.SMAShort = 30
+				p.Indicators.SMALong = 30
+			},
+			wantErr: "must be < sma_long",
+		},
+		{
+			name:    "rsi_period zero",
+			mutate:  func(p *StrategyProfile) { p.Indicators.RSIPeriod = 0 },
+			wantErr: "rsi_period",
+		},
+		{
+			name:    "macd_fast zero",
+			mutate:  func(p *StrategyProfile) { p.Indicators.MACDFast = 0 },
+			wantErr: "macd_fast",
+		},
+		{
+			name:    "macd_slow zero",
+			mutate:  func(p *StrategyProfile) { p.Indicators.MACDSlow = 0 },
+			wantErr: "macd_slow",
+		},
+		{
+			name:    "macd_signal zero",
+			mutate:  func(p *StrategyProfile) { p.Indicators.MACDSignal = 0 },
+			wantErr: "macd_signal",
+		},
+		{
+			name:    "bb_period zero",
+			mutate:  func(p *StrategyProfile) { p.Indicators.BBPeriod = 0 },
+			wantErr: "bb_period",
+		},
+		{
+			name:    "atr_period negative",
+			mutate:  func(p *StrategyProfile) { p.Indicators.ATRPeriod = -1 },
+			wantErr: "atr_period",
+		},
+		{
+			name:    "bb_multiplier zero",
+			mutate:  func(p *StrategyProfile) { p.Indicators.BBMultiplier = 0 },
+			wantErr: "bb_multiplier",
+		},
+		{
+			name:    "rsi_oversold out of range low",
+			mutate:  func(p *StrategyProfile) { p.StanceRules.RSIOversold = 0 },
+			wantErr: "rsi_oversold",
+		},
+		{
+			name:    "rsi_oversold out of range high",
+			mutate:  func(p *StrategyProfile) { p.StanceRules.RSIOversold = 100 },
+			wantErr: "rsi_oversold",
+		},
+		{
+			name:    "rsi_overbought out of range",
+			mutate:  func(p *StrategyProfile) { p.StanceRules.RSIOverbought = 150 },
+			wantErr: "rsi_overbought",
+		},
+		{
+			name: "rsi_oversold >= rsi_overbought",
+			mutate: func(p *StrategyProfile) {
+				p.StanceRules.RSIOversold = 80
+				p.StanceRules.RSIOverbought = 20
+			},
+			wantErr: "must be < rsi_overbought",
+		},
+		{
+			name:    "stop_loss_percent negative",
+			mutate:  func(p *StrategyProfile) { p.Risk.StopLossPercent = -1 },
+			wantErr: "stop_loss_percent",
+		},
+		{
+			name:    "take_profit_percent negative",
+			mutate:  func(p *StrategyProfile) { p.Risk.TakeProfitPercent = -1 },
+			wantErr: "take_profit_percent",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			p := validProfile()
+			tc.mutate(&p)
+			err := p.Validate()
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("expected no error, got: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("expected error containing %q, got: %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+// TestStrategyProfile_JSONRoundTrip confirms JSON tag correctness by
+// marshaling the spec §3.2 example, comparing against the spec-literal JSON,
+// then unmarshaling and checking the struct round-trips. The fixture is
+// inlined so we don't depend on any on-disk file.
+func TestStrategyProfile_JSONRoundTrip(t *testing.T) {
+	// This is the spec §3.2 example verbatim.
+	const specJSON = `{
+  "name": "ltc_aggressive_v3",
+  "description": "LTC向け攻めの短期戦略",
+  "indicators": {
+    "sma_short": 10,
+    "sma_long": 30,
+    "rsi_period": 14,
+    "macd_fast": 12,
+    "macd_slow": 26,
+    "macd_signal": 9,
+    "bb_period": 20,
+    "bb_multiplier": 2.0,
+    "atr_period": 14
+  },
+  "stance_rules": {
+    "rsi_oversold": 20,
+    "rsi_overbought": 80,
+    "sma_convergence_threshold": 0.001,
+    "bb_squeeze_lookback": 5,
+    "breakout_volume_ratio": 1.5
+  },
+  "signal_rules": {
+    "trend_follow": {
+      "enabled": true,
+      "require_macd_confirm": true,
+      "require_ema_cross": true,
+      "rsi_buy_max": 70,
+      "rsi_sell_min": 30
+    },
+    "contrarian": {
+      "enabled": true,
+      "rsi_entry": 30,
+      "rsi_exit": 70,
+      "macd_histogram_limit": 10
+    },
+    "breakout": {
+      "enabled": true,
+      "volume_ratio_min": 1.5,
+      "require_macd_confirm": true
+    }
+  },
+  "strategy_risk": {
+    "stop_loss_percent": 5,
+    "take_profit_percent": 10,
+    "stop_loss_atr_multiplier": 0,
+    "max_position_amount": 100000,
+    "max_daily_loss": 50000
+  },
+  "htf_filter": {
+    "enabled": true,
+    "block_counter_trend": true,
+    "alignment_boost": 0.1
+  }
+}`
+
+	var decoded StrategyProfile
+	if err := json.Unmarshal([]byte(specJSON), &decoded); err != nil {
+		t.Fatalf("unmarshal spec json: %v", err)
+	}
+	if err := decoded.Validate(); err != nil {
+		t.Fatalf("decoded spec profile failed Validate: %v", err)
+	}
+
+	want := validProfile()
+	if !reflect.DeepEqual(decoded, want) {
+		t.Fatalf("decoded profile does not match expected struct\n got: %#v\nwant: %#v", decoded, want)
+	}
+
+	// Marshal the struct, then decode both sides into map[string]any and
+	// compare — avoids whitespace / key-order sensitivity while still
+	// proving all JSON tags are correct.
+	re, err := json.Marshal(want)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var gotMap, wantMap map[string]any
+	if err := json.Unmarshal(re, &gotMap); err != nil {
+		t.Fatalf("unmarshal re-encoded json: %v", err)
+	}
+	if err := json.Unmarshal([]byte(specJSON), &wantMap); err != nil {
+		t.Fatalf("unmarshal spec json as map: %v", err)
+	}
+	if !reflect.DeepEqual(gotMap, wantMap) {
+		t.Fatalf("JSON round-trip differs.\n got: %v\nwant: %v", gotMap, wantMap)
+	}
+}

--- a/backend/internal/infrastructure/strategyprofile/loader.go
+++ b/backend/internal/infrastructure/strategyprofile/loader.go
@@ -57,6 +57,8 @@ func ParseProfile(r io.Reader) (*entity.StrategyProfile, error) {
 	if err := dec.Decode(&profile); err != nil {
 		return nil, fmt.Errorf("decode: %w", err)
 	}
+	// Call Validate on the value (Validate has a value receiver, so this
+	// avoids any nil-pointer question entirely).
 	if err := profile.Validate(); err != nil {
 		return nil, fmt.Errorf("validate: %w", err)
 	}

--- a/backend/internal/infrastructure/strategyprofile/loader.go
+++ b/backend/internal/infrastructure/strategyprofile/loader.go
@@ -1,0 +1,64 @@
+package strategyprofile
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+)
+
+// Loader reads StrategyProfile JSON files from a configurable base directory.
+// In production, baseDir is typically "profiles"; tests pass t.TempDir().
+type Loader struct {
+	baseDir string
+}
+
+// NewLoader returns a Loader rooted at baseDir.
+func NewLoader(baseDir string) *Loader {
+	return &Loader{baseDir: baseDir}
+}
+
+// Load resolves `<baseDir>/<name>.json`, decodes it, and validates the
+// resulting StrategyProfile. Unknown JSON fields cause a decode error so
+// typos in the on-disk config are surfaced at load time rather than silently
+// ignored.
+//
+// Note: the profile's `name` field is NOT required to equal the on-disk
+// filename — callers may have reasons to diverge (e.g. snapshotting). See
+// the loader test for the specific scenario.
+func (l *Loader) Load(name string) (*entity.StrategyProfile, error) {
+	path, err := ResolveProfilePath(l.baseDir, name)
+	if err != nil {
+		return nil, fmt.Errorf("strategyprofile: load %q: %w", name, err)
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("strategyprofile: load %q: %w", name, err)
+	}
+	defer f.Close()
+
+	profile, err := ParseProfile(f)
+	if err != nil {
+		return nil, fmt.Errorf("strategyprofile: load %q: %w", name, err)
+	}
+	return profile, nil
+}
+
+// ParseProfile decodes a StrategyProfile from r and validates it. It is
+// exported so tests (and future callers) can drive decoding without disk I/O.
+// Unknown fields are rejected via json.Decoder.DisallowUnknownFields.
+func ParseProfile(r io.Reader) (*entity.StrategyProfile, error) {
+	dec := json.NewDecoder(r)
+	dec.DisallowUnknownFields()
+
+	var profile entity.StrategyProfile
+	if err := dec.Decode(&profile); err != nil {
+		return nil, fmt.Errorf("decode: %w", err)
+	}
+	if err := profile.Validate(); err != nil {
+		return nil, fmt.Errorf("validate: %w", err)
+	}
+	return &profile, nil
+}

--- a/backend/internal/infrastructure/strategyprofile/loader_test.go
+++ b/backend/internal/infrastructure/strategyprofile/loader_test.go
@@ -1,0 +1,220 @@
+package strategyprofile
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// validProfileJSON is the spec §3.2 fixture, inlined to avoid disk deps.
+const validProfileJSON = `{
+  "name": "ltc_aggressive_v3",
+  "description": "LTC向け攻めの短期戦略",
+  "indicators": {
+    "sma_short": 10,
+    "sma_long": 30,
+    "rsi_period": 14,
+    "macd_fast": 12,
+    "macd_slow": 26,
+    "macd_signal": 9,
+    "bb_period": 20,
+    "bb_multiplier": 2.0,
+    "atr_period": 14
+  },
+  "stance_rules": {
+    "rsi_oversold": 20,
+    "rsi_overbought": 80,
+    "sma_convergence_threshold": 0.001,
+    "bb_squeeze_lookback": 5,
+    "breakout_volume_ratio": 1.5
+  },
+  "signal_rules": {
+    "trend_follow": {
+      "enabled": true,
+      "require_macd_confirm": true,
+      "require_ema_cross": true,
+      "rsi_buy_max": 70,
+      "rsi_sell_min": 30
+    },
+    "contrarian": {
+      "enabled": true,
+      "rsi_entry": 30,
+      "rsi_exit": 70,
+      "macd_histogram_limit": 10
+    },
+    "breakout": {
+      "enabled": true,
+      "volume_ratio_min": 1.5,
+      "require_macd_confirm": true
+    }
+  },
+  "strategy_risk": {
+    "stop_loss_percent": 5,
+    "take_profit_percent": 10,
+    "stop_loss_atr_multiplier": 0,
+    "max_position_amount": 100000,
+    "max_daily_loss": 50000
+  },
+  "htf_filter": {
+    "enabled": true,
+    "block_counter_trend": true,
+    "alignment_boost": 0.1
+  }
+}`
+
+// writeProfile writes the given JSON content to <baseDir>/<name>.json and
+// returns the full path.
+func writeProfile(t *testing.T, baseDir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(baseDir, name+".json")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write profile: %v", err)
+	}
+	return path
+}
+
+func TestLoader_Load_Valid(t *testing.T) {
+	tmp := t.TempDir()
+	writeProfile(t, tmp, "production", validProfileJSON)
+
+	loader := NewLoader(tmp)
+	profile, err := loader.Load("production")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if profile.Name != "ltc_aggressive_v3" {
+		t.Errorf("profile.Name = %q, want %q", profile.Name, "ltc_aggressive_v3")
+	}
+	if profile.Indicators.SMAShort != 10 || profile.Indicators.SMALong != 30 {
+		t.Errorf("SMA short/long = %d/%d, want 10/30", profile.Indicators.SMAShort, profile.Indicators.SMALong)
+	}
+	if profile.Risk.MaxPositionAmount != 100000 {
+		t.Errorf("Risk.MaxPositionAmount = %v, want 100000", profile.Risk.MaxPositionAmount)
+	}
+	if !profile.HTFFilter.BlockCounterTrend {
+		t.Errorf("HTFFilter.BlockCounterTrend = false, want true")
+	}
+	if !profile.SignalRules.TrendFollow.RequireEMACross {
+		t.Errorf("SignalRules.TrendFollow.RequireEMACross = false, want true")
+	}
+}
+
+// TestLoader_Load_NameMismatch documents the (intentional) behaviour that
+// the on-disk filename and the in-JSON `name` field may differ. Callers
+// decide how to interpret the mismatch — the loader does not enforce it.
+func TestLoader_Load_NameMismatch(t *testing.T) {
+	tmp := t.TempDir()
+	// File is called "snapshot.json" but internal name is "ltc_aggressive_v3".
+	writeProfile(t, tmp, "snapshot", validProfileJSON)
+
+	loader := NewLoader(tmp)
+	profile, err := loader.Load("snapshot")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if profile.Name != "ltc_aggressive_v3" {
+		t.Errorf("profile.Name = %q, want %q", profile.Name, "ltc_aggressive_v3")
+	}
+}
+
+func TestLoader_Load_InvalidJSON(t *testing.T) {
+	tmp := t.TempDir()
+	writeProfile(t, tmp, "bad", `{"name": "oops" `) // unclosed brace
+
+	loader := NewLoader(tmp)
+	_, err := loader.Load("bad")
+	if err == nil {
+		t.Fatal("expected error for invalid JSON, got nil")
+	}
+	if !strings.Contains(err.Error(), "bad") {
+		t.Errorf("expected error to mention profile name, got %v", err)
+	}
+}
+
+func TestLoader_Load_UnknownField(t *testing.T) {
+	tmp := t.TempDir()
+	// Add a spurious top-level key.
+	badJSON := strings.Replace(
+		validProfileJSON,
+		`"name": "ltc_aggressive_v3",`,
+		`"name": "ltc_aggressive_v3", "surprise": 123,`,
+		1,
+	)
+	writeProfile(t, tmp, "typo", badJSON)
+
+	loader := NewLoader(tmp)
+	_, err := loader.Load("typo")
+	if err == nil {
+		t.Fatal("expected error for unknown field, got nil")
+	}
+	if !strings.Contains(err.Error(), "surprise") {
+		t.Errorf("expected error to mention unknown field 'surprise', got %v", err)
+	}
+}
+
+func TestLoader_Load_FileMissing(t *testing.T) {
+	tmp := t.TempDir()
+	loader := NewLoader(tmp)
+	_, err := loader.Load("nonexistent")
+	if err == nil {
+		t.Fatal("expected error for missing file, got nil")
+	}
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("expected errors.Is fs.ErrNotExist, got %v", err)
+	}
+}
+
+func TestLoader_Load_ValidationFailure(t *testing.T) {
+	tmp := t.TempDir()
+	// Set atr_period to a negative value — trips Validate() but decodes fine.
+	badJSON := strings.Replace(
+		validProfileJSON,
+		`"atr_period": 14`,
+		`"atr_period": -1`,
+		1,
+	)
+	writeProfile(t, tmp, "badparams", badJSON)
+
+	loader := NewLoader(tmp)
+	_, err := loader.Load("badparams")
+	if err == nil {
+		t.Fatal("expected validation error, got nil")
+	}
+	if !strings.Contains(err.Error(), "atr_period") {
+		t.Errorf("expected validation error to mention atr_period, got %v", err)
+	}
+}
+
+func TestLoader_Load_InvalidName(t *testing.T) {
+	tmp := t.TempDir()
+	loader := NewLoader(tmp)
+	_, err := loader.Load("../etc/passwd")
+	if err == nil {
+		t.Fatal("expected error for invalid name, got nil")
+	}
+	if !errors.Is(err, ErrInvalidProfileName) {
+		t.Errorf("expected errors.Is ErrInvalidProfileName, got %v", err)
+	}
+}
+
+func TestParseProfile_Valid(t *testing.T) {
+	profile, err := ParseProfile(strings.NewReader(validProfileJSON))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if profile.Name != "ltc_aggressive_v3" {
+		t.Errorf("profile.Name = %q, want %q", profile.Name, "ltc_aggressive_v3")
+	}
+}
+
+func TestParseProfile_UnknownField(t *testing.T) {
+	bad := `{"name": "x", "mystery": 1}`
+	_, err := ParseProfile(strings.NewReader(bad))
+	if err == nil {
+		t.Fatal("expected error for unknown field, got nil")
+	}
+}

--- a/backend/internal/infrastructure/strategyprofile/path.go
+++ b/backend/internal/infrastructure/strategyprofile/path.go
@@ -21,22 +21,27 @@ var profileNamePattern = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
 // that fails the allow-list check.
 var ErrInvalidProfileName = errors.New("invalid profile name")
 
-// ErrPathEscape is returned when the resolved path, after cleaning, lies
-// outside baseDir. This should not happen given the regex check, but is kept
-// as a defence-in-depth guard.
+// ErrPathEscape is a defence-in-depth sentinel retained for future changes;
+// the regex above (profileNamePattern) currently makes it unreachable in
+// practice because every name that could cause the cleaned path to escape
+// baseDir would be rejected earlier as ErrInvalidProfileName. It is kept
+// (and returned) so that if the regex is ever relaxed, callers still have
+// a stable error type to match against.
 var ErrPathEscape = errors.New("resolved path escapes base directory")
 
-// ResolveProfilePath returns the cleaned relative path to
+// ResolveProfilePath returns the cleaned *absolute* path to
 // `<baseDir>/<name>.json`, or an error if `name` is unsafe.
 //
 // Contract:
 //   - `name` must be non-empty and match ^[a-zA-Z0-9_-]+$.
-//   - The returned path is the result of filepath.Clean(filepath.Join(baseDir, name+".json"))
-//     — it is intentionally *relative* (not absolute) so logs and test
-//     expectations remain portable. The caller may pass the result straight
-//     to os.Open.
-//   - The cleaned path is double-checked against the absolute baseDir to
-//     guarantee it has not escaped (defence in depth).
+//   - The returned path is absolute (filepath.Abs of
+//     filepath.Clean(filepath.Join(baseDir, name+".json"))). Returning an
+//     absolute path eliminates a TOCTOU class of bug where a caller
+//     changes the process working directory between ResolveProfilePath
+//     and os.Open, causing the "relative" path to resolve to a different
+//     file than intended.
+//   - The absolute path is also checked against the absolute baseDir as a
+//     defence-in-depth guard against directory escape (see ErrPathEscape).
 func ResolveProfilePath(baseDir, name string) (string, error) {
 	if name == "" {
 		return "", fmt.Errorf("%w: name must not be empty", ErrInvalidProfileName)
@@ -66,5 +71,5 @@ func ResolveProfilePath(baseDir, name string) (string, error) {
 		return "", fmt.Errorf("%w: %q", ErrPathEscape, cleaned)
 	}
 
-	return cleaned, nil
+	return absCleaned, nil
 }

--- a/backend/internal/infrastructure/strategyprofile/path.go
+++ b/backend/internal/infrastructure/strategyprofile/path.go
@@ -1,0 +1,70 @@
+// Package strategyprofile loads StrategyProfile JSON files from a configurable
+// base directory (typically "profiles/"). It provides safe path resolution
+// that refuses traversal attempts before touching the filesystem.
+package strategyprofile
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// profileNamePattern is the allow-list for profile names. Only ASCII letters,
+// digits, underscore and hyphen are permitted — no dots, no slashes, no
+// whitespace. This is deliberately strict so callers cannot smuggle in
+// path-traversal fragments like ".." or absolute paths like "/etc/passwd".
+var profileNamePattern = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+
+// ErrInvalidProfileName is returned when the caller supplies a profile name
+// that fails the allow-list check.
+var ErrInvalidProfileName = errors.New("invalid profile name")
+
+// ErrPathEscape is returned when the resolved path, after cleaning, lies
+// outside baseDir. This should not happen given the regex check, but is kept
+// as a defence-in-depth guard.
+var ErrPathEscape = errors.New("resolved path escapes base directory")
+
+// ResolveProfilePath returns the cleaned relative path to
+// `<baseDir>/<name>.json`, or an error if `name` is unsafe.
+//
+// Contract:
+//   - `name` must be non-empty and match ^[a-zA-Z0-9_-]+$.
+//   - The returned path is the result of filepath.Clean(filepath.Join(baseDir, name+".json"))
+//     — it is intentionally *relative* (not absolute) so logs and test
+//     expectations remain portable. The caller may pass the result straight
+//     to os.Open.
+//   - The cleaned path is double-checked against the absolute baseDir to
+//     guarantee it has not escaped (defence in depth).
+func ResolveProfilePath(baseDir, name string) (string, error) {
+	if name == "" {
+		return "", fmt.Errorf("%w: name must not be empty", ErrInvalidProfileName)
+	}
+	if !profileNamePattern.MatchString(name) {
+		return "", fmt.Errorf("%w: %q (only a-zA-Z0-9_- allowed)", ErrInvalidProfileName, name)
+	}
+
+	joined := filepath.Join(baseDir, name+".json")
+	cleaned := filepath.Clean(joined)
+
+	// Defence in depth: even though the regex rejects traversal fragments,
+	// verify the cleaned absolute path is still rooted at baseDir.
+	absBase, err := filepath.Abs(baseDir)
+	if err != nil {
+		return "", fmt.Errorf("resolve base dir: %w", err)
+	}
+	absCleaned, err := filepath.Abs(cleaned)
+	if err != nil {
+		return "", fmt.Errorf("resolve profile path: %w", err)
+	}
+	absBase = filepath.Clean(absBase)
+	// Use absBase + separator so that "/etc/passwordless" is not accepted as
+	// inside "/etc/pass". The cleaned path is an exact match only if it
+	// equals absBase (unlikely for a file) or starts with absBase + sep.
+	if absCleaned != absBase && !strings.HasPrefix(absCleaned, absBase+string(filepath.Separator)) {
+		return "", fmt.Errorf("%w: %q", ErrPathEscape, cleaned)
+	}
+
+	return cleaned, nil
+}

--- a/backend/internal/infrastructure/strategyprofile/path_test.go
+++ b/backend/internal/infrastructure/strategyprofile/path_test.go
@@ -9,30 +9,41 @@ import (
 
 func TestResolveProfilePath(t *testing.T) {
 	// A fixed baseDir is fine for these tests — nothing touches the
-	// filesystem, we only check path math.
+	// filesystem, we only check path math. The expected paths are computed
+	// via filepath.Abs because ResolveProfilePath now returns absolute paths
+	// to avoid a CWD-change TOCTOU class of bug.
 	const baseDir = "profiles"
+
+	mustAbs := func(t *testing.T, p string) string {
+		t.Helper()
+		abs, err := filepath.Abs(p)
+		if err != nil {
+			t.Fatalf("filepath.Abs(%q): %v", p, err)
+		}
+		return abs
+	}
 
 	tests := []struct {
 		name       string
 		profile    string
-		wantPath   string // expected cleaned relative path; "" when an error is expected
+		wantPath   string // expected absolute cleaned path; "" when an error is expected
 		wantErr    error  // expected sentinel via errors.Is; nil when no error expected
 		wantErrSub string // substring check when wantErr is nil but an error is expected
 	}{
 		{
 			name:     "valid simple name",
 			profile:  "production",
-			wantPath: filepath.Join("profiles", "production.json"),
+			wantPath: mustAbs(t, filepath.Join("profiles", "production.json")),
 		},
 		{
 			name:     "valid with hyphen and underscore",
 			profile:  "experiment_2026-04-16_01",
-			wantPath: filepath.Join("profiles", "experiment_2026-04-16_01.json"),
+			wantPath: mustAbs(t, filepath.Join("profiles", "experiment_2026-04-16_01.json")),
 		},
 		{
 			name:     "valid alphanumeric mix",
 			profile:  "ltc_aggressive_v3",
-			wantPath: filepath.Join("profiles", "ltc_aggressive_v3.json"),
+			wantPath: mustAbs(t, filepath.Join("profiles", "ltc_aggressive_v3.json")),
 		},
 		{
 			name:    "empty name rejected",
@@ -82,7 +93,6 @@ func TestResolveProfilePath(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			got, err := ResolveProfilePath(baseDir, tc.profile)

--- a/backend/internal/infrastructure/strategyprofile/path_test.go
+++ b/backend/internal/infrastructure/strategyprofile/path_test.go
@@ -1,0 +1,147 @@
+package strategyprofile
+
+import (
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveProfilePath(t *testing.T) {
+	// A fixed baseDir is fine for these tests — nothing touches the
+	// filesystem, we only check path math.
+	const baseDir = "profiles"
+
+	tests := []struct {
+		name       string
+		profile    string
+		wantPath   string // expected cleaned relative path; "" when an error is expected
+		wantErr    error  // expected sentinel via errors.Is; nil when no error expected
+		wantErrSub string // substring check when wantErr is nil but an error is expected
+	}{
+		{
+			name:     "valid simple name",
+			profile:  "production",
+			wantPath: filepath.Join("profiles", "production.json"),
+		},
+		{
+			name:     "valid with hyphen and underscore",
+			profile:  "experiment_2026-04-16_01",
+			wantPath: filepath.Join("profiles", "experiment_2026-04-16_01.json"),
+		},
+		{
+			name:     "valid alphanumeric mix",
+			profile:  "ltc_aggressive_v3",
+			wantPath: filepath.Join("profiles", "ltc_aggressive_v3.json"),
+		},
+		{
+			name:    "empty name rejected",
+			profile: "",
+			wantErr: ErrInvalidProfileName,
+		},
+		{
+			name:    "dotdot rejected by regex",
+			profile: "..",
+			wantErr: ErrInvalidProfileName,
+		},
+		{
+			name:    "absolute path rejected by regex",
+			profile: "/etc/passwd",
+			wantErr: ErrInvalidProfileName,
+		},
+		{
+			name:    "slash rejected by regex",
+			profile: "a/b",
+			wantErr: ErrInvalidProfileName,
+		},
+		{
+			name:    "backslash rejected by regex",
+			profile: `a\b`,
+			wantErr: ErrInvalidProfileName,
+		},
+		{
+			name:    "trailing space rejected",
+			profile: "production ",
+			wantErr: ErrInvalidProfileName,
+		},
+		{
+			name:    "leading space rejected",
+			profile: " production",
+			wantErr: ErrInvalidProfileName,
+		},
+		{
+			name:    "dot in name rejected",
+			profile: "foo.bar",
+			wantErr: ErrInvalidProfileName,
+		},
+		{
+			name:    "parent traversal embedded rejected",
+			profile: "../../etc/passwd",
+			wantErr: ErrInvalidProfileName,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := ResolveProfilePath(baseDir, tc.profile)
+			if tc.wantErr != nil {
+				if !errors.Is(err, tc.wantErr) {
+					t.Fatalf("expected errors.Is %v, got %v", tc.wantErr, err)
+				}
+				if got != "" {
+					t.Fatalf("expected empty path on error, got %q", got)
+				}
+				return
+			}
+			if tc.wantErrSub != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.wantErrSub)
+				}
+				if !strings.Contains(err.Error(), tc.wantErrSub) {
+					t.Fatalf("expected error substring %q, got %v", tc.wantErrSub, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.wantPath {
+				t.Fatalf("path = %q, want %q", got, tc.wantPath)
+			}
+		})
+	}
+}
+
+// TestResolveProfilePath_CrossPlatformSeparator ensures the joined path uses
+// the platform's native separator (i.e. filepath.Join is doing the work, not
+// a hard-coded "/"). This is defensive — if someone refactors ResolveProfilePath
+// to use path.Join or a literal separator, the test catches it on Windows.
+func TestResolveProfilePath_CrossPlatformSeparator(t *testing.T) {
+	t.Parallel()
+	got, err := ResolveProfilePath("profiles", "production")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	wantSep := string(filepath.Separator)
+	if !strings.Contains(got, wantSep) {
+		t.Fatalf("expected path to contain platform separator %q, got %q", wantSep, got)
+	}
+}
+
+// TestResolveProfilePath_AbsoluteBaseDir exercises the absolute-baseDir
+// branch (the defence-in-depth check). A valid profile name under an
+// absolute baseDir should still resolve cleanly.
+func TestResolveProfilePath_AbsoluteBaseDir(t *testing.T) {
+	t.Parallel()
+	baseDir := t.TempDir()
+	got, err := ResolveProfilePath(baseDir, "production")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := filepath.Join(baseDir, "production.json")
+	if got != want {
+		t.Fatalf("path = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
Replaces #97 (auto-closed when #96 was merged with branch deletion).

## Summary

PDCA 設計書 §3 / §8.3 に対応。

- `entity.StrategyProfile` 及びネスト設定群を追加（JSON タグは §3.2/§3.3 完全一致）
- `Validate()` でスキーマ健全性検証（`errors.Join`、値レシーバで nil-safe、MACD fast<slow 等）
- `infrastructure/strategyprofile`:
  - `ResolveProfilePath(baseDir, name)` — regex allow-list + defence-in-depth prefix check、CWD 変化 TOCTOU 回避のため絶対パスを返す
  - `Loader.Load(name)` + `ParseProfile(io.Reader)` — `DisallowUnknownFields` でタイポ検出

## Test plan

- [x] `go test ./... -race -count=1` — 全 PASS
- [x] `Validate()` 19 ケース、`ResolveProfilePath` 12 ケース、Loader happy/syntax/unknown/missing/invalid/name mismatch
- [x] spec §3.2 JSON 例での round-trip 検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)