### PR TITLE
feat(frontend): multi-period backtest results page (#121 FE-B)

### DIFF
--- a/frontend/src/components/AppFrame.tsx
+++ b/frontend/src/components/AppFrame.tsx
@@ -13,6 +13,7 @@ const navItems = [
   { to: '/settings', label: '設定' },
   { to: '/history', label: '履歴' },
   { to: '/backtest', label: 'バックテスト' },
+  { to: '/backtest-multi', label: 'マルチ期間' },
 ] as const
 
 export function AppFrame({ title, subtitle, children }: AppFrameProps) {

--- a/frontend/src/hooks/useMultiPeriod.ts
+++ b/frontend/src/hooks/useMultiPeriod.ts
@@ -1,0 +1,44 @@
+import { useQuery } from '@tanstack/react-query'
+import {
+  fetchApi,
+  type MultiPeriodResult,
+  type MultiPeriodResultListResponse,
+} from '../lib/api'
+
+export type MultiPeriodResultsFilter = {
+  limit?: number
+  offset?: number
+  profileName?: string
+  pdcaCycleId?: string
+}
+
+function buildURL(filter: MultiPeriodResultsFilter): string {
+  const params = new URLSearchParams()
+  const { limit = 20, offset = 0 } = filter
+  params.set('limit', String(limit))
+  params.set('offset', String(offset))
+  if (filter.profileName) params.set('profileName', filter.profileName)
+  if (filter.pdcaCycleId) params.set('pdcaCycleId', filter.pdcaCycleId)
+  return `/backtest/multi-results?${params.toString()}`
+}
+
+// useMultiPeriodResults fetches the envelope list from
+// GET /backtest/multi-results. Per-period BacktestResult bodies are NOT
+// populated in this response — callers that need them must issue
+// useMultiPeriodResult(id) for the full rehydrated payload.
+export function useMultiPeriodResults(filter: MultiPeriodResultsFilter = {}) {
+  return useQuery({
+    queryKey: ['backtest', 'multi-results', filter] as const,
+    queryFn: () => fetchApi<MultiPeriodResultListResponse>(buildURL(filter)),
+    staleTime: 30_000,
+  })
+}
+
+export function useMultiPeriodResult(id: string) {
+  return useQuery({
+    queryKey: ['backtest', 'multi-result', id],
+    queryFn: () => fetchApi<MultiPeriodResult>(`/backtest/multi-results/${id}`),
+    enabled: id !== '',
+    staleTime: 60_000,
+  })
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -290,6 +290,41 @@ export type BacktestResultListResponse = {
   results: BacktestResult[]
 }
 
+// MultiPeriodAggregate mirrors entity.MultiPeriodAggregate. Scalar fields
+// are nullable because BE emits JSON null for NaN / ±Inf (ruin path).
+export type MultiPeriodAggregate = {
+  geomMeanReturn: number | null
+  returnStdDev: number | null
+  worstReturn: number | null
+  bestReturn: number | null
+  worstDrawdown: number | null
+  allPositive: boolean
+  robustnessScore: number | null
+}
+
+export type LabeledBacktestResult = {
+  label: string
+  result: BacktestResult
+}
+
+export type MultiPeriodResult = {
+  id: string
+  createdAt: number
+  profileName: string
+  pdcaCycleId?: string
+  hypothesis?: string
+  parentResultId?: string | null
+  periods: LabeledBacktestResult[]
+  aggregate: MultiPeriodAggregate
+}
+
+// MultiPeriodResultListResponse: GET /backtest/multi-results returns
+// {results: [...]} — per-period bodies are empty here (envelope only) and
+// must be rehydrated via GET /backtest/multi-results/:id when needed.
+export type MultiPeriodResultListResponse = {
+  results: MultiPeriodResult[]
+}
+
 export type BacktestCSVMeta = {
   data: string
   symbol: string

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as SettingsRouteImport } from './routes/settings'
 import { Route as HistoryRouteImport } from './routes/history'
+import { Route as BacktestMultiRouteImport } from './routes/backtest-multi'
 import { Route as BacktestRouteImport } from './routes/backtest'
 import { Route as IndexRouteImport } from './routes/index'
 
@@ -22,6 +23,11 @@ const SettingsRoute = SettingsRouteImport.update({
 const HistoryRoute = HistoryRouteImport.update({
   id: '/history',
   path: '/history',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const BacktestMultiRoute = BacktestMultiRouteImport.update({
+  id: '/backtest-multi',
+  path: '/backtest-multi',
   getParentRoute: () => rootRouteImport,
 } as any)
 const BacktestRoute = BacktestRouteImport.update({
@@ -38,12 +44,14 @@ const IndexRoute = IndexRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/backtest': typeof BacktestRoute
+  '/backtest-multi': typeof BacktestMultiRoute
   '/history': typeof HistoryRoute
   '/settings': typeof SettingsRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/backtest': typeof BacktestRoute
+  '/backtest-multi': typeof BacktestMultiRoute
   '/history': typeof HistoryRoute
   '/settings': typeof SettingsRoute
 }
@@ -51,20 +59,28 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/backtest': typeof BacktestRoute
+  '/backtest-multi': typeof BacktestMultiRoute
   '/history': typeof HistoryRoute
   '/settings': typeof SettingsRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/backtest' | '/history' | '/settings'
+  fullPaths: '/' | '/backtest' | '/backtest-multi' | '/history' | '/settings'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/backtest' | '/history' | '/settings'
-  id: '__root__' | '/' | '/backtest' | '/history' | '/settings'
+  to: '/' | '/backtest' | '/backtest-multi' | '/history' | '/settings'
+  id:
+    | '__root__'
+    | '/'
+    | '/backtest'
+    | '/backtest-multi'
+    | '/history'
+    | '/settings'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   BacktestRoute: typeof BacktestRoute
+  BacktestMultiRoute: typeof BacktestMultiRoute
   HistoryRoute: typeof HistoryRoute
   SettingsRoute: typeof SettingsRoute
 }
@@ -83,6 +99,13 @@ declare module '@tanstack/react-router' {
       path: '/history'
       fullPath: '/history'
       preLoaderRoute: typeof HistoryRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/backtest-multi': {
+      id: '/backtest-multi'
+      path: '/backtest-multi'
+      fullPath: '/backtest-multi'
+      preLoaderRoute: typeof BacktestMultiRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/backtest': {
@@ -105,6 +128,7 @@ declare module '@tanstack/react-router' {
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   BacktestRoute: BacktestRoute,
+  BacktestMultiRoute: BacktestMultiRoute,
   HistoryRoute: HistoryRoute,
   SettingsRoute: SettingsRoute,
 }

--- a/frontend/src/routes/backtest-multi.tsx
+++ b/frontend/src/routes/backtest-multi.tsx
@@ -1,0 +1,240 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { useMemo, useState } from 'react'
+import { AppFrame } from '../components/AppFrame'
+import {
+  useMultiPeriodResult,
+  useMultiPeriodResults,
+} from '../hooks/useMultiPeriod'
+import type { LabeledBacktestResult, MultiPeriodResult } from '../lib/api'
+
+export const Route = createFileRoute('/backtest-multi')({
+  component: BacktestMultiPage,
+})
+
+function BacktestMultiPage() {
+  const [profileFilter, setProfileFilter] = useState('')
+  const [pdcaFilter, setPdcaFilter] = useState('')
+  const [selectedId, setSelectedId] = useState('')
+
+  const { data, isLoading, isError } = useMultiPeriodResults({
+    profileName: profileFilter,
+    pdcaCycleId: pdcaFilter,
+    limit: 50,
+  })
+  const { data: detail, isLoading: detailLoading } = useMultiPeriodResult(selectedId)
+
+  const rows = useMemo(() => {
+    const items = data?.results ?? []
+    // Rank by RobustnessScore desc (higher is better). Nulls sink to the
+    // bottom so ruin-path runs don't hide profitable candidates.
+    return [...items].sort((a, b) => {
+      const aS = a.aggregate.robustnessScore
+      const bS = b.aggregate.robustnessScore
+      if (aS == null && bS == null) return 0
+      if (aS == null) return 1
+      if (bS == null) return -1
+      return bS - aS
+    })
+  }, [data])
+
+  return (
+    <AppFrame
+      title="マルチ期間バックテスト"
+      subtitle="`/backtest/run-multi` で保存された envelope を RobustnessScore でランキング表示"
+    >
+      <section className="rounded-3xl border border-white/8 bg-bg-card p-5 sm:p-6">
+        <div className="mb-4 flex flex-wrap items-end gap-3">
+          <label className="flex flex-col gap-1 text-xs text-text-secondary">
+            Profile Name
+            <input
+              value={profileFilter}
+              onChange={(e) => setProfileFilter(e.target.value)}
+              className="rounded-lg border border-white/10 bg-white/5 px-3 py-1.5 text-sm text-white"
+              placeholder="production"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-xs text-text-secondary">
+            PDCA Cycle ID
+            <input
+              value={pdcaFilter}
+              onChange={(e) => setPdcaFilter(e.target.value)}
+              className="rounded-lg border border-white/10 bg-white/5 px-3 py-1.5 text-sm text-white"
+              placeholder="cycle22"
+            />
+          </label>
+        </div>
+
+        {isLoading && <p className="text-sm text-text-secondary">Loading…</p>}
+        {isError && (
+          <p className="text-sm text-accent-red">Multi-period 結果の取得に失敗しました。</p>
+        )}
+        {!isLoading && !isError && rows.length === 0 && (
+          <p className="text-sm text-text-secondary">
+            該当する multi-period 実行がありません。`POST /api/v1/backtest/run-multi` で実行してください。
+          </p>
+        )}
+
+        {rows.length > 0 && <MultiResultsTable rows={rows} onSelect={setSelectedId} selectedId={selectedId} />}
+      </section>
+
+      {selectedId !== '' && (
+        <section className="mt-6 rounded-3xl border border-white/8 bg-bg-card p-5 sm:p-6">
+          {detailLoading && <p className="text-sm text-text-secondary">Detail loading…</p>}
+          {detail && <MultiResultDetail detail={detail} />}
+        </section>
+      )}
+    </AppFrame>
+  )
+}
+
+function MultiResultsTable({
+  rows,
+  onSelect,
+  selectedId,
+}: {
+  rows: MultiPeriodResult[]
+  onSelect: (id: string) => void
+  selectedId: string
+}) {
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full min-w-[720px] text-sm">
+        <thead>
+          <tr className="border-b border-white/8 text-left text-xs uppercase tracking-wider text-text-secondary">
+            <th className="px-3 py-2">Created</th>
+            <th className="px-3 py-2">Profile</th>
+            <th className="px-3 py-2">Cycle</th>
+            <th className="px-3 py-2 text-right">Periods</th>
+            <th className="px-3 py-2 text-right">GeomMean %</th>
+            <th className="px-3 py-2 text-right">Worst %</th>
+            <th className="px-3 py-2 text-right">Best %</th>
+            <th className="px-3 py-2 text-right">Robustness</th>
+            <th className="px-3 py-2">All+?</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((r) => {
+            const a = r.aggregate
+            const createdAt = new Date(r.createdAt * 1000).toLocaleString('ja-JP')
+            const isSelected = r.id === selectedId
+            return (
+              <tr
+                key={r.id}
+                onClick={() => onSelect(r.id)}
+                className={`cursor-pointer border-b border-white/5 hover:bg-white/5 ${isSelected ? 'bg-white/10' : ''}`}
+              >
+                <td className="px-3 py-2 text-text-secondary text-xs">{createdAt}</td>
+                <td className="px-3 py-2 text-white">{r.profileName || '—'}</td>
+                <td className="px-3 py-2 text-text-secondary">{r.pdcaCycleId || '—'}</td>
+                <td className="px-3 py-2 text-right text-white">{r.periods?.length ?? 0}</td>
+                <td className={`px-3 py-2 text-right ${pnlColor(a.geomMeanReturn)}`}>{formatPercent(a.geomMeanReturn)}</td>
+                <td className={`px-3 py-2 text-right ${pnlColor(a.worstReturn)}`}>{formatPercent(a.worstReturn)}</td>
+                <td className={`px-3 py-2 text-right ${pnlColor(a.bestReturn)}`}>{formatPercent(a.bestReturn)}</td>
+                <td className="px-3 py-2 text-right text-white">{formatNum(a.robustnessScore)}</td>
+                <td className="px-3 py-2">
+                  <span className={a.allPositive ? 'text-accent-green' : 'text-text-secondary'}>
+                    {a.allPositive ? '✓' : '—'}
+                  </span>
+                </td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function MultiResultDetail({ detail }: { detail: MultiPeriodResult }) {
+  const a = detail.aggregate
+  return (
+    <div>
+      <p className="text-xs uppercase tracking-[0.28em] text-text-secondary">Detail</p>
+      <h2 className="mt-2 text-xl font-semibold text-white">
+        {detail.profileName} {detail.pdcaCycleId ? `/ ${detail.pdcaCycleId}` : ''}
+      </h2>
+      {detail.hypothesis && (
+        <p className="mt-1 text-sm text-text-secondary">Hypothesis: {detail.hypothesis}</p>
+      )}
+
+      {/* Aggregate KPIs */}
+      <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        <KpiCard label="GeomMean Return" value={formatPercent(a.geomMeanReturn)} color={pnlColor(a.geomMeanReturn)} />
+        <KpiCard label="StdDev Return" value={formatPercent(a.returnStdDev)} />
+        <KpiCard label="Worst Return" value={formatPercent(a.worstReturn)} color={pnlColor(a.worstReturn)} />
+        <KpiCard label="Best Return" value={formatPercent(a.bestReturn)} color={pnlColor(a.bestReturn)} />
+        <KpiCard label="Worst Drawdown" value={formatPercent(a.worstDrawdown)} color="text-accent-red" />
+        <KpiCard label="Robustness" value={formatNum(a.robustnessScore)} />
+        <KpiCard label="All Positive" value={a.allPositive ? 'Yes' : 'No'} color={a.allPositive ? 'text-accent-green' : 'text-accent-red'} />
+      </div>
+
+      {/* Per-period table */}
+      <h3 className="mt-6 text-lg font-semibold text-white">Per-period 結果</h3>
+      <div className="mt-3 overflow-x-auto">
+        <table className="w-full min-w-[720px] text-sm">
+          <thead>
+            <tr className="border-b border-white/8 text-left text-xs uppercase tracking-wider text-text-secondary">
+              <th className="px-3 py-2">Label</th>
+              <th className="px-3 py-2 text-right">Return</th>
+              <th className="px-3 py-2 text-right">Max DD</th>
+              <th className="px-3 py-2 text-right">Win Rate</th>
+              <th className="px-3 py-2 text-right">Profit Factor</th>
+              <th className="px-3 py-2 text-right">Sharpe</th>
+              <th className="px-3 py-2 text-right">Trades</th>
+            </tr>
+          </thead>
+          <tbody>
+            {detail.periods.map((p) => (
+              <PeriodRow key={p.label} period={p} />
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}
+
+function PeriodRow({ period }: { period: LabeledBacktestResult }) {
+  const s = period.result.summary
+  return (
+    <tr className="border-b border-white/5">
+      <td className="px-3 py-2 text-white">{period.label}</td>
+      <td className={`px-3 py-2 text-right ${pnlColor(s.totalReturn)}`}>
+        {`${(s.totalReturn * 100).toFixed(2)}%`}
+      </td>
+      <td className="px-3 py-2 text-right text-accent-red">{`${(s.maxDrawdown * 100).toFixed(2)}%`}</td>
+      <td className="px-3 py-2 text-right text-white">{s.winRate.toFixed(1)}%</td>
+      <td className={`px-3 py-2 text-right ${s.profitFactor >= 1 ? 'text-accent-green' : 'text-accent-red'}`}>
+        {s.profitFactor.toFixed(2)}
+      </td>
+      <td className="px-3 py-2 text-right text-white">{s.sharpeRatio.toFixed(2)}</td>
+      <td className="px-3 py-2 text-right text-white">{s.totalTrades}</td>
+    </tr>
+  )
+}
+
+function KpiCard({ label, value, color = 'text-white' }: { label: string; value: string; color?: string }) {
+  return (
+    <div className="rounded-2xl border border-white/8 bg-white/4 p-4">
+      <p className="text-xs uppercase tracking-[0.25em] text-text-secondary">{label}</p>
+      <p className={`mt-2 text-lg font-semibold ${color}`}>{value}</p>
+    </div>
+  )
+}
+
+function pnlColor(v: number | null | undefined): string {
+  if (v == null) return 'text-text-secondary'
+  if (v > 0) return 'text-accent-green'
+  if (v < 0) return 'text-accent-red'
+  return 'text-white'
+}
+
+function formatPercent(v: number | null | undefined): string {
+  if (v == null) return '—'
+  return `${(v * 100).toFixed(2)}%`
+}
+
+function formatNum(v: number | null | undefined): string {
+  if (v == null) return '—'
+  return v.toFixed(4)
+}


### PR DESCRIPTION
## Summary
- New \`/backtest-multi\` route listing rows from GET /api/v1/backtest/multi-results, ranked by RobustnessScore desc.
- Detail panel on row click shows aggregate KPIs (GeomMean / StdDev / Worst / Best / WorstDD / Robustness / AllPositive) + per-period summary table.
- Filter inputs for Profile Name / PDCA Cycle ID; nav gets a new \"マルチ期間\" tab.
- Adds MultiPeriodAggregate / LabeledBacktestResult / MultiPeriodResult types; aggregate scalars nullable to round-trip BE's NaN→null encoding.

## Why
PR-2 has been persisting multi-period envelopes for cycles but the only way to view them was raw JSON. This page unblocks v5 cycle triage (#118) — ranking candidates by robustness at a glance.

## Test plan
- [x] \`pnpm test --run\` 27/27 green.
- [x] \`pnpm build\` succeeds; routeTree.gen.ts regenerated to include /backtest-multi.
- [ ] Manual: with a running BE that has multi-period rows, listing/filter/detail all render.

Part of #121. Next: FE-E walk-forward page (depends on #124 merged — done).

🤖 Generated with [Claude Code](https://claude.com/claude-code)