### PR TITLE
feat(backtest): persist walk-forward results + GET endpoints + CLI (#120)

### DIFF
--- a/backend/cmd/backtest/main.go
+++ b/backend/cmd/backtest/main.go
@@ -57,6 +57,11 @@ func main() {
 			fmt.Fprintf(os.Stderr, "backtest download failed: %v\n", err)
 			os.Exit(1)
 		}
+	case "walk-forward":
+		if err := walkForwardCommand(os.Args[2:]); err != nil {
+			fmt.Fprintf(os.Stderr, "backtest walk-forward failed: %v\n", err)
+			os.Exit(1)
+		}
 	default:
 		usage()
 		os.Exit(2)
@@ -69,6 +74,7 @@ func usage() {
 	fmt.Println("  go run ./cmd/backtest optimize --data <primary.csv> --param \"stop_loss_percent=1:10:1\" [flags]")
 	fmt.Println("  go run ./cmd/backtest refine --data <primary.csv> --param \"stop_loss_percent=1:10:1\" [--top 5] [--step-div 4] [flags]")
 	fmt.Println("  go run ./cmd/backtest download ...")
+	fmt.Println("  go run ./cmd/backtest walk-forward --data <primary.csv> --from <YYYY-MM-DD> --to <YYYY-MM-DD> --profile <name> [--grid path=v1,v2,v3] [--grid-file path.json]")
 }
 
 // runFlags is the parsed set of CLI flags for the `run` subcommand. Kept in

--- a/backend/cmd/backtest/walkforward.go
+++ b/backend/cmd/backtest/walkforward.go
@@ -1,0 +1,287 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+	csvinfra "github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/infrastructure/csv"
+	bt "github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/backtest"
+	strategyuc "github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/strategy"
+)
+
+// walkForwardCommand drives `backtest walk-forward`: same grid semantics as
+// POST /backtest/walk-forward but usable from the shell without a running
+// server. The CLI path is deliberately thin — all the heavy lifting
+// (grid expansion, window schedule, runner) is shared with the HTTP handler.
+func walkForwardCommand(args []string) error {
+	fs := flag.NewFlagSet("walk-forward", flag.ContinueOnError)
+
+	var (
+		dataPath       = fs.String("data", "", "primary timeframe CSV path (required)")
+		dataHTFPath    = fs.String("data-htf", "", "higher timeframe CSV path")
+		fromDate       = fs.String("from", "", "window schedule start (YYYY-MM-DD) (required)")
+		toDate         = fs.String("to", "", "window schedule end   (YYYY-MM-DD) (required)")
+		inMonths       = fs.Int("in", 6, "in-sample months per window")
+		oosMonths      = fs.Int("oos", 3, "out-of-sample months per window")
+		stepMonths     = fs.Int("step", 3, "step size between window starts (months)")
+		baseProfile    = fs.String("profile", "", "base strategy profile name (required)")
+		objective      = fs.String("objective", "return", `objective for IS selection: "return" | "sharpe" | "profit_factor"`)
+		gridFile       = fs.String("grid-file", "", "path to a JSON file shaped like [{path,values}, ...]")
+		initialBalance = fs.Float64("initial-balance", 100000, "initial balance in JPY")
+		spread         = fs.Float64("spread", 0.1, "spread percent")
+		carryingCost   = fs.Float64("carrying-cost", 0.04, "daily carrying cost percent")
+		slippage       = fs.Float64("slippage", 0, "slippage percent")
+		tradeAmount    = fs.Float64("trade-amount", 0.01, "trade amount")
+		outputJSON     = fs.String("output", "", "write result envelope to this path as JSON (optional)")
+	)
+	var gridInline paramFlags
+	fs.Var(&gridInline, "grid", `parameter axis, repeatable: "path=v1,v2,v3". e.g. --grid "signal_rules.contrarian.stoch_entry_max=0,10,20"`)
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *dataPath == "" {
+		return fmt.Errorf("--data is required")
+	}
+	if *baseProfile == "" {
+		return fmt.Errorf("--profile is required")
+	}
+	if *fromDate == "" || *toDate == "" {
+		return fmt.Errorf("--from and --to are required")
+	}
+	switch *objective {
+	case "", "return", "sharpe", "profit_factor":
+	default:
+		return fmt.Errorf("invalid --objective %q (want return|sharpe|profit_factor)", *objective)
+	}
+
+	profile, err := loadProfileIfSet(*baseProfile, profilesBaseDir)
+	if err != nil {
+		return err
+	}
+	if profile == nil {
+		return fmt.Errorf("profile %q not found", *baseProfile)
+	}
+
+	overrides, err := resolveWalkForwardGrid(gridInline, *gridFile)
+	if err != nil {
+		return err
+	}
+	// Pre-validate every path so a typo fails the CLI up-front.
+	for _, ov := range overrides {
+		if _, err := bt.ApplyOverrides(entity.StrategyProfile{}, map[string]float64{ov.Path: 0}); err != nil {
+			return fmt.Errorf("invalid --grid path %q: %w", ov.Path, err)
+		}
+	}
+	grid, err := bt.ExpandGrid(overrides)
+	if err != nil {
+		return fmt.Errorf("expand grid: %w", err)
+	}
+
+	fromT, err := parseWFDate(*fromDate)
+	if err != nil {
+		return fmt.Errorf("--from: %w", err)
+	}
+	toT, err := parseWFDate(*toDate)
+	if err != nil {
+		return fmt.Errorf("--to: %w", err)
+	}
+	windows, err := bt.ComputeWindows(fromT, toT, *inMonths, *oosMonths, *stepMonths)
+	if err != nil {
+		return err
+	}
+
+	primary, err := csvinfra.LoadCandles(*dataPath)
+	if err != nil {
+		return fmt.Errorf("load primary csv: %w", err)
+	}
+	var higherCandles []entity.Candle
+	if *dataHTFPath != "" {
+		htf, err := csvinfra.LoadCandles(*dataHTFPath)
+		if err != nil {
+			return fmt.Errorf("load higher tf csv: %w", err)
+		}
+		higherCandles = htf.Candles
+	}
+
+	runner := bt.NewWalkForwardRunner()
+	in := bt.WalkForwardInput{
+		BaseProfile: *profile,
+		Windows:     windows,
+		Grid:        grid,
+		Objective:   *objective,
+		RunWindow: func(ctx context.Context, phase bt.WalkForwardPhase, pf entity.StrategyProfile, wFrom, wTo time.Time) (*entity.BacktestResult, error) {
+			strat, err := strategyuc.NewConfigurableStrategy(&pf)
+			if err != nil {
+				return nil, err
+			}
+			cfg := entity.BacktestConfig{
+				Symbol:           primary.Symbol,
+				SymbolID:         primary.SymbolID,
+				PrimaryInterval:  primary.Interval,
+				HigherTFInterval: "PT1H",
+				FromTimestamp:    wFrom.UnixMilli(),
+				ToTimestamp:      wTo.UnixMilli(),
+				InitialBalance:   *initialBalance,
+				SpreadPercent:    *spread,
+				DailyCarryCost:   *carryingCost,
+				SlippagePercent:  *slippage,
+			}
+			if len(higherCandles) == 0 {
+				cfg.HigherTFInterval = ""
+			}
+			risk := entity.RiskConfig{
+				MaxPositionAmount:     nonZeroFloat(pf.Risk.MaxPositionAmount, 1_000_000_000.0),
+				MaxDailyLoss:          nonZeroFloat(pf.Risk.MaxDailyLoss, 1_000_000_000.0),
+				StopLossPercent:       pf.Risk.StopLossPercent,
+				StopLossATRMultiplier: pf.Risk.StopLossATRMultiplier,
+				TrailingATRMultiplier: pf.Risk.TrailingATRMultiplier,
+				TakeProfitPercent:     pf.Risk.TakeProfitPercent,
+				InitialCapital:        *initialBalance,
+			}
+			windowRunner := bt.NewBacktestRunner(bt.WithStrategy(strat))
+			return windowRunner.Run(ctx, bt.RunInput{
+				Config:         cfg,
+				TradeAmount:    *tradeAmount,
+				PrimaryCandles: primary.Candles,
+				HigherCandles:  higherCandles,
+				RiskConfig:     risk,
+			})
+		},
+	}
+
+	out, err := runner.Run(context.Background(), in)
+	if err != nil {
+		return err
+	}
+
+	printWalkForwardSummary(out)
+
+	if *outputJSON != "" {
+		b, err := json.MarshalIndent(out, "", "  ")
+		if err != nil {
+			return fmt.Errorf("marshal: %w", err)
+		}
+		if err := os.WriteFile(*outputJSON, b, 0o644); err != nil {
+			return fmt.Errorf("write output: %w", err)
+		}
+		fmt.Printf("envelope json: %s\n", *outputJSON)
+	}
+	return nil
+}
+
+// resolveWalkForwardGrid builds the []ParameterOverride from either a JSON
+// file (preferred when many axes) or the repeated --grid "path=v1,v2,v3"
+// inline flag. Both sources cannot be mixed — specifying both is a caller
+// error because the priority would be ambiguous.
+func resolveWalkForwardGrid(inline paramFlags, file string) ([]bt.ParameterOverride, error) {
+	switch {
+	case file != "" && len(inline) > 0:
+		return nil, fmt.Errorf("use --grid OR --grid-file, not both")
+	case file != "":
+		return readGridFile(file)
+	case len(inline) > 0:
+		return parseGridInline(inline)
+	default:
+		// Empty grid → single baseline-only combo. ExpandGrid understands
+		// this case, so return nil to surface exactly that behaviour.
+		return nil, nil
+	}
+}
+
+func readGridFile(path string) ([]bt.ParameterOverride, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read grid file: %w", err)
+	}
+	var out []bt.ParameterOverride
+	if err := json.Unmarshal(data, &out); err != nil {
+		return nil, fmt.Errorf("parse grid file: %w", err)
+	}
+	return out, nil
+}
+
+func parseGridInline(inline paramFlags) ([]bt.ParameterOverride, error) {
+	out := make([]bt.ParameterOverride, 0, len(inline))
+	for _, spec := range inline {
+		eq := strings.IndexByte(spec, '=')
+		if eq <= 0 {
+			return nil, fmt.Errorf("invalid --grid %q: want path=v1,v2,v3", spec)
+		}
+		path := strings.TrimSpace(spec[:eq])
+		raw := strings.TrimSpace(spec[eq+1:])
+		if path == "" || raw == "" {
+			return nil, fmt.Errorf("invalid --grid %q: empty path or values", spec)
+		}
+		pieces := strings.Split(raw, ",")
+		values := make([]float64, 0, len(pieces))
+		for _, p := range pieces {
+			p = strings.TrimSpace(p)
+			if p == "" {
+				return nil, fmt.Errorf("invalid --grid %q: empty value", spec)
+			}
+			v, err := strconv.ParseFloat(p, 64)
+			if err != nil {
+				return nil, fmt.Errorf("invalid --grid value %q: %w", p, err)
+			}
+			values = append(values, v)
+		}
+		out = append(out, bt.ParameterOverride{Path: path, Values: values})
+	}
+	return out, nil
+}
+
+// parseWFDate parses YYYY-MM-DD into a UTC time. The walk-forward CLI runs
+// server-side on a Linux container so UTC is the least-surprising default;
+// HTTP handler already treats from/to as UTC.
+func parseWFDate(v string) (time.Time, error) {
+	t, err := time.Parse("2006-01-02", v)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("parse date %q: %w", v, err)
+	}
+	return t, nil
+}
+
+// nonZeroFloat is the CLI-side counterpart of the handler's helper; kept
+// here so the CLI doesn't import the HTTP handler package.
+func nonZeroFloat(primary, fallback float64) float64 {
+	if primary > 0 {
+		return primary
+	}
+	return fallback
+}
+
+func printWalkForwardSummary(r *bt.WalkForwardResult) {
+	fmt.Println("=== Walk-Forward Result ===")
+	fmt.Printf("ID:           %s\n", r.ID)
+	fmt.Printf("Profile:      %s\n", r.BaseProfile)
+	fmt.Printf("Objective:    %s\n", r.Objective)
+	fmt.Printf("Windows:      %d\n", len(r.Windows))
+	for _, w := range r.Windows {
+		fmt.Printf("  #%d IS[%s..%s] OOS[%s..%s]  best=%v  OOSReturn=%+.2f%%\n",
+			w.Index,
+			formatDateUnixMS(w.InSampleFrom), formatDateUnixMS(w.InSampleTo),
+			formatDateUnixMS(w.OOSFrom), formatDateUnixMS(w.OOSTo),
+			w.BestParameters,
+			w.OOSResult.Summary.TotalReturn*100,
+		)
+	}
+	fmt.Printf("Aggregate:    geomMean=%+.2f%%  worst=%+.2f%%  best=%+.2f%%  worstDD=%.2f%%  robustness=%.4f\n",
+		r.AggregateOOS.GeomMeanReturn*100,
+		r.AggregateOOS.WorstReturn*100,
+		r.AggregateOOS.BestReturn*100,
+		r.AggregateOOS.WorstDrawdown*100,
+		r.AggregateOOS.RobustnessScore,
+	)
+}
+
+func formatDateUnixMS(ms int64) string {
+	return time.UnixMilli(ms).UTC().Format("2006-01-02")
+}

