### PR TITLE
feat(strategy): add Ichimoku indicator + htf_filter.mode=ichimoku (PR-8)

### DIFF
--- a/backend/internal/domain/entity/indicator.go
+++ b/backend/internal/domain/entity/indicator.go
@@ -37,5 +37,21 @@ type IndicatorSet struct {
 	StochD14_3 *float64 `json:"stochD14_3"`
 	StochRSI14 *float64 `json:"stochRsi14"`
 
+	// PR-8: Ichimoku cloud snapshot. nil when the warmup is insufficient.
+	// Individual fields inside IchimokuSnapshot are omitted from JSON when
+	// they could not be computed (yields cleaner payloads during warmup).
+	Ichimoku *IchimokuSnapshot `json:"ichimoku,omitempty"`
+
 	Timestamp int64 `json:"timestamp"`
+}
+
+// IchimokuSnapshot is the per-bar Ichimoku Kinkō Hyō reading exposed to the
+// Strategy layer and Frontend. All fields are pointers so the JSON payload
+// distinguishes "not yet defined during warmup" from "zero".
+type IchimokuSnapshot struct {
+	Tenkan  *float64 `json:"tenkan,omitempty"`  // conversion line (9)
+	Kijun   *float64 `json:"kijun,omitempty"`   // base line (26)
+	SenkouA *float64 `json:"senkouA,omitempty"` // leading span A (Tenkan+Kijun)/2, plotted +26
+	SenkouB *float64 `json:"senkouB,omitempty"` // leading span B (high/low mid over 52), plotted +26
+	Chikou  *float64 `json:"chikou,omitempty"`  // lagging span — latest close
 }

--- a/backend/internal/domain/entity/strategy_config.go
+++ b/backend/internal/domain/entity/strategy_config.go
@@ -94,6 +94,16 @@ type HTFFilterConfig struct {
 	Enabled           bool    `json:"enabled"`
 	BlockCounterTrend bool    `json:"block_counter_trend"`
 	AlignmentBoost    float64 `json:"alignment_boost"`
+	// PR-8: Mode selects the HTF trend-detection method.
+	//   - "" or "ema":      legacy SMA20/SMA50 comparison (default).
+	//   - "ichimoku":       price vs. cloud on the higher timeframe.
+	//                       above-cloud -> uptrend, below-cloud -> downtrend,
+	//                       inside-cloud -> neutral (blocks both directions
+	//                       when block_counter_trend is true).
+	// A missing Ichimoku snapshot falls through to "unknown" and takes no
+	// action (neither blocks nor boosts) so partial warmup never silently
+	// opens up a counter-trend signal.
+	Mode string `json:"mode,omitempty"`
 }
 
 // StrategyRiskConfig configures the per-strategy risk envelope (position

