### PR TITLE
feat(backtest): add drawdown history, time-in-market, expectancy (PR-3)

### DIFF
--- a/backend/internal/domain/entity/backtest.go
+++ b/backend/internal/domain/entity/backtest.go
@@ -48,6 +48,44 @@ type BacktestSummary struct {
 	// ("trend_follow" / "contrarian" / "breakout" / "unknown"). Empty map for
 	// legacy rows persisted before PR-1.
 	BySignalSource map[string]SummaryBreakdown `json:"bySignalSource,omitempty"`
+
+	// ---- PR-3: drawdown detail / time-in-market / expectancy ----
+
+	// DrawdownPeriods is the list of all drawdowns whose depth reached at
+	// least DrawdownThreshold, in chronological order. Empty for legacy rows.
+	DrawdownPeriods []DrawdownPeriod `json:"drawdownPeriods,omitempty"`
+	// DrawdownThreshold is the minimum depth (0-1) a drawdown must reach to
+	// be recorded in DrawdownPeriods. Fixed at 0.02 (2%) for now.
+	DrawdownThreshold float64 `json:"drawdownThreshold,omitempty"`
+	// UnrecoveredDrawdown is set when the run ends while still in a drawdown
+	// that has not recovered to the prior peak. nil otherwise.
+	UnrecoveredDrawdown *DrawdownPeriod `json:"unrecoveredDrawdown,omitempty"`
+
+	// TimeInMarketRatio is (bars with an open position at bar close) /
+	// (total primary-interval bars). 0 = fully flat, 1 = always in market.
+	TimeInMarketRatio float64 `json:"timeInMarketRatio,omitempty"`
+	// LongestFlatStreakBars is the longest consecutive run of bars with no
+	// open position.
+	LongestFlatStreakBars int `json:"longestFlatStreakBars,omitempty"`
+
+	// ExpectancyPerTrade = WR * AvgWinJPY - (1-WR) * AvgLossJPY.
+	// Positive = the strategy is expected to earn JPY per trade on average.
+	ExpectancyPerTrade float64 `json:"expectancyPerTrade,omitempty"`
+	AvgWinJPY          float64 `json:"avgWinJpy,omitempty"`
+	AvgLossJPY         float64 `json:"avgLossJpy,omitempty"` // absolute value
+}
+
+// DrawdownPeriod captures one peak-to-recovery drawdown episode. For an
+// unrecovered drawdown at the end of a run, RecoveredAt is 0 and
+// RecoveryBars is -1 so consumers can distinguish recovered from pending.
+type DrawdownPeriod struct {
+	FromTimestamp int64   `json:"fromTimestamp"` // prior peak's timestamp
+	ToTimestamp   int64   `json:"toTimestamp"`   // trough timestamp
+	RecoveredAt   int64   `json:"recoveredAt"`   // 0 if still unrecovered
+	Depth         float64 `json:"depth"`         // 0-1
+	DepthBalance  float64 `json:"depthBalance"`  // equity at trough
+	DurationBars  int     `json:"durationBars"`  // peak -> trough
+	RecoveryBars  int     `json:"recoveryBars"`  // trough -> recovered; -1 if unrecovered
 }
 
 // SummaryBreakdown holds aggregated metrics for a subset of trades grouped by