--- a/backend/cmd/backtest/walkforward_test.go
+++ b/backend/cmd/backtest/walkforward_test.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestParseGridInline_ValidPaths(t *testing.T) {
+	pf := paramFlags{
+		"signal_rules.contrarian.stoch_entry_max=0,10,20",
+		"strategy_risk.stop_loss_percent=3,5,7",
+	}
+	got, err := parseGridInline(pf)
+	if err != nil {
+		t.Fatalf("parseGridInline: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 axes, got %d", len(got))
+	}
+	if got[0].Path != "signal_rules.contrarian.stoch_entry_max" {
+		t.Fatalf("axis 0 path: %s", got[0].Path)
+	}
+	if !reflect.DeepEqual(got[0].Values, []float64{0, 10, 20}) {
+		t.Fatalf("axis 0 values: %v", got[0].Values)
+	}
+	if !reflect.DeepEqual(got[1].Values, []float64{3, 5, 7}) {
+		t.Fatalf("axis 1 values: %v", got[1].Values)
+	}
+}
+
+func TestParseGridInline_RejectsBadSpec(t *testing.T) {
+	bads := []string{
+		"no-equal-sign",
+		"=empty-path",
+		"path=",
+		"path=1,,3",
+		"path=abc",
+	}
+	for _, b := range bads {
+		if _, err := parseGridInline(paramFlags{b}); err == nil {
+			t.Fatalf("expected error for %q, got nil", b)
+		}
+	}
+}
+
+func TestReadGridFile_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "grid.json")
+	content := `[
+		{"path": "signal_rules.contrarian.adx_max", "values": [0, 15, 25]},
+		{"path": "strategy_risk.take_profit_percent", "values": [2, 4, 6]}
+	]`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got, err := readGridFile(path)
+	if err != nil {
+		t.Fatalf("readGridFile: %v", err)
+	}
+	if len(got) != 2 || got[0].Path != "signal_rules.contrarian.adx_max" {
+		t.Fatalf("unexpected grid: %+v", got)
+	}
+}
+
+func TestResolveWalkForwardGrid_FileAndInlineAreMutuallyExclusive(t *testing.T) {
+	_, err := resolveWalkForwardGrid(paramFlags{"foo=1,2"}, "some.json")
+	if err == nil {
+		t.Fatal("expected error when both --grid and --grid-file are set")
+	}
+}
+
+func TestResolveWalkForwardGrid_EmptyIsNil(t *testing.T) {
+	got, err := resolveWalkForwardGrid(nil, "")
+	if err != nil {
+		t.Fatalf("no-args should be allowed: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil (baseline-only); got %+v", got)
+	}
+}
+
+func TestParseWFDate_RoundTrip(t *testing.T) {
+	ts, err := parseWFDate("2024-03-15")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if ts.Year() != 2024 || ts.Month() != 3 || ts.Day() != 15 {
+		t.Fatalf("unexpected date: %v", ts)
+	}
+}
+
+func TestParseWFDate_InvalidRejected(t *testing.T) {
+	if _, err := parseWFDate("not-a-date"); err == nil {
+		t.Fatal("expected error")
+	}
+	if _, err := parseWFDate(""); err == nil {
+		t.Fatal("expected error for empty input")
+	}
+}