--- a/backend/internal/infrastructure/indicator/ichimoku.go
+++ b/backend/internal/infrastructure/indicator/ichimoku.go
@@ -1,0 +1,126 @@
+package indicator
+
+import "math"
+
+// IchimokuResult carries the five-line Ichimoku cloud snapshot for the latest
+// bar. All fields are NaN when there is not enough history to define them:
+//   - Tenkan: needs 9 bars
+//   - Kijun:  needs 26 bars
+//   - SenkouA / SenkouB: at the latest bar the "future" projection is what was
+//     computed 26 bars ago (because A/B are plotted +26 ahead). That means
+//     we can fill SenkouA/B at bar i only when i-26 >= 0 AND the source
+//     bar i-26 had a valid Tenkan (9+26=35 bars) / SenkouB (52+26=78 bars).
+//   - Chikou: close plotted 26 bars back. At the latest bar Chikou simply
+//     equals the latest close (there is no "future close" available).
+//     Exposed for completeness; the Strategy layer currently doesn't use it.
+type IchimokuResult struct {
+	Tenkan  float64
+	Kijun   float64
+	SenkouA float64
+	SenkouB float64
+	Chikou  float64
+}
+
+// highLowMid returns the midpoint of the highest-high / lowest-low over the
+// trailing `period` bars ending at `index` (inclusive). Returns NaN when the
+// window is incomplete or inputs mismatch.
+func highLowMid(highs, lows []float64, period, index int) float64 {
+	if period <= 0 || index < period-1 || len(highs) != len(lows) {
+		return math.NaN()
+	}
+	if index >= len(highs) {
+		return math.NaN()
+	}
+	hi := math.Inf(-1)
+	lo := math.Inf(1)
+	for j := index - period + 1; j <= index; j++ {
+		if highs[j] > hi {
+			hi = highs[j]
+		}
+		if lows[j] < lo {
+			lo = lows[j]
+		}
+	}
+	return (hi + lo) / 2
+}
+
+// Ichimoku computes the five Ichimoku lines for the latest bar.
+//
+// Parameters follow the canonical Ichimoku Kinkō Hyō definition:
+//   - tenkanPeriod = 9
+//   - kijunPeriod = 26 (also doubles as the Senkou projection offset)
+//   - senkouBPeriod = 52
+//
+// Returns an IchimokuResult whose fields are NaN when the warmup is not yet
+// long enough to define that specific line.
+//
+// The "displayed" Senkou Span A/B at the latest bar come from a source bar
+// kijunPeriod (26) bars in the past — i.e. what was projected forward 26
+// bars ago and is now arriving. This mirrors the FE calcIchimoku behaviour
+// where senkouA[i] for i >= kijunPeriod derives from tenkan/kijun at
+// i-kijunPeriod, and senkouB[i] uses highLowMid over senkouBPeriod ending
+// at i-kijunPeriod.
+func Ichimoku(highs, lows, closes []float64, tenkanPeriod, kijunPeriod, senkouBPeriod int) IchimokuResult {
+	out := IchimokuResult{
+		Tenkan:  math.NaN(),
+		Kijun:   math.NaN(),
+		SenkouA: math.NaN(),
+		SenkouB: math.NaN(),
+		Chikou:  math.NaN(),
+	}
+	n := len(closes)
+	if tenkanPeriod <= 0 || kijunPeriod <= 0 || senkouBPeriod <= 0 {
+		return out
+	}
+	if n != len(highs) || n != len(lows) {
+		return out
+	}
+	if n == 0 {
+		return out
+	}
+	last := n - 1
+
+	out.Tenkan = highLowMid(highs, lows, tenkanPeriod, last)
+	out.Kijun = highLowMid(highs, lows, kijunPeriod, last)
+
+	// Senkou Span A/B: displayed at `last` come from source bar `last - kijunPeriod`.
+	srcIdx := last - kijunPeriod
+	if srcIdx >= 0 {
+		t := highLowMid(highs, lows, tenkanPeriod, srcIdx)
+		k := highLowMid(highs, lows, kijunPeriod, srcIdx)
+		if !math.IsNaN(t) && !math.IsNaN(k) {
+			out.SenkouA = (t + k) / 2
+		}
+		out.SenkouB = highLowMid(highs, lows, senkouBPeriod, srcIdx)
+	}
+
+	// Chikou Span: at the latest bar there is no "future close" yet, so it
+	// simply equals the latest close. (Plot offset is handled on the FE.)
+	out.Chikou = closes[last]
+	return out
+}
+
+// IchimokuCloudPosition classifies price position relative to the cloud.
+//   - "above": price strictly above both SenkouA and SenkouB (bullish)
+//   - "below": price strictly below both SenkouA and SenkouB (bearish)
+//   - "inside": price is between the two spans (neutral / consolidation)
+//   - "": cloud not yet defined (NaN spans) — caller should treat as "unknown"
+//
+// The function takes the price explicitly (rather than pulling the latest
+// close) so callers can evaluate it against any reference price — tick
+// close, bar mid, or a what-if value.
+func IchimokuCloudPosition(price float64, ic IchimokuResult) string {
+	if math.IsNaN(ic.SenkouA) || math.IsNaN(ic.SenkouB) {
+		return ""
+	}
+	upper := math.Max(ic.SenkouA, ic.SenkouB)
+	lower := math.Min(ic.SenkouA, ic.SenkouB)
+	switch {
+	case price > upper:
+		return "above"
+	case price < lower:
+		return "below"
+	default:
+		return "inside"
+	}
+}

