### PR TITLE
chore: sync local docs, ignores, and generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,8 @@ dist/
 *.log
 yarn.lock
 package-lock.json
+.pnpm-store/
+frontend/.pnpm-store/
 
 # Database
 data/
@@ -53,3 +55,6 @@ results/
 go.sum
 
 .gocache
+
+
+.playwright-mcp

--- a/docs/backtest-csv-data-guide.md
+++ b/docs/backtest-csv-data-guide.md
@@ -1,0 +1,153 @@
+# バックテスト用 CSV データ作成手順
+
+バックテスト実行 (`POST /api/v1/backtest/run`) で使う CSV の作成手順。
+
+## 1. 前提
+
+- 作業ディレクトリ: リポジトリルート
+- 出力先（ホスト）: `backend/data/`
+- API 実行時に参照するパス: `data/candles_XXX_YYY.csv`
+  - 例: `data/candles_LTC_JPY_PT15M.csv`
+
+## 2. まずシンボル ID を確認する
+
+```bash
+curl -s 'https://exchange.rakuten-wallet.co.jp/api/v1/cfd/symbol' \
+  | jq -r '.[] | "\(.currencyPair)\t\(.id)"'
+```
+
+例:
+- `BTC_JPY` -> `7`
+- `LTC_JPY` -> `10`
+
+## 3. 最新付近だけ欲しい場合（簡易）
+
+`cmd/backtest download` は簡易取得用。短い期間の確認にはこれで十分。
+
+```bash
+cd backend
+go run ./cmd/backtest download --symbol LTC_JPY --interval PT15M --from 2026-01-01
+go run ./cmd/backtest download --symbol LTC_JPY --interval PT1H  --from 2026-01-01
+```
+
+## 4. 全期間を取得したい場合（推奨）
+
+楽天 API の `candlestick` は 1 回で最大 500 本返るため、`dateTo` を過去方向へずらしてページングする。
+
+以下は `LTC_JPY` の `PT15M` と `PT1H` を作る例（必要に応じて `SYMBOL` / `SYMBOL_ID` を変更）。
+
+```bash
+cat > /tmp/fetch_ltc_history.sh <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="https://exchange.rakuten-wallet.co.jp/api/v1/candlestick"
+SYMBOL="LTC_JPY"
+SYMBOL_ID="10"
+FROM_TS="1483228800000" # 2017-01-01 00:00:00 JST
+OUT_DIR="backend/data"
+
+mkdir -p "$OUT_DIR"
+
+fetch_interval() {
+  local interval="$1"
+  local out_path="$OUT_DIR/candles_${SYMBOL}_${interval}.csv"
+  local tmp_raw
+  tmp_raw="$(mktemp)"
+
+  local now_ms
+  now_ms="$(($(date +%s) * 1000))"
+  local to_ts="$now_ms"
+
+  while true; do
+    local url="${BASE_URL}?symbolId=${SYMBOL_ID}&candlestickType=${interval}&dateFrom=${FROM_TS}&dateTo=${to_ts}"
+    local json
+    json="$(curl -s "$url")"
+
+    local len
+    len="$(jq '.candlesticks | length' <<<"$json")"
+    if [[ "$len" == "0" ]]; then
+      break
+    fi
+
+    jq -r --arg symbol "$SYMBOL" --arg sid "$SYMBOL_ID" --arg interval "$interval" '
+      .candlesticks[]
+      | [$symbol, $sid, $interval, (.time|tostring), (.open|tostring), (.high|tostring), (.low|tostring), (.close|tostring), (.volume|tostring)]
+      | @csv
+    ' <<<"$json" >> "$tmp_raw"
+
+    local min_ts
+    min_ts="$(jq '[.candlesticks[].time] | min' <<<"$json")"
+
+    if (( len < 500 )) || (( min_ts <= FROM_TS )); then
+      break
+    fi
+
+    to_ts=$((min_ts - 1))
+    sleep 0.25
+  done
+
+  {
+    echo "symbol,symbol_id,interval,time,open,high,low,close,volume"
+    sort -t, -k4,4n "$tmp_raw" | awk -F, '!seen[$4]++'
+  } > "$out_path"
+
+  rm -f "$tmp_raw"
+  echo "[${interval}] done -> ${out_path}"
+}
+
+fetch_interval "PT15M"
+fetch_interval "PT1H"
+EOF
+
+chmod +x /tmp/fetch_ltc_history.sh
+/tmp/fetch_ltc_history.sh
+```
+
+## 5. 並び順チェック（時刻逆行がないか）
+
+```bash
+awk -F, 'NR==1{next} {gsub(/"/,"",$4); t=$4+0; if (NR>2 && t<prev) dec++; prev=t} END{print "rows=",NR-1,"decreases=",dec+0}' \
+  backend/data/candles_LTC_JPY_PT15M.csv
+```
+
+- `decreases=0` なら時刻列は昇順で問題なし。
+
+## 6. コンテナへ反映（API から参照させる）
+
+`compose.yaml` では backend は named volume (`backend-data`) を使うため、必要ならコピーする。
+
+```bash
+docker compose cp backend/data/candles_LTC_JPY_PT15M.csv backend:/app/backend/data/candles_LTC_JPY_PT15M.csv
+docker compose cp backend/data/candles_LTC_JPY_PT1H.csv  backend:/app/backend/data/candles_LTC_JPY_PT1H.csv
+```
+
+確認:
+
+```bash
+docker compose exec backend ls -lh /app/backend/data | rg 'candles_LTC_JPY'
+```
+
+## 7. API で期間が見えるか確認
+
+```bash
+curl -sS 'http://localhost:38080/api/v1/backtest/csv-meta?data=data/candles_LTC_JPY_PT15M.csv' | jq
+```
+
+`fromTimestamp` / `toTimestamp` / `rowCount` が返れば利用可能。
+
+## 8. バックテスト実行例
+
+```bash
+curl -sS -X POST 'http://localhost:38080/api/v1/backtest/run' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "data":"data/candles_LTC_JPY_PT15M.csv",
+    "dataHtf":"data/candles_LTC_JPY_PT1H.csv",
+    "from":"2024-01-01",
+    "to":"2024-12-31",
+    "initialBalance":100000,
+    "tradeAmount":0.01
+  }' | jq '{id:.id, symbol:.config.symbol, totalTrades:.summary.totalTrades, totalReturn:.summary.totalReturn}'
+```
+