--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -58,6 +58,7 @@ func main() {
 	clientOrderRepo := database.NewClientOrderRepo(db)
 	backtestResultRepo := backtestinfra.NewResultRepository(db)
 	multiPeriodRepo := backtestinfra.NewMultiPeriodResultRepository(db, backtestResultRepo)
+	walkForwardRepo := backtestinfra.NewWalkForwardResultRepository(db)
 	stanceResolver := usecase.NewRuleBasedStanceResolver(stanceOverrideRepo)
 	strategyEngine := usecase.NewStrategyEngine(stanceResolver)
 	// The StrategyRegistry lives in the strategy package and is exercised by
@@ -163,6 +164,7 @@ func main() {
 		BacktestRunner:        backtestRunner,
 		BacktestResultRepo:    backtestResultRepo,
 		MultiPeriodResultRepo: multiPeriodRepo,
+		WalkForwardResultRepo: walkForwardRepo,
 		OnSymbolSwitch:        onSymbolSwitch,
 		DailyPnLCalculator:    dailyPnLCalc,
 	})

--- a/backend/internal/domain/entity/walk_forward.go
+++ b/backend/internal/domain/entity/walk_forward.go
@@ -1,0 +1,35 @@
+package entity
+
+// WalkForwardPersisted is the database-facing envelope for a walk-forward
+// run. The full per-window result payload is serialised to JSON upstream
+// (usecase/backtest owns the struct, so the domain layer does not pull
+// in that dependency); only the metadata the repository filters on
+// surfaces here as structured fields.
+//
+// Fields:
+//   - ID:           same UUID the runner put into WalkForwardResult.ID.
+//   - CreatedAt:    unix seconds, set by the runner.
+//   - BaseProfile:  profile name at the time of the run.
+//   - Objective:    "return" | "sharpe" | "profit_factor" | "".
+//   - PDCACycleID / Hypothesis / ParentResultID: PDCA metadata echoing the
+//     request body (same three columns as multi_period_results).
+//   - RequestJSON:  the full request body as received by the handler so a
+//     saved row can be replayed byte-for-byte.
+//   - ResultJSON:   the full WalkForwardResult envelope as returned by the
+//     runner (includes per-window BacktestResult bodies verbatim).
+//   - AggregateOOSJSON: denormalised copy of ResultJSON's aggregateOOS
+//     field so list views can rank runs by RobustnessScore without parsing
+//     the potentially-large ResultJSON.
+type WalkForwardPersisted struct {
+	ID             string
+	CreatedAt      int64
+	BaseProfile    string
+	Objective      string
+	PDCACycleID    string
+	Hypothesis     string
+	ParentResultID *string
+
+	RequestJSON      string
+	ResultJSON       string
+	AggregateOOSJSON string
+}

--- a/backend/internal/domain/repository/walk_forward_result.go
+++ b/backend/internal/domain/repository/walk_forward_result.go
@@ -1,0 +1,31 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+)
+
+// WalkForwardResultFilter is the query surface for List.
+// Empty strings and zero values mean "no filter".
+type WalkForwardResultFilter struct {
+	Limit  int
+	Offset int
+
+	BaseProfile string
+	PDCACycleID string
+}
+
+// WalkForwardResultRepository persists walk-forward envelopes. The runner
+// returns WalkForwardResult embedded per-window BacktestResults so the
+// repository stores the full envelope verbatim (no cross-table fan-out
+// like multi_period_results). Request / aggregate are stored separately
+// from the full envelope so list views can rank by RobustnessScore
+// without parsing the (potentially large) result payload.
+type WalkForwardResultRepository interface {
+	// Save writes a new row. `request` is an opaque blob — the caller
+	// chooses whether to round-trip it.
+	Save(ctx context.Context, rec entity.WalkForwardPersisted) error
+	List(ctx context.Context, filter WalkForwardResultFilter) ([]entity.WalkForwardPersisted, error)
+	FindByID(ctx context.Context, id string) (*entity.WalkForwardPersisted, error)
+}