--- a/backend/internal/infrastructure/indicator/ichimoku_test.go
+++ b/backend/internal/infrastructure/indicator/ichimoku_test.go
@@ -1,0 +1,113 @@
+package indicator
+
+import (
+	"math"
+	"testing"
+)
+
+func TestIchimoku_InsufficientDataGivesNaN(t *testing.T) {
+	// 10 bars isn't even enough for Kijun (26).
+	h, l, c := buildFlatSeries(10, 100)
+	ic := Ichimoku(h, l, c, 9, 26, 52)
+	if !math.IsNaN(ic.Kijun) {
+		t.Fatalf("Kijun should be NaN on 10 bars; got %v", ic.Kijun)
+	}
+	if !math.IsNaN(ic.SenkouA) || !math.IsNaN(ic.SenkouB) {
+		t.Fatalf("Senkou should be NaN without 26 bars of source; got A=%v B=%v", ic.SenkouA, ic.SenkouB)
+	}
+}
+
+func TestIchimoku_LengthMismatchGivesAllNaN(t *testing.T) {
+	h := make([]float64, 80)
+	l := make([]float64, 80)
+	c := make([]float64, 79)
+	ic := Ichimoku(h, l, c, 9, 26, 52)
+	if !math.IsNaN(ic.Tenkan) || !math.IsNaN(ic.Kijun) || !math.IsNaN(ic.SenkouA) || !math.IsNaN(ic.SenkouB) {
+		t.Fatalf("mismatched lengths must give all-NaN, got %+v", ic)
+	}
+}
+
+func TestIchimoku_FlatSeriesAllLinesEqualPrice(t *testing.T) {
+	// A flat price series: every line should equal the price itself.
+	h, l, c := buildFlatSeries(100, 100)
+	ic := Ichimoku(h, l, c, 9, 26, 52)
+	if ic.Tenkan != 100 || ic.Kijun != 100 {
+		t.Fatalf("flat: expected 100/100, got tenkan=%v kijun=%v", ic.Tenkan, ic.Kijun)
+	}
+	if ic.SenkouA != 100 || ic.SenkouB != 100 {
+		t.Fatalf("flat: expected senkouA=B=100, got A=%v B=%v", ic.SenkouA, ic.SenkouB)
+	}
+	if ic.Chikou != 100 {
+		t.Fatalf("flat: expected chikou=100, got %v", ic.Chikou)
+	}
+}
+
+func TestIchimoku_UptrendTenkanLeadsKijun(t *testing.T) {
+	// Monotonic uptrend: Tenkan is shorter, so it sits above Kijun.
+	h, l, c := buildMonotonicUptrend(100, 100, 1.0)
+	ic := Ichimoku(h, l, c, 9, 26, 52)
+	if math.IsNaN(ic.Tenkan) || math.IsNaN(ic.Kijun) {
+		t.Fatalf("expected non-NaN tenkan/kijun in uptrend, got %+v", ic)
+	}
+	if ic.Tenkan <= ic.Kijun {
+		t.Fatalf("uptrend: expected Tenkan > Kijun, got %v vs %v", ic.Tenkan, ic.Kijun)
+	}
+	// Price should be above the cloud in a sustained uptrend (after 100
+	// bars of monotonic rise, the displayed Senkou spans come from 26 bars
+	// ago, so price is well above them).
+	price := c[len(c)-1]
+	pos := IchimokuCloudPosition(price, ic)
+	if pos != "above" {
+		t.Fatalf("uptrend: expected price above cloud, got %q (price=%v A=%v B=%v)", pos, price, ic.SenkouA, ic.SenkouB)
+	}
+}
+
+func TestIchimoku_DowntrendPriceBelowCloud(t *testing.T) {
+	n := 100
+	highs := make([]float64, n)
+	lows := make([]float64, n)
+	closes := make([]float64, n)
+	price := 200.0
+	for i := 0; i < n; i++ {
+		closes[i] = price
+		highs[i] = price + 0.5
+		lows[i] = price - 0.5
+		price -= 1.0
+	}
+	ic := Ichimoku(highs, lows, closes, 9, 26, 52)
+	pos := IchimokuCloudPosition(closes[n-1], ic)
+	if pos != "below" {
+		t.Fatalf("downtrend: expected below, got %q (price=%v A=%v B=%v)", pos, closes[n-1], ic.SenkouA, ic.SenkouB)
+	}
+	if ic.Tenkan >= ic.Kijun {
+		t.Fatalf("downtrend: expected Tenkan < Kijun, got %v vs %v", ic.Tenkan, ic.Kijun)
+	}
+}
+
+func TestIchimokuCloudPosition_EmptyWhenCloudUndefined(t *testing.T) {
+	ic := IchimokuResult{
+		Tenkan:  50,
+		Kijun:   50,
+		SenkouA: math.NaN(),
+		SenkouB: math.NaN(),
+		Chikou:  50,
+	}
+	if pos := IchimokuCloudPosition(100, ic); pos != "" {
+		t.Fatalf("NaN cloud should give empty string, got %q", pos)
+	}
+}
+
+func TestIchimokuCloudPosition_InsideCloud(t *testing.T) {
+	ic := IchimokuResult{SenkouA: 110, SenkouB: 90}
+	for _, price := range []float64{95, 100, 109} {
+		if pos := IchimokuCloudPosition(price, ic); pos != "inside" {
+			t.Fatalf("price=%v expected inside, got %q", price, pos)
+		}
+	}
+	if pos := IchimokuCloudPosition(111, ic); pos != "above" {
+		t.Fatalf("price=111 expected above, got %q", pos)
+	}
+	if pos := IchimokuCloudPosition(89, ic); pos != "below" {
+		t.Fatalf("price=89 expected below, got %q", pos)
+	}
+}

