### PR TITLE
fix(backtest): accept stoch gates in WFO overrides + cycle22-23 PDCA record

### DIFF
--- a/backend/internal/usecase/backtest/walkforward.go
+++ b/backend/internal/usecase/backtest/walkforward.go
@@ -191,7 +191,7 @@ func ExpandGrid(overrides []ParameterOverride) ([]map[string]float64, error) {
 //   strategy_risk.max_position_amount
 //   strategy_risk.max_daily_loss
 //   signal_rules.trend_follow.{rsi_buy_max,rsi_sell_min,adx_min}
-//   signal_rules.contrarian.{rsi_entry,rsi_exit,macd_histogram_limit,adx_max}
+//   signal_rules.contrarian.{rsi_entry,rsi_exit,macd_histogram_limit,adx_max,stoch_entry_max,stoch_exit_min}
 //   signal_rules.breakout.{volume_ratio_min,adx_min}
 //   stance_rules.{rsi_oversold,rsi_overbought,sma_convergence_threshold,breakout_volume_ratio}
 //   htf_filter.alignment_boost
@@ -225,6 +225,10 @@ func ApplyOverrides(base entity.StrategyProfile, overrides map[string]float64) (
 			out.SignalRules.Contrarian.MACDHistogramLimit = value
 		case "signal_rules.contrarian.adx_max":
 			out.SignalRules.Contrarian.ADXMax = value
+		case "signal_rules.contrarian.stoch_entry_max":
+			out.SignalRules.Contrarian.StochEntryMax = value
+		case "signal_rules.contrarian.stoch_exit_min":
+			out.SignalRules.Contrarian.StochExitMin = value
 		case "signal_rules.breakout.volume_ratio_min":
 			out.SignalRules.Breakout.VolumeRatioMin = value
 		case "signal_rules.breakout.adx_min":

--- a/docs/pdca/2026-04-22_cycle22-23.md
+++ b/docs/pdca/2026-04-22_cycle22-23.md
@@ -1,0 +1,108 @@
+# PDCA cycle22–23 — PR-7 Stoch gate WFO
+
+**Date:** 2026-04-22
+**Baseline:** `profiles/production.json` (v4b promotion from #117)
+**Goal:** evaluate whether the new PR-7 Stochastics gates
+(`signal_rules.contrarian.stoch_entry_max` / `stoch_exit_min`) help v5
+promotion to `#118`.
+
+## Enablers
+
+- **#122 (PR-7)** merged: Stochastics indicator + contrarian `stoch_entry_max` / `stoch_exit_min` gates wired to `StrategyEngine`.
+- **#123 (PR-8)** merged: Ichimoku indicator + `htf_filter.mode = "ichimoku"` (not yet exercised here).
+- **#124 (WFO DB)** merged: DB persistence + CLI `backtest walk-forward` subcommand.
+- **This PR (fix/wfo-apply-overrides-stoch-htf)**: add the two new override paths to `ApplyOverrides` so WFO grids can tune them. Without it the CLI rejects the paths at validation time.
+
+## Cycle22 — `stoch_entry_max` grid, LTC 1yr/3yr
+
+```
+backtest walk-forward --data data/candles_LTC_JPY_PT15M.csv \
+  --from 2024-01-01 --to 2025-01-01 --in 6 --oos 3 --step 3 \
+  --profile production --objective return \
+  --grid "signal_rules.contrarian.stoch_entry_max=0,15,25"
+```
+
+Result (2 windows):
+
+| # | IS | OOS | Best | OOS Return |
+|---|----|-----|------|-----------:|
+| 0 | 2024-01..07 | 2024-07..10 | stoch_entry_max=15 | +0.04% |
+| 1 | 2024-04..10 | 2024-10..2025-01 | stoch_entry_max=15 | +0.12% |
+
+Aggregate: geomMean +0.08% / worst +0.04% / best +0.12% / robustness 0.0004.
+
+**Observation:** on a 1yr LTC window, `stoch_entry_max=15` is the IS
+winner in 2/2 windows. Encouraging but too narrow a sample to promote.
+
+## Cycle23 — same grid, widen to 3yr
+
+```
+backtest walk-forward --data data/candles_LTC_JPY_PT15M.csv \
+  --from 2022-01-01 --to 2025-01-01 --in 12 --oos 6 --step 6 \
+  --profile production --objective return \
+  --grid "signal_rules.contrarian.stoch_entry_max=0,10,15,20,25"
+```
+
+Result (4 windows):
+
+| # | IS | OOS | Best | OOS Return |
+|---|----|-----|------|-----------:|
+| 0 | 2022..2023 | 2023-01..07 | stoch_entry_max=0 | +1.43% |
+| 1 | 2022-07..2023-07 | 2023-07..2024-01 | 0 | +0.59% |
+| 2 | 2023..2024 | 2024-01..07 | 0 | −0.39% |
+| 3 | 2023-07..2024-07 | 2024-07..2025-01 | 0 | +0.07% |
+
+Aggregate: geomMean +0.42% / worst −0.39% / best +1.43% / robustness −0.0026.
+
+**Observation:** on the 3yr wider IS, the gate=0 (disabled) branch wins
+4/4 windows. The gate adds no IS edge once the IS window is long enough
+to contain both trending and sideways regimes. Cycle22's 2/2 preference
+for `=15` was noise from the narrower window.
+
+## Cycle23b — `stoch_exit_min` grid
+
+```
+--grid "signal_rules.contrarian.stoch_exit_min=0,75,80,85"
+```
+
+Result: gate=0 wins in 3/4 windows, `=75` only in cycle #0 which then
+registered **−1.71% OOS** (worst of the run). Robustness degrades to
+−0.0122 vs. baseline −0.0026.
+
+## Conclusion
+
+**PR-7 Stochastics gates do NOT currently justify a v5 promotion on LTC
+production.** The contrarian entry/exit gates add no IS advantage over
+the 3yr window and drag OOS when they do fire.
+
+Rationales to keep in memory for the next PDCA cycle:
+
+1. The v4b production is already well-optimized on RSI + MACD; `%K`
+   does not add orthogonal information on 15m LTC candles.
+2. PR-7 still landed the wiring safely — the silent-no-op regression
+   (cycle08) cannot recur, and future symbol/timeframe experiments can
+   activate it cheaply.
+3. **Next candidate: PR-8 Ichimoku HTF mode.** Issue #118 explicitly
+   flagged the 2024 regime (where 3yr wins but 2yr loses) as a target
+   for a better HTF filter — Ichimoku cloud position is the remaining
+   unexplored axis, and it does not need WFO on the Stoch gate to be
+   evaluated.
+
+## Next steps
+
+- [ ] Cycle24: `htf_filter.mode=ichimoku` WFO (requires an ApplyOverrides
+  entry for `htf_filter.mode` since it is a string, not a float64 —
+  needs a typed override path or a separate evaluator flag).
+- [ ] Cycle25: grid over `strategy_risk.stop_loss_percent` (3–8) on the
+  12/6/6 schedule to exploit the corrected WFO TP-wiring from #116.
+- [ ] If cycle24+25 produce a candidate with 1yr/2yr/3yr all > 0 and
+  aggregate geomMean > v4b's +1.15%, open a promote PR.
+
+## Links
+
+- PR-7: #122 (merged)
+- PR-8: #123 (merged)
+- WFO persistence + CLI: #124 (merged)
+- FE dashboards: #125 #126 #127 #128 #129 (all merged, closed #121)
+- PDCA parent issue: #118 (still open — awaits cycle24+)
+- Previous cycles: `docs/pdca/2026-04-21_cycle13-19.md`, `docs/pdca/2026-04-21_promotion_v4.md`


### PR DESCRIPTION
## Summary
- \`ApplyOverrides\` now recognises \`signal_rules.contrarian.stoch_entry_max\` / \`stoch_exit_min\`. Without this, the #124 CLI rejects the PR-7 gate paths at request validation even though the profile + engine accept them.
- \`docs/pdca/2026-04-22_cycle22-23.md\`: PDCA cycle record of the WFO runs I did to evaluate the PR-7 gates against v4b production.

## Findings
On LTC 15m, 3yr IS (12/6/6 schedule):
- \`stoch_entry_max\`: gate=0 (disabled) wins 4/4 windows → no promotion justification.
- \`stoch_exit_min\`: gate=0 wins 3/4; best candidate drags OOS to −1.71%.

Conclusion: PR-7 gates stay wired (zero-regression, future-proof) but do not earn a v5 entry. Next PDCA candidate is PR-8 Ichimoku HTF mode + \`stop_loss_percent\` grid.

## Test plan
- [x] \`go test ./... -count=1\` 21/21 green.
- [x] \`backtest walk-forward --grid \"signal_rules.contrarian.stoch_entry_max=0,10,15,20,25\"\` now runs end-to-end (previously errored before the WFO loop started).

Part of #118 cycle record. Does NOT promote v5 — only clears a blocker and documents the negative result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)