--- a/backend/internal/infrastructure/backtest/walk_forward_repository.go
+++ b/backend/internal/infrastructure/backtest/walk_forward_repository.go
@@ -1,0 +1,157 @@
+package backtest
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/repository"
+)
+
+// WalkForwardResultRepository persists a WalkForwardResult envelope into
+// walk_forward_results. Mirror of MultiPeriodResultRepository in shape,
+// but the per-window BacktestResult bodies are stored inline (inside
+// result_json) because the walk-forward handler does not write per-window
+// rows into backtest_results — the envelope is self-contained.
+type WalkForwardResultRepository struct {
+	db *sql.DB
+}
+
+func NewWalkForwardResultRepository(db *sql.DB) *WalkForwardResultRepository {
+	return &WalkForwardResultRepository{db: db}
+}
+
+func (r *WalkForwardResultRepository) Save(ctx context.Context, rec entity.WalkForwardPersisted) error {
+	if rec.ID == "" {
+		return fmt.Errorf("walk_forward_results: id must not be empty")
+	}
+	if rec.ResultJSON == "" || rec.AggregateOOSJSON == "" {
+		return fmt.Errorf("walk_forward_results: result_json and aggregate_oos_json are required")
+	}
+	if rec.RequestJSON == "" {
+		// Keep the column NOT NULL but empty JSON object is fine for
+		// CLI-initiated runs that don't have a literal HTTP body.
+		rec.RequestJSON = "{}"
+	}
+	parentID := sql.NullString{}
+	if rec.ParentResultID != nil {
+		parentID = sql.NullString{String: *rec.ParentResultID, Valid: true}
+	}
+
+	_, err := r.db.ExecContext(ctx, `INSERT INTO walk_forward_results (
+		id, created_at, base_profile, pdca_cycle_id, hypothesis, objective,
+		parent_result_id, request_json, result_json, aggregate_oos_json
+	) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		rec.ID,
+		rec.CreatedAt,
+		rec.BaseProfile,
+		rec.PDCACycleID,
+		rec.Hypothesis,
+		rec.Objective,
+		parentID,
+		rec.RequestJSON,
+		rec.ResultJSON,
+		rec.AggregateOOSJSON,
+	)
+	if err != nil {
+		return fmt.Errorf("insert walk_forward_results: %w", err)
+	}
+	return nil
+}
+
+func (r *WalkForwardResultRepository) List(ctx context.Context, filter repository.WalkForwardResultFilter) ([]entity.WalkForwardPersisted, error) {
+	limit := filter.Limit
+	if limit <= 0 {
+		limit = 20
+	}
+	offset := filter.Offset
+	if offset < 0 {
+		offset = 0
+	}
+
+	var clauses []string
+	var args []any
+	if filter.BaseProfile != "" {
+		clauses = append(clauses, "base_profile = ?")
+		args = append(args, filter.BaseProfile)
+	}
+	if filter.PDCACycleID != "" {
+		clauses = append(clauses, "pdca_cycle_id = ?")
+		args = append(args, filter.PDCACycleID)
+	}
+	where := ""
+	if len(clauses) > 0 {
+		where = " WHERE " + strings.Join(clauses, " AND ")
+	}
+	args = append(args, limit, offset)
+
+	// List intentionally omits result_json (potentially large) — callers
+	// that need the full envelope should issue FindByID.
+	query := `SELECT id, created_at, base_profile, pdca_cycle_id, hypothesis,
+		objective, parent_result_id, request_json, aggregate_oos_json
+		FROM walk_forward_results` + where + `
+		ORDER BY created_at DESC, id DESC
+		LIMIT ? OFFSET ?`
+	rows, err := r.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list walk_forward_results: %w", err)
+	}
+	defer rows.Close()
+
+	var out []entity.WalkForwardPersisted
+	for rows.Next() {
+		var (
+			rec      entity.WalkForwardPersisted
+			parentID sql.NullString
+		)
+		if err := rows.Scan(
+			&rec.ID, &rec.CreatedAt, &rec.BaseProfile, &rec.PDCACycleID,
+			&rec.Hypothesis, &rec.Objective, &parentID,
+			&rec.RequestJSON, &rec.AggregateOOSJSON,
+		); err != nil {
+			return nil, fmt.Errorf("scan walk_forward row: %w", err)
+		}
+		if parentID.Valid {
+			v := parentID.String
+			rec.ParentResultID = &v
+		}
+		out = append(out, rec)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate walk_forward_results: %w", err)
+	}
+	return out, nil
+}
+
+func (r *WalkForwardResultRepository) FindByID(ctx context.Context, id string) (*entity.WalkForwardPersisted, error) {
+	row := r.db.QueryRowContext(ctx, `SELECT id, created_at, base_profile,
+		pdca_cycle_id, hypothesis, objective, parent_result_id,
+		request_json, result_json, aggregate_oos_json
+		FROM walk_forward_results WHERE id = ?`, id)
+
+	var (
+		rec      entity.WalkForwardPersisted
+		parentID sql.NullString
+	)
+	err := row.Scan(
+		&rec.ID, &rec.CreatedAt, &rec.BaseProfile, &rec.PDCACycleID,
+		&rec.Hypothesis, &rec.Objective, &parentID,
+		&rec.RequestJSON, &rec.ResultJSON, &rec.AggregateOOSJSON,
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("scan walk_forward row: %w", err)
+	}
+	if parentID.Valid {
+		v := parentID.String
+		rec.ParentResultID = &v
+	}
+	return &rec, nil
+}
+
+// Compile-time assertion.
+var _ repository.WalkForwardResultRepository = (*WalkForwardResultRepository)(nil)

--- a/backend/internal/infrastructure/backtest/walk_forward_repository_test.go
+++ b/backend/internal/infrastructure/backtest/walk_forward_repository_test.go
@@ -1,0 +1,144 @@
+package backtest
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/repository"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/infrastructure/database"
+)
+
+func newTestDB(t *testing.T) *WalkForwardResultRepository {
+	t.Helper()
+	db, err := database.NewDB(filepath.Join(t.TempDir(), "wf.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := database.RunMigrations(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	return NewWalkForwardResultRepository(db)
+}
+
+func TestWalkForwardResultRepository_SaveFindByIDRoundTrip(t *testing.T) {
+	repo := newTestDB(t)
+	ctx := context.Background()
+
+	parent := "parent-id"
+	rec := entity.WalkForwardPersisted{
+		ID:               "wf-001",
+		CreatedAt:        1700000000,
+		BaseProfile:      "production",
+		Objective:        "return",
+		PDCACycleID:      "cycle22",
+		Hypothesis:       "grid over stoch_entry_max",
+		ParentResultID:   &parent,
+		RequestJSON:      `{"from":"2023-01-01","to":"2024-01-01"}`,
+		ResultJSON:       `{"id":"wf-001","windows":[]}`,
+		AggregateOOSJSON: `{"robustnessScore":0.42}`,
+	}
+	if err := repo.Save(ctx, rec); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	got, err := repo.FindByID(ctx, "wf-001")
+	if err != nil {
+		t.Fatalf("find: %v", err)
+	}
+	if got == nil {
+		t.Fatal("find returned nil")
+	}
+	if got.ID != rec.ID || got.BaseProfile != rec.BaseProfile ||
+		got.RequestJSON != rec.RequestJSON || got.ResultJSON != rec.ResultJSON ||
+		got.AggregateOOSJSON != rec.AggregateOOSJSON ||
+		got.Objective != rec.Objective || got.PDCACycleID != rec.PDCACycleID ||
+		got.Hypothesis != rec.Hypothesis {
+		t.Fatalf("round-trip mismatch: got %+v", got)
+	}
+	if got.ParentResultID == nil || *got.ParentResultID != parent {
+		t.Fatalf("parent mismatch: got %v", got.ParentResultID)
+	}
+}
+
+func TestWalkForwardResultRepository_FindByIDMissingReturnsNil(t *testing.T) {
+	repo := newTestDB(t)
+	got, err := repo.FindByID(context.Background(), "nope")
+	if err != nil {
+		t.Fatalf("find: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil for missing id, got %+v", got)
+	}
+}
+
+func TestWalkForwardResultRepository_ListFiltersAndOrders(t *testing.T) {
+	repo := newTestDB(t)
+	ctx := context.Background()
+
+	records := []entity.WalkForwardPersisted{
+		{ID: "a", CreatedAt: 100, BaseProfile: "production", PDCACycleID: "cycle01",
+			RequestJSON: "{}", ResultJSON: "{}", AggregateOOSJSON: "{}"},
+		{ID: "b", CreatedAt: 200, BaseProfile: "experimental", PDCACycleID: "cycle01",
+			RequestJSON: "{}", ResultJSON: "{}", AggregateOOSJSON: "{}"},
+		{ID: "c", CreatedAt: 300, BaseProfile: "production", PDCACycleID: "cycle02",
+			RequestJSON: "{}", ResultJSON: "{}", AggregateOOSJSON: "{}"},
+	}
+	for _, r := range records {
+		if err := repo.Save(ctx, r); err != nil {
+			t.Fatalf("save %s: %v", r.ID, err)
+		}
+	}
+
+	all, err := repo.List(ctx, repository.WalkForwardResultFilter{})
+	if err != nil {
+		t.Fatalf("list all: %v", err)
+	}
+	if len(all) != 3 {
+		t.Fatalf("expected 3 rows, got %d", len(all))
+	}
+	// ORDER BY created_at DESC -> c, b, a.
+	if all[0].ID != "c" || all[1].ID != "b" || all[2].ID != "a" {
+		t.Fatalf("wrong order: %s,%s,%s", all[0].ID, all[1].ID, all[2].ID)
+	}
+
+	prod, err := repo.List(ctx, repository.WalkForwardResultFilter{BaseProfile: "production"})
+	if err != nil {
+		t.Fatalf("list prod: %v", err)
+	}
+	if len(prod) != 2 {
+		t.Fatalf("expected 2 production rows, got %d", len(prod))
+	}
+
+	cyc1, err := repo.List(ctx, repository.WalkForwardResultFilter{PDCACycleID: "cycle01"})
+	if err != nil {
+		t.Fatalf("list cycle01: %v", err)
+	}
+	if len(cyc1) != 2 {
+		t.Fatalf("expected 2 cycle01 rows, got %d", len(cyc1))
+	}
+
+	// Combined filter
+	both, err := repo.List(ctx, repository.WalkForwardResultFilter{BaseProfile: "production", PDCACycleID: "cycle01"})
+	if err != nil {
+		t.Fatalf("list both: %v", err)
+	}
+	if len(both) != 1 || both[0].ID != "a" {
+		t.Fatalf("expected [a], got %+v", both)
+	}
+
+	// List must not expose result_json (empty because the SELECT omits it)
+	if all[0].ResultJSON != "" {
+		t.Fatalf("list should not return result_json; got %q", all[0].ResultJSON)
+	}
+}
+
+func TestWalkForwardResultRepository_SaveRejectsEmptyID(t *testing.T) {
+	repo := newTestDB(t)
+	err := repo.Save(context.Background(), entity.WalkForwardPersisted{
+		ResultJSON: "{}", AggregateOOSJSON: "{}",
+	})
+	if err == nil {
+		t.Fatal("expected error for empty id")
+	}
+}

--- a/backend/internal/infrastructure/database/migrations.go
+++ b/backend/internal/infrastructure/database/migrations.go
@@ -312,5 +312,47 @@ func RunMigrations(db *sql.DB) error {
 		}
 	}
 
+	// PR-13 follow-up (#120): walk-forward envelope. Mirrors the
+	// multi_period_results layout — per-window BacktestResult rows are saved
+	// independently into backtest_results; this table only stores the
+	// envelope (request, aggregate, per-window metadata + ID references).
+	//   - request_json:       the original POST body so a window can be
+	//                         re-run deterministically from the saved row.
+	//   - result_json:        full WalkForwardResult minus the embedded
+	//                         BacktestResult bodies (those live in
+	//                         backtest_results and are rehydrated on read).
+	//   - aggregate_oos_json: denormalised copy of result_json.aggregateOOS
+	//                         so list views can rank by RobustnessScore
+	//                         without parsing the full result_json.
+	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS walk_forward_results (
+		id                 TEXT PRIMARY KEY,
+		created_at         INTEGER NOT NULL,
+		base_profile       TEXT NOT NULL,
+		pdca_cycle_id      TEXT NOT NULL DEFAULT '',
+		hypothesis         TEXT NOT NULL DEFAULT '',
+		objective          TEXT NOT NULL DEFAULT 'return',
+		parent_result_id   TEXT DEFAULT NULL,
+		request_json       TEXT NOT NULL,
+		result_json        TEXT NOT NULL,
+		aggregate_oos_json TEXT NOT NULL
+	)`); err != nil {
+		return fmt.Errorf("create walk_forward_results: %w", err)
+	}
+	walkForwardIndexes := []string{
+		`CREATE INDEX IF NOT EXISTS idx_wf_created
+			ON walk_forward_results(created_at DESC, id DESC)`,
+		`CREATE INDEX IF NOT EXISTS idx_wf_profile
+			ON walk_forward_results(base_profile)
+			WHERE base_profile <> ''`,
+		`CREATE INDEX IF NOT EXISTS idx_wf_pdca
+			ON walk_forward_results(pdca_cycle_id)
+			WHERE pdca_cycle_id <> ''`,
+	}
+	for _, stmt := range walkForwardIndexes {
+		if _, err := db.Exec(stmt); err != nil {
+			return fmt.Errorf("create walk_forward index: %w", err)
+		}
+	}
+
 	return nil
 }

