### PR TITLE
fix(backtest): apply Codex review findings for PR-12 and PR-13

### DIFF
--- a/backend/internal/interfaces/api/handler/backtest_walkforward.go
+++ b/backend/internal/interfaces/api/handler/backtest_walkforward.go
@@ -102,6 +102,31 @@ func (h *BacktestHandler) RunWalkForward(c *gin.Context) {
 		return
 	}
 
+	// Validate the objective at the API boundary so a typo (e.g.
+	// "returns" vs "return") fails the request up front instead of
+	// silently defaulting to TotalReturn in SelectByObjective and
+	// producing results that disagree with the caller's intent.
+	switch req.Objective {
+	case "", "return", "sharpe", "profit_factor":
+		// ok; "" resolves to TotalReturn in SelectByObjective.
+	default:
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": fmt.Sprintf("invalid objective %q: must be one of return, sharpe, profit_factor", req.Objective),
+		})
+		return
+	}
+
+	// Pre-validate that every override path is supported by ApplyOverrides,
+	// so an unsupported path surfaces as HTTP 400 up front instead of
+	// deep inside WalkForwardRunner.Run where it would currently bubble
+	// out as HTTP 500.
+	for _, ov := range req.ParameterGrid {
+		if _, err := bt.ApplyOverrides(entity.StrategyProfile{}, map[string]float64{ov.Path: 0}); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+	}
+
 	baseDir := h.profilesBaseDir
 	if baseDir == "" {
 		baseDir = defaultProfilesBaseDir

--- a/backend/internal/interfaces/api/handler/backtest_walkforward_test.go
+++ b/backend/internal/interfaces/api/handler/backtest_walkforward_test.go
@@ -1,0 +1,82 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	bt "github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/backtest"
+)
+
+// The handler validations below do NOT require a real backtest run — they
+// should reject the request before ExpandGrid/ComputeWindows/runner are
+// reached. A minimal BacktestHandler is enough.
+
+func newWalkForwardHandler(t *testing.T) *BacktestHandler {
+	t.Helper()
+	return NewBacktestHandler(
+		bt.NewBacktestRunner(),
+		&mockBacktestResultRepo{},
+	)
+}
+
+// TestWalkForward_RejectsInvalidObjective locks in the Codex PR-13
+// follow-up: a typo in the objective name must surface as 400, not
+// silently fall back to TotalReturn inside SelectByObjective.
+func TestWalkForward_RejectsInvalidObjective(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := newWalkForwardHandler(t)
+	r := gin.New()
+	r.POST("/backtest/walk-forward", h.RunWalkForward)
+
+	body := `{
+		"data": "x.csv",
+		"from": "2024-01-01",
+		"to":   "2024-12-01",
+		"baseProfile": "production",
+		"objective":   "returns"
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/backtest/walk-forward", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "invalid objective") {
+		t.Fatalf("body should mention invalid objective, got: %s", w.Body.String())
+	}
+}
+
+// TestWalkForward_RejectsUnknownOverridePath locks in the follow-up: an
+// unknown override path must be a 400 (caller error), not a 500 from
+// ApplyOverrides failing mid-run.
+func TestWalkForward_RejectsUnknownOverridePath(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := newWalkForwardHandler(t)
+	r := gin.New()
+	r.POST("/backtest/walk-forward", h.RunWalkForward)
+
+	body := `{
+		"data": "x.csv",
+		"from": "2024-01-01",
+		"to":   "2024-12-01",
+		"baseProfile": "production",
+		"objective":   "return",
+		"parameterGrid": [{"path": "not.a.real.path", "values": [1, 2]}]
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/backtest/walk-forward", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "unsupported override path") {
+		t.Fatalf("body should mention unsupported path, got: %s", w.Body.String())
+	}
+}

--- a/backend/internal/usecase/backtest/handler.go
+++ b/backend/internal/usecase/backtest/handler.go
@@ -317,9 +317,17 @@ func (h *TickRiskHandler) SetATRMultipliers(stopLossATR, trailingATR float64) {
 }
 
 // UpdateATR is called by the IndicatorHandler (or a test fixture) whenever a