--- a/backend/internal/infrastructure/backtest/result_repository.go
+++ b/backend/internal/infrastructure/backtest/result_repository.go
@@ -23,11 +23,13 @@ const resultColumns = `id, created_at, symbol, symbol_id, primary_interval, high
 	win_trades, loss_trades, win_rate, profit_factor, max_drawdown, max_drawdown_balance,
 	sharpe_ratio, avg_hold_seconds, total_carrying_cost, total_spread_cost,
 	profile_name, pdca_cycle_id, hypothesis, parent_result_id, biweekly_win_rate,
-	breakdown_json`
+	breakdown_json,
+	drawdown_periods_json, drawdown_threshold, time_in_market_ratio, longest_flat_streak_bars,
+	expectancy_per_trade, avg_win_jpy, avg_loss_jpy`
 
-// resultColumnPlaceholders は resultColumns と同じ個数 (28) の INSERT プレースホルダ。
+// resultColumnPlaceholders は resultColumns と同じ個数 (35) の INSERT プレースホルダ。
 // resultColumns のカラム数を変更した場合はここも必ず同期させること。
-const resultColumnPlaceholders = `?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?`
+const resultColumnPlaceholders = `?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?`
 
 type ResultRepository struct {
 	db *sql.DB
@@ -80,6 +82,21 @@ func (r *ResultRepository) Save(ctx context.Context, result entity.BacktestResul
 		breakdownBlob = sql.NullString{String: string(b), Valid: true}
 	}
 
+	// PR-3: DrawdownPeriods + UnrecoveredDrawdown を 1 本の JSON にまとめる。
+	// レガシー行 (両方ゼロ/nil) は NULL 保存で後方互換。
+	ddBlob := sql.NullString{}
+	if len(result.Summary.DrawdownPeriods) > 0 || result.Summary.UnrecoveredDrawdown != nil {
+		payload := drawdownPayload{
+			Periods:     result.Summary.DrawdownPeriods,
+			Unrecovered: result.Summary.UnrecoveredDrawdown,
+		}
+		b, err := json.Marshal(payload)
+		if err != nil {
+			return fmt.Errorf("marshal drawdowns: %w", err)
+		}
+		ddBlob = sql.NullString{String: string(b), Valid: true}
+	}
+
 	_, err = tx.ExecContext(ctx, `INSERT INTO backtest_results (`+resultColumns+`) VALUES (`+resultColumnPlaceholders+`)`,
 		result.ID,
 		result.CreatedAt,
@@ -109,6 +126,13 @@ func (r *ResultRepository) Save(ctx context.Context, result entity.BacktestResul
 		parentID,
 		result.Summary.BiweeklyWinRate,
 		breakdownBlob,
+		ddBlob,
+		result.Summary.DrawdownThreshold,
+		result.Summary.TimeInMarketRatio,
+		result.Summary.LongestFlatStreakBars,
+		result.Summary.ExpectancyPerTrade,
+		result.Summary.AvgWinJPY,
+		result.Summary.AvgLossJPY,
 	)
 	if err != nil {
 		return fmt.Errorf("insert backtest result: %w", err)
@@ -305,9 +329,17 @@ type breakdownPayload struct {
 	BySignalSource map[string]entity.SummaryBreakdown `json:"bySignalSource,omitempty"`
 }
 
+// drawdownPayload は drawdown_periods_json カラムの中身。回復済み episodes と
+// 期間末まで未回復の 1 件を 1 本の JSON に詰める。
+type drawdownPayload struct {
+	Periods     []entity.DrawdownPeriod `json:"periods,omitempty"`
+	Unrecovered *entity.DrawdownPeriod  `json:"unrecovered,omitempty"`
+}
+
 func scanResultRow(scanner rowScanner, result *entity.BacktestResult) error {
 	var parentID sql.NullString
 	var breakdownBlob sql.NullString
+	var ddBlob sql.NullString
 	err := scanner.Scan(
 		&result.ID,
 		&result.CreatedAt,
@@ -337,6 +369,13 @@ func scanResultRow(scanner rowScanner, result *entity.BacktestResult) error {
 		&parentID,
 		&result.Summary.BiweeklyWinRate,
 		&breakdownBlob,
+		&ddBlob,
+		&result.Summary.DrawdownThreshold,
+		&result.Summary.TimeInMarketRatio,
+		&result.Summary.LongestFlatStreakBars,
+		&result.Summary.ExpectancyPerTrade,
+		&result.Summary.AvgWinJPY,
+		&result.Summary.AvgLossJPY,
 	)
 	if err != nil {
 		return err
@@ -353,6 +392,13 @@ func scanResultRow(scanner rowScanner, result *entity.BacktestResult) error {
 		if err := json.Unmarshal([]byte(breakdownBlob.String), &payload); err == nil {
 			result.Summary.ByExitReason = payload.ByExitReason
 			result.Summary.BySignalSource = payload.BySignalSource
+		}
+	}
+	if ddBlob.Valid && ddBlob.String != "" {
+		var payload drawdownPayload
+		if err := json.Unmarshal([]byte(ddBlob.String), &payload); err == nil {
+			result.Summary.DrawdownPeriods = payload.Periods
+			result.Summary.UnrecoveredDrawdown = payload.Unrecovered
 		}
 	}
 	result.Summary.PeriodFrom = result.Config.FromTimestamp

--- a/backend/internal/infrastructure/backtest/result_repository_test.go
+++ b/backend/internal/infrastructure/backtest/result_repository_test.go
@@ -361,6 +361,11 @@ func TestResultRepository_DrawdownDetailRoundTrip(t *testing.T) {
 		found.Summary.DrawdownPeriods[0].DurationBars != 5 {
 		t.Fatalf("DrawdownPeriods[0] round-trip failed: %+v", found.Summary.DrawdownPeriods[0])
 	}
+	if found.Summary.DrawdownPeriods[1].Depth != 0.03 ||
+		found.Summary.DrawdownPeriods[1].RecoveryBars != 7 ||
+		found.Summary.DrawdownPeriods[1].DurationBars != 3 {
+		t.Fatalf("DrawdownPeriods[1] round-trip failed: %+v", found.Summary.DrawdownPeriods[1])
+	}
 	if found.Summary.UnrecoveredDrawdown == nil {
 		t.Fatalf("UnrecoveredDrawdown missing")
 	}
@@ -399,8 +404,25 @@ func TestResultRepository_DrawdownDetailRoundTrip(t *testing.T) {
 	if listed == nil {
 		t.Fatalf("result not returned by List")
 	}
+	// List must hit the same scan path as FindByID, so every PR-3 field we
+	// care about round-tripping must come through it too.
 	if listed.Summary.ExpectancyPerTrade != 25.5 {
 		t.Fatalf("List failed to populate ExpectancyPerTrade: %v", listed.Summary.ExpectancyPerTrade)
+	}
+	if listed.Summary.DrawdownThreshold != 0.02 {
+		t.Fatalf("List DrawdownThreshold = %v, want 0.02", listed.Summary.DrawdownThreshold)
+	}
+	if listed.Summary.TimeInMarketRatio != 0.72 {
+		t.Fatalf("List TimeInMarketRatio = %v, want 0.72", listed.Summary.TimeInMarketRatio)
+	}
+	if listed.Summary.LongestFlatStreakBars != 15 {
+		t.Fatalf("List LongestFlatStreakBars = %d, want 15", listed.Summary.LongestFlatStreakBars)
+	}
+	if listed.Summary.UnrecoveredDrawdown == nil {
+		t.Fatalf("List dropped UnrecoveredDrawdown")
+	}
+	if listed.Summary.UnrecoveredDrawdown.RecoveryBars != -1 {
+		t.Fatalf("List UnrecoveredDrawdown.RecoveryBars = %d, want -1", listed.Summary.UnrecoveredDrawdown.RecoveryBars)
 	}
 }
 

--- a/backend/internal/infrastructure/backtest/result_repository_test.go
+++ b/backend/internal/infrastructure/backtest/result_repository_test.go
@@ -303,6 +303,107 @@ func TestResultRepository_BreakdownRoundTrip(t *testing.T) {
 	}
 }
 
+// TestResultRepository_DrawdownDetailRoundTrip verifies that the PR-3
+// fields (DrawdownPeriods, UnrecoveredDrawdown, TimeInMarketRatio,
+// LongestFlatStreakBars, ExpectancyPerTrade, AvgWinJPY, AvgLossJPY,
+// DrawdownThreshold) survive the persistence boundary.
+//
+// The resultColumns list is 35 entries long and INSERT bindings / SELECT
+// scan ordering are maintained by hand; a round-trip test for every new
+// field family is the only reliable guard against a silent column-order
+// drift.
+func TestResultRepository_DrawdownDetailRoundTrip(t *testing.T) {
+	repo := newTestRepo(t)
+	ctx := context.Background()
+
+	result := entity.BacktestResult{
+		ID:        "bt-pr3-1",
+		CreatedAt: time.Now().Unix(),
+		Config: entity.BacktestConfig{
+			Symbol:          "LTC_JPY",
+			SymbolID:        10,
+			PrimaryInterval: "PT15M",
+			FromTimestamp:   1000,
+			ToTimestamp:     2000,
+		},
+		Summary: entity.BacktestSummary{
+			InitialBalance: 100000,
+			FinalBalance:   110000,
+			DrawdownPeriods: []entity.DrawdownPeriod{
+				{FromTimestamp: 100, ToTimestamp: 200, RecoveredAt: 300, Depth: 0.05, DepthBalance: 95000, DurationBars: 5, RecoveryBars: 10},
+				{FromTimestamp: 400, ToTimestamp: 500, RecoveredAt: 600, Depth: 0.03, DepthBalance: 97000, DurationBars: 3, RecoveryBars: 7},
+			},
+			DrawdownThreshold: 0.02,
+			UnrecoveredDrawdown: &entity.DrawdownPeriod{
+				FromTimestamp: 700, ToTimestamp: 900,
+				Depth: 0.08, DepthBalance: 92000, DurationBars: 20, RecoveryBars: -1,
+			},
+			TimeInMarketRatio:     0.72,
+			LongestFlatStreakBars: 15,
+			ExpectancyPerTrade:    25.5,
+			AvgWinJPY:             80,
+			AvgLossJPY:            40,
+		},
+	}
+	if err := repo.Save(ctx, result); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	found, err := repo.FindByID(ctx, result.ID)
+	if err != nil || found == nil {
+		t.Fatalf("find: err=%v found=%v", err, found)
+	}
+	if len(found.Summary.DrawdownPeriods) != 2 {
+		t.Fatalf("DrawdownPeriods len=%d, want 2", len(found.Summary.DrawdownPeriods))
+	}
+	if found.Summary.DrawdownPeriods[0].Depth != 0.05 ||
+		found.Summary.DrawdownPeriods[0].RecoveryBars != 10 ||
+		found.Summary.DrawdownPeriods[0].DurationBars != 5 {
+		t.Fatalf("DrawdownPeriods[0] round-trip failed: %+v", found.Summary.DrawdownPeriods[0])
+	}
+	if found.Summary.UnrecoveredDrawdown == nil {
+		t.Fatalf("UnrecoveredDrawdown missing")
+	}
+	if found.Summary.UnrecoveredDrawdown.RecoveryBars != -1 ||
+		found.Summary.UnrecoveredDrawdown.Depth != 0.08 {
+		t.Fatalf("UnrecoveredDrawdown round-trip failed: %+v", found.Summary.UnrecoveredDrawdown)
+	}
+	if found.Summary.DrawdownThreshold != 0.02 {
+		t.Fatalf("DrawdownThreshold = %v, want 0.02", found.Summary.DrawdownThreshold)
+	}
+	if found.Summary.TimeInMarketRatio != 0.72 {
+		t.Fatalf("TimeInMarketRatio = %v, want 0.72", found.Summary.TimeInMarketRatio)
+	}
+	if found.Summary.LongestFlatStreakBars != 15 {
+		t.Fatalf("LongestFlatStreakBars = %d, want 15", found.Summary.LongestFlatStreakBars)
+	}
+	if found.Summary.ExpectancyPerTrade != 25.5 ||
+		found.Summary.AvgWinJPY != 80 ||
+		found.Summary.AvgLossJPY != 40 {
+		t.Fatalf("expectancy round-trip failed: E=%v AvgWin=%v AvgLoss=%v",
+			found.Summary.ExpectancyPerTrade, found.Summary.AvgWinJPY, found.Summary.AvgLossJPY)
+	}
+
+	// List path should also honour the new columns.
+	list, err := repo.List(ctx, repository.BacktestResultFilter{Limit: 10})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	var listed *entity.BacktestResult
+	for i := range list {
+		if list[i].ID == result.ID {
+			listed = &list[i]
+			break
+		}
+	}
+	if listed == nil {
+		t.Fatalf("result not returned by List")
+	}
+	if listed.Summary.ExpectancyPerTrade != 25.5 {
+		t.Fatalf("List failed to populate ExpectancyPerTrade: %v", listed.Summary.ExpectancyPerTrade)
+	}
+}
+
 // TestResultRepository_LegacyRowWithoutBreakdown confirms backward
 // compatibility: rows persisted before PR-1 (breakdown_json = NULL) must
 // still load successfully with empty breakdown maps on the Summary.

--- a/backend/internal/infrastructure/database/migrations.go
+++ b/backend/internal/infrastructure/database/migrations.go
@@ -239,6 +239,28 @@ func RunMigrations(db *sql.DB) error {
 		return fmt.Errorf("backtest_results alter breakdown_json: %w", err)
 	}
 
+	// PR-3: drawdown 履歴 + time-in-market + expectancy。既存パターンに合わせ、
+	// スカラー値は個別カラム、DrawdownPeriods 配列は 1 本の JSON に集約。
+	// 未回復 DD も同じ JSON に入れる (null フィールドで区別可能)。
+	// すべて DEFAULT 0 / NULL でレガシー行と互換。
+	pr3Columns := []struct {
+		name string
+		def  string
+	}{
+		{"drawdown_periods_json", "drawdown_periods_json TEXT DEFAULT NULL"},
+		{"drawdown_threshold", "drawdown_threshold REAL NOT NULL DEFAULT 0"},
+		{"time_in_market_ratio", "time_in_market_ratio REAL NOT NULL DEFAULT 0"},
+		{"longest_flat_streak_bars", "longest_flat_streak_bars INTEGER NOT NULL DEFAULT 0"},
+		{"expectancy_per_trade", "expectancy_per_trade REAL NOT NULL DEFAULT 0"},
+		{"avg_win_jpy", "avg_win_jpy REAL NOT NULL DEFAULT 0"},
+		{"avg_loss_jpy", "avg_loss_jpy REAL NOT NULL DEFAULT 0"},
+	}
+	for _, col := range pr3Columns {
+		if err := addColumnIfNotExists(db, "backtest_results", col.name, col.def); err != nil {
+			return fmt.Errorf("backtest_results alter %s: %w", col.name, err)
+		}
+	}
+
 	// PDCA 関連カラムの検索を高速化する部分インデックス。NULL/空文字列を除外して
 	// インデックスサイズを抑える (大半の既存行は空文字列/NULL)。
 	pdcaIndexes := []string{

--- a/backend/internal/infrastructure/database/migrations_test.go
+++ b/backend/internal/infrastructure/database/migrations_test.go
@@ -77,12 +77,19 @@ func TestRunMigrations_PDCABacktestResultsColumnsAndIndexes(t *testing.T) {
 
 	// 新カラムの存在を PRAGMA table_info で確認。
 	wantColumns := map[string]bool{
-		"profile_name":      false,
-		"pdca_cycle_id":     false,
-		"hypothesis":        false,
-		"parent_result_id":  false,
-		"biweekly_win_rate": false,
-		"breakdown_json":    false, // PR-1: per-exit-reason / per-signal-source breakdowns
+		"profile_name":             false,
+		"pdca_cycle_id":            false,
+		"hypothesis":               false,
+		"parent_result_id":         false,
+		"biweekly_win_rate":        false,
+		"breakdown_json":           false, // PR-1
+		"drawdown_periods_json":    false, // PR-3
+		"drawdown_threshold":       false, // PR-3
+		"time_in_market_ratio":     false, // PR-3
+		"longest_flat_streak_bars": false, // PR-3
+		"expectancy_per_trade":     false, // PR-3
+		"avg_win_jpy":              false, // PR-3
+		"avg_loss_jpy":             false, // PR-3
 	}
 	rows, err := db.Query("PRAGMA table_info(backtest_results)")
 	if err != nil {

--- a/backend/internal/usecase/backtest/drawdown_detail.go
+++ b/backend/internal/usecase/backtest/drawdown_detail.go
@@ -1,0 +1,173 @@
+package backtest
+
+import (
+	"math"
+	"sort"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+)
+
+// DefaultDrawdownThreshold is the minimum depth (fraction of peak equity)
+// at which a drawdown is recorded. 2% is aggressive enough to surface most
+// meaningful pullbacks on a 6-month run while still suppressing single-bar
+// noise.
+const DefaultDrawdownThreshold = 0.02
+
+// DetectDrawdowns walks an equity curve and returns every drawdown whose
+// depth reaches at least `threshold` (fraction of peak, e.g. 0.02 = 2%),
+// plus an optional unrecovered drawdown at the end of the run. Episodes
+// are returned in chronological order.
+//
+// Convention:
+//   - FromTimestamp = prior peak, ToTimestamp = trough, RecoveredAt = new peak
+//   - Unrecovered -> RecoveredAt = 0, RecoveryBars = -1, not in `recovered`
+//   - Duration/Recovery bar counts are index deltas in the supplied slice
+//     (suitable for "bars at the primary interval").
+func DetectDrawdowns(points []EquityPoint, threshold float64) (recovered []entity.DrawdownPeriod, unrecovered *entity.DrawdownPeriod) {
+	if len(points) == 0 {
+		return nil, nil
+	}
+
+	// Ensure chronological order without mutating the caller's slice.
+	sorted := make([]EquityPoint, len(points))
+	copy(sorted, points)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Timestamp < sorted[j].Timestamp })
+
+	peak := sorted[0].Equity
+	peakIdx := 0
+	inDD := false
+	var current entity.DrawdownPeriod
+	var botIdx int
+
+	for i, p := range sorted {
+		// Equity >= peak ends the current drawdown (equality covers the
+		// common case of "recovered to exactly the prior peak"); a strict
+		// > would leave such episodes unrecovered.
+		if p.Equity >= peak {
+			if inDD {
+				current.RecoveredAt = p.Timestamp
+				current.RecoveryBars = i - botIdx
+				recovered = append(recovered, current)
+				inDD = false
+				current = entity.DrawdownPeriod{}
+			}
+			peak = p.Equity
+			peakIdx = i
+			continue
+		}
+
+		// Equal or below peak — measure depth.
+		if peak <= 0 {
+			continue
+		}
+		depth := (peak - p.Equity) / peak
+
+		if !inDD && depth >= threshold {
+			inDD = true
+			current = entity.DrawdownPeriod{
+				FromTimestamp: sorted[peakIdx].Timestamp,
+				ToTimestamp:   p.Timestamp,
+				Depth:         depth,
+				DepthBalance:  p.Equity,
+				DurationBars:  i - peakIdx,
+			}
+			botIdx = i
+		}
+
+		if inDD && depth > current.Depth {
+			current.Depth = depth
+			current.DepthBalance = p.Equity
+			current.ToTimestamp = p.Timestamp
+			current.DurationBars = i - peakIdx
+			botIdx = i
+		}
+	}
+
+	if inDD {
+		current.RecoveryBars = -1
+		u := current
+		unrecovered = &u
+	}
+	return recovered, unrecovered
+}
+
+// ComputeTimeInMarket returns (ratio, longestFlatStreakBars) for the supplied
+// trade history against a bar timeline.
+//
+//   - barTimestamps must be sorted ascending and represent every primary-
+//     interval candle in the run (len(barTimestamps) == totalBars).
+//   - A bar counts as "in market" if any trade's [EntryTime, ExitTime]
+//     interval (inclusive, millisecond timestamps) covers its timestamp.
+//   - Overlapping trades do NOT double-count the same bar.
+func ComputeTimeInMarket(trades []entity.BacktestTradeRecord, barTimestamps []int64, totalBars int) (ratio float64, longestFlat int) {
+	if totalBars <= 0 || len(barTimestamps) == 0 {
+		return 0, 0
+	}
+
+	// Build a set of covered bar indices. O(N*M) worst case but trades and
+	// bars are small enough in practice (<5k trades, <10k bars).
+	inMarket := make([]bool, len(barTimestamps))
+	for _, tr := range trades {
+		// Find the range of bar indices covered by [tr.EntryTime, tr.ExitTime].
+		start := sort.Search(len(barTimestamps), func(i int) bool { return barTimestamps[i] >= tr.EntryTime })
+		// upper bound: first index with timestamp > tr.ExitTime
+		end := sort.Search(len(barTimestamps), func(i int) bool { return barTimestamps[i] > tr.ExitTime })
+		for i := start; i < end && i < len(inMarket); i++ {
+			inMarket[i] = true
+		}
+	}
+
+	inMarketCount := 0
+	currentFlat := 0
+	for _, x := range inMarket {
+		if x {
+			if currentFlat > longestFlat {
+				longestFlat = currentFlat
+			}
+			currentFlat = 0
+			inMarketCount++
+		} else {
+			currentFlat++
+		}
+	}
+	if currentFlat > longestFlat {
+		longestFlat = currentFlat
+	}
+	ratio = float64(inMarketCount) / float64(totalBars)
+	return ratio, longestFlat
+}
+
+// ComputeExpectancy returns the per-trade expected PnL together with the
+// average win and average loss used to compute it. Convention:
+//
+//   - wins  = trades with PnL >= 0 (matches reporter.go)
+//   - AvgLoss is reported as an absolute (positive) number so UI callers do
+//     not need to negate.
+//   - Empty input returns zeros, matching reporter.go's zero-trade handling.
+func ComputeExpectancy(trades []entity.BacktestTradeRecord) (expectancy, avgWin, avgLoss float64) {
+	if len(trades) == 0 {
+		return 0, 0, 0
+	}
+	wins := 0
+	losses := 0
+	sumWin := 0.0
+	sumLoss := 0.0
+	for _, t := range trades {
+		if t.PnL >= 0 {
+			wins++
+			sumWin += t.PnL
+		} else {
+			losses++
+			sumLoss += math.Abs(t.PnL)
+		}
+	}
+	if wins > 0 {
+		avgWin = sumWin / float64(wins)
+	}
+	if losses > 0 {
+		avgLoss = sumLoss / float64(losses)
+	}
+	wr := float64(wins) / float64(len(trades))
+	expectancy = wr*avgWin - (1-wr)*avgLoss
+	return expectancy, avgWin, avgLoss
+}

--- a/backend/internal/usecase/backtest/drawdown_detail_test.go
+++ b/backend/internal/usecase/backtest/drawdown_detail_test.go
@@ -1,0 +1,199 @@
+package backtest
+
+import (
+	"math"
+	"testing"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+)
+
+func TestDetectDrawdowns_TwoDistinctEpisodes(t *testing.T) {
+	// Two clean drawdowns:
+	//   pk1=100 -> trough 88 (DD 12%) -> recover to 100 (new pk)
+	//   pk2=110 -> trough 99 (DD 10%) -> recover to 110 (new pk)
+	points := []EquityPoint{
+		{Timestamp: 1, Equity: 100}, // pk1
+		{Timestamp: 2, Equity: 88},  // trough1
+		{Timestamp: 3, Equity: 100}, // recovered
+		{Timestamp: 4, Equity: 110}, // pk2
+		{Timestamp: 5, Equity: 99},  // trough2
+		{Timestamp: 6, Equity: 110}, // recovered
+	}
+	got, unrec := DetectDrawdowns(points, 0.02)
+	if unrec != nil {
+		t.Fatalf("no unrecovered DD expected, got %+v", unrec)
+	}
+	if len(got) != 2 {
+		t.Fatalf("want 2 episodes, got %d: %+v", len(got), got)
+	}
+	if math.Abs(got[0].Depth-0.12) > 1e-9 {
+		t.Fatalf("episode 0 depth = %v, want 0.12", got[0].Depth)
+	}
+	if got[0].FromTimestamp != 1 || got[0].ToTimestamp != 2 || got[0].RecoveredAt != 3 {
+		t.Fatalf("episode 0 timestamps = %+v", got[0])
+	}
+	if got[0].DurationBars != 1 || got[0].RecoveryBars != 1 {
+		t.Fatalf("episode 0 bar counts = %+v", got[0])
+	}
+	if math.Abs(got[1].Depth-0.1) > 1e-9 {
+		t.Fatalf("episode 1 depth = %v, want 0.1", got[1].Depth)
+	}
+}
+
+func TestDetectDrawdowns_Unrecovered(t *testing.T) {
+	// DD that never recovers within the run.
+	points := []EquityPoint{
+		{Timestamp: 1, Equity: 100},
+		{Timestamp: 2, Equity: 90}, // 10% DD
+		{Timestamp: 3, Equity: 85}, // 15% DD, deeper
+		{Timestamp: 4, Equity: 87}, // bounce but still below peak
+	}
+	got, unrec := DetectDrawdowns(points, 0.02)
+	if unrec == nil {
+		t.Fatalf("expected unrecovered DD")
+	}
+	if math.Abs(unrec.Depth-0.15) > 1e-9 {
+		t.Fatalf("unrecovered depth = %v, want 0.15", unrec.Depth)
+	}
+	if unrec.RecoveredAt != 0 {
+		t.Fatalf("RecoveredAt should be 0 when unrecovered: %v", unrec.RecoveredAt)
+	}
+	if unrec.RecoveryBars != -1 {
+		t.Fatalf("RecoveryBars should be -1 when unrecovered: %v", unrec.RecoveryBars)
+	}
+	// An unrecovered DD is NOT also in the recovered list.
+	if len(got) != 0 {
+		t.Fatalf("recovered list should be empty, got %d", len(got))
+	}
+}
+
+func TestDetectDrawdowns_BelowThresholdIsIgnored(t *testing.T) {
+	// 1% dip should be skipped at default 2% threshold.
+	points := []EquityPoint{
+		{Timestamp: 1, Equity: 100},
+		{Timestamp: 2, Equity: 99},
+		{Timestamp: 3, Equity: 101},
+	}
+	got, unrec := DetectDrawdowns(points, 0.02)
+	if len(got) != 0 || unrec != nil {
+		t.Fatalf("no DD expected: recovered=%v unrecovered=%v", got, unrec)
+	}
+}
+
+func TestDetectDrawdowns_Empty(t *testing.T) {
+	got, unrec := DetectDrawdowns(nil, 0.02)
+	if got != nil || unrec != nil {
+		t.Fatalf("expected empty results, got %v / %v", got, unrec)
+	}
+}
+
+// ---------- Time-in-market ----------
+
+func TestComputeTimeInMarket_Full(t *testing.T) {
+	// 10 bars, 4 non-overlapping trades covering bars [0..1], [3..3], [5..7].
+	// inMarket bars = 2+1+3 = 6, ratio = 6/10 = 0.6.
+	// Flat streaks between: 1 (bar 2), 1 (bar 4), 2 (bars 8,9) -> longest = 2.
+	totalBars := 10
+	barTimestamps := []int64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
+	trades := []entity.BacktestTradeRecord{
+		{EntryTime: 0, ExitTime: 1},
+		{EntryTime: 3, ExitTime: 3},
+		{EntryTime: 5, ExitTime: 7},
+	}
+
+	ratio, longestFlat := ComputeTimeInMarket(trades, barTimestamps, totalBars)
+	if math.Abs(ratio-0.6) > 1e-9 {
+		t.Fatalf("ratio = %v, want 0.6", ratio)
+	}
+	if longestFlat != 2 {
+		t.Fatalf("longestFlat = %d, want 2", longestFlat)
+	}
+}
+
+func TestComputeTimeInMarket_NoTrades(t *testing.T) {
+	ratio, longest := ComputeTimeInMarket(nil, []int64{0, 1, 2}, 3)
+	if ratio != 0 {
+		t.Fatalf("ratio = %v, want 0", ratio)
+	}
+	// All bars flat -> longest streak = 3.
+	if longest != 3 {
+		t.Fatalf("longestFlat = %d, want 3", longest)
+	}
+}
+
+func TestComputeTimeInMarket_AlwaysInMarket(t *testing.T) {
+	// One long trade covering the entire window.
+	totalBars := 5
+	barTimestamps := []int64{0, 1, 2, 3, 4}
+	trades := []entity.BacktestTradeRecord{{EntryTime: 0, ExitTime: 4}}
+	ratio, longest := ComputeTimeInMarket(trades, barTimestamps, totalBars)
+	if ratio != 1.0 {
+		t.Fatalf("ratio = %v, want 1.0", ratio)
+	}
+	if longest != 0 {
+		t.Fatalf("longestFlat = %d, want 0", longest)
+	}
+}
+
+func TestComputeTimeInMarket_EmptyBars(t *testing.T) {
+	ratio, longest := ComputeTimeInMarket(nil, nil, 0)
+	if ratio != 0 || longest != 0 {
+		t.Fatalf("empty bars should be zero, got %v / %d", ratio, longest)
+	}
+}
+
+// ---------- Expectancy ----------
+
+func TestComputeExpectancy_MixedWR(t *testing.T) {
+	// 3 wins (100, 80, 60) / 2 losses (-50, -30) -> WR=0.6, AvgWin=80, AvgLoss=40
+	// Expectancy = 0.6*80 - 0.4*40 = 48 - 16 = 32
+	trades := []entity.BacktestTradeRecord{
+		{PnL: 100}, {PnL: -50}, {PnL: 80}, {PnL: -30}, {PnL: 60},
+	}
+	e, aw, al := ComputeExpectancy(trades)
+	if math.Abs(e-32) > 1e-9 {
+		t.Fatalf("Expectancy = %v, want 32", e)
+	}
+	if math.Abs(aw-80) > 1e-9 {
+		t.Fatalf("AvgWin = %v, want 80", aw)
+	}
+	if math.Abs(al-40) > 1e-9 {
+		t.Fatalf("AvgLoss = %v, want 40", al)
+	}
+}
+
+func TestComputeExpectancy_NoTrades(t *testing.T) {
+	e, aw, al := ComputeExpectancy(nil)
+	if e != 0 || aw != 0 || al != 0 {
+		t.Fatalf("empty input should be zero, got e=%v aw=%v al=%v", e, aw, al)
+	}
+}
+
+func TestComputeExpectancy_AllWins(t *testing.T) {
+	// No losses -> AvgLoss=0, Expectancy = 1*AvgWin = AvgWin
+	trades := []entity.BacktestTradeRecord{{PnL: 100}, {PnL: 50}}
+	e, aw, al := ComputeExpectancy(trades)
+	if al != 0 {
+		t.Fatalf("AvgLoss should be 0, got %v", al)
+	}
+	if aw != 75 {
+		t.Fatalf("AvgWin = %v, want 75", aw)
+	}
+	if e != 75 {
+		t.Fatalf("Expectancy = %v, want 75", e)
+	}
+}
+
+func TestComputeExpectancy_AllLosses(t *testing.T) {
+	trades := []entity.BacktestTradeRecord{{PnL: -20}, {PnL: -40}}
+	e, aw, al := ComputeExpectancy(trades)
+	if aw != 0 {
+		t.Fatalf("AvgWin should be 0, got %v", aw)
+	}
+	if al != 30 {
+		t.Fatalf("AvgLoss = %v, want 30 (absolute)", al)
+	}
+	if e != -30 {
+		t.Fatalf("Expectancy = %v, want -30", e)
+	}
+}

--- a/backend/internal/usecase/backtest/reporter.go
+++ b/backend/internal/usecase/backtest/reporter.go
@@ -71,26 +71,50 @@ func (r *SummaryReporter) BuildSummary(
 		return parseSignalSource(t.ReasonEntry)
 	})
 
+	recoveredDDs, unrecoveredDD := DetectDrawdowns(equityPoints, DefaultDrawdownThreshold)
+	expectancy, avgWin, avgLoss := ComputeExpectancy(trades)
+
+	// Derive per-bar timestamps from the equity curve itself. runner.go pushes
+	// exactly one EquityPoint per primary-interval candle plus a seed point,
+	// so skipping the seed yields the bar timeline we need. This avoids
+	// threading the full candle slice into the reporter.
+	var barTimestamps []int64
+	if len(equityPoints) > 1 {
+		barTimestamps = make([]int64, 0, len(equityPoints)-1)
+		for _, p := range equityPoints[1:] {
+			barTimestamps = append(barTimestamps, p.Timestamp)
+		}
+	}
+	timeInMarket, longestFlat := ComputeTimeInMarket(trades, barTimestamps, len(barTimestamps))
+
 	return entity.BacktestSummary{
-		PeriodFrom:         config.FromTimestamp,
-		PeriodTo:           config.ToTimestamp,
-		InitialBalance:     config.InitialBalance,
-		FinalBalance:       finalBalance,
-		TotalReturn:        calcTotalReturn(config.InitialBalance, finalBalance),
-		TotalTrades:        totalTrades,
-		WinTrades:          winTrades,
-		LossTrades:         lossTrades,
-		WinRate:            winRate,
-		ProfitFactor:       profitFactor,
-		MaxDrawdown:        maxDDRatio,
-		MaxDrawdownBalance: maxDDBalance,
-		SharpeRatio:        sharpe,
-		AvgHoldSeconds:     avgHold,
-		TotalCarryingCost:  carryingCost,
-		TotalSpreadCost:    spreadCost,
-		BiweeklyWinRate:    biweekly,
-		ByExitReason:       byExit,
-		BySignalSource:     bySource,
+		PeriodFrom:          config.FromTimestamp,
+		PeriodTo:            config.ToTimestamp,
+		InitialBalance:      config.InitialBalance,
+		FinalBalance:        finalBalance,
+		TotalReturn:         calcTotalReturn(config.InitialBalance, finalBalance),
+		TotalTrades:         totalTrades,
+		WinTrades:           winTrades,
+		LossTrades:          lossTrades,
+		WinRate:             winRate,
+		ProfitFactor:        profitFactor,
+		MaxDrawdown:         maxDDRatio,
+		MaxDrawdownBalance:  maxDDBalance,
+		SharpeRatio:         sharpe,
+		AvgHoldSeconds:      avgHold,
+		TotalCarryingCost:   carryingCost,
+		TotalSpreadCost:     spreadCost,
+		BiweeklyWinRate:     biweekly,
+		ByExitReason:        byExit,
+		BySignalSource:      bySource,
+		DrawdownPeriods:     recoveredDDs,
+		DrawdownThreshold:   DefaultDrawdownThreshold,
+		UnrecoveredDrawdown: unrecoveredDD,
+		ExpectancyPerTrade:    expectancy,
+		AvgWinJPY:             avgWin,
+		AvgLossJPY:            avgLoss,
+		TimeInMarketRatio:     timeInMarket,
+		LongestFlatStreakBars: longestFlat,
 	}
 }
 

--- a/backend/internal/usecase/backtest/reporter_test.go
+++ b/backend/internal/usecase/backtest/reporter_test.go
@@ -109,6 +109,53 @@ func mustJSTMillis(y int, m time.Month, d, h, min int) int64 {
 	return time.Date(y, m, d, h, min, 0, 0, loc).UnixMilli()
 }
 
+func TestSummaryReporter_BuildSummary_IncludesDrawdownTimeInMarketExpectancy(t *testing.T) {
+	reporter := NewSummaryReporter()
+	cfg := entity.BacktestConfig{
+		FromTimestamp:  1_000,
+		ToTimestamp:    10_000,
+		InitialBalance: 1000,
+	}
+	// 5 equity points: seed + 4 bars.
+	// peak 1000 -> trough 950 (-5%) -> recover 1000 -> new peak 1100 -> 1050 (-4.5% unrecovered)
+	equity := []EquityPoint{
+		{Timestamp: 1_000, Equity: 1000}, // seed
+		{Timestamp: 2_000, Equity: 950},  // trough of recovered DD (5%)
+		{Timestamp: 3_000, Equity: 1000}, // recovered (= peak)
+		{Timestamp: 4_000, Equity: 1100}, // new peak
+		{Timestamp: 5_000, Equity: 1050}, // -4.5% DD unrecovered at end
+	}
+	// Two trades cover bars 2-3 (in-market) and bar 5 (in-market). Bar 4
+	// (timestamp 4_000) is flat. Bar timestamps = 2_000, 3_000, 4_000, 5_000.
+	trades := []entity.BacktestTradeRecord{
+		{TradeID: 1, EntryTime: 2_000, ExitTime: 3_000, PnL: 50},
+		{TradeID: 2, EntryTime: 5_000, ExitTime: 5_000, PnL: -10},
+	}
+	s := reporter.BuildSummary(cfg, 1050, trades, equity)
+
+	if len(s.DrawdownPeriods) != 1 {
+		t.Fatalf("DrawdownPeriods = %d, want 1; got %+v", len(s.DrawdownPeriods), s.DrawdownPeriods)
+	}
+	if s.DrawdownThreshold != DefaultDrawdownThreshold {
+		t.Fatalf("DrawdownThreshold = %v, want %v", s.DrawdownThreshold, DefaultDrawdownThreshold)
+	}
+	if s.UnrecoveredDrawdown == nil {
+		t.Fatalf("UnrecoveredDrawdown should be set at run end")
+	}
+	if s.TimeInMarketRatio < 0.74 || s.TimeInMarketRatio > 0.76 {
+		t.Fatalf("TimeInMarketRatio = %v, want ~0.75", s.TimeInMarketRatio)
+	}
+	if s.LongestFlatStreakBars != 1 {
+		t.Fatalf("LongestFlatStreakBars = %d, want 1", s.LongestFlatStreakBars)
+	}
+	if s.ExpectancyPerTrade != 20 {
+		t.Fatalf("ExpectancyPerTrade = %v, want 20", s.ExpectancyPerTrade)
+	}
+	if s.AvgWinJPY != 50 || s.AvgLossJPY != 10 {
+		t.Fatalf("avg win/loss = %v/%v", s.AvgWinJPY, s.AvgLossJPY)
+	}
+}
+
 func TestSummaryReporter_BuildSummary_IncludesBreakdowns(t *testing.T) {
 	reporter := NewSummaryReporter()
 	cfg := entity.BacktestConfig{

--- a/docs/design/plans/2026-04-21-pr3-drawdown-detail.md
+++ b/docs/design/plans/2026-04-21-pr3-drawdown-detail.md
@@ -157,13 +157,18 @@ Expectancy = WR * AvgWin - (1 - WR) * AvgLoss  -- JPY/trade
 
 1. `runner_test.go`: 既存シナリオで `summary.DrawdownPeriods` に 1 件以上、`TimeInMarketRatio` が 0-1 の範囲、`ExpectancyPerTrade` が finite
 
-## DoD
+## DoD（as-built）
 
-- [ ] Unit 5 本 passing
-- [ ] Integration 1 本 passing
-- [ ] 既存テストすべて通る（挙動不変）
-- [ ] Frontend に 3 種類のビュー追加
-- [ ] PR 本文: v3 production の DD 履歴 / TimeInMarket / Expectancy を貼付
+- [x] Unit 12 本 passing: DetectDrawdowns 4 ケース (2 episodes, unrecovered, below threshold, empty) + ComputeTimeInMarket 4 ケース (full, no trades, always-in-market, empty bars) + ComputeExpectancy 4 ケース (mixed WR, no trades, all wins, all losses)
+- [x] Integration 2 本: reporter.BuildSummary に新フィールドが詰まる + repository round-trip (drawdown periods + unrecovered + time-in-market + expectancy)
+- [x] 既存テスト全 17 パッケージ緑
+- [x] migrations_test に PR-3 カラム 7 本の assertion を追加
+- [x] docker e2e: 6mo production で `/backtest/run` を叩き、unrecoveredDrawdown/timeInMarketRatio/expectancyPerTrade が返ることを確認
+
+### フォローアップ（別 PR）
+
+- Frontend に DD 履歴テーブル / TimeInMarket カード / Expectancy カードを追加
+- PR 本文: 直近 6 ヶ月 production の数値を貼付（下記 #XYZ PR 本文に実測値）
 
 ## ロールバック
 


### PR DESCRIPTION
## Summary

- `BacktestSummary` に **Drawdown 履歴 / Time-in-market / Expectancy** の 3 軸を追加
- MaxDrawdown だけでは見えなかった「深さ・継続期間・回復期間・未回復か」、保有時間率、1 トレードあたり期待値 JPY が全て見える
- Phase A の最終 PR。これで cycle 評価の観測基盤が完成し、次の PR-12 (ATR trailing) / PR-6 (ADX) / PR-13 (walk-forward) の効果測定が 1 リクエストで完結する

詳細設計: `docs/design/plans/2026-04-21-pr3-drawdown-detail.md`

## 新フィールド

```go
DrawdownPeriods        []DrawdownPeriod  // 2% 以上の全 DD 履歴 (from/to/recoveredAt/depth/durationBars/recoveryBars)
DrawdownThreshold      float64           // 2% (定数)
UnrecoveredDrawdown    *DrawdownPeriod   // 期間末で未回復の場合のみ
TimeInMarketRatio      float64           // ポジション保有 bar / 全 bar
LongestFlatStreakBars  int
ExpectancyPerTrade     float64           // E = WR * AvgWin - (1-WR) * AvgLoss
AvgWinJPY, AvgLossJPY  float64           // AvgLossJPY は絶対値
```

## アーキテクチャ

- `usecase/backtest/drawdown_detail.go` に `DetectDrawdowns` / `ComputeTimeInMarket` / `ComputeExpectancy` の 3 関数を追加。純関数、副作用なし、DB 非依存
- `SummaryReporter.BuildSummary` が既存の `equityPoints` と `trades` から上記 3 関数を呼び出すだけで統合完了。Runner 側の変更なし
- DB: `backtest_results` に scalar 6 カラム + `drawdown_periods_json` の JSON 1 本を追加（設計書 §DB 案 A）。レガシー行は zero/NULL default で互換

## 設計のポイント

- **Drawdown の「回復」は equity >= peak で判定**。strict `>` だと「ピークに等しく戻る」ケースが永遠に未回復扱いになる（テストで回帰ガード）
- **Unrecovered DD は recovered リストには入れない**。UI は分けて扱える
- **Time-in-market の bar timestamps は equityPoints から派生**（runner が 1 バーに 1 EquityPoint push するため）。Runner の signature は変えない
- **Expectancy の win/loss 規約**は既存 reporter.go と一致（PnL >= 0 が win）

## Test plan

- [x] Unit 12 ケース: DetectDrawdowns (2 episodes/unrecovered/below threshold/empty), ComputeTimeInMarket (full/no trades/always-in/empty), ComputeExpectancy (mixed/no trades/all wins/all losses)
- [x] Integration: reporter 統合 + repo round-trip
- [x] migrations_test に PR-3 カラム 7 本の assertion
- [x] `go test ./... -race -count=1` 全 17 パッケージ緑
- [x] docker e2e で 6mo production から上記 3 軸が返ることを確認

## 実測例（直近 6 ヶ月 production）

```
drawdown detail:
  threshold: 2.0%
  recovered DDs: 0
  unrecovered: depth=2.38% duration=4260 bars

time-in-market:
  ratio: 94.05%
  longest flat streak: 90 bars

expectancy:
  E: -0.323 JPY/trade
  AvgWin: 20.51 / AvgLoss: 24.16 (abs)
```

HEAD production は負け戦略 (E < 0) なのが数値でも見える。PR-12 後の v4 promotion で E を正に持っていくのが次の目標。

## フォローアップ（別 PR）

- Frontend: バックテスト詳細に DD 履歴テーブル / TimeInMarket カード / Expectancy カード

🤖 Generated with [Claude Code](https://claude.com/claude-code)