--- a/backend/internal/infrastructure/database/migrations_test.go
+++ b/backend/internal/infrastructure/database/migrations_test.go
@@ -219,4 +219,72 @@ func TestRunMigrations_PDCABacktestResultsColumnsAndIndexes(t *testing.T) {
 			t.Errorf("expected index %q on multi_period_results", idx)
 		}
 	}
+
+	// PR-13 follow-up (#120): walk_forward_results table + indexes.
+	wantWFCols := map[string]bool{
+		"id":                 false,
+		"created_at":         false,
+		"base_profile":       false,
+		"pdca_cycle_id":      false,
+		"hypothesis":         false,
+		"objective":          false,
+		"parent_result_id":   false,
+		"request_json":       false,
+		"result_json":        false,
+		"aggregate_oos_json": false,
+	}
+	wfRows, err := db.Query("PRAGMA table_info(walk_forward_results)")
+	if err != nil {
+		t.Fatalf("pragma table_info(walk_forward_results): %v", err)
+	}
+	defer wfRows.Close()
+	for wfRows.Next() {
+		var (
+			cid     int
+			name    string
+			ctype   string
+			notnull int
+			dflt    interface{}
+			pk      int
+		)
+		if err := wfRows.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk); err != nil {
+			t.Fatalf("scan walk_forward_results table_info: %v", err)
+		}
+		if _, ok := wantWFCols[name]; ok {
+			wantWFCols[name] = true
+		}
+	}
+	if err := wfRows.Err(); err != nil {
+		t.Fatalf("iterate walk_forward_results table_info: %v", err)
+	}
+	for col, seen := range wantWFCols {
+		if !seen {
+			t.Errorf("expected column %q in walk_forward_results", col)
+		}
+	}
+
+	wantWFIndexes := map[string]bool{
+		"idx_wf_created": false,
+		"idx_wf_profile": false,
+		"idx_wf_pdca":    false,
+	}
+	wfIdxRows, err := db.Query("SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='walk_forward_results'")
+	if err != nil {
+		t.Fatalf("query walk_forward indexes: %v", err)
+	}
+	defer wfIdxRows.Close()
+	for wfIdxRows.Next() {
+		var name string
+		if err := wfIdxRows.Scan(&name); err != nil {
+			t.Fatalf("scan walk_forward index name: %v", err)
+		}
+		if _, ok := wantWFIndexes[name]; ok {
+			wantWFIndexes[name] = true
+		}
+	}
+	for idx, seen := range wantWFIndexes {
+		if !seen {
+			t.Errorf("expected index %q on walk_forward_results", idx)
+		}
+	}
 }