-// fresh primary-interval ATR value is available. Zero or NaN is ignored.
+// fresh primary-interval ATR value is available. NaN is ignored (the
+// indicator calculator emits NaN when there is insufficient data). Zero
+// *is* accepted so the handler correctly returns to the percent-only
+// fallback path when the market genuinely has zero range — a previous
+// version silently retained a stale positive ATR in that case, breaking
+// the max(percent, ATR) policy when ATR transitioned back to 0.
 func (h *TickRiskHandler) UpdateATR(atr float64) {
-	if atr <= 0 || atr != atr { // NaN check
+	if atr != atr { // NaN check
+		return
+	}
+	if atr < 0 {
 		return
 	}
 	h.currentATR = atr

--- a/backend/internal/usecase/backtest/tickrisk_atr_test.go
+++ b/backend/internal/usecase/backtest/tickrisk_atr_test.go
@@ -2,6 +2,7 @@ package backtest
 
 import (
 	"context"
+	"math"
 	"testing"
 
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
@@ -103,6 +104,46 @@ func TestTickRiskHandler_StopLossDistance_ATRBiggerThanPercent(t *testing.T) {
 // TestTickRiskHandler_UpdateATRFromIndicatorEvent verifies the event wiring:
 // when an IndicatorEvent with a Primary.ATR14 arrives, Handle feeds the value
 // into the handler so the next TickEvent sees the updated distance.
+// TestTickRiskHandler_UpdateATRAcceptsZero is the Codex PR-12 follow-up:
+// previously UpdateATR rejected zero (treated it like NaN), which meant a
+// flat-market bar could not clear a stale positive ATR, and the handler
+// would keep "max(percent, old ATR)" in effect when it should have fallen
+// back to percent-only.
+func TestTickRiskHandler_UpdateATRAcceptsZero(t *testing.T) {
+	h := NewTickRiskHandler("PT15M", &atrTestExecutor{}, 5, 10)
+	h.SetATRMultipliers(2.0, 2.0)
+
+	// Seed with a real ATR.
+	h.UpdateATR(500)
+	if h.currentATR != 500 {
+		t.Fatalf("seed: currentATR = %v, want 500", h.currentATR)
+	}
+	// Market goes flat: ATR should zero out. Before the fix this was a
+	// no-op.
+	h.UpdateATR(0)
+	if h.currentATR != 0 {
+		t.Fatalf("zero should be accepted, currentATR = %v", h.currentATR)
+	}
+	// trailingDistance now falls back to percent because ATR*mult == 0.
+	got := h.trailingDistance(10_000)
+	if got != 500 {
+		t.Fatalf("trailing distance with ATR=0 should revert to percent=500, got %v", got)
+	}
+}
+
+// TestTickRiskHandler_UpdateATRRejectsNaN keeps the NaN-rejection
+// behaviour (NaN is emitted by the indicator calculator when data is
+// insufficient; treating that as "flat market" would be wrong).
+func TestTickRiskHandler_UpdateATRRejectsNaN(t *testing.T) {
+	h := NewTickRiskHandler("PT15M", &atrTestExecutor{}, 5, 10)
+	h.SetATRMultipliers(2.0, 2.0)
+	h.UpdateATR(500)
+	h.UpdateATR(math.NaN())
+	if h.currentATR != 500 {
+		t.Fatalf("NaN should be ignored, currentATR = %v, want 500", h.currentATR)
+	}
+}
+
 func TestTickRiskHandler_UpdateATRFromIndicatorEvent(t *testing.T) {
 	h := NewTickRiskHandler("PT15M", &atrTestExecutor{}, 5, 10)
 	h.SetATRMultipliers(0, 2.0)

--- a/backend/internal/usecase/backtest/walkforward.go
+++ b/backend/internal/usecase/backtest/walkforward.go
@@ -47,12 +47,18 @@ func ComputeWindows(from, to time.Time, inSampleMonths, oosMonths, stepMonths in
 		return nil, fmt.Errorf("walk-forward: from must be before to")
 	}
 
+	// addMonthsClamped is used instead of time.Time.AddDate directly because
+	// AddDate normalises an out-of-range day into the next month:
+	// e.g. 2024-01-31 + 1m => 2024-03-02, which silently skips February
+	// and progressively drifts later windows. Clamping to the target
+	// month's last day keeps month-aligned schedules stable through
+	// 30/31-day and leap-year boundaries.
 	var out []WalkForwardWindow
 	idx := 0
 	isStart := from
 	for {
-		isEnd := isStart.AddDate(0, inSampleMonths, 0)
-		oosEnd := isEnd.AddDate(0, oosMonths, 0)
+		isEnd := addMonthsClamped(isStart, inSampleMonths)
+		oosEnd := addMonthsClamped(isEnd, oosMonths)
 		if oosEnd.After(to) {
 			break
 		}
@@ -64,13 +70,56 @@ func ComputeWindows(from, to time.Time, inSampleMonths, oosMonths, stepMonths in
 			OOSTo:        oosEnd,
 		})
 		idx++
-		isStart = isStart.AddDate(0, stepMonths, 0)
+		isStart = addMonthsClamped(isStart, stepMonths)
 	}
 	if len(out) == 0 {
 		return nil, fmt.Errorf("walk-forward: [%s, %s] is too short for in=%d oos=%d months",
 			from.Format("2006-01-02"), to.Format("2006-01-02"), inSampleMonths, oosMonths)
 	}
 	return out, nil
+}
+
+// addMonthsClamped adds n calendar months to t with two invariants the
+// stdlib time.Time.AddDate violates:
+//
+//  1. If t is already on the last day of its month, the result is also
+//     on the last day of the target month. e.g. 2024-01-31 + 1m =>
+//     2024-02-29 (and subsequent monthly steps stay anchored on the last
+//     day, never drifting to 02-29 -> 03-29 -> 04-29).
+//  2. If t's day-of-month does not exist in the target month, clamp to
+//     the target's last day. e.g. 2024-03-31 + 1m => 2024-04-30.
+//
+// Without these, AddDate(0,1,0) on 2024-01-31 returns 2024-03-02, which
+// silently skips February and breaks any walk-forward schedule whose
+// cadence depends on "month +1" meaning "same point of the next month".
+func addMonthsClamped(t time.Time, months int) time.Time {
+	y, m, d := t.Date()
+
+	// Normalise target year/month with a negative-safe modulo.
+	total := int(m) - 1 + months
+	targetYear := y + total/12
+	targetMonthIdx := total % 12
+	if targetMonthIdx < 0 {
+		targetYear--
+		targetMonthIdx += 12
+	}
+	targetMonth := time.Month(targetMonthIdx + 1)
+
+	// Last day of source month and target month: "day 0 of next month".
+	srcLastDay := time.Date(y, m+1, 0, 0, 0, 0, 0, t.Location()).Day()
+	targetLastDay := time.Date(targetYear, targetMonth+1, 0, 0, 0, 0, 0, t.Location()).Day()
+
+	switch {
+	case d == srcLastDay:
+		// Month-end anchor: stay on month-end across calls.
+		d = targetLastDay
+	case d > targetLastDay:
+		// Source day doesn't exist in target month — clamp down.
+		d = targetLastDay
+	}
+
+	return time.Date(targetYear, targetMonth, d,
+		t.Hour(), t.Minute(), t.Second(), t.Nanosecond(), t.Location())
 }
 
 // ExpandGrid computes the full cartesian product of the supplied
@@ -81,8 +130,20 @@ func ExpandGrid(overrides []ParameterOverride) ([]map[string]float64, error) {
 		return []map[string]float64{{}}, nil
 	}
 
+	// Reject duplicate paths up-front: a later axis would silently overwrite
+	// the earlier one in the combo map, producing visible combo count >
+	// distinct combos and a scoring signal that is not what the caller
+	// asked for.
+	seenPaths := make(map[string]struct{}, len(overrides))
 	total := 1
 	for _, o := range overrides {
+		if o.Path == "" {
+			return nil, fmt.Errorf("walk-forward: override path must not be empty")
+		}
+		if _, dup := seenPaths[o.Path]; dup {
+			return nil, fmt.Errorf("walk-forward: duplicate override path %q", o.Path)
+		}
+		seenPaths[o.Path] = struct{}{}
 		if len(o.Values) == 0 {
 			return nil, fmt.Errorf("walk-forward: override %q has no values", o.Path)
 		}

--- a/backend/internal/usecase/backtest/walkforward_test.go
+++ b/backend/internal/usecase/backtest/walkforward_test.go
@@ -53,6 +53,54 @@ func TestComputeWindows_TooShortReturnsError(t *testing.T) {
 	}
 }
 
+// TestComputeWindows_MonthEndDoesNotDrift is the regression lock for the
+// Codex review finding on PR #115: stdlib time.AddDate would roll
+// 2024-01-31 + 1mo into 2024-03-02, silently skipping February and
+// drifting later windows later and later. After the clamping fix, the
+// window set must still be anchored on the last day of each month.
+func TestComputeWindows_MonthEndDoesNotDrift(t *testing.T) {
+	// 2024-01-31 start, 1-month IS, 1-month OOS, 1-month step.
+	// The first window ends at IS(2024-02-29) because 2024 is a leap
+	// year; OOS then ends at 2024-03-31.
+	from := time.Date(2024, 1, 31, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2024, 6, 30, 0, 0, 0, 0, time.UTC)
+	ws, err := ComputeWindows(from, to, 1, 1, 1)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(ws) < 2 {
+		t.Fatalf("want at least 2 windows, got %d", len(ws))
+	}
+	// w0: [2024-01-31 .. 2024-02-29] IS, [2024-02-29 .. 2024-03-31] OOS
+	wantISEnd0 := time.Date(2024, 2, 29, 0, 0, 0, 0, time.UTC)
+	wantOOSEnd0 := time.Date(2024, 3, 31, 0, 0, 0, 0, time.UTC)
+	if !ws[0].InSampleTo.Equal(wantISEnd0) {
+		t.Fatalf("w0.InSampleTo = %v, want %v (leap-year clamp)", ws[0].InSampleTo, wantISEnd0)
+	}
+	if !ws[0].OOSTo.Equal(wantOOSEnd0) {
+		t.Fatalf("w0.OOSTo = %v, want %v", ws[0].OOSTo, wantOOSEnd0)
+	}
+	// w1 must start at 2024-02-29 (clamped) — with AddDate this would have
+	// been 2024-03-02 and the test would fail.
+	wantW1Start := time.Date(2024, 2, 29, 0, 0, 0, 0, time.UTC)
+	if !ws[1].InSampleFrom.Equal(wantW1Start) {
+		t.Fatalf("w1.InSampleFrom = %v, want %v", ws[1].InSampleFrom, wantW1Start)
+	}
+}
+
+func TestComputeWindows_NonLeapYearClampsFebTo28(t *testing.T) {
+	from := time.Date(2023, 1, 31, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2023, 6, 30, 0, 0, 0, 0, time.UTC)
+	ws, err := ComputeWindows(from, to, 1, 1, 1)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	wantISEnd0 := time.Date(2023, 2, 28, 0, 0, 0, 0, time.UTC)
+	if !ws[0].InSampleTo.Equal(wantISEnd0) {
+		t.Fatalf("non-leap year clamp: InSampleTo = %v, want %v", ws[0].InSampleTo, wantISEnd0)
+	}
+}
+
 func TestComputeWindows_InvalidInputs(t *testing.T) {
 	from := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	to := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
@@ -137,6 +185,27 @@ func TestExpandGrid_RejectsEmptyValues(t *testing.T) {
 	_, err := ExpandGrid([]ParameterOverride{{Path: "a", Values: nil}})
 	if err == nil {
 		t.Fatalf("expected error on empty values list")
+	}
+}
+
+// TestExpandGrid_RejectsDuplicatePaths locks in the Codex PR-13 follow-up:
+// if two overrides share the same Path, the later one silently overwrites
+// the earlier one in every combo, so the caller's "N×M" grid actually
+// produces only M distinct combos and its scoring signal is compromised.
+func TestExpandGrid_RejectsDuplicatePaths(t *testing.T) {
+	_, err := ExpandGrid([]ParameterOverride{
+		{Path: "a", Values: []float64{1, 2}},
+		{Path: "a", Values: []float64{3, 4}},
+	})
+	if err == nil {
+		t.Fatalf("expected error on duplicate path")
+	}
+}
+
+func TestExpandGrid_RejectsEmptyPath(t *testing.T) {
+	_, err := ExpandGrid([]ParameterOverride{{Path: "", Values: []float64{1}}})
+	if err == nil {
+		t.Fatalf("expected error on empty path")
 	}
 }
 


### PR DESCRIPTION
## Summary

Consolidates fixes for two retroactive Codex reviews on recently-merged Phase B PRs. Both PRs were merged before Codex was available; this PR closes the loop on the BLOCKING findings and picks up the cheap non-blocking hardening at the same time.

## PR-12 (ATR trailing stop) — BLOCKING

- **`UpdateATR(0)` was silently ignored** alongside NaN, so a transition from "ATR = 500" back to "ATR = 0" (truly flat market) left a stale positive ATR in place. The `max(percent, ATR)` policy therefore kept applying the ATR distance instead of correctly falling back to percent-only.
- NaN is still rejected (the indicator calculator emits NaN when data is insufficient); 0 is now accepted.
- Regression test: `TestTickRiskHandler_UpdateATRAcceptsZero` + `TestTickRiskHandler_UpdateATRRejectsNaN`

## PR-13 (walk-forward) — BLOCKING

- **`ComputeWindows` used `time.Time.AddDate`**, which rolls `2024-01-31 + 1m` into `2024-03-02` (silently skipping February). Every downstream window drifted later and later across the schedule.
- New `addMonthsClamped` enforces two invariants:
  1. Month-end anchoring — if `t` is the last day of its month, the result is the last day of the target month (so `2024-01-31 + 1m => 2024-02-29` and further steps stay on month-end)
  2. Day-of-month clamping — if the source day doesn't exist in the target month, clamp to the last day (`2024-03-31 + 1m => 2024-04-30`)
- Regression tests: `TestComputeWindows_MonthEndDoesNotDrift` (leap year) + `TestComputeWindows_NonLeapYearClampsFebTo28`

## PR-13 — non-blocking hardening

- `ExpandGrid` now rejects **duplicate override paths** and **empty paths** at expansion time. A grid with two axes on the same path used to silently overwrite earlier values in the combo map, producing M distinct combos instead of the expected N × M and contaminating the scoring signal.
- `POST /backtest/walk-forward` now returns 400 on:
  - unknown `objective` values (typos like `"returns"` previously fell back silently to TotalReturn inside `SelectByObjective`)
  - unsupported override paths (previously deep-failed as 500 inside the runner)

## Test plan

- [x] New regression tests: 2 for `UpdateATR`, 2 for `ComputeWindows`, 2 for `ExpandGrid`, 2 for the walk-forward handler = 8 new cases
- [x] `go test ./... -race -count=1` all 17 packages pass
- [x] No API shape changes, no DB migrations — pure behavioural correctness fixes

## Codex sessions

- PR-13 review session: `019dae89-56b3-7ef3-be90-19e417d9ff89`
- PR-12 review: via codex rescue agent (no long-lived session id)

🤖 Generated with [Claude Code](https://claude.com/claude-code)