--- a/backend/internal/usecase/backtest/handler.go
+++ b/backend/internal/usecase/backtest/handler.go
@@ -584,6 +584,12 @@ func calculateIndicatorSet(symbolID int64, candles []entity.Candle) entity.Indic
 	result.StochD14_3 = floatToPtr(stochD)
 	result.StochRSI14 = floatToPtr(indicator.StochasticRSI(closes, 14, 14))
 
+	// PR-8: Ichimoku. Mirror the live pipeline; nil when all five lines
+	// are still in warmup.
+	if snap := buildIchimokuSnapshotBT(indicator.Ichimoku(highs, lows, closes, 9, 26, 52)); snap != nil {
+		result.Ichimoku = snap
+	}
+
 	// Volume indicators
 	volumes := make([]float64, n)
 	for i, c := range candles {
@@ -623,6 +629,23 @@ func floatToPtr(v float64) *float64 {
 		return nil
 	}
 	return &v
+}
+
+// buildIchimokuSnapshotBT mirrors usecase.buildIchimokuSnapshot for the
+// backtest path. Kept as a sibling helper (rather than exported) so both
+// calculators evolve independently without cross-package coupling.
+func buildIchimokuSnapshotBT(r indicator.IchimokuResult) *entity.IchimokuSnapshot {
+	snap := &entity.IchimokuSnapshot{
+		Tenkan:  floatToPtr(r.Tenkan),
+		Kijun:   floatToPtr(r.Kijun),
+		SenkouA: floatToPtr(r.SenkouA),
+		SenkouB: floatToPtr(r.SenkouB),
+		Chikou:  floatToPtr(r.Chikou),
+	}
+	if snap.Tenkan == nil && snap.Kijun == nil && snap.SenkouA == nil && snap.SenkouB == nil && snap.Chikou == nil {
+		return nil
+	}
+	return snap
 }
 
 func intervalDurationMillis(interval string) (int64, error) {

--- a/backend/internal/usecase/indicator.go
+++ b/backend/internal/usecase/indicator.go
@@ -83,6 +83,12 @@ func (c *IndicatorCalculator) Calculate(ctx context.Context, symbolID int64, int
 	result.StochD14_3 = toPtr(stochD)
 	result.StochRSI14 = toPtr(indicator.StochasticRSI(prices, 14, 14))
 
+	// PR-8: Ichimoku. Each of the five lines may be NaN independently during
+	// warmup; buildIchimokuSnapshot returns nil when every line is unknown.
+	if snap := buildIchimokuSnapshot(indicator.Ichimoku(highs, lows, prices, 9, 26, 52)); snap != nil {
+		result.Ichimoku = snap
+	}
+
 	// Volume indicators
 	volumes := make([]float64, n)
 	for i, cd := range candles {
@@ -123,4 +129,21 @@ func toPtr(v float64) *float64 {
 		return nil
 	}
 	return &v
+}
+
+// buildIchimokuSnapshot maps an indicator.IchimokuResult onto the entity
+// pointer snapshot. Returns nil when every line is NaN (pure warmup state)
+// so consumers can cheaply branch on `if snap := ...; snap != nil`.
+func buildIchimokuSnapshot(r indicator.IchimokuResult) *entity.IchimokuSnapshot {
+	snap := &entity.IchimokuSnapshot{
+		Tenkan:  toPtr(r.Tenkan),
+		Kijun:   toPtr(r.Kijun),
+		SenkouA: toPtr(r.SenkouA),
+		SenkouB: toPtr(r.SenkouB),
+		Chikou:  toPtr(r.Chikou),
+	}
+	if snap.Tenkan == nil && snap.Kijun == nil && snap.SenkouA == nil && snap.SenkouB == nil && snap.Chikou == nil {
+		return nil
+	}
+	return snap
 }

--- a/backend/internal/usecase/strategy.go
+++ b/backend/internal/usecase/strategy.go
@@ -54,6 +54,9 @@ type StrategyEngineOptions struct {
 	HTFEnabled           bool    // if false, skip the HTF filter entirely; default true
 	HTFBlockCounterTrend bool    // if true, block signals against higher-TF trend; default true
 	HTFAlignmentBoost    float64 // confidence boost when HTF aligns; default 0.1
+	// PR-8: selects the HTF trend-detection method ("ema" = legacy SMA20/50,
+	// "ichimoku" = price vs. cloud). Empty string defaults to "ema".
+	HTFMode string
 
 	// Stance-level feature toggles
 	EnableTrendFollow bool // if false, TREND_FOLLOW stance yields HOLD; default true
@@ -208,7 +211,7 @@ func (e *StrategyEngine) EvaluateWithHigherTFAt(
 		}
 	}
 
-	if !e.options.HTFEnabled || higherTF == nil || higherTF.SMA20 == nil || higherTF.SMA50 == nil {
+	if !e.options.HTFEnabled || higherTF == nil {
 		return signal, nil
 	}
 
@@ -217,22 +220,37 @@ func (e *StrategyEngine) EvaluateWithHigherTFAt(
 		return signal, nil
 	}
 
-	higherUptrend := *higherTF.SMA20 > *higherTF.SMA50
+	// PR-8: trend direction on the higher timeframe. Three-valued so the
+	// ichimoku "inside the cloud" state can block both directions. When
+	// the measurement is unavailable (early warmup), we fall through and
+	// take no action — same as the legacy "missing SMA => skip" path.
+	dir := htfTrendDirection(e.options.HTFMode, higherTF, lastPrice)
+	if dir == htfTrendUnknown {
+		return signal, nil
+	}
 
 	if e.options.HTFBlockCounterTrend {
-		if signal.Action == entity.SignalActionBuy && !higherUptrend {
+		if signal.Action == entity.SignalActionBuy && dir != htfTrendUp {
+			reason := "MTF filter: higher timeframe downtrend blocks buy"
+			if dir == htfTrendNeutral {
+				reason = "MTF filter: higher timeframe inside cloud blocks buy"
+			}
 			return &entity.Signal{
 				SymbolID:  indicators.SymbolID,
 				Action:    entity.SignalActionHold,
-				Reason:    "MTF filter: higher timeframe downtrend blocks buy",
+				Reason:    reason,
 				Timestamp: signal.Timestamp,
 			}, nil
 		}
-		if signal.Action == entity.SignalActionSell && higherUptrend {
+		if signal.Action == entity.SignalActionSell && dir != htfTrendDown {
+			reason := "MTF filter: higher timeframe uptrend blocks sell"
+			if dir == htfTrendNeutral {
+				reason = "MTF filter: higher timeframe inside cloud blocks sell"
+			}
 			return &entity.Signal{
 				SymbolID:  indicators.SymbolID,
 				Action:    entity.SignalActionHold,
-				Reason:    "MTF filter: higher timeframe uptrend blocks sell",
+				Reason:    reason,
 				Timestamp: signal.Timestamp,
 			}, nil
 		}
@@ -240,13 +258,62 @@ func (e *StrategyEngine) EvaluateWithHigherTFAt(
 
 	// Signal aligns with higher TF: boost confidence by HTFAlignmentBoost
 	// (capped at 1.0). Boost only applies when the signal direction matches
-	// the higher-timeframe trend direction.
-	aligned := (signal.Action == entity.SignalActionBuy && higherUptrend) ||
-		(signal.Action == entity.SignalActionSell && !higherUptrend)
+	// the higher-timeframe trend direction. Neutral HTF produces no boost.
+	aligned := (signal.Action == entity.SignalActionBuy && dir == htfTrendUp) ||
+		(signal.Action == entity.SignalActionSell && dir == htfTrendDown)
 	if aligned {
 		signal.Confidence = math.Min(signal.Confidence+e.options.HTFAlignmentBoost, 1.0)
 	}
 	return signal, nil
+}
+
+type htfTrend int
+
+const (
+	htfTrendUnknown htfTrend = iota
+	htfTrendUp
+	htfTrendDown
+	htfTrendNeutral
+)
+
+// htfTrendDirection returns the higher-timeframe trend classification using
+// the configured HTF mode. "ema" (default) mirrors the legacy
+// SMA20>SMA50/SMA20<SMA50 behaviour; "ichimoku" uses the cloud position.
+// htfTrendUnknown is returned when the required inputs are unavailable so
+// the caller can short-circuit without taking action.
+func htfTrendDirection(mode string, higherTF *entity.IndicatorSet, lastPrice float64) htfTrend {
+	switch mode {
+	case "ichimoku":
+		if higherTF == nil || higherTF.Ichimoku == nil {
+			return htfTrendUnknown
+		}
+		ic := higherTF.Ichimoku
+		if ic.SenkouA == nil || ic.SenkouB == nil {
+			return htfTrendUnknown
+		}
+		upper := *ic.SenkouA
+		lower := *ic.SenkouB
+		if lower > upper {
+			upper, lower = lower, upper
+		}
+		switch {
+		case lastPrice > upper:
+			return htfTrendUp
+		case lastPrice < lower:
+			return htfTrendDown
+		default:
+			return htfTrendNeutral
+		}
+	default:
+		// "" and "ema" both use the legacy SMA cross.
+		if higherTF == nil || higherTF.SMA20 == nil || higherTF.SMA50 == nil {
+			return htfTrendUnknown
+		}
+		if *higherTF.SMA20 > *higherTF.SMA50 {
+			return htfTrendUp
+		}
+		return htfTrendDown
+	}
 }
 
 // Evaluate はテクニカル指標と現在価格から売買シグナルを生成する。

--- a/backend/internal/usecase/strategy/configurable_strategy.go
+++ b/backend/internal/usecase/strategy/configurable_strategy.go
@@ -83,6 +83,7 @@ func NewConfigurableStrategy(profile *entity.StrategyProfile) (*ConfigurableStra
 		HTFEnabled:           profile.HTFFilter.Enabled,
 		HTFBlockCounterTrend: profile.HTFFilter.BlockCounterTrend,
 		HTFAlignmentBoost:    profile.HTFFilter.AlignmentBoost,
+		HTFMode:              profile.HTFFilter.Mode, // PR-8
 	}
 	engine := usecase.NewStrategyEngineWithOptions(resolver, engineOpts)
 

--- a/backend/internal/usecase/strategy/htf_ichimoku_test.go
+++ b/backend/internal/usecase/strategy/htf_ichimoku_test.go
@@ -1,0 +1,154 @@
+package strategy
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+)
+
+// TestConfigurableStrategy_HTFIchimokuModeBlocksBuyInsideCloud is the PR-8
+// wiring confirmation. With htf_filter.mode="ichimoku" a trend-follow BUY
+// against a higher-timeframe cloud where price sits inside the cloud must
+// be blocked ("inside cloud blocks buy"). This guards against silent-no-op
+// regression for the new mode field.
+func TestConfigurableStrategy_HTFIchimokuModeBlocksBuyInsideCloud(t *testing.T) {
+	profile := productionProfile(t)
+	profile.HTFFilter.Enabled = true
+	profile.HTFFilter.BlockCounterTrend = true
+	profile.HTFFilter.Mode = "ichimoku"
+	// Disable the production ADX gate so only the HTF filter is in play.
+	profile.SignalRules.TrendFollow.ADXMin = 0
+
+	s, err := NewConfigurableStrategy(profile)
+	if err != nil {
+		t.Fatalf("NewConfigurableStrategy: %v", err)
+	}
+
+	ind := makeTrendFollowReadyIndicators()
+	// Build a higher-TF indicator set whose cloud is 90..110 and last
+	// price (100 on the primary TF) is inside it.
+	higherTF := &entity.IndicatorSet{
+		Ichimoku: makeCloud(110, 90),
+	}
+
+	sig, err := s.Evaluate(context.Background(), &ind, higherTF, 100.0, time.Now())
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if sig.Action != entity.SignalActionHold {
+		t.Fatalf("expected HOLD inside cloud; got %v (reason=%q)", sig.Action, sig.Reason)
+	}
+	if !containsSubstring(sig.Reason, "cloud") {
+		t.Fatalf("expected reason to mention cloud; got %q", sig.Reason)
+	}
+}
+
+// TestConfigurableStrategy_HTFIchimokuModeAllowsBuyAboveCloud: price above
+// cloud = HTF uptrend => BUY not blocked.
+func TestConfigurableStrategy_HTFIchimokuModeAllowsBuyAboveCloud(t *testing.T) {
+	profile := productionProfile(t)
+	profile.HTFFilter.Enabled = true
+	profile.HTFFilter.BlockCounterTrend = true
+	profile.HTFFilter.Mode = "ichimoku"
+	profile.SignalRules.TrendFollow.ADXMin = 0
+
+	s, err := NewConfigurableStrategy(profile)
+	if err != nil {
+		t.Fatalf("NewConfigurableStrategy: %v", err)
+	}
+
+	ind := makeTrendFollowReadyIndicators()
+	higherTF := &entity.IndicatorSet{
+		Ichimoku: makeCloud(95, 85), // cloud well below lastPrice=100
+	}
+
+	sig, err := s.Evaluate(context.Background(), &ind, higherTF, 100.0, time.Now())
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if sig.Action != entity.SignalActionBuy {
+		t.Fatalf("expected BUY above cloud; got %v (reason=%q)", sig.Action, sig.Reason)
+	}
+}
+
+// TestConfigurableStrategy_HTFIchimokuModeMissingCloudDoesNothing: no cloud
+// data => falls through, no block, no boost. This is the partial-warmup
+// invariant: absence of data must never silently open a counter-trend BUY.
+func TestConfigurableStrategy_HTFIchimokuModeMissingCloudDoesNothing(t *testing.T) {
+	profile := productionProfile(t)
+	profile.HTFFilter.Enabled = true
+	profile.HTFFilter.BlockCounterTrend = true
+	profile.HTFFilter.Mode = "ichimoku"
+	profile.SignalRules.TrendFollow.ADXMin = 0
+
+	s, err := NewConfigurableStrategy(profile)
+	if err != nil {
+		t.Fatalf("NewConfigurableStrategy: %v", err)
+	}
+
+	ind := makeTrendFollowReadyIndicators()
+	higherTF := &entity.IndicatorSet{} // no Ichimoku snapshot
+
+	sig, err := s.Evaluate(context.Background(), &ind, higherTF, 100.0, time.Now())
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	// The underlying indicator would have produced a BUY; with no HTF
+	// data and mode=ichimoku the filter cannot decide, so we expect the
+	// primary signal to pass through unchanged.
+	if sig.Action != entity.SignalActionBuy {
+		t.Fatalf("expected pass-through BUY; got %v (reason=%q)", sig.Action, sig.Reason)
+	}
+	// And the reason must not cite the cloud gate.
+	if containsSubstring(sig.Reason, "cloud") {
+		t.Fatalf("unexpected cloud-gate reason on missing data: %q", sig.Reason)
+	}
+}
+
+// TestConfigurableStrategy_HTFEMAModeDefaultUnchanged: empty Mode (and
+// "ema") must preserve legacy SMA-based behaviour so existing profiles
+// keep working.
+func TestConfigurableStrategy_HTFEMAModeDefaultUnchanged(t *testing.T) {
+	profile := productionProfile(t)
+	profile.HTFFilter.Enabled = true
+	profile.HTFFilter.BlockCounterTrend = true
+	profile.HTFFilter.Mode = "" // legacy
+	profile.SignalRules.TrendFollow.ADXMin = 0
+
+	s, err := NewConfigurableStrategy(profile)
+	if err != nil {
+		t.Fatalf("NewConfigurableStrategy: %v", err)
+	}
+
+	ind := makeTrendFollowReadyIndicators()
+	down20 := 100.0
+	down50 := 110.0 // SMA20 < SMA50 => higher-TF downtrend
+	higherTF := &entity.IndicatorSet{
+		SMA20: &down20,
+		SMA50: &down50,
+	}
+
+	sig, err := s.Evaluate(context.Background(), &ind, higherTF, 100.0, time.Now())
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if sig.Action != entity.SignalActionHold {
+		t.Fatalf("expected HOLD under legacy EMA-mode downtrend; got %v (reason=%q)", sig.Action, sig.Reason)
+	}
+	if containsSubstring(sig.Reason, "cloud") {
+		t.Fatalf("legacy mode must not mention cloud; got %q", sig.Reason)
+	}
+}
+
+// makeCloud builds an IchimokuSnapshot whose SenkouA/SenkouB bound the
+// cloud. Other lines are left nil because the HTF filter only consults A/B.
+func makeCloud(senkouA, senkouB float64) *entity.IchimokuSnapshot {
+	a := senkouA
+	b := senkouB
+	return &entity.IchimokuSnapshot{
+		SenkouA: &a,
+		SenkouB: &b,
+	}
+}


### PR DESCRIPTION
## Summary
- Go port of FE `CandlestickChart.calcIchimoku` → `indicator.Ichimoku` (9,26,52) returning Tenkan/Kijun/SenkouA/SenkouB/Chikou with per-field NaN warmup.
- `IndicatorSet.Ichimoku` exposes an `*IchimokuSnapshot` (pointer fields so warmup is lean in JSON).
- `HTFFilterConfig.Mode` ∈ {\"\", \"ema\", \"ichimoku\"} wired into the HTF filter. \"ema\" / \"\" preserve the legacy SMA20/50 comparison bit-for-bit; \"ichimoku\" classifies the higher timeframe as up/down/**neutral** (price-inside-cloud blocks both directions) or **unknown** (missing snapshot falls through, never silently opens a counter-trend signal).

## Why
Part of #119 (Phase C). Ichimoku cloud gives a more robust regime filter than SMA20/50 alone — the 2024 loss (profitable on 3yr window, negative on 2yr) is a candidate target for v5 promotion (#118). Wiring mirrors PR-6 (ADX) and PR-7 (Stoch) deliberately so \"profile field does nothing\" regressions (cycle08) cannot recur.

## Test plan
- [x] `go test ./... -count=1` — 21/21 packages green.
- [x] `indicator/ichimoku_test.go` — warmup / length mismatch / flat series / uptrend-tenkan-above-kijun / downtrend / cloud position classifier.
- [x] `strategy/htf_ichimoku_test.go` — block inside cloud, allow above cloud, missing snapshot passes through, legacy EMA mode unchanged.
- [x] `pnpm test --run` — 27/27 FE tests green.

Part of #119. Next: #120 WFO DB persistence + #118 v5 grid over the new gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)