--- a/docs/superpowers/plans/2026-04-10-symbol-switcher.md
+++ b/docs/superpowers/plans/2026-04-10-symbol-switcher.md
@@ -1,0 +1,1651 @@
+# Symbol Switcher (フロント画面からの取引銘柄切替) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** フロントエンドのダッシュボードから取引対象銘柄（BTC/JPY, ETH/JPY 等）を切り替えられるようにする。銘柄変更時はパイプライン・WebSocket 購読も動的に追従する。
+
+**Architecture:** バックエンドに (1) 銘柄一覧 API、(2) 取引設定 GET/PUT API を追加し、TradingPipeline に symbolID のランタイム切替メソッドを実装する。フロントエンドではグローバルな `symbolId` state を React Context で管理し、ダッシュボード上部にセレクタを配置して全 hook に伝播させる。
+
+**Tech Stack:** Go (Gin), React 19 (TanStack Router / React Query), TypeScript, Tailwind CSS v4
+
+---
+
+## File Structure
+
+### Backend (新規)
+- `backend/internal/interfaces/api/handler/symbol.go` — `GET /api/v1/symbols` ハンドラ
+- `backend/internal/interfaces/api/handler/trading_config.go` — `GET /PUT /api/v1/trading-config` ハンドラ
+
+### Backend (変更)
+- `backend/internal/interfaces/api/router.go` — 新エンドポイント登録 + Dependencies に RESTClient 利用
+- `backend/cmd/pipeline.go` — `SwitchSymbol()` メソッド追加
+- `backend/cmd/main.go` — `startMarketRelay` を symbolID 切替対応に変更
+
+### Frontend (新規)
+- `frontend/src/hooks/useSymbols.ts` — `GET /symbols` フック
+- `frontend/src/hooks/useTradingConfig.ts` — `GET/PUT /trading-config` フック
+- `frontend/src/contexts/SymbolContext.tsx` — 選択 symbolId の Context + Provider
+- `frontend/src/components/SymbolSelector.tsx` — 銘柄セレクタ UI
+
+### Frontend (変更)
+- `frontend/src/lib/api.ts` — `Symbol`, `TradingConfig` 型追加
+- `frontend/src/routes/__root.tsx` — SymbolProvider ラップ
+- `frontend/src/routes/index.tsx` — ハードコード `7` → Context 経由
+- `frontend/src/routes/settings.tsx` — ハードコード `7` → Context 経由
+- `frontend/src/routes/history.tsx` — ハードコード `7` → Context 経由
+- `frontend/src/components/AppFrame.tsx` — SymbolSelector 配置
+- `frontend/src/components/LiveTickerCard.tsx` — ハードコード "BTC/JPY" → 動的表示
+
+### Backend テスト (新規)
+- `backend/cmd/pipeline_test.go` — `SwitchSymbol` と `Start`/`Stop` の並行性テスト（`go test -race` 前提）
+
+---
+
+## レビュー反映履歴 (2026-04-11)
+
+2人のレビュワーからの指摘を反映済み:
+
+- **C-NEW1 (Reviewer 1):** `main.go` の `ctx, cancel` 定義と `onSymbolSwitch` を `NewRouter` 呼び出しより前に移動（Task 4 Step 2）
+- **Codex #1 High:** `SwitchSymbol` と `Stop` の競合 → `Start`/`Stop` に `switchMu` を拡張（Task 2 Step 2）
+- **Codex #2 High:** `SwitchSymbol` の bootstrap 中に `Start` が割り込む問題 → 同上修正で解消（Task 2 Step 2）
+- **M-NEW2 (Reviewer 1):** `tradeAmount` 誤上書き → `tradingConfig` 未ロード時は `switchSymbol` を disabled（Task 7/8）
+- **Codex #3 Medium:** 無効銘柄フォールバック → 失敗時は `symbols` から最初の有効銘柄を選ぶ（Task 7）
+- **Codex #4 Medium:** テストギャップ → 並行性ユニットテスト追加（Task 2 Step 9）+ 統合手動確認追加（Task 11 Step 9）
+- **m3 (Reviewer 1):** Task 11 Step 4 の symbolId を Step 2 の結果から動的に取得
+
+---
+
+## Task 1: Backend — GET /api/v1/symbols エンドポイント
+
+**Files:**
+- Create: `backend/internal/interfaces/api/handler/symbol.go`
+- Modify: `backend/internal/interfaces/api/router.go`
+
+- [ ] **Step 1: SymbolHandler を作成**
+
+```go
+// backend/internal/interfaces/api/handler/symbol.go
+package handler
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/infrastructure/rakuten"
+)
+
+type SymbolHandler struct {
+	restClient *rakuten.RESTClient
+}
+
+func NewSymbolHandler(restClient *rakuten.RESTClient) *SymbolHandler {
+	return &SymbolHandler{restClient: restClient}
+}
+
+// GetSymbols handles GET /api/v1/symbols.
+func (h *SymbolHandler) GetSymbols(c *gin.Context) {
+	symbols, err := h.restClient.GetSymbols(c.Request.Context())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, symbols)
+}
+```
+
+- [ ] **Step 2: ルーターに登録**
+
+`backend/internal/interfaces/api/router.go` の `NewRouter` 関数内、`orderHandler` 登録ブロックの後に追加:
+
+```go
+	if deps.RESTClient != nil {
+		symbolHandler := handler.NewSymbolHandler(deps.RESTClient)
+		v1.GET("/symbols", symbolHandler.GetSymbols)
+	}
+```
+
+- [ ] **Step 3: ビルド確認**
+
+Run: `cd backend && go build ./...`
+Expected: エラーなし
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/internal/interfaces/api/handler/symbol.go backend/internal/interfaces/api/router.go
+git commit -m "feat: add GET /api/v1/symbols endpoint for listing tradable pairs"
+```
+
+---
+
+## Task 2: Backend — TradingPipeline を RWMutex 化 + SwitchSymbol メソッド
+
+> **Review fix (H1):** `evaluate`/`runStopLossMonitor` がロックなしで `symbolID`/`tradeAmount` を読んでいるデータレースを修正。`sync.Mutex` → `sync.RWMutex` に変更し、読み取り側はスナップショットを取得。`SwitchSymbol` は停止→更新→起動を一貫してロック内で実行する。
+> **注意:** `interval` フィールドは SwitchSymbol で変更しないため snapshot 対象外（不変フィールドとして扱う）。
+
+**Files:**
+- Modify: `backend/cmd/pipeline.go`
+
+- [ ] **Step 1: Mutex を RWMutex に変更**
+
+`backend/cmd/pipeline.go` の `TradingPipeline` struct の `mu` フィールドを変更:
+
+```go
+type TradingPipeline struct {
+	mu     sync.RWMutex
+	cancel context.CancelFunc
+
+	symbolID    int64
+	interval    time.Duration
+	tradeAmount float64
+	// ... (以降のフィールドは変更なし)
+```
+
+- [ ] **Step 2: Start/Stop/Running のロックを RWMutex + switchMu に変更**
+
+> **Review fix (Codex #1/#2):** `Start()` / `Stop()` にも `switchMu` を取得させて `SwitchSymbol` 全体と直列化する。これにより「SwitchSymbol の onSwitch 実行中に Stop が来て握りつぶされる」「bootstrap 完了前に Start が入ってローソク足不足で評価が走る」問題を防ぐ。
+> **ロック順序:** 必ず `switchMu` → `mu` の順で取得する。逆順で取るコードパスを作らないこと。
+
+`Start()` / `Stop()` を以下に変更。内部実装を `startLocked` / `stopLocked` に分離し、`SwitchSymbol` からは `switchMu` 保持したまま呼べるようにする。
+
+**ロック順序の原則:** 常に `switchMu` → `mu` の順。逆順で取得するコードパスを作らない。
+
+```go
+// Start はパイプラインを開始する。すでに実行中なら何もしない。
+// switchMu で SwitchSymbol との並行実行を防ぐ。
+func (p *TradingPipeline) Start() {
+	p.switchMu.Lock()
+	defer p.switchMu.Unlock()
+	p.startLocked()
+}
+
+// startLocked は switchMu を保持した状態で呼ぶこと。
+// SwitchSymbol から再利用するために分離されている。
+func (p *TradingPipeline) startLocked() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.cancel != nil {
+		return // already running
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	p.cancel = cancel
+
+	go p.runTradingLoop(ctx)
+	go p.runStopLossMonitor(ctx)
+
+	slog.Info("trading pipeline started")
+}
+
+// Stop はパイプラインを停止する。
+// switchMu で SwitchSymbol との並行実行を防ぐ。
+func (p *TradingPipeline) Stop() {
+	p.switchMu.Lock()
+	defer p.switchMu.Unlock()
+	p.stopLocked()
+}
+
+// stopLocked は switchMu を保持した状態で呼ぶこと。
+func (p *TradingPipeline) stopLocked() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.cancel == nil {
+		return
+	}
+
+	p.cancel()
+	p.cancel = nil
+
+	slog.Info("trading pipeline stopped")
+}
+```
+
+`Running()` は読み取りのみなので `switchMu` は不要。`RLock` に変更:
+
+```go
+func (p *TradingPipeline) Running() bool {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.cancel != nil
+}
+```
+
+- [ ] **Step 3: SymbolID / TradeAmount getter を追加**
+
+`Running()` の後に追加:
+
+```go
+// SymbolID は現在の取引対象シンボルIDを返す。
+func (p *TradingPipeline) SymbolID() int64 {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.symbolID
+}
+
+// TradeAmount は現在の1回あたりの注文金額を返す。
+func (p *TradingPipeline) TradeAmount() float64 {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.tradeAmount
+}
+```
+
+- [ ] **Step 4: スナップショット取得用の内部メソッドを追加**
+
+```go
+// tradingSnapshot は evaluate / stopLoss ループの冒頭でロック下にコピーを取るための構造体。
+type tradingSnapshot struct {
+	symbolID    int64
+	tradeAmount float64
+}
+
+func (p *TradingPipeline) snapshot() tradingSnapshot {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return tradingSnapshot{
+		symbolID:    p.symbolID,
+		tradeAmount: p.tradeAmount,
+	}
+}
+```
+
+- [ ] **Step 5: evaluate を snapshot 経由に変更**
+
+`evaluate` メソッドの冒頭で snapshot を取得し、`p.symbolID` / `p.tradeAmount` の直接参照をすべて置換:
+
+```go
+func (p *TradingPipeline) evaluate(ctx context.Context) {
+	snap := p.snapshot()
+
+	// 1. 最新ティッカーを取得
+	latestTicker, err := p.marketDataSvc.GetLatestTicker(ctx, snap.symbolID)
+	if err != nil || latestTicker == nil {
+		slog.Warn("pipeline: failed to get latest ticker", "error", err)
+		return
+	}
+
+	// 2. テクニカル指標を計算
+	indicators, err := p.indicatorCalc.Calculate(ctx, snap.symbolID, "15min")
+	if err != nil {
+		slog.Warn("pipeline: failed to calculate indicators", "error", err)
+		return
+	}
+
+	// 3. 戦略判定
+	signal, err := p.strategyEngine.Evaluate(ctx, *indicators, latestTicker.Last)
+	if err != nil {
+		slog.Warn("pipeline: failed to evaluate strategy", "error", err)
+		return
+	}
+
+	slog.Info("pipeline: signal evaluated", "action", signal.Action, "reason", signal.Reason, "price", latestTicker.Last)
+
+	if signal.Action == entity.SignalActionHold {
+		return
+	}
+
+	// 4. 同一方向のポジションを保持中ならスキップ
+	positions, err := p.restClient.GetPositions(ctx, snap.symbolID)
+	if err != nil {
+		slog.Warn("pipeline: failed to get positions", "error", err)
+		return
+	}
+
+	side := entity.OrderSideBuy
+	if signal.Action == entity.SignalActionSell {
+		side = entity.OrderSideSell
+	}
+
+	for _, pos := range positions {
+		if pos.OrderSide == side && pos.RemainingAmount > 0 {
+			slog.Info("pipeline: skip, already holding position", "action", signal.Action, "side", side, "positionID", pos.ID)
+			return
+		}
+	}
+
+	// 5. 注文数量を計算
+	price := latestTicker.BestAsk
+	if signal.Action == entity.SignalActionSell {
+		price = latestTicker.BestBid
+	}
+	if price <= 0 {
+		slog.Warn("pipeline: invalid price, skip", "price", price)
+		return
+	}
+
+	amount := snap.tradeAmount / price
+	amount = math.Floor(amount*10000) / 10000
+	if amount <= 0 {
+		slog.Warn("pipeline: calculated amount is 0, skip", "tradeAmount", snap.tradeAmount, "price", price)
+		return
+	}
+
+	// 6. 注文実行
+	result, err := p.orderExecutor.ExecuteSignal(ctx, *signal, price, amount)
+	if err != nil {
+		slog.Error("pipeline: order execution failed", "error", err)
+		return
+	}
+
+	if result.Executed {
+		slog.Info("pipeline: order executed", "orderID", result.OrderID, "side", side, "amount", amount, "price", price)
+		p.recordTrade(ctx, snap.symbolID, result.OrderID, string(side), "open", price, amount, signal.Reason, false)
+		p.syncState(ctx)
+		p.persistRiskState(ctx)
+	} else {
+		slog.Info("pipeline: order not executed", "reason", result.Reason)
+	}
+}
+```
+
+- [ ] **Step 6: runStopLossMonitor を snapshot 経由に変更**
+
+`runStopLossMonitor` 内の `p.symbolID` 参照を snapshot 経由にする:
+
+```go
+func (p *TradingPipeline) runStopLossMonitor(ctx context.Context) {
+	tickerCh := p.marketDataSvc.SubscribeTicker()
+	defer p.marketDataSvc.UnsubscribeTicker(tickerCh)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case t, ok := <-tickerCh:
+			if !ok {
+				return
+			}
+			snap := p.snapshot()
+			if t.SymbolID != snap.symbolID {
+				continue
+			}
+
+			targets := p.riskMgr.CheckStopLoss(t.SymbolID, t.Last)
+			for _, pos := range targets {
+				slog.Warn("pipeline: stop-loss triggered",
+					"positionID", pos.ID, "side", pos.OrderSide, "entryPrice", pos.Price, "currentPrice", t.Last)
+
+				result, err := p.orderExecutor.ClosePosition(ctx, pos, t.Last)
+				if err != nil {
+					slog.Error("pipeline: stop-loss close failed", "error", err)
+					continue
+				}
+				if result.Executed {
+					slog.Info("pipeline: stop-loss closed", "orderID", result.OrderID)
+					loss := math.Abs(pos.FloatingProfit)
+					p.riskMgr.RecordLoss(loss)
+					closeSide := string(entity.OrderSideSell)
+					if pos.OrderSide == entity.OrderSideSell {
+						closeSide = string(entity.OrderSideBuy)
+					}
+					p.recordTrade(ctx, pos.SymbolID, result.OrderID, closeSide, "close", t.Last, pos.RemainingAmount, "stop-loss", true)
+					p.persistRiskState(ctx)
+				}
+			}
+		}
+	}
+}
+```
+
+- [ ] **Step 7: syncState を snapshot 経由に変更**
+
+```go
+func (p *TradingPipeline) syncState(ctx context.Context) {
+	snap := p.snapshot()
+	positions, err := p.restClient.GetPositions(ctx, snap.symbolID)
+	if err != nil {
+		slog.Warn("pipeline: failed to sync positions", "error", err)
+	} else {
+		p.riskMgr.UpdatePositions(positions)
+	}
+
+	assets, err := p.restClient.GetAssets(ctx)
+	if err != nil {
+		slog.Warn("pipeline: failed to sync assets", "error", err)
+	} else {
+		for _, a := range assets {
+			if a.Currency == "JPY" {
+				if balance, err := strconv.ParseFloat(a.OnhandAmount, 64); err == nil {
+					p.riskMgr.UpdateBalance(balance)
+				}
+			}
+		}
+	}
+}
+```
+
+- [ ] **Step 8: switchMu フィールドと SwitchSymbol メソッドを追加**
+
+> **Review fix (H1 連続切替):** `SwitchSymbol` を pipeline 内の専用 mutex (`switchMu`) でシリアライズする。連続切替時も前の切替処理（bootstrap 含む）が完了してから次の切替が始まるため、逆順適用のリスクがなくなる。
+> **Review fix (H-hang 再考):** `switchMu` で順序保証するため `onSwitch` を同期実行する。HTTP handler は 1リクエストあたり bootstrap API 1回 + WS切替を待つが、bootstrap は約 1秒程度で完了するため許容範囲。
+> **Review fix (Codex #1/#2):** `Start()` / `Stop()` も Step 2 で `switchMu` を取得するよう変更済み。これにより `SwitchSymbol` の onSwitch 実行中に Stop/Start が割り込まず、停止要求の握りつぶしや bootstrap 完了前の Start を防ぐ。
+> **方針:** `Start()` を直接呼ぶと `switchMu` の二重取得でデッドロックするため、SwitchSymbol 内では内部実装の `startLocked()`（ロックを取らない版）を呼ぶ。
+
+struct に専用 mutex を追加:
+
+```go
+type TradingPipeline struct {
+	mu       sync.RWMutex   // symbolID/tradeAmount/cancel 用
+	switchMu sync.Mutex     // SwitchSymbol 全体をシリアライズ
+	cancel   context.CancelFunc
+
+	symbolID    int64
+	interval    time.Duration
+	tradeAmount float64
+	// ... (以降のフィールドは変更なし)
+```
+
+SwitchSymbol メソッドを追加:
+
+```go
+// SwitchSymbol は取引対象シンボルを切り替える。
+// switchMu でシリアライズすることで:
+//   - 連続切替の順序保証（逆順適用を防ぐ）
+//   - SwitchSymbol 実行中の Start/Stop 割込みを防ぐ（Codex #1/#2 対応）
+//
+// 処理順序: 停止 → フィールド更新 → onSwitch（bootstrap + WS切替）→ 再開
+// onSwitch は同期実行されるため HTTP レスポンスは bootstrap 完了まで待つ。
+//
+// ロック順序: switchMu → mu（startLocked/stopLocked 内部で mu を取る）
+func (p *TradingPipeline) SwitchSymbol(symbolID int64, tradeAmount float64, onSwitch func(oldID, newID int64)) {
+	p.switchMu.Lock()
+	defer p.switchMu.Unlock()
+
+	// 現在の状態を読み取り（switchMu 保持中なので Start/Stop は進行できない）
+	p.mu.RLock()
+	oldID := p.symbolID
+	wasRunning := p.cancel != nil
+	p.mu.RUnlock()
+
+	// 停止（switchMu 保持済みなので stopLocked を使う）
+	if wasRunning {
+		p.stopLocked()
+	}
+
+	// フィールド更新
+	p.mu.Lock()
+	p.symbolID = symbolID
+	if tradeAmount > 0 {
+		p.tradeAmount = tradeAmount
+	}
+	p.mu.Unlock()
+
+	// onSwitch（bootstrapCandles + WS切替）を同期実行
+	// switchMu で順序保証されているため、連続切替でも逆順適用されない
+	// この間 Start/Stop は switchMu 待ちでブロックされるので、
+	// bootstrap 完了前にパイプラインが動き出すことはない
+	if onSwitch != nil {
+		onSwitch(oldID, symbolID)
+	}
+
+	// 再開（switchMu 保持済みなので startLocked を使う）
+	// bootstrap 完了後に再開することで、新シンボルの指標計算が即座に可能になる
+	if wasRunning {
+		p.startLocked()
+	}
+}
+```
+
+- [ ] **Step 9: 並行性ユニットテストを追加（Codex #4 対応）**
+
+> **Review fix (Codex #4):** `SwitchSymbol` と `Start`/`Stop` の並行呼び出しで状態が一貫することを `-race` で検証する。実際の `marketDataSvc` や `restClient` は評価ループが走り出すと必要だが、Start 直後に Stop すれば `evaluate` が間に合わず nil 参照しないため、ダミー依存でテストできる（goroutine が spawn されても最初の `time.NewTicker` は走るが、`evaluate` が1回走る前に Stop できるよう interval を十分大きくする）。
+> **方針:** ユニットテストは `backend/cmd` パッケージ内（`pipeline_test.go`）に置く。race 検出が目的なので「panic せず、最終状態が決定論的」であることを確認する。
+
+`backend/cmd/pipeline_test.go` を新規作成:
+
+```go
+package main
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// newTestPipeline はテスト用に最小構成の TradingPipeline を返す。
+// 実際の評価ループが走らないよう interval は十分長く設定する。
+// evaluate / runStopLossMonitor 内で nil 参照しないよう、必要な依存だけ nil でない値を渡す。
+func newTestPipeline(t *testing.T) *TradingPipeline {
+	t.Helper()
+	return &TradingPipeline{
+		symbolID:    7,
+		interval:    1 * time.Hour, // 評価ループが走らない程度に長く
+		tradeAmount: 1000,
+		// marketDataSvc / indicatorCalc 等は nil のまま。
+		// Start が goroutine を起動した直後に Stop するので、
+		// evaluate が1回走る前にキャンセルされる前提。
+		//
+		// ただし runTradingLoop は起動直後に p.evaluate(ctx) を呼ぶため、
+		// nil 参照で panic する。テストでは evaluate を呼ばない版の内部メソッドに置き換えるか、
+		// 最小限のスタブを用意する必要がある。
+		//
+		// 実装ヒント: pipeline.go 側で `runTradingLoop` を直接触らず、
+		// テスト対象を `SwitchSymbol` / `Start` / `Stop` の「ロック挙動」に絞るため、
+		// runTradingLoop を差し替え可能にするか、下記のようにテスト用コンストラクタを用意する。
+	}
+}
+
+// TestSwitchSymbol_ConcurrentStartStop は SwitchSymbol と Start/Stop が
+// 並行実行されても panic せず、最終状態が一貫することを検証する。
+// go test -race で実行すること。
+func TestSwitchSymbol_ConcurrentStartStop(t *testing.T) {
+	p := newTestPipelineForConcurrency(t)
+
+	var wg sync.WaitGroup
+	var switchCount atomic.Int64
+
+	// 100回並行して Switch/Start/Stop を呼ぶ
+	for i := 0; i < 100; i++ {
+		wg.Add(3)
+		go func(i int) {
+			defer wg.Done()
+			p.SwitchSymbol(int64(7+i%3), 1000, func(oldID, newID int64) {
+				// bootstrap の代わりに短い sleep で実処理を模擬
+				time.Sleep(100 * time.Microsecond)
+			})
+			switchCount.Add(1)
+		}(i)
+		go func() {
+			defer wg.Done()
+			p.Start()
+		}()
+		go func() {
+			defer wg.Done()
+			p.Stop()
+		}()
+	}
+
+	wg.Wait()
+
+	// 最終的に Stop しておく
+	p.Stop()
+	if p.Running() {
+		t.Errorf("pipeline should be stopped after final Stop, got Running=true")
+	}
+	if switchCount.Load() != 100 {
+		t.Errorf("expected 100 switches, got %d", switchCount.Load())
+	}
+}
+
+// TestSwitchSymbol_StopDuringSwitch は SwitchSymbol の onSwitch 実行中に
+// Stop が来ても、最終的に停止状態になることを検証する（Codex #1 対応）。
+func TestSwitchSymbol_StopDuringSwitch(t *testing.T) {
+	p := newTestPipelineForConcurrency(t)
+
+	p.Start()
+	if !p.Running() {
+		t.Fatal("pipeline should be running after Start")
+	}
+
+	// onSwitch が走っている最中に Stop を呼ぶ
+	stopCalled := make(chan struct{})
+	onSwitch := func(oldID, newID int64) {
+		go func() {
+			p.Stop()
+			close(stopCalled)
+		}()
+		// Stop が switchMu 待ちでブロックされることを確認するため、
+		// onSwitch 内で少し待つ
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	p.SwitchSymbol(8, 1000, onSwitch)
+
+	// SwitchSymbol 完了後、Stop が switchMu を取得して走る
+	<-stopCalled
+
+	if p.Running() {
+		t.Error("pipeline should be stopped, got Running=true")
+	}
+}
+```
+
+**補足:** `newTestPipelineForConcurrency` は `runTradingLoop` / `runStopLossMonitor` が nil 依存で panic しないよう、最小スタブを差し込んで pipeline を生成するヘルパー。pipeline.go 側で `runTradingLoop` を即 return するテスト用ビルドタグを切るか、`marketDataSvc` 等をインターフェース化してスタブを渡す。**実装時に現状の pipeline.go 構造を踏まえて最小限のリファクタを行うこと**（インターフェース化は影響範囲が大きいため、テスト用に `evaluate` をスタブ差し替え可能にする方法を推奨）。
+
+- [ ] **Step 10: ビルド + race テスト確認**
+
+Run: `cd backend && go build ./... && go test -race -run TestSwitchSymbol ./cmd`
+Expected: エラーなし、race 検出なし
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add backend/cmd/pipeline.go backend/cmd/pipeline_test.go
+git commit -m "feat: RWMutex + snapshot + SwitchSymbol with Start/Stop serialization"
+```
+
+---
+
+## Task 3: Backend — GET/PUT /api/v1/trading-config エンドポイント
+
+> **Review fix (C1/M4):** handler 側に別インターフェースを定義せず、`router.go` の `PipelineController` を直接使う。
+> **Review fix (M1):** `PUT /trading-config` で `GetSymbols` を呼び、`enabled && !viewOnly && !closeOnly` を検証する。
+> **Review fix (M-amount):** `tradeAmount` が 0 以下の場合は 400 を返す。
+> **Review fix (M1 onSwitch 冗長):** handler は `onSwitch` を保持せず、router 側でクロージャで `SwitchSymbol` と `onSwitch` を包んで `switchSymbol func(id, amt)` として渡す。handler の責務が「switch する」ことだけに限定される。
+
+**Files:**
+- Create: `backend/internal/interfaces/api/handler/trading_config.go`
+- Modify: `backend/internal/interfaces/api/router.go`
+
+- [ ] **Step 1: PipelineController インターフェースを拡張**
+
+`backend/internal/interfaces/api/router.go` の `PipelineController` インターフェースに追加:
+
+```go
+type PipelineController interface {
+	Start()
+	Stop()
+	Running() bool
+	SymbolID() int64
+	TradeAmount() float64
+	SwitchSymbol(symbolID int64, tradeAmount float64, onSwitch func(oldID, newID int64))
+}
+```
+
+- [ ] **Step 2: TradingConfigHandler を作成（PipelineController を直接使用、別インターフェース不要）**
+
+> **Review fix (C1):** handler 独自のインターフェースは定義しない。`PipelineController` は Go の implicit interface satisfaction により、handler パッケージから `api` パッケージを import せずに使える。handler は必要なメソッドだけを引数の型として受け取る。
+
+```go
+// backend/internal/interfaces/api/handler/trading_config.go
+package handler
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/infrastructure/rakuten"
+)
+
+// TradingConfigHandler は取引設定の取得・切替を行うハンドラ。
+// M1 修正: onSwitch は router 側でクロージャとして switchSymbol に包まれるため、
+// handler は onSwitch を知らない。
+type TradingConfigHandler struct {
+	getSymbolID    func() int64
+	getTradeAmount func() float64
+	switchSymbol   func(symbolID int64, tradeAmount float64)
+	restClient     *rakuten.RESTClient
+}
+
+func NewTradingConfigHandler(
+	getSymbolID func() int64,
+	getTradeAmount func() float64,
+	switchSymbol func(symbolID int64, tradeAmount float64),
+	restClient *rakuten.RESTClient,
+) *TradingConfigHandler {
+	return &TradingConfigHandler{
+		getSymbolID:    getSymbolID,
+		getTradeAmount: getTradeAmount,
+		switchSymbol:   switchSymbol,
+		restClient:     restClient,
+	}
+}
+
+type tradingConfigResponse struct {
+	SymbolID    int64   `json:"symbolId"`
+	TradeAmount float64 `json:"tradeAmount"`
+}
+
+type updateTradingConfigRequest struct {
+	SymbolID    int64   `json:"symbolId"`
+	TradeAmount float64 `json:"tradeAmount"`
+}
+
+// GetTradingConfig handles GET /api/v1/trading-config.
+func (h *TradingConfigHandler) GetTradingConfig(c *gin.Context) {
+	c.JSON(http.StatusOK, tradingConfigResponse{
+		SymbolID:    h.getSymbolID(),
+		TradeAmount: h.getTradeAmount(),
+	})
+}
+
+// UpdateTradingConfig handles PUT /api/v1/trading-config.
+func (h *TradingConfigHandler) UpdateTradingConfig(c *gin.Context) {
+	var req updateTradingConfigRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+		return
+	}
+
+	if req.SymbolID <= 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "symbolId must be positive"})
+		return
+	}
+
+	if req.TradeAmount <= 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "tradeAmount must be positive"})
+		return
+	}
+
+	// シンボルの存在確認と取引可否の検証
+	symbols, err := h.restClient.GetSymbols(c.Request.Context())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch symbols"})
+		return
+	}
+
+	var found bool
+	for _, s := range symbols {
+		if s.ID == req.SymbolID {
+			if !s.Enabled {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "symbol is disabled"})
+				return
+			}
+			if s.ViewOnly {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "symbol is view-only"})
+				return
+			}
+			if s.CloseOnly {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "symbol is close-only"})
+				return
+			}
+			found = true
+			break
+		}
+	}
+	if !found {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "unknown symbolId"})
+		return
+	}
+
+	h.switchSymbol(req.SymbolID, req.TradeAmount)
+
+	c.JSON(http.StatusOK, tradingConfigResponse{
+		SymbolID:    h.getSymbolID(),
+		TradeAmount: h.getTradeAmount(),
+	})
+}
+```
+
+- [ ] **Step 3: Dependencies に OnSymbolSwitch コールバックを追加**
+
+`backend/internal/interfaces/api/router.go` の `Dependencies` struct に追加:
+
+```go
+type Dependencies struct {
+	RiskManager         *usecase.RiskManager
+	StanceResolver      *usecase.RuleBasedStanceResolver
+	IndicatorCalculator *usecase.IndicatorCalculator
+	MarketDataService   *usecase.MarketDataService
+	RealtimeHub         *usecase.RealtimeHub
+	OrderClient         repository.OrderClient
+	OrderExecutor       *usecase.OrderExecutor
+	Pipeline            PipelineController
+	RESTClient          *rakuten.RESTClient
+	ClientOrderRepo     repository.ClientOrderRepository
+	OnSymbolSwitch      func(oldID, newID int64)
+}
+```
+
+- [ ] **Step 4: ルーターに trading-config エンドポイントを登録**
+
+`NewRouter` 関数内、`symbolHandler` 登録の後に追加:
+
+```go
+	if deps.Pipeline != nil && deps.RESTClient != nil {
+		// M1 修正: onSwitch を含む switchSymbol をクロージャで包んで handler に渡す
+		pipelineForHandler := deps.Pipeline
+		onSwitchForHandler := deps.OnSymbolSwitch
+		switchSymbolFn := func(symbolID int64, tradeAmount float64) {
+			pipelineForHandler.SwitchSymbol(symbolID, tradeAmount, onSwitchForHandler)
+		}
+		tradingConfigHandler := handler.NewTradingConfigHandler(
+			deps.Pipeline.SymbolID,
+			deps.Pipeline.TradeAmount,
+			switchSymbolFn,
+			deps.RESTClient,
+		)
+		v1.GET("/trading-config", tradingConfigHandler.GetTradingConfig)
+		v1.PUT("/trading-config", tradingConfigHandler.UpdateTradingConfig)
+	}
+```
+
+- [ ] **Step 5: ビルド確認**
+
+Run: `cd backend && go build ./...`
+Expected: エラーなし
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/internal/interfaces/api/handler/trading_config.go backend/internal/interfaces/api/router.go
+git commit -m "feat: add GET/PUT /api/v1/trading-config with symbol validation"
+```
+
+---
+
+## Task 4: Backend — WebSocket 購読の動的切替 + ローソク足 bootstrap
+
+> **Review fix (H2):** `symbolSwitchCh` の `default` ドロップを廃止。古い値を drain してから新しい値を送信する上書き方式にする。
+> **Review fix (H3):** シンボル切替時に `bootstrapCandles` を実行し、指標データ不足で HOLD 固定になる問題を防ぐ。
+> **Review fix (M2):** Subscribe 失敗時の `continue` が内側ループにしか効かない既存バグを修正。
+> **Review fix (M3):** WS の Unsubscribe/Subscribe エラーをログ出力し、Subscribe 失敗時は reconnect する。
+
+**Files:**
+- Modify: `backend/cmd/main.go`
+
+- [ ] **Step 1: startMarketRelay を全面書き換え**
+
+`backend/cmd/main.go` の既存 `startMarketRelay` 関数を以下で置き換える:
+
+```go
+func startMarketRelay(ctx context.Context, wsClient *rakuten.WSClient, marketDataSvc *usecase.MarketDataService, realtimeHub *usecase.RealtimeHub, initialSymbolID int64, symbolSwitchCh <-chan [2]int64) {
+	if wsClient == nil || marketDataSvc == nil {
+		return
+	}
+
+	currentSymbolID := initialSymbolID
+	backoff := wsInitialBackoff
+
+	for {
+		select {
+		case <-ctx.Done():
+			_ = wsClient.Close()
+			return
+		default:
+		}
+
+		msgCh, err := wsClient.Connect(ctx)
+		if err != nil {
+			slog.Warn("market websocket connect failed", "error", err, "retryIn", backoff)
+			waitFor(ctx, backoff)
+			backoff = nextBackoff(backoff)
+			continue
+		}
+
+		// Subscribe — 失敗時は外側ループで reconnect する（M2 修正）
+		subscribeOK := true
+		for _, dataType := range []rakuten.DataType{rakuten.DataTypeTicker, rakuten.DataTypeOrderbook, rakuten.DataTypeTrades} {
+			if err := wsClient.Subscribe(ctx, currentSymbolID, dataType); err != nil {
+				slog.Warn("market websocket subscribe failed", "dataType", dataType, "error", err)
+				subscribeOK = false
+				break
+			}
+		}
+		if !subscribeOK {
+			_ = wsClient.Close()
+			waitFor(ctx, backoff)
+			backoff = nextBackoff(backoff)
+			continue
+		}
+
+		slog.Info("market websocket subscribed", "symbolID", currentSymbolID)
+		backoff = wsInitialBackoff
+
+		sessionTimer := time.NewTimer(wsMaxSessionDuration)
+
+		reconnect := false
+		for !reconnect {
+			select {
+			case <-ctx.Done():
+				sessionTimer.Stop()
+				_ = wsClient.Close()
+				return
+			case <-sessionTimer.C:
+				slog.Info("market websocket session approaching 2h limit, reconnecting proactively")
+				reconnect = true
+			case ids := <-symbolSwitchCh:
+				oldID, newID := ids[0], ids[1]
+				slog.Info("switching websocket symbol subscription", "from", oldID, "to", newID)
+
+				// Unsubscribe（エラーはログのみ、M3 修正）
+				for _, dataType := range []rakuten.DataType{rakuten.DataTypeTicker, rakuten.DataTypeOrderbook, rakuten.DataTypeTrades} {
+					if err := wsClient.Unsubscribe(ctx, oldID, dataType); err != nil {
+						slog.Warn("market websocket unsubscribe failed", "dataType", dataType, "error", err)
+					}
+				}
+
+				// Subscribe（エラー時は reconnect、M3 修正）
+				// C3 修正: Subscribe 成功時のみ currentSymbolID を更新。
+				// 失敗時は reconnect で currentSymbolID（=newID）を使って再接続する。
+				switchOK := true
+				for _, dataType := range []rakuten.DataType{rakuten.DataTypeTicker, rakuten.DataTypeOrderbook, rakuten.DataTypeTrades} {
+					if err := wsClient.Subscribe(ctx, newID, dataType); err != nil {
+						slog.Error("market websocket re-subscribe failed, will reconnect", "dataType", dataType, "error", err)
+						switchOK = false
+						break
+					}
+				}
+				// パイプライン側は既に newID に切り替え済みなので、
+				// Subscribe 成否に関わらず currentSymbolID を newID にして
+				// reconnect 時に新シンボルで再接続する
+				currentSymbolID = newID
+				if !switchOK {
+					reconnect = true
+				}
+			case raw, ok := <-msgCh:
+				if !ok {
+					reconnect = true
+					break
+				}
+				handleMarketMessage(ctx, raw, marketDataSvc, realtimeHub)
+			}
+		}
+
+		sessionTimer.Stop()
+		slog.Info("market websocket disconnected, reconnecting")
+		_ = wsClient.Close()
+		waitFor(ctx, wsInitialBackoff)
+	}
+}
+```
+
+- [ ] **Step 2: main 関数を再構成 — ctx/NewRouter 順序変更 + symbolSwitchCh + bootstrapCandles コールバック**
+
+> **Review fix (C-NEW1):** 現状 `main.go:95` で `NewRouter` を呼び、`main.go:109` で `ctx, cancel` を定義している。`NewRouter` に `OnSymbolSwitch` を渡すためには、`onSymbolSwitch` が参照する `ctx` が先に定義されている必要がある。そのため `ctx, cancel` 定義と `symbolSwitchCh` / `onSymbolSwitch` 定義を `NewRouter` 呼び出しより**前**に移動する。
+> **Review fix (H3 ctx):** `bootstrapCandles` には `main` の `ctx` をクロージャでキャプチャして渡す。アプリ終了時にキャンセルされる。
+
+**Step 2a: `ctx, cancel := context.WithCancel(...)` を `pipeline.syncStateInitial(...)` の直後、`api.NewRouter(...)` の前に移動する。**
+
+現状の `main.go:109-110` の以下の行を削除:
+
+```go
+	// --- Graceful Shutdown ---
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+```
+
+そして `pipeline.syncStateInitial(context.Background())`（現 `main.go:92`）の**直後**、`// --- REST API ---` コメントの**前**に配置する:
+
+```go
+	// 起動時にポジション・残高を同期
+	pipeline.syncStateInitial(context.Background())
+
+	// --- Graceful Shutdown context（onSymbolSwitch と startMarketRelay で使用）---
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// --- Symbol Switch channel + callback ---
+	symbolSwitchCh := make(chan [2]int64, 1)
+
+	onSymbolSwitch := func(oldID, newID int64) {
+		// H3 修正: 新シンボルのローソク足を bootstrap（main の ctx を使う）
+		if err := bootstrapCandles(ctx, restClient, marketDataSvc, newID, "15min", "PT15M", 500); err != nil {
+			slog.Warn("candle bootstrap for new symbol failed", "symbolID", newID, "error", err)
+		}
+
+		// H2 修正: 古い値を drain してから送信（上書き方式）
+		// SwitchSymbol は pipeline の switchMu でシリアライズされているため、
+		// この関数が並行実行されることはない
+		select {
+		case <-symbolSwitchCh:
+			// 古い値を破棄
+		default:
+		}
+		select {
+		case symbolSwitchCh <- [2]int64{oldID, newID}:
+		case <-ctx.Done():
+		}
+	}
+
+	// --- REST API ---
+	router := api.NewRouter(api.Dependencies{
+		RiskManager:         riskMgr,
+		StanceResolver:      stanceResolver,
+		IndicatorCalculator: indicatorCalc,
+		MarketDataService:   marketDataSvc,
+		RealtimeHub:         realtimeHub,
+		OrderClient:         restClient,
+		OrderExecutor:       orderExecutor,
+		Pipeline:            pipeline,
+		RESTClient:          restClient,
+		ClientOrderRepo:     clientOrderRepo,
+		OnSymbolSwitch:      onSymbolSwitch,
+	})
+```
+
+**Step 2b: `startMarketRelay` の呼び出しを更新:**
+
+`main.go:130` の以下を:
+
+```go
+	go startMarketRelay(ctx, wsClient, marketDataSvc, realtimeHub, symbolID)
+```
+
+次のように変更:
+
+```go
+	go startMarketRelay(ctx, wsClient, marketDataSvc, realtimeHub, symbolID, symbolSwitchCh)
+```
+
+**Step 2c: 旧 `ctx, cancel :=` が `sigCh` 前にもう残っていないことを確認する（削除漏れチェック）。**
+
+- [ ] **Step 3: ビルド確認**
+
+Run: `cd backend && go build ./...`
+Expected: エラーなし
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/cmd/main.go
+git commit -m "feat: dynamic WS symbol switching with candle bootstrap and error handling"
+```
+
+---
+
+## Task 5: Frontend — TradableSymbol 型と TradingConfig 型の追加
+
+> **Review fix (C3):** TypeScript グローバルの `Symbol`（ES Symbol プリミティブ）と衝突を避けるため `TradableSymbol` にリネーム。
+
+**Files:**
+- Modify: `frontend/src/lib/api.ts`
+
+- [ ] **Step 1: 型定義を追加**
+
+`frontend/src/lib/api.ts` の `RiskConfig` 型定義の後（`BotControlResponse` の前）に追加:
+
+```typescript
+export type TradableSymbol = {
+  id: number
+  authority: string
+  tradeType: string
+  currencyPair: string
+  baseCurrency: string
+  quoteCurrency: string
+  baseScale: number
+  quoteScale: number
+  baseStepAmount: number
+  minOrderAmount: number
+  maxOrderAmount: number
+  makerTradeFeePercent: number
+  takerTradeFeePercent: number
+  closeOnly: boolean
+  viewOnly: boolean
+  enabled: boolean
+}
+
+export type TradingConfig = {
+  symbolId: number
+  tradeAmount: number
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add frontend/src/lib/api.ts
+git commit -m "feat: add TradableSymbol and TradingConfig types to frontend API layer"
+```
+
+---
+
+## Task 6: Frontend — useSymbols / useTradingConfig hooks
+
+**Files:**
+- Create: `frontend/src/hooks/useSymbols.ts`
+- Create: `frontend/src/hooks/useTradingConfig.ts`
+
+- [ ] **Step 1: useSymbols フックを作成**
+
+```typescript
+// frontend/src/hooks/useSymbols.ts
+import { useQuery } from '@tanstack/react-query'
+import { fetchApi, type TradableSymbol } from '../lib/api'
+
+export function useSymbols() {
+  return useQuery({
+    queryKey: ['symbols'],
+    queryFn: () => fetchApi<TradableSymbol[]>('/symbols'),
+    staleTime: 5 * 60 * 1000, // 銘柄一覧は滅多に変更されないため5分キャッシュ
+  })
+}
+```
+
+- [ ] **Step 2: useTradingConfig フックを作成**
+
+```typescript
+// frontend/src/hooks/useTradingConfig.ts
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { fetchApi, sendApi, type TradingConfig } from '../lib/api'
+
+export function useTradingConfig() {
+  return useQuery({
+    queryKey: ['trading-config'],
+    queryFn: () => fetchApi<TradingConfig>('/trading-config'),
+  })
+}
+
+export function useUpdateTradingConfig() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (config: TradingConfig) =>
+      sendApi<TradingConfig, TradingConfig>('/trading-config', 'PUT', config),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['trading-config'] })
+    },
+  })
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/hooks/useSymbols.ts frontend/src/hooks/useTradingConfig.ts
+git commit -m "feat: add useSymbols and useTradingConfig hooks"
+```
+
+---
+
+## Task 7: Frontend — SymbolContext (グローバル symbolId 管理)
+
+> **Review fix (C3):** `Symbol` → `TradableSymbol` リネーム。
+> **Review fix (H2 API エラー無限ローディング):** `isError` ケースのフォールバックを追加。
+> **Review fix (Codex #3 無効銘柄フォールバック):** trading-config 取得失敗時、ハードコード `DEFAULT_SYMBOL_ID = 7` ではなく、`symbols` から最初の有効銘柄（`enabled && !viewOnly && !closeOnly`）を選ぶ。両方とも取得できない極端なケースのみ 7 に退避。
+> **Review fix (M-NEW2 tradeAmount 誤上書き防止):** `tradingConfig` がロード完了する前は `switchSymbol` を実行不可にする。`isSwitchAllowed` フラグを Context で公開し、SymbolSelector 側で `disabled` に反映する。これにより「設定取得失敗時に tradeAmount=1000 を誤って PUT する」問題を防ぐ。
+> **Review fix (C2 ticker リセット):** 本ファイルでは `symbolId` state の更新のみ。ticker state のリセットは Task 10 で `useMarketTickerStream.ts` 側に `setTicker(null)` を追加することで対応する。
+
+**Files:**
+- Create: `frontend/src/contexts/SymbolContext.tsx`
+
+- [ ] **Step 1: SymbolContext を作成**
+
+```typescript
+// frontend/src/contexts/SymbolContext.tsx
+import { createContext, useContext, useState, useCallback, useEffect, type ReactNode } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import { useTradingConfig, useUpdateTradingConfig } from '../hooks/useTradingConfig'
+import { useSymbols } from '../hooks/useSymbols'
+import type { TradableSymbol } from '../lib/api'
+
+// 両 API が失敗した極端ケースのみ使う最終退避値
+const FALLBACK_SYMBOL_ID = 7
+
+type SymbolContextValue = {
+  symbolId: number
+  symbols: TradableSymbol[]
+  currentSymbol: TradableSymbol | undefined
+  switchSymbol: (symbolId: number) => void
+  isSwitching: boolean
+  // tradingConfig がロード完了するまで false。switchSymbol の実行可否を示す。
+  // Codex M-NEW2 対応: 未ロード時に fallback tradeAmount で PUT して誤上書きするのを防ぐ。
+  isSwitchAllowed: boolean
+}
+
+const SymbolContext = createContext<SymbolContextValue | null>(null)
+
+function pickFirstTradableId(symbols: TradableSymbol[] | undefined): number | null {
+  if (!symbols || symbols.length === 0) return null
+  const found = symbols.find((s) => s.enabled && !s.viewOnly && !s.closeOnly)
+  return found?.id ?? null
+}
+
+export function SymbolProvider({ children }: { children: ReactNode }) {
+  const {
+    data: tradingConfig,
+    isLoading: isConfigLoading,
+    isError: isConfigError,
+  } = useTradingConfig()
+  const { data: symbols, isLoading: isSymbolsLoading } = useSymbols()
+  const updateConfig = useUpdateTradingConfig()
+  const queryClient = useQueryClient()
+
+  const [symbolId, setSymbolId] = useState<number | null>(null)
+
+  // 初期化:
+  //   1. tradingConfig 取得成功 → その値を使う
+  //   2. tradingConfig 失敗 + symbols あり → symbols から最初の有効銘柄（Codex #3）
+  //   3. 両方失敗 → FALLBACK_SYMBOL_ID
+  useEffect(() => {
+    if (symbolId !== null) return
+    if (tradingConfig) {
+      setSymbolId(tradingConfig.symbolId)
+      return
+    }
+    if (isConfigError) {
+      const fallbackFromSymbols = pickFirstTradableId(symbols)
+      if (fallbackFromSymbols !== null) {
+        setSymbolId(fallbackFromSymbols)
+      } else if (!isSymbolsLoading) {
+        // symbols も取れない（エラー or 空配列）— 最終退避
+        setSymbolId(FALLBACK_SYMBOL_ID)
+      }
+    }
+  }, [tradingConfig, isConfigError, symbols, isSymbolsLoading, symbolId])
+
+  // tradingConfig がロード完了している時だけ switchSymbol を許可（M-NEW2 対応）
+  // これにより「未ロード時にデフォルト tradeAmount を PUT して誤上書きする」問題を防ぐ
+  const isSwitchAllowed = tradingConfig !== undefined
+
+  const switchSymbol = useCallback(
+    (newSymbolId: number) => {
+      if (!tradingConfig) {
+        // 未ロード時は何もしない（UI 側でも disabled にしているが、防御的にガード）
+        return
+      }
+      const prevSymbolId = symbolId
+      setSymbolId(newSymbolId)
+      updateConfig.mutate(
+        { symbolId: newSymbolId, tradeAmount: tradingConfig.tradeAmount },
+        {
+          onSuccess: () => {
+            void queryClient.invalidateQueries({ queryKey: ['candles'] })
+            void queryClient.invalidateQueries({ queryKey: ['indicators'] })
+            void queryClient.invalidateQueries({ queryKey: ['positions'] })
+            void queryClient.invalidateQueries({ queryKey: ['trades'] })
+            void queryClient.invalidateQueries({ queryKey: ['status'] })
+            void queryClient.invalidateQueries({ queryKey: ['pnl'] })
+          },
+          onError: () => {
+            setSymbolId(prevSymbolId)
+          },
+        },
+      )
+    },
+    [symbolId, tradingConfig, updateConfig, queryClient],
+  )
+
+  // 初期化完了までは Loading 表示
+  if (symbolId === null) {
+    if (isConfigLoading || isSymbolsLoading) {
+      return (
+        <div className="flex min-h-screen items-center justify-center">
+          <p className="text-sm text-text-secondary">Loading...</p>
+        </div>
+      )
+    }
+    // 両 API 失敗直後、useEffect が走る前の1フレーム
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <p className="text-sm text-text-secondary">Loading...</p>
+      </div>
+    )
+  }
+
+  // symbols は取得失敗時も空配列で動作継続（SymbolSelector 側で空時は非表示）
+  const safeSymbols = symbols ?? []
+  const currentSymbol = safeSymbols.find((s) => s.id === symbolId)
+
+  return (
+    <SymbolContext.Provider
+      value={{
+        symbolId,
+        symbols: safeSymbols,
+        currentSymbol,
+        switchSymbol,
+        isSwitching: updateConfig.isPending,
+        isSwitchAllowed,
+      }}
+    >
+      {children}
+    </SymbolContext.Provider>
+  )
+}
+
+export function useSymbolContext() {
+  const ctx = useContext(SymbolContext)
+  if (!ctx) throw new Error('useSymbolContext must be used within SymbolProvider')
+  return ctx
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add frontend/src/contexts/SymbolContext.tsx
+git commit -m "feat: add SymbolContext for global symbol state management"
+```
+
+---
+
+## Task 8: Frontend — SymbolSelector コンポーネント
+
+**Files:**
+- Create: `frontend/src/components/SymbolSelector.tsx`
+
+- [ ] **Step 1: SymbolSelector を作成**
+
+```typescript
+// frontend/src/components/SymbolSelector.tsx
+import { useSymbolContext } from '../contexts/SymbolContext'
+
+export function SymbolSelector() {
+  const { symbolId, symbols, switchSymbol, isSwitching, isSwitchAllowed } = useSymbolContext()
+
+  const tradableSymbols = symbols.filter((s) => s.enabled && !s.viewOnly && !s.closeOnly)
+
+  if (tradableSymbols.length === 0) {
+    return null
+  }
+
+  // isSwitchAllowed=false は tradingConfig 未ロード時（Review fix M-NEW2）
+  // → 誤って fallback tradeAmount で PUT しないよう disabled にする
+  const disabled = isSwitching || !isSwitchAllowed
+
+  return (
+    <div className="flex items-center gap-2">
+      <label
+        htmlFor="symbol-select"
+        className="text-xs uppercase tracking-[0.18em] text-text-secondary"
+      >
+        銘柄
+      </label>
+      <select
+        id="symbol-select"
+        value={symbolId}
+        onChange={(e) => switchSymbol(Number(e.target.value))}
+        disabled={disabled}
+        className="rounded-full border border-white/10 bg-white/6 px-4 py-2 text-sm font-medium text-white outline-none transition focus:border-cyan-200 disabled:opacity-50"
+      >
+        {tradableSymbols.map((s) => (
+          <option key={s.id} value={s.id} className="bg-bg-card text-white">
+            {s.currencyPair.replace('_', '/')}
+          </option>
+        ))}
+      </select>
+      {isSwitching && (
+        <span className="text-xs text-cyan-200">切替中...</span>
+      )}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add frontend/src/components/SymbolSelector.tsx
+git commit -m "feat: add SymbolSelector dropdown component"
+```
+
+---
+
+## Task 9: Frontend — SymbolProvider をルートに配置 + AppFrame にセレクタ追加
+
+**Files:**
+- Modify: `frontend/src/routes/__root.tsx`
+- Modify: `frontend/src/components/AppFrame.tsx`
+
+- [ ] **Step 1: __root.tsx を読んで現状を確認**
+
+Run: `cat frontend/src/routes/__root.tsx`
+
+- [ ] **Step 2: __root.tsx に SymbolProvider をラップ**
+
+`frontend/src/routes/__root.tsx` のルートコンポーネント内で、`<Outlet />` を `<SymbolProvider>` でラップする。
+
+import を追加:
+```typescript
+import { SymbolProvider } from '../contexts/SymbolContext'
+```
+
+`<Outlet />` を以下に変更:
+```tsx
+<SymbolProvider>
+  <Outlet />
+</SymbolProvider>
+```
+
+- [ ] **Step 3: AppFrame にセレクタを配置**
+
+`frontend/src/components/AppFrame.tsx` を変更:
+
+import を追加:
+```typescript
+import { SymbolSelector } from './SymbolSelector'
+```
+
+ヘッダー部分の `<nav>` の前に `SymbolSelector` を追加:
+
+```tsx
+<div className="flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
+  <div>
+    <p className="text-[0.7rem] uppercase tracking-[0.35em] text-cyan-200/70">Rakuten CFD Bot</p>
+    <h1 className="mt-2 text-3xl font-semibold tracking-tight text-white sm:text-4xl">{title}</h1>
+    <p className="mt-2 max-w-2xl text-sm text-slate-300">{subtitle}</p>
+  </div>
+  <div className="flex flex-col items-end gap-3">
+    <SymbolSelector />
+    <nav className="flex flex-wrap gap-2">
+      {navItems.map((item) => (
+        <Link
+          key={item.to}
+          to={item.to}
+          activeProps={{ className: 'bg-white text-slate-950 shadow-lg' }}
+          inactiveProps={{ className: 'bg-white/8 text-slate-200 hover:bg-white/14' }}
+          className="rounded-full px-4 py-2 text-sm font-medium transition"
+        >
+          {item.label}
+        </Link>
+      ))}
+    </nav>
+  </div>
+</div>
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/routes/__root.tsx frontend/src/components/AppFrame.tsx
+git commit -m "feat: integrate SymbolProvider and SymbolSelector into app shell"
+```
+
+---
+
+## Task 10: Frontend — ハードコード symbolId=7 をすべて Context 経由に変更 + ticker リセット
+
+> **Review fix (C2):** `useMarketTickerStream` の `useEffect` 冒頭に `setTicker(null)` を追加し、`symbolId` が変わった瞬間に ticker local state をクリアする。これにより「新ペア名 + 旧ペア価格」の一時表示を防ぐ。
+
+**Files:**
+- Modify: `frontend/src/hooks/useMarketTickerStream.ts`
+- Modify: `frontend/src/routes/index.tsx`
+- Modify: `frontend/src/routes/settings.tsx`
+- Modify: `frontend/src/routes/history.tsx`
+- Modify: `frontend/src/components/LiveTickerCard.tsx`
+
+- [ ] **Step 0: useMarketTickerStream.ts に ticker リセットを追加 (C2 修正)**
+
+`frontend/src/hooks/useMarketTickerStream.ts` の `useEffect` 冒頭（`let active = true` の前）に `setTicker(null)` を追加:
+
+```typescript
+  useEffect(() => {
+    // symbolId 変更時に旧シンボルの価格が残らないよう、即座にリセット
+    setTicker(null)
+
+    let active = true
+    let socket: WebSocket | null = null
+    let retryTimer: ReturnType<typeof setTimeout> | null = null
+
+    const connect = () => {
+      // ... (既存コードそのまま)
+```
+
+`useEffect` の依存配列は既に `[queryClient, symbolId]` なので、`symbolId` 変更時にこのコードが再実行される。
+
+- [ ] **Step 1: index.tsx を更新**
+
+`frontend/src/routes/index.tsx` の `Dashboard` 関数を変更:
+
+import を追加:
+```typescript
+import { useSymbolContext } from '../contexts/SymbolContext'
+```
+
+関数冒頭に追加:
+```typescript
+const { symbolId } = useSymbolContext()
+```
+
+ハードコード `7` をすべて `symbolId` に置き換える:
+```typescript
+const { data: indicators } = useIndicators(symbolId)
+const { data: candles } = useCandles(symbolId)
+const { data: positions } = usePositions(symbolId)
+const { ticker, connectionState } = useMarketTickerStream(symbolId)
+```
+
+- [ ] **Step 2: settings.tsx を更新**
+
+`frontend/src/routes/settings.tsx` の `SettingsPage` 関数を変更:
+
+import を追加:
+```typescript
+import { useSymbolContext } from '../contexts/SymbolContext'
+```
+
+関数冒頭に追加:
+```typescript
+const { symbolId } = useSymbolContext()
+```
+
+`useMarketTickerStream(7)` を `useMarketTickerStream(symbolId)` に変更。
+
+- [ ] **Step 3: history.tsx を更新**
+
+`frontend/src/routes/history.tsx` の `HistoryPage` 関数を変更:
+
+import を追加:
+```typescript
+import { useSymbolContext } from '../contexts/SymbolContext'
+```
+
+関数冒頭に追加:
+```typescript
+const { symbolId } = useSymbolContext()
+```
+
+以下を変更:
+```typescript
+useMarketTickerStream(symbolId)
+const { data: trades } = useTradeHistory(symbolId)
+```
+
+- [ ] **Step 4: LiveTickerCard.tsx を更新**
+
+`frontend/src/components/LiveTickerCard.tsx` を変更:
+
+props に `currencyPair` を追加:
+```typescript
+type LiveTickerCardProps = {
+  ticker: LiveTicker | null
+  connectionState: 'connecting' | 'connected' | 'disconnected'
+  currencyPair?: string
+}
+
+export function LiveTickerCard({ ticker, connectionState, currencyPair }: LiveTickerCardProps) {
+```
+
+ハードコード `"BTC/JPY ライブ価格"` を動的に:
+```tsx
+<h2 className="mt-2 text-xl font-semibold text-white">{currencyPair ?? 'BTC/JPY'} ライブ価格</h2>
+```
+
+`frontend/src/routes/index.tsx` の `LiveTickerCard` 呼び出しを更新:
+
+import を追加（既に Step 1 で追加済み）:
+```typescript
+import { useSymbolContext } from '../contexts/SymbolContext'
+```
+
+props に追加:
+```tsx
+<LiveTickerCard
+  ticker={ticker}
+  connectionState={connectionState}
+  currencyPair={currentSymbol?.currencyPair?.replace('_', '/')}
+/>
+```
+
+`useSymbolContext` の destructure に `currentSymbol` を追加:
+```typescript
+const { symbolId, currentSymbol } = useSymbolContext()
+```
+
+- [ ] **Step 5: ビルド確認**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: エラーなし
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/hooks/useMarketTickerStream.ts frontend/src/routes/index.tsx frontend/src/routes/settings.tsx frontend/src/routes/history.tsx frontend/src/components/LiveTickerCard.tsx
+git commit -m "feat: replace hardcoded symbolId=7 with SymbolContext and reset ticker on switch"
+```
+
+---
+
+## Task 11: 動作確認
+
+- [ ] **Step 1: バックエンド起動確認**
+
+Run: `cd backend && go build -o main ./cmd && ./main`
+Expected: サーバーが起動する
+
+- [ ] **Step 2: 銘柄一覧 API 確認 + 切替先 ID を決定**
+
+Run: `curl -s localhost:8080/api/v1/symbols | python3 -m json.tool | head -60`
+Expected: Symbol 配列が返る（id, currencyPair, enabled 等のフィールド）
+
+**重要 (m3 対応):** このレスポンスから **現在の symbolId 以外で `enabled=true && viewOnly=false && closeOnly=false` の銘柄 ID を1つ選ぶ**。以降の Step 4 ではその ID を使う。
+
+例: ETH_JPY の id が 8 なら Step 4 で `symbolId:8` を指定する。以下シェル変数 `TARGET_SYMBOL_ID` に入れておくと便利:
+
+```bash
+# 現在の symbolId を取得
+CURRENT_SYMBOL_ID=$(curl -s localhost:8080/api/v1/trading-config | python3 -c 'import sys, json; print(json.load(sys.stdin)["symbolId"])')
+# 現在以外で取引可能な最初の symbol id を取得
+TARGET_SYMBOL_ID=$(curl -s localhost:8080/api/v1/symbols | python3 -c "
+import sys, json
+current = $CURRENT_SYMBOL_ID
+for s in json.load(sys.stdin):
+    if s['id'] != current and s['enabled'] and not s['viewOnly'] and not s['closeOnly']:
+        print(s['id']); break
+")
+echo "TARGET_SYMBOL_ID=$TARGET_SYMBOL_ID"
+```
+
+- [ ] **Step 3: trading-config API 確認**
+
+Run: `curl -s localhost:8080/api/v1/trading-config | python3 -m json.tool`
+Expected: 200 で `symbolId` と `tradeAmount` を含むオブジェクトが返る（具体的な値は起動時の環境変数次第）
+
+- [ ] **Step 4: trading-config 切替確認（Step 2 で決めた ID を使う）**
+
+Run: `curl -s -X PUT localhost:8080/api/v1/trading-config -H 'Content-Type: application/json' -d "{\"symbolId\":$TARGET_SYMBOL_ID,\"tradeAmount\":1000}" | python3 -m json.tool`
+Expected: 200 で `{"symbolId": <TARGET_SYMBOL_ID>, "tradeAmount": 1000}` が返る
+
+- [ ] **Step 5: 無効シンボルのバリデーション確認 (M1)**
+
+Run: `curl -s -X PUT localhost:8080/api/v1/trading-config -H 'Content-Type: application/json' -d '{"symbolId":99999,"tradeAmount":1000}'`
+Expected: `{"error": "unknown symbolId"}` で 400 が返る
+
+- [ ] **Step 6: tradeAmount バリデーション確認 (M-amount)**
+
+Run: `curl -s -X PUT localhost:8080/api/v1/trading-config -H 'Content-Type: application/json' -d "{\"symbolId\":$CURRENT_SYMBOL_ID,\"tradeAmount\":0}"`
+Expected: `{"error": "tradeAmount must be positive"}` で 400 が返る
+
+- [ ] **Step 7: フロントエンド起動確認**
+
+Run: `cd frontend && npm run dev`
+Expected: localhost:3000 で画面が表示される
+
+- [ ] **Step 8: 画面上で銘柄セレクタを操作**
+
+ブラウザで localhost:3000 を開き、ヘッダーの銘柄セレクタから別の通貨ペアを選択。
+Expected: ティッカー、チャート、インジケーター、ポジションの表示が選択した銘柄に切り替わる。切替直後にティッカー値は「Loading...」状態になり、旧ペアの価格は表示されない。
+
+- [ ] **Step 9: Start/Stop と切替の並行呼び出しを確認（Codex #1/#2 対応）**
+
+> **目的:** ユニットテスト（Task 2 Step 9）で検証済みの並行性を、実際の統合環境でも手動で再確認する。
+
+`/api/v1/start` でパイプラインを開始した直後に、連続して銘柄切替を叩く:
+
+```bash
+curl -X POST localhost:8080/api/v1/start
+curl -X PUT localhost:8080/api/v1/trading-config -H 'Content-Type: application/json' -d "{\"symbolId\":$TARGET_SYMBOL_ID,\"tradeAmount\":1000}" &
+curl -X POST localhost:8080/api/v1/stop &
+wait
+curl -s localhost:8080/api/v1/status
+```
+
+Expected:
+- サーバーログに panic / deadlock の気配がない
+- 最終的な `status` が `running=false`（Stop が効いている。Codex #1 対応）
+- ログに `trading pipeline stopped` が記録されている
+
+もし `running=true` になっている場合は Codex #1 の不具合が残っているので Task 2 の実装を確認する。

--- a/docs/superpowers/plans/2026-04-13-strategy-improvements.md
+++ b/docs/superpowers/plans/2026-04-13-strategy-improvements.md
@@ -1,0 +1,1099 @@
+# Trading Strategy Improvements Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Improve the auto-trading bot's win rate by adding MACD confirmation, take-profit exits, trailing stop-loss, and a consecutive-loss circuit breaker — each as a separate PR on its own branch.
+
+**Architecture:** Each improvement is an isolated, incremental enhancement to the existing strategy/risk/pipeline layers. No new services or external dependencies. Each PR is independently deployable and reversible.
+
+**Tech Stack:** Go 1.22+, existing indicator/entity/usecase/pipeline packages
+
+---
+
+## Branch / PR Strategy
+
+Each task below produces **one branch → one PR**. Branch off `main` each time.
+
+| # | Branch | Summary |
+|---|--------|---------|
+| 1 | `improve/macd-confirmation` | MACD ヒストグラムによるシグナル確認フィルター |
+| 2 | `improve/take-profit` | 利確ロジック（リスクリワード 1:2） |
+| 3 | `improve/trailing-stop` | トレーリングストップ |
+| 4 | `improve/consecutive-loss-breaker` | 連敗ブレーカー（N連敗で冷却期間） |
+
+---
+
+## Task 1: MACD Confirmation Filter
+
+**Branch:** `improve/macd-confirmation`
+
+**Problem:** 現在 MACD/EMA を計算しているが売買判断に使っていない。SMA 交差だけでは偽シグナルが多い。
+
+**Solution:** TREND_FOLLOW/CONTRARIAN のシグナル生成時に MACD ヒストグラムの方向を確認条件として追加する。
+
+**Files:**
+- Modify: `backend/internal/usecase/strategy.go` — Evaluate / evaluateTrendFollow / evaluateContrarian に MACD 確認を追加
+- Modify: `backend/internal/usecase/strategy_test.go` — 新しいテストケース追加
+- Modify: `backend/internal/domain/entity/indicator.go` — (変更なし、既に MACDLine/SignalLine/Histogram あり)
+
+### Steps
+
+- [ ] **Step 1: strategy_test.go にテスト追加 — MACD が逆方向なら HOLD**
+
+`backend/internal/usecase/strategy_test.go` に以下を追加:
+
+```go
+func TestStrategyEngine_TrendFollow_HoldWhenMACDAgainst(t *testing.T) {
+	// SMA20 > SMA50 (uptrend) but MACD histogram is negative → HOLD
+	resolver := &mockStanceResolver{
+		result: StanceResult{
+			Stance:    entity.MarketStanceTrendFollow,
+			Reasoning: "uptrend",
+			Source:    "rule-based",
+			UpdatedAt: time.Now().Unix(),
+		},
+	}
+	engine := NewStrategyEngine(resolver)
+
+	indicators := entity.IndicatorSet{
+		SymbolID:  7,
+		SMA20:     ptr(5100000),
+		SMA50:     ptr(5000000),
+		RSI14:     ptr(55.0),
+		Histogram: ptr(-5.0), // MACD histogram negative = against buy
+	}
+	signal, err := engine.Evaluate(context.Background(), indicators, 5100000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if signal.Action != entity.SignalActionHold {
+		t.Fatalf("expected HOLD when MACD histogram against trend, got %s", signal.Action)
+	}
+}
+
+func TestStrategyEngine_TrendFollow_SellBlockedByPositiveHistogram(t *testing.T) {
+	// SMA20 < SMA50 (downtrend) but MACD histogram is positive → HOLD
+	resolver := &mockStanceResolver{
+		result: StanceResult{
+			Stance:    entity.MarketStanceTrendFollow,
+			Reasoning: "downtrend",
+			Source:    "rule-based",
+			UpdatedAt: time.Now().Unix(),
+		},
+	}
+	engine := NewStrategyEngine(resolver)
+
+	indicators := entity.IndicatorSet{
+		SymbolID:  7,
+		SMA20:     ptr(4900000),
+		SMA50:     ptr(5000000),
+		RSI14:     ptr(45.0),
+		Histogram: ptr(3.0), // positive histogram blocks sell
+	}
+	signal, err := engine.Evaluate(context.Background(), indicators, 4900000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if signal.Action != entity.SignalActionHold {
+		t.Fatalf("expected HOLD when MACD histogram against sell, got %s", signal.Action)
+	}
+}
+
+func TestStrategyEngine_TrendFollow_BuyWithMACDConfirmation(t *testing.T) {
+	resolver := &mockStanceResolver{
+		result: StanceResult{
+			Stance:    entity.MarketStanceTrendFollow,
+			Reasoning: "uptrend",
+			Source:    "rule-based",
+			UpdatedAt: time.Now().Unix(),
+		},
+	}
+	engine := NewStrategyEngine(resolver)
+
+	indicators := entity.IndicatorSet{
+		SymbolID:  7,
+		SMA20:     ptr(5100000),
+		SMA50:     ptr(5000000),
+		RSI14:     ptr(55.0),
+		Histogram: ptr(10.0), // positive histogram confirms buy
+	}
+	signal, err := engine.Evaluate(context.Background(), indicators, 5100000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if signal.Action != entity.SignalActionBuy {
+		t.Fatalf("expected BUY with MACD confirmation, got %s", signal.Action)
+	}
+}
+
+func TestStrategyEngine_Contrarian_HoldWhenMACDAgainst(t *testing.T) {
+	// RSI < 30 (oversold) but MACD histogram still strongly negative → HOLD
+	resolver := &mockStanceResolver{
+		result: StanceResult{
+			Stance:    entity.MarketStanceContrarian,
+			Reasoning: "RSI oversold",
+			Source:    "rule-based",
+			UpdatedAt: time.Now().Unix(),
+		},
+	}
+	engine := NewStrategyEngine(resolver)
+
+	indicators := entity.IndicatorSet{
+		SymbolID:  7,
+		SMA20:     ptr(4900000),
+		SMA50:     ptr(5000000),
+		RSI14:     ptr(25.0),
+		Histogram: ptr(-20.0), // strong negative momentum = don't buy the dip
+	}
+	signal, err := engine.Evaluate(context.Background(), indicators, 4900000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if signal.Action != entity.SignalActionHold {
+		t.Fatalf("expected HOLD when MACD strongly against contrarian buy, got %s", signal.Action)
+	}
+}
+
+func TestStrategyEngine_TrendFollow_NilHistogramStillTrades(t *testing.T) {
+	// Histogram が nil(データ不足) の場合は従来通り SMA+RSI だけで判断
+	resolver := &mockStanceResolver{
+		result: StanceResult{
+			Stance:    entity.MarketStanceTrendFollow,
+			Reasoning: "uptrend",
+			Source:    "rule-based",
+			UpdatedAt: time.Now().Unix(),
+		},
+	}
+	engine := NewStrategyEngine(resolver)
+
+	indicators := entity.IndicatorSet{
+		SymbolID: 7,
+		SMA20:    ptr(5100000),
+		SMA50:    ptr(5000000),
+		RSI14:    ptr(55.0),
+		// Histogram is nil
+	}
+	signal, err := engine.Evaluate(context.Background(), indicators, 5100000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if signal.Action != entity.SignalActionBuy {
+		t.Fatalf("expected BUY when histogram nil (fallback), got %s", signal.Action)
+	}
+}
+```
+
+- [ ] **Step 2: テストが FAIL することを確認**
+
+Run: `cd backend && go test ./internal/usecase/ -run "TestStrategyEngine_TrendFollow_HoldWhenMACDAgainst|TestStrategyEngine_TrendFollow_SellBlockedByPositiveHistogram|TestStrategyEngine_TrendFollow_BuyWithMACDConfirmation|TestStrategyEngine_Contrarian_HoldWhenMACDAgainst|TestStrategyEngine_TrendFollow_NilHistogramStillTrades" -v`
+
+Expected: 2 test failures (`HoldWhenMACDAgainst`, `SellBlockedByPositiveHistogram`, `Contrarian_HoldWhenMACDAgainst`) — 現在の実装は MACD を無視して BUY/SELL を返すため。
+
+- [ ] **Step 3: strategy.go の evaluateTrendFollow を修正**
+
+`backend/internal/usecase/strategy.go` の `evaluateTrendFollow` を修正:
+
+```go
+func (e *StrategyEngine) evaluateTrendFollow(symbolID int64, sma20, sma50, rsi float64, histogram *float64) *entity.Signal {
+	now := time.Now().Unix()
+
+	if sma20 > sma50 && rsi < 70 {
+		// MACD ヒストグラムが負なら見送り（momentum が逆方向）
+		if histogram != nil && *histogram < 0 {
+			return &entity.Signal{
+				SymbolID:  symbolID,
+				Action:    entity.SignalActionHold,
+				Reason:    "trend follow: MACD histogram negative, skipping buy",
+				Timestamp: now,
+			}
+		}
+		return &entity.Signal{
+			SymbolID:  symbolID,
+			Action:    entity.SignalActionBuy,
+			Reason:    "trend follow: SMA20 > SMA50, RSI not overbought, MACD confirmed",
+			Timestamp: now,
+		}
+	}
+	if sma20 < sma50 && rsi > 30 {
+		// MACD ヒストグラムが正なら見送り（momentum が逆方向）
+		if histogram != nil && *histogram > 0 {
+			return &entity.Signal{
+				SymbolID:  symbolID,
+				Action:    entity.SignalActionHold,
+				Reason:    "trend follow: MACD histogram positive, skipping sell",
+				Timestamp: now,
+			}
+		}
+		return &entity.Signal{
+			SymbolID:  symbolID,
+			Action:    entity.SignalActionSell,
+			Reason:    "trend follow: SMA20 < SMA50, RSI not oversold, MACD confirmed",
+			Timestamp: now,
+		}
+	}
+	return &entity.Signal{
+		SymbolID:  symbolID,
+		Action:    entity.SignalActionHold,
+		Reason:    "trend follow: no clear signal",
+		Timestamp: now,
+	}
+}
+```
+
+- [ ] **Step 4: evaluateContrarian を修正**
+
+```go
+func (e *StrategyEngine) evaluateContrarian(symbolID int64, rsi float64, histogram *float64) *entity.Signal {
+	now := time.Now().Unix()
+
+	if rsi < 30 {
+		// ヒストグラムがまだ強く下落中なら、底を打っていないのでスキップ
+		if histogram != nil && *histogram < -10 {
+			return &entity.Signal{
+				SymbolID:  symbolID,
+				Action:    entity.SignalActionHold,
+				Reason:    "contrarian: RSI oversold but MACD momentum still strongly negative",
+				Timestamp: now,
+			}
+		}
+		return &entity.Signal{
+			SymbolID:  symbolID,
+			Action:    entity.SignalActionBuy,
+			Reason:    "contrarian: RSI oversold, MACD momentum easing",
+			Timestamp: now,
+		}
+	}
+	if rsi > 70 {
+		if histogram != nil && *histogram > 10 {
+			return &entity.Signal{
+				SymbolID:  symbolID,
+				Action:    entity.SignalActionHold,
+				Reason:    "contrarian: RSI overbought but MACD momentum still strongly positive",
+				Timestamp: now,
+			}
+		}
+		return &entity.Signal{
+			SymbolID:  symbolID,
+			Action:    entity.SignalActionSell,
+			Reason:    "contrarian: RSI overbought, MACD momentum easing",
+			Timestamp: now,
+		}
+	}
+	return &entity.Signal{
+		SymbolID:  symbolID,
+		Action:    entity.SignalActionHold,
+		Reason:    "contrarian: RSI in neutral zone",
+		Timestamp: now,
+	}
+}
+```
+
+- [ ] **Step 5: Evaluate メソッドのシグネチャ更新**
+
+`Evaluate` 内の呼び出しを更新し、`indicators.Histogram` を渡す:
+
+```go
+switch result.Stance {
+case entity.MarketStanceTrendFollow:
+	return e.evaluateTrendFollow(indicators.SymbolID, sma20, sma50, rsi, indicators.Histogram), nil
+case entity.MarketStanceContrarian:
+	return e.evaluateContrarian(indicators.SymbolID, rsi, indicators.Histogram), nil
+default:
+	// ...
+}
+```
+
+- [ ] **Step 6: 全テスト PASS を確認**
+
+Run: `cd backend && go test ./internal/usecase/ -v -run TestStrategy`
+Expected: ALL PASS（既存テストは Histogram=nil で従来動作を維持）
+
+- [ ] **Step 7: 全体テスト PASS を確認**
+
+Run: `cd backend && go test ./...`
+Expected: ALL PASS
+
+- [ ] **Step 8: コミット → PR**
+
+```bash
+git checkout main && git pull
+git checkout -b improve/macd-confirmation
+git add backend/internal/usecase/strategy.go backend/internal/usecase/strategy_test.go
+git commit -m "feat(strategy): add MACD histogram confirmation filter
+
+TREND_FOLLOW: skip buy when histogram < 0, skip sell when histogram > 0
+CONTRARIAN: skip entry when MACD momentum is strongly against direction
+Nil histogram (insufficient data) falls back to previous SMA+RSI logic"
+git push -u origin improve/macd-confirmation
+gh pr create --base main --title "feat(strategy): add MACD histogram confirmation filter" --body "$(cat <<'EOF'
+## Summary
+- TREND_FOLLOW: MACD ヒストグラムがトレンド方向と逆の場合はエントリーをスキップ
+- CONTRARIAN: MACD モメンタムが強く逆方向の場合はエントリーをスキップ
+- Histogram が nil（データ不足）の場合は従来の SMA+RSI ロジックにフォールバック
+
+## Why
+現状 MACD/EMA を計算しているが売買判断に使っていない。SMA 交差だけでは偽シグナルが多く、毎回負けている原因の一つ。
+
+## Test plan
+- [ ] `go test ./internal/usecase/ -run TestStrategy -v` — 全テスト PASS
+- [ ] `go test ./...` — 既存テスト regression なし
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Task 2: Take-Profit Logic
+
+**Branch:** `improve/take-profit`
+
+**Problem:** ストップロス（-5%）しかなく利確ロジックがない。含み益が出てもいずれ損切りで終わる。
+
+**Solution:** RiskManager に `CheckTakeProfit` を追加し、ストップロスモニタと同じ経路で利確を実行する。デフォルト利確ラインはストップロスの2倍（10%）。
+
+**Files:**
+- Modify: `backend/internal/domain/entity/risk.go` — `TakeProfitPercent` フィールド追加
+- Modify: `backend/config/config.go` — `TakeProfitPercent` 環境変数読み込み
+- Modify: `backend/internal/usecase/risk.go` — `CheckTakeProfit` メソッド追加
+- Modify: `backend/internal/usecase/risk_test.go` — テスト追加
+- Modify: `backend/cmd/pipeline.go` — ストップロスモニタに利確チェック追加
+
+### Steps
+
+- [ ] **Step 1: entity/risk.go に TakeProfitPercent 追加**
+
+```go
+type RiskConfig struct {
+	MaxPositionAmount float64 `json:"maxPositionAmount"`
+	MaxDailyLoss      float64 `json:"maxDailyLoss"`
+	StopLossPercent   float64 `json:"stopLossPercent"`
+	TakeProfitPercent float64 `json:"takeProfitPercent"` // 利確ライン（%）
+	InitialCapital    float64 `json:"initialCapital"`
+}
+```
+
+- [ ] **Step 2: config.go に環境変数追加**
+
+```go
+Risk: RiskConfig{
+	MaxPositionAmount: getEnvFloat("RISK_MAX_POSITION_AMOUNT", 5000),
+	MaxDailyLoss:      getEnvFloat("RISK_MAX_DAILY_LOSS", 5000),
+	StopLossPercent:   getEnvFloat("RISK_STOP_LOSS_PERCENT", 5),
+	TakeProfitPercent: getEnvFloat("RISK_TAKE_PROFIT_PERCENT", 10), // デフォルト: SLの2倍
+	InitialCapital:    getEnvFloat("RISK_INITIAL_CAPITAL", 10000),
+},
+```
+
+- [ ] **Step 3: risk_test.go にテスト追加**
+
+```go
+func TestRiskManager_CheckTakeProfit_BuyPosition(t *testing.T) {
+	cfg := defaultRiskConfig()
+	cfg.TakeProfitPercent = 10
+	rm := NewRiskManager(cfg)
+	rm.UpdatePositions([]entity.Position{
+		{ID: 1, SymbolID: 7, OrderSide: entity.OrderSideBuy, Price: 5000000, Amount: 0.001, RemainingAmount: 0.001},
+	})
+	// 10% profit: 5000000 * 1.10 = 5500000
+	targets := rm.CheckTakeProfit(7, 5500000)
+	if len(targets) != 1 {
+		t.Fatalf("expected 1 take-profit position, got %d", len(targets))
+	}
+}
+
+func TestRiskManager_CheckTakeProfit_NoTrigger(t *testing.T) {
+	cfg := defaultRiskConfig()
+	cfg.TakeProfitPercent = 10
+	rm := NewRiskManager(cfg)
+	rm.UpdatePositions([]entity.Position{
+		{ID: 1, SymbolID: 7, OrderSide: entity.OrderSideBuy, Price: 5000000, Amount: 0.001, RemainingAmount: 0.001},
+	})
+	// Only 5% profit → not enough
+	targets := rm.CheckTakeProfit(7, 5250000)
+	if len(targets) != 0 {
+		t.Fatalf("expected 0 take-profit positions, got %d", len(targets))
+	}
+}
+
+func TestRiskManager_CheckTakeProfit_SellPosition(t *testing.T) {
+	cfg := defaultRiskConfig()
+	cfg.TakeProfitPercent = 10
+	rm := NewRiskManager(cfg)
+	rm.UpdatePositions([]entity.Position{
+		{ID: 1, SymbolID: 7, OrderSide: entity.OrderSideSell, Price: 5000000, Amount: 0.001, RemainingAmount: 0.001},
+	})
+	// Sell position profit when price drops: (5000000 - 4500000) / 5000000 = 10%
+	targets := rm.CheckTakeProfit(7, 4500000)
+	if len(targets) != 1 {
+		t.Fatalf("expected 1 take-profit position, got %d", len(targets))
+	}
+}
+
+func TestRiskManager_CheckTakeProfit_ZeroConfig_NeverTriggers(t *testing.T) {
+	cfg := defaultRiskConfig()
+	cfg.TakeProfitPercent = 0 // disabled
+	rm := NewRiskManager(cfg)
+	rm.UpdatePositions([]entity.Position{
+		{ID: 1, SymbolID: 7, OrderSide: entity.OrderSideBuy, Price: 5000000, Amount: 0.001, RemainingAmount: 0.001},
+	})
+	targets := rm.CheckTakeProfit(7, 99999999)
+	if len(targets) != 0 {
+		t.Fatalf("expected 0 when take-profit disabled, got %d", len(targets))
+	}
+}
+```
+
+- [ ] **Step 4: テスト FAIL 確認**
+
+Run: `cd backend && go test ./internal/usecase/ -run TestRiskManager_CheckTakeProfit -v`
+Expected: compilation error (`CheckTakeProfit` not defined)
+
+- [ ] **Step 5: risk.go に CheckTakeProfit 実装**
+
+```go
+func (rm *RiskManager) CheckTakeProfit(symbolID int64, currentPrice float64) []entity.Position {
+	if rm.config.TakeProfitPercent <= 0 {
+		return nil
+	}
+
+	rm.mu.RLock()
+	defer rm.mu.RUnlock()
+
+	var result []entity.Position
+	for _, pos := range rm.positions {
+		if pos.SymbolID != symbolID {
+			continue
+		}
+		var profitPercent float64
+		if pos.OrderSide == entity.OrderSideBuy {
+			profitPercent = (currentPrice - pos.Price) / pos.Price * 100
+		} else {
+			profitPercent = (pos.Price - currentPrice) / pos.Price * 100
+		}
+		if profitPercent >= rm.config.TakeProfitPercent {
+			result = append(result, pos)
+		}
+	}
+	return result
+}
+```
+
+- [ ] **Step 6: テスト PASS 確認**
+
+Run: `cd backend && go test ./internal/usecase/ -run TestRiskManager_CheckTakeProfit -v`
+Expected: ALL PASS
+
+- [ ] **Step 7: pipeline.go の runStopLossMonitor に利確チェック追加**
+
+`runStopLossMonitor` 内、stop-loss チェックの後に以下を追加:
+
+```go
+// Take-profit チェック
+tpTargets := p.riskMgr.CheckTakeProfit(t.SymbolID, t.Last)
+for _, pos := range tpTargets {
+	slog.Info("pipeline: take-profit triggered",
+		"positionID", pos.ID, "side", pos.OrderSide, "entryPrice", pos.Price, "currentPrice", t.Last)
+
+	clientOrderID := newAgentClientOrderID("takeprofit")
+	result, err := p.orderExecutor.ClosePosition(ctx, clientOrderID, pos, t.Last)
+	if err != nil {
+		slog.Error("pipeline: take-profit close failed", "error", err)
+		continue
+	}
+	if result.Executed {
+		slog.Info("pipeline: take-profit closed", "orderID", result.OrderID)
+		closeSide := string(entity.OrderSideSell)
+		if pos.OrderSide == entity.OrderSideSell {
+			closeSide = string(entity.OrderSideBuy)
+		}
+		p.recordTrade(ctx, pos.SymbolID, result.OrderID, closeSide, "close", t.Last, pos.RemainingAmount, "take-profit", false)
+		p.persistRiskState(ctx)
+	}
+}
+```
+
+- [ ] **Step 8: risk_test.go の defaultRiskConfig を更新**
+
+```go
+func defaultRiskConfig() entity.RiskConfig {
+	return entity.RiskConfig{
+		MaxPositionAmount: 5000,
+		MaxDailyLoss:      5000,
+		StopLossPercent:   5,
+		TakeProfitPercent: 10,
+		InitialCapital:    10000,
+	}
+}
+```
+
+- [ ] **Step 9: 全体テスト PASS 確認**
+
+Run: `cd backend && go test ./...`
+Expected: ALL PASS
+
+- [ ] **Step 10: コミット → PR**
+
+```bash
+git checkout main && git pull
+git checkout -b improve/take-profit
+git add backend/internal/domain/entity/risk.go backend/config/config.go backend/internal/usecase/risk.go backend/internal/usecase/risk_test.go backend/cmd/pipeline.go
+git commit -m "feat(risk): add take-profit exit logic
+
+Add CheckTakeProfit to RiskManager with configurable RISK_TAKE_PROFIT_PERCENT (default 10%).
+Integrate into stop-loss monitor loop for real-time profit taking.
+Risk/reward ratio is now 1:2 (5% SL : 10% TP) by default."
+git push -u origin improve/take-profit
+gh pr create --base main --title "feat(risk): add take-profit exit logic (R:R 1:2)" --body "$(cat <<'EOF'
+## Summary
+- RiskManager に `CheckTakeProfit` メソッドを追加
+- `RISK_TAKE_PROFIT_PERCENT` 環境変数（デフォルト 10%）で利確ラインを設定
+- ストップロスモニタループに利確チェックを統合
+- デフォルトのリスクリワード比は 1:2（SL 5% : TP 10%）
+
+## Why
+利確ロジックがなく、含み益が出てもいずれ損切りで終わる非対称なリスクプロファイルが負け続ける原因。
+
+## Test plan
+- [ ] `go test ./internal/usecase/ -run TestRiskManager_CheckTakeProfit -v` — 全テスト PASS
+- [ ] `go test ./...` — 既存テスト regression なし
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Task 3: Trailing Stop-Loss
+
+**Branch:** `improve/trailing-stop`
+
+**Problem:** 固定5%ストップロスでは含み益を守れない。利益が出た後に反転して損切りになる。
+
+**Solution:** RiskManager にポジションごとの最高値/最安値を追跡するフィールドを追加し、トレーリングストップを実装する。
+
+**Files:**
+- Modify: `backend/internal/usecase/risk.go` — 高値追跡 + `UpdateHighWaterMark` + `CheckTrailingStop`
+- Modify: `backend/internal/usecase/risk_test.go` — テスト追加
+- Modify: `backend/cmd/pipeline.go` — モニタループにトレーリングストップチェック追加
+
+### Steps
+
+- [ ] **Step 1: risk_test.go にテスト追加**
+
+```go
+func TestRiskManager_TrailingStop_BuyPosition(t *testing.T) {
+	rm := NewRiskManager(defaultRiskConfig())
+	rm.UpdatePositions([]entity.Position{
+		{ID: 1, SymbolID: 7, OrderSide: entity.OrderSideBuy, Price: 5000000, Amount: 0.001, RemainingAmount: 0.001},
+	})
+	// Price goes up to 5500000 then drops
+	rm.UpdateHighWaterMark(1, 5500000)
+	// Trail = 5% of high water mark: 5500000 * 0.95 = 5225000
+	// Current price 5200000 < 5225000 → trigger
+	targets := rm.CheckTrailingStop(7, 5200000)
+	if len(targets) != 1 {
+		t.Fatalf("expected 1 trailing stop position, got %d", len(targets))
+	}
+}
+
+func TestRiskManager_TrailingStop_NoTriggerAboveTrail(t *testing.T) {
+	rm := NewRiskManager(defaultRiskConfig())
+	rm.UpdatePositions([]entity.Position{
+		{ID: 1, SymbolID: 7, OrderSide: entity.OrderSideBuy, Price: 5000000, Amount: 0.001, RemainingAmount: 0.001},
+	})
+	rm.UpdateHighWaterMark(1, 5500000)
+	// Trail = 5225000; price 5300000 > 5225000 → no trigger
+	targets := rm.CheckTrailingStop(7, 5300000)
+	if len(targets) != 0 {
+		t.Fatalf("expected 0 trailing stop positions, got %d", len(targets))
+	}
+}
+
+func TestRiskManager_TrailingStop_OnlyActivatesAfterProfit(t *testing.T) {
+	rm := NewRiskManager(defaultRiskConfig())
+	rm.UpdatePositions([]entity.Position{
+		{ID: 1, SymbolID: 7, OrderSide: entity.OrderSideBuy, Price: 5000000, Amount: 0.001, RemainingAmount: 0.001},
+	})
+	// No high water mark set (or entry price = high water mark)
+	// Trailing stop should not activate until position is in profit
+	// Price drops to 4800000 — this should be caught by regular stop-loss, not trailing
+	targets := rm.CheckTrailingStop(7, 4800000)
+	if len(targets) != 0 {
+		t.Fatalf("expected 0 — trailing stop should not activate before profit, got %d", len(targets))
+	}
+}
+
+func TestRiskManager_TrailingStop_SellPosition(t *testing.T) {
+	rm := NewRiskManager(defaultRiskConfig())
+	rm.UpdatePositions([]entity.Position{
+		{ID: 1, SymbolID: 7, OrderSide: entity.OrderSideSell, Price: 5000000, Amount: 0.001, RemainingAmount: 0.001},
+	})
+	// Sell position: track low water mark (price went down to 4500000)
+	rm.UpdateHighWaterMark(1, 4500000)
+	// Trail for sell = 5% above low: 4500000 * 1.05 = 4725000
+	// Price bounces to 4750000 → trigger
+	targets := rm.CheckTrailingStop(7, 4750000)
+	if len(targets) != 1 {
+		t.Fatalf("expected 1 trailing stop for sell position, got %d", len(targets))
+	}
+}
+```
+
+- [ ] **Step 2: テスト FAIL 確認 (compilation error)**
+
+- [ ] **Step 3: risk.go にトレーリングストップ実装**
+
+`RiskManager` 構造体にフィールド追加:
+
+```go
+type RiskManager struct {
+	config     entity.RiskConfig
+	mu         sync.RWMutex
+	balance    float64
+	dailyLoss  float64
+	positions  []entity.Position
+	manualStop bool
+	highWaterMarks map[int64]float64 // positionID → best price (high for buy, low for sell)
+}
+```
+
+`NewRiskManager` で初期化:
+
+```go
+func NewRiskManager(config entity.RiskConfig) *RiskManager {
+	return &RiskManager{
+		config:         config,
+		balance:        config.InitialCapital,
+		highWaterMarks: make(map[int64]float64),
+	}
+}
+```
+
+新メソッド:
+
+```go
+// UpdateHighWaterMark はポジションの最良価格を更新する。
+// buy ポジション: 最高値を追跡。sell ポジション: 最安値を追跡。
+func (rm *RiskManager) UpdateHighWaterMark(positionID int64, currentPrice float64) {
+	rm.mu.Lock()
+	defer rm.mu.Unlock()
+
+	existing, ok := rm.highWaterMarks[positionID]
+	if !ok {
+		rm.highWaterMarks[positionID] = currentPrice
+		return
+	}
+
+	// ポジションの方向を判定
+	var isBuy bool
+	for _, pos := range rm.positions {
+		if pos.ID == positionID {
+			isBuy = pos.OrderSide == entity.OrderSideBuy
+			break
+		}
+	}
+
+	if isBuy && currentPrice > existing {
+		rm.highWaterMarks[positionID] = currentPrice
+	} else if !isBuy && currentPrice < existing {
+		rm.highWaterMarks[positionID] = currentPrice
+	}
+}
+
+// CheckTrailingStop はトレーリングストップに達したポジションを返す。
+// エントリー価格より利益が出ていない場合は発動しない（通常のストップロスに委ねる）。
+func (rm *RiskManager) CheckTrailingStop(symbolID int64, currentPrice float64) []entity.Position {
+	rm.mu.RLock()
+	defer rm.mu.RUnlock()
+
+	var result []entity.Position
+	for _, pos := range rm.positions {
+		if pos.SymbolID != symbolID {
+			continue
+		}
+
+		hwm, ok := rm.highWaterMarks[pos.ID]
+		if !ok {
+			continue
+		}
+
+		if pos.OrderSide == entity.OrderSideBuy {
+			// 利益が出ていない場合はスキップ
+			if hwm <= pos.Price {
+				continue
+			}
+			// トレーリングストップライン = 最高値 × (1 - SL%)
+			trailLine := hwm * (1 - rm.config.StopLossPercent/100)
+			if currentPrice <= trailLine {
+				result = append(result, pos)
+			}
+		} else {
+			// sell: 利益が出ていない場合はスキップ
+			if hwm >= pos.Price {
+				continue
+			}
+			// トレーリングストップライン = 最安値 × (1 + SL%)
+			trailLine := hwm * (1 + rm.config.StopLossPercent/100)
+			if currentPrice >= trailLine {
+				result = append(result, pos)
+			}
+		}
+	}
+	return result
+}
+```
+
+`UpdatePositions` でクリーンアップ追加:
+
+```go
+func (rm *RiskManager) UpdatePositions(positions []entity.Position) {
+	rm.mu.Lock()
+	defer rm.mu.Unlock()
+	rm.positions = positions
+
+	// 閉じたポジションの high water mark をクリーンアップ
+	active := make(map[int64]bool, len(positions))
+	for _, pos := range positions {
+		active[pos.ID] = true
+	}
+	for id := range rm.highWaterMarks {
+		if !active[id] {
+			delete(rm.highWaterMarks, id)
+		}
+	}
+}
+```
+
+- [ ] **Step 4: テスト PASS 確認**
+
+Run: `cd backend && go test ./internal/usecase/ -run TestRiskManager_TrailingStop -v`
+Expected: ALL PASS
+
+- [ ] **Step 5: pipeline.go のストップロスモニタに統合**
+
+`runStopLossMonitor` 内のティッカー受信ループに追加:
+
+```go
+// High water mark 更新
+positions, posErr := p.restClient.GetPositions(ctx, snap.symbolID)
+if posErr == nil {
+	for _, pos := range positions {
+		p.riskMgr.UpdateHighWaterMark(pos.ID, t.Last)
+	}
+}
+
+// Trailing stop チェック（通常 SL より先にチェック）
+trailTargets := p.riskMgr.CheckTrailingStop(t.SymbolID, t.Last)
+for _, pos := range trailTargets {
+	slog.Info("pipeline: trailing stop triggered",
+		"positionID", pos.ID, "side", pos.OrderSide, "entryPrice", pos.Price, "currentPrice", t.Last)
+
+	clientOrderID := newAgentClientOrderID("trailstop")
+	result, err := p.orderExecutor.ClosePosition(ctx, clientOrderID, pos, t.Last)
+	if err != nil {
+		slog.Error("pipeline: trailing stop close failed", "error", err)
+		continue
+	}
+	if result.Executed {
+		slog.Info("pipeline: trailing stop closed", "orderID", result.OrderID)
+		closeSide := string(entity.OrderSideSell)
+		if pos.OrderSide == entity.OrderSideSell {
+			closeSide = string(entity.OrderSideBuy)
+		}
+		p.recordTrade(ctx, pos.SymbolID, result.OrderID, closeSide, "close", t.Last, pos.RemainingAmount, "trailing-stop", false)
+		p.persistRiskState(ctx)
+	}
+}
+```
+
+- [ ] **Step 6: 全体テスト PASS 確認**
+
+Run: `cd backend && go test ./...`
+Expected: ALL PASS
+
+- [ ] **Step 7: コミット → PR**
+
+```bash
+git checkout main && git pull
+git checkout -b improve/trailing-stop
+git add backend/internal/usecase/risk.go backend/internal/usecase/risk_test.go backend/cmd/pipeline.go
+git commit -m "feat(risk): add trailing stop-loss
+
+Track high water mark per position. Once position is in profit,
+trail stop at StopLossPercent from the best price reached.
+Positions not yet in profit fall through to regular stop-loss."
+git push -u origin improve/trailing-stop
+gh pr create --base main --title "feat(risk): add trailing stop-loss to protect profits" --body "$(cat <<'EOF'
+## Summary
+- ポジションごとの最高値/最安値（high water mark）を追跡
+- 含み益が出たポジションに対してトレーリングストップを適用
+- まだ含み益が出ていないポジションは従来の固定ストップロスで保護
+- ポジションクローズ時に自動クリーンアップ
+
+## Why
+固定5%ストップロスでは含み益を守れない。利益が出た後に反転して損切りになるケースが多い。
+
+## Test plan
+- [ ] `go test ./internal/usecase/ -run TestRiskManager_TrailingStop -v` — 全テスト PASS
+- [ ] `go test ./...` — 既存テスト regression なし
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Task 4: Consecutive Loss Breaker
+
+**Branch:** `improve/consecutive-loss-breaker`
+
+**Problem:** 連敗しても止まらず、日次損失上限に達するまで負け続ける。
+
+**Solution:** RiskManager に連敗カウンターを追加し、N連敗（デフォルト3）で冷却期間（デフォルト30分）に入る。
+
+**Files:**
+- Modify: `backend/config/config.go` — `MaxConsecutiveLosses` と `CooldownMinutes` 追加
+- Modify: `backend/internal/domain/entity/risk.go` — 設定フィールド追加
+- Modify: `backend/internal/usecase/risk.go` — 連敗追跡 + cooldown チェック
+- Modify: `backend/internal/usecase/risk_test.go` — テスト追加
+
+### Steps
+
+- [ ] **Step 1: entity/risk.go に設定フィールド追加**
+
+```go
+type RiskConfig struct {
+	MaxPositionAmount    float64 `json:"maxPositionAmount"`
+	MaxDailyLoss         float64 `json:"maxDailyLoss"`
+	StopLossPercent      float64 `json:"stopLossPercent"`
+	TakeProfitPercent    float64 `json:"takeProfitPercent"`
+	InitialCapital       float64 `json:"initialCapital"`
+	MaxConsecutiveLosses int     `json:"maxConsecutiveLosses"` // 連敗上限（0=無効）
+	CooldownMinutes      int     `json:"cooldownMinutes"`      // 冷却期間（分）
+}
+```
+
+- [ ] **Step 2: config.go に環境変数追加**
+
+```go
+Risk: RiskConfig{
+	// ...existing...
+	MaxConsecutiveLosses: getEnvInt("RISK_MAX_CONSECUTIVE_LOSSES", 3),
+	CooldownMinutes:     getEnvInt("RISK_COOLDOWN_MINUTES", 30),
+},
+```
+
+- [ ] **Step 3: risk_test.go にテスト追加**
+
+```go
+func TestRiskManager_ConsecutiveLossBreaker_BlocksAfterNLosses(t *testing.T) {
+	cfg := defaultRiskConfig()
+	cfg.MaxConsecutiveLosses = 3
+	cfg.CooldownMinutes = 30
+	rm := NewRiskManager(cfg)
+
+	rm.RecordConsecutiveLoss()
+	rm.RecordConsecutiveLoss()
+	rm.RecordConsecutiveLoss()
+
+	proposal := entity.OrderProposal{
+		SymbolID: 7, Side: entity.OrderSideBuy, OrderType: entity.OrderTypeMarket,
+		Amount: 0.001, Price: 1000000,
+	}
+	result := rm.CheckOrder(context.Background(), proposal)
+	if result.Approved {
+		t.Fatal("order should be rejected after 3 consecutive losses")
+	}
+	if result.Reason == "" {
+		t.Fatal("expected rejection reason")
+	}
+}
+
+func TestRiskManager_ConsecutiveLossBreaker_ResetOnWin(t *testing.T) {
+	cfg := defaultRiskConfig()
+	cfg.MaxConsecutiveLosses = 3
+	cfg.CooldownMinutes = 30
+	rm := NewRiskManager(cfg)
+
+	rm.RecordConsecutiveLoss()
+	rm.RecordConsecutiveLoss()
+	rm.ResetConsecutiveLosses() // win resets counter
+
+	proposal := entity.OrderProposal{
+		SymbolID: 7, Side: entity.OrderSideBuy, OrderType: entity.OrderTypeMarket,
+		Amount: 0.001, Price: 1000000,
+	}
+	result := rm.CheckOrder(context.Background(), proposal)
+	if !result.Approved {
+		t.Fatalf("order should be approved after win resets counter: %s", result.Reason)
+	}
+}
+
+func TestRiskManager_ConsecutiveLossBreaker_DisabledWhenZero(t *testing.T) {
+	cfg := defaultRiskConfig()
+	cfg.MaxConsecutiveLosses = 0 // disabled
+	rm := NewRiskManager(cfg)
+
+	for i := 0; i < 10; i++ {
+		rm.RecordConsecutiveLoss()
+	}
+
+	proposal := entity.OrderProposal{
+		SymbolID: 7, Side: entity.OrderSideBuy, OrderType: entity.OrderTypeMarket,
+		Amount: 0.001, Price: 1000000,
+	}
+	result := rm.CheckOrder(context.Background(), proposal)
+	if !result.Approved {
+		t.Fatalf("should be approved when breaker disabled: %s", result.Reason)
+	}
+}
+
+func TestRiskManager_ConsecutiveLossBreaker_CloseOrdersAllowed(t *testing.T) {
+	cfg := defaultRiskConfig()
+	cfg.MaxConsecutiveLosses = 3
+	cfg.CooldownMinutes = 30
+	rm := NewRiskManager(cfg)
+
+	rm.RecordConsecutiveLoss()
+	rm.RecordConsecutiveLoss()
+	rm.RecordConsecutiveLoss()
+
+	proposal := entity.OrderProposal{
+		SymbolID: 7, Side: entity.OrderSideSell, OrderType: entity.OrderTypeMarket,
+		Amount: 0.001, Price: 1000000, IsClose: true,
+	}
+	result := rm.CheckOrder(context.Background(), proposal)
+	if !result.Approved {
+		t.Fatalf("close orders should be allowed even during cooldown: %s", result.Reason)
+	}
+}
+```
+
+- [ ] **Step 4: テスト FAIL 確認 (compilation error)**
+
+- [ ] **Step 5: risk.go に連敗ロジック実装**
+
+`RiskManager` にフィールド追加:
+
+```go
+type RiskManager struct {
+	config           entity.RiskConfig
+	mu               sync.RWMutex
+	balance          float64
+	dailyLoss        float64
+	positions        []entity.Position
+	manualStop       bool
+	highWaterMarks   map[int64]float64
+	consecutiveLosses int
+	cooldownUntil    time.Time
+}
+```
+
+新メソッド:
+
+```go
+func (rm *RiskManager) RecordConsecutiveLoss() {
+	rm.mu.Lock()
+	defer rm.mu.Unlock()
+	rm.consecutiveLosses++
+
+	if rm.config.MaxConsecutiveLosses > 0 && rm.consecutiveLosses >= rm.config.MaxConsecutiveLosses {
+		rm.cooldownUntil = time.Now().Add(time.Duration(rm.config.CooldownMinutes) * time.Minute)
+	}
+}
+
+func (rm *RiskManager) ResetConsecutiveLosses() {
+	rm.mu.Lock()
+	defer rm.mu.Unlock()
+	rm.consecutiveLosses = 0
+	rm.cooldownUntil = time.Time{}
+}
+```
+
+`CheckOrder` に cooldown チェック追加（`manualStop` チェックの後、`dailyLoss` チェックの前）:
+
+```go
+if rm.config.MaxConsecutiveLosses > 0 && !rm.cooldownUntil.IsZero() && time.Now().Before(rm.cooldownUntil) {
+	return entity.RiskCheckResult{
+		Approved: false,
+		Reason:   fmt.Sprintf("cooldown: %d consecutive losses, trading paused until %s", rm.consecutiveLosses, rm.cooldownUntil.Format("15:04")),
+	}
+}
+```
+
+- [ ] **Step 6: pipeline.go でストップロス時に RecordConsecutiveLoss を呼ぶ**
+
+`runStopLossMonitor` のストップロス実行後:
+
+```go
+if result.Executed {
+	// ...existing logging/recording...
+	p.riskMgr.RecordConsecutiveLoss()
+}
+```
+
+利確実行後:
+
+```go
+if result.Executed {
+	// ...existing logging/recording...
+	p.riskMgr.ResetConsecutiveLosses()
+}
+```
+
+- [ ] **Step 7: テスト PASS 確認**
+
+Run: `cd backend && go test ./internal/usecase/ -run TestRiskManager_ConsecutiveLoss -v`
+Expected: ALL PASS
+
+- [ ] **Step 8: 全体テスト PASS 確認**
+
+Run: `cd backend && go test ./...`
+Expected: ALL PASS
+
+- [ ] **Step 9: コミット → PR**
+
+```bash
+git checkout main && git pull
+git checkout -b improve/consecutive-loss-breaker
+git add backend/internal/domain/entity/risk.go backend/config/config.go backend/internal/usecase/risk.go backend/internal/usecase/risk_test.go backend/cmd/pipeline.go
+git commit -m "feat(risk): add consecutive loss breaker with cooldown
+
+Block new orders after N consecutive stop-losses (default 3).
+Cooldown period of M minutes (default 30) before resuming.
+Winning trades (take-profit) reset the counter.
+Close orders are always allowed during cooldown."
+git push -u origin improve/consecutive-loss-breaker
+gh pr create --base main --title "feat(risk): consecutive loss breaker with cooldown" --body "$(cat <<'EOF'
+## Summary
+- N連敗（デフォルト3）後に新規注文をブロック
+- M分間（デフォルト30）の冷却期間を設ける
+- 利確成功時にカウンターをリセット
+- 決済注文は冷却期間中も許可
+- `RISK_MAX_CONSECUTIVE_LOSSES` / `RISK_COOLDOWN_MINUTES` 環境変数で設定
+
+## Why
+連敗しても止まらず日次損失上限に達するまで負け続ける問題を解決。相場が不利な時に一旦停止して損失を最小化する。
+
+## Test plan
+- [ ] `go test ./internal/usecase/ -run TestRiskManager_ConsecutiveLoss -v` — 全テスト PASS
+- [ ] `go test ./...` — 既存テスト regression なし
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Dependency Note
+
+Task 1 (MACD confirmation) は独立。Task 2 (take-profit) は独立。Task 3 (trailing stop) は Task 2 の `TakeProfitPercent` フィールドが entity/risk.go に追加された前提。Task 4 (loss breaker) は Task 2 + 3 のフィールドが追加された前提。
+
+**推奨マージ順序:** Task 1 → Task 2 → Task 3 → Task 4
+
+各 PR を main にマージしてから次のブランチを切ること。

--- a/docs/superpowers/specs/2026-04-16-pdca-strategy-optimizer-design.md
+++ b/docs/superpowers/specs/2026-04-16-pdca-strategy-optimizer-design.md
@@ -11,7 +11,7 @@
 ### 1.1 目標
 
 - MaxDrawdown 20%以下の制約のもとで Total Return を最大化する
-- 2週間区間での勝率80%を目標とする（バックテスト期間を2週間ウィンドウでスライドし、各ウィンドウの勝率を算出、その平均値で評価）
+- 2週間区間での勝率80%を目標とする（バックテスト期間を2週間ウィンドウでスライドし、各ウィンドウの勝率を算出、その平均値で評価。勝率は 0-100 の百分率で扱う）
 - 本番運用の戦略とは独立して実験的な戦略を試行できるようにする
 - うまくいった戦略を手動承認で本番に昇格させる
 
@@ -232,7 +232,7 @@ Do:
        --profile experiment_2026-04-16_01 \
        --data data/candles_LTC_JPY_PT15M.csv \
        --data-htf data/candles_LTC_JPY_PT1H.csv
-     ※ --data/--data-htf は常に必須。プロファイルは戦略パラメータのみを持ち、
+     ※ --data は必須、--data-htf は任意。プロファイルは戦略パラメータのみを持ち、
        データソースと期間はCLI引数で指定する（再現性のためPDCA記録にも残す）。
 
 Check:
@@ -321,7 +321,7 @@ backtestPDCAColumns := []struct {
     {"profile_name", "profile_name TEXT NOT NULL DEFAULT ''"},
     {"pdca_cycle_id", "pdca_cycle_id TEXT NOT NULL DEFAULT ''"},
     {"hypothesis", "hypothesis TEXT NOT NULL DEFAULT ''"},
-    {"parent_result_id", "parent_result_id TEXT DEFAULT NULL REFERENCES backtest_results(id)"},
+    {"parent_result_id", "parent_result_id TEXT DEFAULT NULL REFERENCES backtest_results(id) ON DELETE SET NULL"},
     {"biweekly_win_rate", "biweekly_win_rate REAL NOT NULL DEFAULT 0"},
 }
 for _, col := range backtestPDCAColumns {
@@ -334,6 +334,7 @@ for _, col := range backtestPDCAColumns {
 `parent_result_id` にはインデックスと自己参照 FK 制約を設定する。
 本プロジェクトは `PRAGMA foreign_keys=ON`（`sqlite.go:31`）を有効化しているため、FK が実効的に機能する。
 `parent_result_id` のルートノード（親なし）は NULL で表現する。SQLite では NULL の FK 参照はチェックをスキップする。
+親レコード削除時は `ON DELETE SET NULL` により子レコードをルートノードへ昇格させる（履歴保持を優先し、保持期間削除ジョブと衝突しないようにする）。
 
 **`parent_result_id` の整合性ルール（アプリケーション層）:**
 
@@ -341,6 +342,11 @@ for _, col := range backtestPDCAColumns {
 - **自己参照禁止:** 自身の result_id と同一の値を拒否する（保存前に検証、HTTP 422 を返す）
 - **別プロファイル参照:** 許可する。異なるプロファイル間の比較チェーンは有効なユースケース（例: production → experiment_v1 の系譜）
 - **エラーレスポンス:** parent_result_id が不正な場合は HTTP 422 Unprocessable Entity を返し、理由を含める
+
+**エラーマッピング方針（API層）:**
+
+- Repository/UseCase は `parent_result_id` の自己参照・存在不正を判別可能なドメインエラーで返す
+- Handler は上記ドメインエラーのみ HTTP 422 とし、それ以外の永続化エラーは HTTP 500 とする
 
 ```sql
 CREATE INDEX IF NOT EXISTS idx_backtest_results_parent
@@ -383,15 +389,19 @@ type BacktestResultFilter struct {
     Offset         int
     ProfileName    string // 完全一致フィルタ (空文字 = フィルタなし)
     PDCACycleID    string // 完全一致フィルタ
-    ParentResultID string // 系譜追跡用
+    ParentResultID *string // 完全一致フィルタ (nil = フィルタなし)
+    HasParent      *bool   // nil = フィルタなし, true = IS NOT NULL, false = IS NULL
 }
 ```
 
 ```
 GET /api/v1/backtest/results?limit=20&offset=0&profileName=ltc_aggressive_v3&pdcaCycleId=2026-04-16_cycle01
+GET /api/v1/backtest/results?hasParent=false
+GET /api/v1/backtest/results?parentResultId=01HXYZ...
 ```
 
 Repository 実装では追加カラムを `WHERE` 句に動的追加する。
+`parentResultId` と `hasParent` が同時指定された場合は `parentResultId` を優先し、`hasParent` は無視する。
 
 ### 5.4 フロントエンド一覧表示
 
@@ -444,8 +454,8 @@ type PDCAEvaluation struct {
     // 主目的 — 高いほど良い
     TotalReturn         float64
 
-    // 副目的 — 高いほど良い (目標 0.80)
-    BiweeklyWinRate     float64 // 2週間スライドウィンドウ勝率の平均
+    // 副目的 — 高いほど良い (目標 80.0)
+    BiweeklyWinRate     float64 // 2週間スライドウィンドウ勝率の平均 (0-100)
 
     // 参考指標
     SharpeRatio         float64
@@ -457,7 +467,7 @@ type PDCAEvaluation struct {
 ### 7.2 2週間スライド勝率の計算
 
 バックテスト期間をタイムスタンプベースで2週間 (14日) のウィンドウに分割し、1日ずつスライドする。
-各ウィンドウ内のクローズ済みトレードから勝率を算出し、全ウィンドウの平均を取る。
+各ウィンドウ内のクローズ済みトレードから勝率（0-100）を算出し、全ウィンドウの平均を取る。
 
 **最低トレード数制約:** 各ウィンドウ内のトレード数が3件未満の場合はそのウィンドウの勝率を0%として扱う（スキップではなくペナルティ）。
 これにより低頻度売買戦略が見かけ上高い勝率を得ることを防ぐ。
@@ -479,7 +489,7 @@ BiweeklyWinRate = カバレッジ率 ≥ 50% ? avg(全ウィンドウ) : 0
 ```go
 type BacktestSummary struct {
     // ... 既存フィールド
-    BiweeklyWinRate float64 // 2週間スライド勝率の平均
+    BiweeklyWinRate float64 // 2週間スライド勝率の平均 (0-100)
 }
 ```
 
@@ -596,11 +606,11 @@ func resolveProfilePath(name string) (string, error) {
 |---|---|---|
 | マイグレーション | 新カラム追加が冪等に実行できること（2回実行してエラーなし） | 統合テスト |
 | resolveProfilePath | 正常名、空文字、`..` 含み、絶対パス、特殊文字を拒否 | 単体テスト |
-| parent_result_id | 自己参照で 422、存在しないIDで FK エラー、NULL で正常保存 | 統合テスト |
+| parent_result_id | 自己参照で 422、存在しないIDで 422、NULL で正常保存、親削除時に子の parent_result_id が NULL 化される | 統合テスト |
 | profileName + 個別パラメータ | 個別パラメータがプロファイル値をオーバーライドすること | 単体テスト |
-| BiweeklyWinRate | 3件未満ペナルティ、カバレッジ50%未満で0、正常算出 | 単体テスト |
-| ConfigurableStrategy | プロファイルから生成した戦略が DefaultStrategy と同一入力で動作すること | 単体テスト |
-| API /backtest/results フィルタ | profileName / pdcaCycleId でフィルタ結果が正しいこと | 統合テスト |
+| BiweeklyWinRate | 3件未満ペナルティ、カバレッジ50%未満で0、正常算出（0-100スケール） | 単体テスト |
+| ConfigurableStrategy | production 相当プロファイルで DefaultStrategy と互換動作すること | 単体テスト |
+| API /backtest/results フィルタ | profileName / pdcaCycleId / hasParent / parentResultId でフィルタ結果が正しいこと | 統合テスト |
 
 ### 今回実装しないもの
 

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -111,3 +111,12 @@ const rootRouteChildren: RootRouteChildren = {
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>()
+
+import type { getRouter } from './router.tsx'
+import type { createStart } from '@tanstack/react-start'
+declare module '@tanstack/react-start' {
+  interface Register {
+    ssr: true
+    router: Awaited<ReturnType<typeof getRouter>>
+  }
+}


### PR DESCRIPTION
## Summary

ローカルに残っていた未コミットのドキュメント・ignore 設定・自動生成物を main に取り込む housekeeping PR。挙動変更なし。

## Changes (commit 粒度)

| # | Commit | 内容 |
|---|---|---|
| 1 | \`chore: ignore pnpm-store and .playwright-mcp working dirs\` | 開発中に生成される pnpm キャッシュと Playwright MCP 作業ディレクトリを .gitignore |
| 2 | \`docs(spec): catch up PDCA spec with implemented behavior\` | PDCA 設計書を #96-#105 で確定した実装と同期（勝率スケール、--data-htf 任意、ON DELETE SET NULL、HasParent 型、422 マッピング方針） |
| 3 | \`chore(frontend): regenerate routeTree with Start SSR declarations\` | TanStack Router / React Start の SSR 宣言を自動生成物に反映 |
| 4 | \`docs: add backtest CSV data preparation guide\` | バックテスト用 CSV の作成手順を docs/backtest-csv-data-guide.md に |
| 5 | \`docs: archive superpowers implementation plans\` | Symbol Switcher / Strategy Improvements のプラン資料をアーカイブ |

## Test plan

- [x] 実装側の挙動変更なし（ドキュメント・ignore・生成物のみ）
- [x] \`git status\` がクリーンになることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)