--- a/backend/internal/interfaces/api/handler/backtest.go
+++ b/backend/internal/interfaces/api/handler/backtest.go
@@ -32,6 +32,12 @@ type BacktestHandler struct {
 	// This keeps legacy construction paths working without forcing all
 	// callers to wire the new repo at once.
 	multiRepo repository.MultiPeriodResultRepository
+
+	// wfRepo is optional; when nil, walk-forward runs execute but are not
+	// persisted and the GET endpoints return 503. PR-13 shipped compute-
+	// only; wiring this repo re-enables /backtest/walk-forward/:id and
+	// GET listing without touching the happy path.
+	wfRepo repository.WalkForwardResultRepository
 }
 
 // BacktestHandlerOption configures optional aspects of a BacktestHandler at
@@ -56,6 +62,15 @@ func WithProfilesBaseDir(dir string) BacktestHandlerOption {
 func WithMultiPeriodRepo(repo repository.MultiPeriodResultRepository) BacktestHandlerOption {
 	return func(h *BacktestHandler) {
 		h.multiRepo = repo
+	}
+}
+
+// WithWalkForwardRepo wires the WalkForwardResultRepository so POST
+// /backtest/walk-forward persists the envelope and the GET counterparts
+// become available. Nil keeps the compute-only behaviour of PR-13.
+func WithWalkForwardRepo(repo repository.WalkForwardResultRepository) BacktestHandlerOption {
+	return func(h *BacktestHandler) {
+		h.wfRepo = repo
 	}
 }
 

--- a/backend/internal/interfaces/api/handler/backtest_walkforward.go
+++ b/backend/internal/interfaces/api/handler/backtest_walkforward.go
@@ -2,12 +2,15 @@ package handler
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/repository"
 	csvinfra "github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/infrastructure/csv"
 	bt "github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/backtest"
 	strategyuc "github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/strategy"
@@ -231,7 +234,131 @@ func (h *BacktestHandler) RunWalkForward(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
+
+	// PR-13 follow-up (#120): persist the envelope so GET endpoints can
+	// serve saved runs. Save failures do not fail the request — the caller
+	// already got a valid result envelope back — but are logged via the
+	// response body so the operator notices.
+	if h.wfRepo != nil && out != nil {
+		resultJSON, mErr := json.Marshal(out)
+		reqJSON, rErr := json.Marshal(req)
+		aggJSON, aErr := json.Marshal(out.AggregateOOS)
+		if mErr == nil && rErr == nil && aErr == nil {
+			rec := entity.WalkForwardPersisted{
+				ID:               out.ID,
+				CreatedAt:        out.CreatedAt,
+				BaseProfile:      out.BaseProfile,
+				Objective:        out.Objective,
+				PDCACycleID:      out.PDCACycleID,
+				Hypothesis:       out.Hypothesis,
+				ParentResultID:   out.ParentResultID,
+				RequestJSON:      string(reqJSON),
+				ResultJSON:       string(resultJSON),
+				AggregateOOSJSON: string(aggJSON),
+			}
+			if err := h.wfRepo.Save(c.Request.Context(), rec); err != nil {
+				c.Header("X-WalkForward-Persist-Error", err.Error())
+			}
+		}
+	}
+
 	c.JSON(http.StatusOK, out)
+}
+
+// GetWalkForward handles GET /backtest/walk-forward/:id. Returns 404 when
+// the row is absent, 503 when the repo is not wired.
+func (h *BacktestHandler) GetWalkForward(c *gin.Context) {
+	if h.wfRepo == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "walk-forward repository not configured"})
+		return
+	}
+	id := c.Param("id")
+	if id == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "id is required"})
+		return
+	}
+	rec, err := h.wfRepo.FindByID(c.Request.Context(), id)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	if rec == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "walk-forward result not found"})
+		return
+	}
+	c.JSON(http.StatusOK, walkForwardPersistedToResponse(*rec))
+}
+
+// ListWalkForward handles GET /backtest/walk-forward?baseProfile=X&pdcaCycleId=Y
+// with optional limit/offset. Returns envelope-only rows (no per-window
+// bodies) — callers call GetWalkForward for the full payload.
+func (h *BacktestHandler) ListWalkForward(c *gin.Context) {
+	if h.wfRepo == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "walk-forward repository not configured"})
+		return
+	}
+	filter := repository.WalkForwardResultFilter{
+		BaseProfile: c.Query("baseProfile"),
+		PDCACycleID: c.Query("pdcaCycleId"),
+	}
+	if v := c.Query("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			filter.Limit = n
+		}
+	}
+	if v := c.Query("offset"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			filter.Offset = n
+		}
+	}
+	list, err := h.wfRepo.List(c.Request.Context(), filter)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	out := make([]walkForwardResponse, 0, len(list))
+	for _, rec := range list {
+		out = append(out, walkForwardPersistedToResponse(rec))
+	}
+	c.JSON(http.StatusOK, gin.H{"items": out, "total": len(out)})
+}
+
+// walkForwardResponse is the JSON shape surfaced by GET endpoints. The
+// *_json columns are exposed as already-parsed objects so clients do not
+// need to re-parse strings; raw JSON string form is kept only in the DB.
+type walkForwardResponse struct {
+	ID             string          `json:"id"`
+	CreatedAt      int64           `json:"createdAt"`
+	BaseProfile    string          `json:"baseProfile"`
+	Objective      string          `json:"objective"`
+	PDCACycleID    string          `json:"pdcaCycleId,omitempty"`
+	Hypothesis     string          `json:"hypothesis,omitempty"`
+	ParentResultID *string         `json:"parentResultId,omitempty"`
+	Request        json.RawMessage `json:"request,omitempty"`
+	Result         json.RawMessage `json:"result,omitempty"`
+	AggregateOOS   json.RawMessage `json:"aggregateOOS,omitempty"`
+}
+
+func walkForwardPersistedToResponse(rec entity.WalkForwardPersisted) walkForwardResponse {
+	resp := walkForwardResponse{
+		ID:             rec.ID,
+		CreatedAt:      rec.CreatedAt,
+		BaseProfile:    rec.BaseProfile,
+		Objective:      rec.Objective,
+		PDCACycleID:    rec.PDCACycleID,
+		Hypothesis:     rec.Hypothesis,
+		ParentResultID: rec.ParentResultID,
+	}
+	if rec.RequestJSON != "" {
+		resp.Request = json.RawMessage(rec.RequestJSON)
+	}
+	if rec.ResultJSON != "" {
+		resp.Result = json.RawMessage(rec.ResultJSON)
+	}
+	if rec.AggregateOOSJSON != "" {
+		resp.AggregateOOS = json.RawMessage(rec.AggregateOOSJSON)
+	}
+	return resp
 }
 
 // nonZeroFloat returns primary when it is strictly positive, otherwise the

--- a/backend/internal/interfaces/api/handler/backtest_walkforward_persist_test.go
+++ b/backend/internal/interfaces/api/handler/backtest_walkforward_persist_test.go
@@ -1,0 +1,176 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/repository"
+	bt "github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/backtest"
+)
+
+// fakeWalkForwardRepo is an in-memory WalkForwardResultRepository for the
+// handler-level tests. Real persistence is covered by the repo unit test;
+// here we only need to assert the handler routes to the right methods and
+// serialises request/response correctly.
+type fakeWalkForwardRepo struct {
+	mu   sync.Mutex
+	rows map[string]entity.WalkForwardPersisted
+	err  error
+}
+
+func newFakeWFRepo() *fakeWalkForwardRepo {
+	return &fakeWalkForwardRepo{rows: make(map[string]entity.WalkForwardPersisted)}
+}
+
+func (r *fakeWalkForwardRepo) Save(_ context.Context, rec entity.WalkForwardPersisted) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.err != nil {
+		return r.err
+	}
+	r.rows[rec.ID] = rec
+	return nil
+}
+
+func (r *fakeWalkForwardRepo) List(_ context.Context, filter repository.WalkForwardResultFilter) ([]entity.WalkForwardPersisted, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var out []entity.WalkForwardPersisted
+	for _, rec := range r.rows {
+		if filter.BaseProfile != "" && rec.BaseProfile != filter.BaseProfile {
+			continue
+		}
+		if filter.PDCACycleID != "" && rec.PDCACycleID != filter.PDCACycleID {
+			continue
+		}
+		out = append(out, rec)
+	}
+	return out, nil
+}
+
+func (r *fakeWalkForwardRepo) FindByID(_ context.Context, id string) (*entity.WalkForwardPersisted, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if rec, ok := r.rows[id]; ok {
+		return &rec, nil
+	}
+	return nil, nil
+}
+
+func TestGetWalkForward_NotFoundReturns404(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	repo := newFakeWFRepo()
+	h := NewBacktestHandler(bt.NewBacktestRunner(), &mockBacktestResultRepo{}, WithWalkForwardRepo(repo))
+	r := gin.New()
+	r.GET("/backtest/walk-forward/:id", h.GetWalkForward)
+
+	req := httptest.NewRequest(http.MethodGet, "/backtest/walk-forward/missing", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d (%s)", w.Code, w.Body.String())
+	}
+}
+
+func TestGetWalkForward_NoRepoReturns503(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	// No WithWalkForwardRepo -> wfRepo is nil.
+	h := NewBacktestHandler(bt.NewBacktestRunner(), &mockBacktestResultRepo{})
+	r := gin.New()
+	r.GET("/backtest/walk-forward/:id", h.GetWalkForward)
+
+	req := httptest.NewRequest(http.MethodGet, "/backtest/walk-forward/anything", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", w.Code)
+	}
+}
+
+func TestGetWalkForward_ReturnsRowAsRawJSON(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	repo := newFakeWFRepo()
+	// Seed a row with non-trivial JSON blobs to make sure the handler
+	// surfaces them as parsed objects (RawMessage), not double-escaped
+	// strings.
+	_ = repo.Save(context.Background(), entity.WalkForwardPersisted{
+		ID:               "wf-42",
+		CreatedAt:        1700000000,
+		BaseProfile:      "production",
+		Objective:        "return",
+		PDCACycleID:      "cycle22",
+		RequestJSON:      `{"baseProfile":"production"}`,
+		ResultJSON:       `{"id":"wf-42","windows":[{"index":0}]}`,
+		AggregateOOSJSON: `{"robustnessScore":0.5}`,
+	})
+
+	h := NewBacktestHandler(bt.NewBacktestRunner(), &mockBacktestResultRepo{}, WithWalkForwardRepo(repo))
+	r := gin.New()
+	r.GET("/backtest/walk-forward/:id", h.GetWalkForward)
+
+	req := httptest.NewRequest(http.MethodGet, "/backtest/walk-forward/wf-42", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (%s)", w.Code, w.Body.String())
+	}
+
+	var resp walkForwardResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if resp.ID != "wf-42" {
+		t.Fatalf("wrong id: %q", resp.ID)
+	}
+	// Result should round-trip as a JSON object with nested windows.
+	var parsedResult struct {
+		ID      string `json:"id"`
+		Windows []struct {
+			Index int `json:"index"`
+		} `json:"windows"`
+	}
+	if err := json.Unmarshal(resp.Result, &parsedResult); err != nil {
+		t.Fatalf("parse result json: %v", err)
+	}
+	if parsedResult.ID != "wf-42" || len(parsedResult.Windows) != 1 {
+		t.Fatalf("result json not structured: %+v", parsedResult)
+	}
+}
+
+func TestListWalkForward_AppliesFilters(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	repo := newFakeWFRepo()
+	_ = repo.Save(context.Background(), entity.WalkForwardPersisted{
+		ID: "a", BaseProfile: "production", PDCACycleID: "cycle01",
+		RequestJSON: "{}", ResultJSON: "{}", AggregateOOSJSON: "{}",
+	})
+	_ = repo.Save(context.Background(), entity.WalkForwardPersisted{
+		ID: "b", BaseProfile: "experiment", PDCACycleID: "cycle01",
+		RequestJSON: "{}", ResultJSON: "{}", AggregateOOSJSON: "{}",
+	})
+
+	h := NewBacktestHandler(bt.NewBacktestRunner(), &mockBacktestResultRepo{}, WithWalkForwardRepo(repo))
+	r := gin.New()
+	r.GET("/backtest/walk-forward", h.ListWalkForward)
+
+	req := httptest.NewRequest(http.MethodGet, "/backtest/walk-forward?baseProfile=production", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (%s)", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, `"id":"a"`) {
+		t.Fatalf("filter=production should include a; got: %s", body)
+	}
+	if strings.Contains(body, `"id":"b"`) {
+		t.Fatalf("filter=production should exclude b; got: %s", body)
+	}
+}

--- a/backend/internal/interfaces/api/router.go
+++ b/backend/internal/interfaces/api/router.go
@@ -37,6 +37,9 @@ type Dependencies struct {
 	// MultiPeriodResultRepo is optional; when nil the /backtest/run-multi
 	// and /backtest/multi-results endpoints respond with 503.
 	MultiPeriodResultRepo repository.MultiPeriodResultRepository
+	// WalkForwardResultRepo is optional; when nil the walk-forward endpoint
+	// still computes but does not persist, and GET endpoints return 503.
+	WalkForwardResultRepo repository.WalkForwardResultRepository
 	// OnSymbolSwitch はシンボル切替時に pipeline から呼び出されるコールバック。
 	// main 側で WebSocket 購読切替とローソク足 bootstrap を実行する。
 	OnSymbolSwitch func(oldID, newID int64)
@@ -134,6 +137,9 @@ func NewRouter(deps Dependencies) *gin.Engine {
 		if deps.MultiPeriodResultRepo != nil {
 			opts = append(opts, handler.WithMultiPeriodRepo(deps.MultiPeriodResultRepo))
 		}
+		if deps.WalkForwardResultRepo != nil {
+			opts = append(opts, handler.WithWalkForwardRepo(deps.WalkForwardResultRepo))
+		}
 		backtestHandler := handler.NewBacktestHandler(deps.BacktestRunner, deps.BacktestResultRepo, opts...)
 		v1.POST("/backtest/run", backtestHandler.Run)
 		v1.GET("/backtest/csv-meta", backtestHandler.CSVMeta)
@@ -144,9 +150,14 @@ func NewRouter(deps Dependencies) *gin.Engine {
 			v1.GET("/backtest/multi-results", backtestHandler.ListMultiResults)
 			v1.GET("/backtest/multi-results/:id", backtestHandler.GetMultiResult)
 		}
-		// PR-13: Walk-forward optimisation. MVP is compute-only (response
-		// only, no DB). GET / list / CLI come in a follow-up PR.
+		// PR-13 follow-up (#120): walk-forward now persists to the DB.
+		// GET endpoints require the repo; POST always computes but only
+		// persists when the repo is wired.
 		v1.POST("/backtest/walk-forward", backtestHandler.RunWalkForward)
+		if deps.WalkForwardResultRepo != nil {
+			v1.GET("/backtest/walk-forward", backtestHandler.ListWalkForward)
+			v1.GET("/backtest/walk-forward/:id", backtestHandler.GetWalkForward)
+		}
 	}
 
 	return r


### PR DESCRIPTION
## Summary
- DB: walk_forward_results migration + filtered indexes (same shape as multi_period_results) + repository interface + sqlite implementation with Save / List / FindByID.
- HTTP: POST /backtest/walk-forward now persists the envelope alongside the response (non-fatal save failure → X-WalkForward-Persist-Error response header); new GET /backtest/walk-forward/:id and GET /backtest/walk-forward?baseProfile=&pdcaCycleId=&limit=&offset= serve saved runs. 503 when the repo isn't wired.
- CLI: new \`backtest walk-forward\` subcommand with --data / --from / --to / --in / --oos / --step / --profile / --grid (repeatable path=v1,v2,v3) / --grid-file / --objective / --output.

## Why
PR-13 shipped compute-only. PDCA cycles currently keep WFO numbers in docs by hand; DB persistence + CLI make cycle22+ (#118) repeatable and queryable. Envelope self-contains per-window BacktestResult bodies (no cross-table fan-out) so a single FindByID rehydrates everything.

## Test plan
- [x] \`go test ./... -count=1\` green — 21/21 packages.
- [x] migrations_test: new columns + 3 indexes present and idempotent.
- [x] repo round-trip: Save/FindByID, missing → nil, List filters + order, empty-id rejection.
- [x] handler: 503 without repo, 404 on missing id, full envelope surfaces as parsed JSON (not double-escaped strings), baseProfile filter honoured.
- [x] CLI: grid parser valid/invalid, file round-trip, --grid vs --grid-file mutual exclusion, date parser.

## Not in this PR
- FE /backtest/walk-forward page (#121 FE-E) — depends on these GET endpoints, tracked separately.

Closes part of #120 (DB persistence + GET + CLI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)