### PR TITLE
feat(backtest): add string-valued WFO grid axis (htf_filter.mode)

### DIFF
--- a/backend/cmd/backtest/walkforward.go
+++ b/backend/cmd/backtest/walkforward.go
@@ -70,7 +70,7 @@ func walkForwardCommand(args []string) error {
 		return fmt.Errorf("profile %q not found", *baseProfile)
 	}
 
-	overrides, err := resolveWalkForwardGrid(gridInline, *gridFile)
+	overrides, stringOverrides, err := resolveWalkForwardGrid(gridInline, *gridFile)
 	if err != nil {
 		return err
 	}
@@ -80,7 +80,12 @@ func walkForwardCommand(args []string) error {
 			return fmt.Errorf("invalid --grid path %q: %w", ov.Path, err)
 		}
 	}
-	grid, err := bt.ExpandGrid(overrides)
+	for _, ov := range stringOverrides {
+		if _, err := bt.ApplyStringOverrides(entity.StrategyProfile{}, map[string]string{ov.Path: ""}); err != nil {
+			return fmt.Errorf("invalid --grid path %q: %w", ov.Path, err)
+		}
+	}
+	combos, err := bt.ExpandCombinedGrid(overrides, stringOverrides)
 	if err != nil {
 		return fmt.Errorf("expand grid: %w", err)
 	}
@@ -113,10 +118,10 @@ func walkForwardCommand(args []string) error {
 
 	runner := bt.NewWalkForwardRunner()
 	in := bt.WalkForwardInput{
-		BaseProfile: *profile,
-		Windows:     windows,
-		Grid:        grid,
-		Objective:   *objective,
+		BaseProfile:  *profile,
+		Windows:      windows,
+		Combinations: combos,
+		Objective:    *objective,
 		RunWindow: func(ctx context.Context, phase bt.WalkForwardPhase, pf entity.StrategyProfile, wFrom, wTo time.Time) (*entity.BacktestResult, error) {
 			strat, err := strategyuc.NewConfigurableStrategy(&pf)
 			if err != nil {
@@ -177,65 +182,149 @@ func walkForwardCommand(args []string) error {
 	return nil
 }
 
-// resolveWalkForwardGrid builds the []ParameterOverride from either a JSON
-// file (preferred when many axes) or the repeated --grid "path=v1,v2,v3"
-// inline flag. Both sources cannot be mixed — specifying both is a caller
-// error because the priority would be ambiguous.
-func resolveWalkForwardGrid(inline paramFlags, file string) ([]bt.ParameterOverride, error) {
+// resolveWalkForwardGrid builds the numeric and string override slices
+// from either a JSON file (preferred when many axes) or the repeated
+// --grid "path=v1,v2,v3" inline flag. Both sources cannot be mixed —
+// specifying both is a caller error because the priority would be
+// ambiguous.
+//
+// The inline flag auto-detects numeric vs. string axes: if every value
+// parses as float64 the axis is numeric; otherwise every value is
+// treated as a string (no mixed-type axes). This matches the file
+// format, which uses the shape {path, values} and infers type from
+// whether values are JSON numbers or JSON strings.
+func resolveWalkForwardGrid(inline paramFlags, file string) ([]bt.ParameterOverride, []bt.ParameterStringOverride, error) {
 	switch {
 	case file != "" && len(inline) > 0:
-		return nil, fmt.Errorf("use --grid OR --grid-file, not both")
+		return nil, nil, fmt.Errorf("use --grid OR --grid-file, not both")
 	case file != "":
 		return readGridFile(file)
 	case len(inline) > 0:
 		return parseGridInline(inline)
 	default:
-		// Empty grid → single baseline-only combo. ExpandGrid understands
-		// this case, so return nil to surface exactly that behaviour.
-		return nil, nil
+		// Empty grid → single baseline-only combo. ExpandCombinedGrid
+		// understands this case, so return nil to surface that behaviour.
+		return nil, nil, nil
 	}
 }
 
-func readGridFile(path string) ([]bt.ParameterOverride, error) {
+// rawGridAxis is the file format each entry can take. Values may be
+// either JSON numbers (populating Values) or JSON strings (populating
+// StringValues); a mix within one axis is rejected at unmarshal time.
+type rawGridAxis struct {
+	Path   string            `json:"path"`
+	Values []json.RawMessage `json:"values"`
+}
+
+func readGridFile(path string) ([]bt.ParameterOverride, []bt.ParameterStringOverride, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return nil, fmt.Errorf("read grid file: %w", err)
+		return nil, nil, fmt.Errorf("read grid file: %w", err)
 	}
-	var out []bt.ParameterOverride
-	if err := json.Unmarshal(data, &out); err != nil {
-		return nil, fmt.Errorf("parse grid file: %w", err)
+	var raw []rawGridAxis
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, nil, fmt.Errorf("parse grid file: %w", err)
 	}
-	return out, nil
+	var numeric []bt.ParameterOverride
+	var strings []bt.ParameterStringOverride
+	for _, axis := range raw {
+		num, str, err := classifyAxisValues(axis.Path, axis.Values)
+		if err != nil {
+			return nil, nil, err
+		}
+		if num != nil {
+			numeric = append(numeric, bt.ParameterOverride{Path: axis.Path, Values: num})
+			continue
+		}
+		strings = append(strings, bt.ParameterStringOverride{Path: axis.Path, Values: str})
+	}
+	return numeric, strings, nil
 }
 
-func parseGridInline(inline paramFlags) ([]bt.ParameterOverride, error) {
-	out := make([]bt.ParameterOverride, 0, len(inline))
+// classifyAxisValues inspects the JSON-raw values of one axis. An axis
+// is numeric when every value is a JSON number, string when every value
+// is a JSON string; anything else (bool, object, mixed) is a caller
+// error.
+func classifyAxisValues(path string, values []json.RawMessage) ([]float64, []string, error) {
+	if len(values) == 0 {
+		return nil, nil, fmt.Errorf("grid axis %q has no values", path)
+	}
+	allNumeric := true
+	allString := true
+	for _, v := range values {
+		trimmed := strings.TrimSpace(string(v))
+		if trimmed == "" {
+			return nil, nil, fmt.Errorf("grid axis %q has empty value", path)
+		}
+		if trimmed[0] != '"' {
+			allString = false
+		}
+		var probe float64
+		if err := json.Unmarshal(v, &probe); err != nil {
+			allNumeric = false
+		}
+	}
+	if allNumeric {
+		nums := make([]float64, 0, len(values))
+		for _, v := range values {
+			var n float64
+			if err := json.Unmarshal(v, &n); err != nil {
+				return nil, nil, fmt.Errorf("grid axis %q: parse number: %w", path, err)
+			}
+			nums = append(nums, n)
+		}
+		return nums, nil, nil
+	}
+	if allString {
+		strs := make([]string, 0, len(values))
+		for _, v := range values {
+			var s string
+			if err := json.Unmarshal(v, &s); err != nil {
+				return nil, nil, fmt.Errorf("grid axis %q: parse string: %w", path, err)
+			}
+			strs = append(strs, s)
+		}
+		return nil, strs, nil
+	}
+	return nil, nil, fmt.Errorf("grid axis %q mixes numeric and string values (pick one)", path)
+}
+
+func parseGridInline(inline paramFlags) ([]bt.ParameterOverride, []bt.ParameterStringOverride, error) {
+	var numeric []bt.ParameterOverride
+	var strs []bt.ParameterStringOverride
 	for _, spec := range inline {
 		eq := strings.IndexByte(spec, '=')
 		if eq <= 0 {
-			return nil, fmt.Errorf("invalid --grid %q: want path=v1,v2,v3", spec)
+			return nil, nil, fmt.Errorf("invalid --grid %q: want path=v1,v2,v3", spec)
 		}
 		path := strings.TrimSpace(spec[:eq])
 		raw := strings.TrimSpace(spec[eq+1:])
 		if path == "" || raw == "" {
-			return nil, fmt.Errorf("invalid --grid %q: empty path or values", spec)
+			return nil, nil, fmt.Errorf("invalid --grid %q: empty path or values", spec)
 		}
 		pieces := strings.Split(raw, ",")
 		values := make([]float64, 0, len(pieces))
+		stringValues := make([]string, 0, len(pieces))
+		allNumeric := true
 		for _, p := range pieces {
 			p = strings.TrimSpace(p)
 			if p == "" {
-				return nil, fmt.Errorf("invalid --grid %q: empty value", spec)
+				return nil, nil, fmt.Errorf("invalid --grid %q: empty value", spec)
 			}
-			v, err := strconv.ParseFloat(p, 64)
-			if err != nil {
-				return nil, fmt.Errorf("invalid --grid value %q: %w", p, err)
+			if v, err := strconv.ParseFloat(p, 64); err == nil {
+				values = append(values, v)
+			} else {
+				allNumeric = false
 			}
-			values = append(values, v)
+			stringValues = append(stringValues, p)
 		}
-		out = append(out, bt.ParameterOverride{Path: path, Values: values})
+		if allNumeric {
+			numeric = append(numeric, bt.ParameterOverride{Path: path, Values: values})
+		} else {
+			strs = append(strs, bt.ParameterStringOverride{Path: path, Values: stringValues})
+		}
 	}
-	return out, nil
+	return numeric, strs, nil
 }
 
 // parseWFDate parses YYYY-MM-DD into a UTC time. The walk-forward CLI runs

--- a/backend/cmd/backtest/walkforward_test.go
+++ b/backend/cmd/backtest/walkforward_test.go
@@ -12,12 +12,15 @@ func TestParseGridInline_ValidPaths(t *testing.T) {
 		"signal_rules.contrarian.stoch_entry_max=0,10,20",
 		"strategy_risk.stop_loss_percent=3,5,7",
 	}
-	got, err := parseGridInline(pf)
+	got, strs, err := parseGridInline(pf)
 	if err != nil {
 		t.Fatalf("parseGridInline: %v", err)
 	}
+	if len(strs) != 0 {
+		t.Fatalf("expected no string axes, got %d", len(strs))
+	}
 	if len(got) != 2 {
-		t.Fatalf("expected 2 axes, got %d", len(got))
+		t.Fatalf("expected 2 numeric axes, got %d", len(got))
 	}
 	if got[0].Path != "signal_rules.contrarian.stoch_entry_max" {
 		t.Fatalf("axis 0 path: %s", got[0].Path)
@@ -30,16 +33,55 @@ func TestParseGridInline_ValidPaths(t *testing.T) {
 	}
 }
 
+func TestParseGridInline_StringAxis(t *testing.T) {
+	pf := paramFlags{"htf_filter.mode=ema,ichimoku"}
+	nums, strs, err := parseGridInline(pf)
+	if err != nil {
+		t.Fatalf("parseGridInline: %v", err)
+	}
+	if len(nums) != 0 {
+		t.Fatalf("expected no numeric axes, got %d", len(nums))
+	}
+	if len(strs) != 1 {
+		t.Fatalf("expected 1 string axis, got %d", len(strs))
+	}
+	if strs[0].Path != "htf_filter.mode" {
+		t.Fatalf("axis path: %s", strs[0].Path)
+	}
+	if !reflect.DeepEqual(strs[0].Values, []string{"ema", "ichimoku"}) {
+		t.Fatalf("axis values: %v", strs[0].Values)
+	}
+}
+
+func TestParseGridInline_MixedNumericAndStringAxes(t *testing.T) {
+	pf := paramFlags{
+		"strategy_risk.stop_loss_percent=4,5,6",
+		"htf_filter.mode=ema,ichimoku",
+	}
+	nums, strs, err := parseGridInline(pf)
+	if err != nil {
+		t.Fatalf("parseGridInline: %v", err)
+	}
+	if len(nums) != 1 || len(strs) != 1 {
+		t.Fatalf("expected 1 numeric + 1 string axis, got %d + %d", len(nums), len(strs))
+	}
+	if nums[0].Path != "strategy_risk.stop_loss_percent" {
+		t.Fatalf("numeric axis: %+v", nums[0])
+	}
+	if strs[0].Path != "htf_filter.mode" {
+		t.Fatalf("string axis: %+v", strs[0])
+	}
+}
+
 func TestParseGridInline_RejectsBadSpec(t *testing.T) {
 	bads := []string{
 		"no-equal-sign",
 		"=empty-path",
 		"path=",
 		"path=1,,3",
-		"path=abc",
 	}
 	for _, b := range bads {
-		if _, err := parseGridInline(paramFlags{b}); err == nil {
+		if _, _, err := parseGridInline(paramFlags{b}); err == nil {
 			t.Fatalf("expected error for %q, got nil", b)
 		}
 	}
@@ -55,29 +97,69 @@ func TestReadGridFile_RoundTrip(t *testing.T) {
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	got, err := readGridFile(path)
+	got, strs, err := readGridFile(path)
 	if err != nil {
 		t.Fatalf("readGridFile: %v", err)
+	}
+	if len(strs) != 0 {
+		t.Fatalf("expected 0 string axes, got %d", len(strs))
 	}
 	if len(got) != 2 || got[0].Path != "signal_rules.contrarian.adx_max" {
 		t.Fatalf("unexpected grid: %+v", got)
 	}
 }
 
+func TestReadGridFile_StringAxis(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "grid.json")
+	content := `[
+		{"path": "htf_filter.mode", "values": ["ema", "ichimoku"]},
+		{"path": "strategy_risk.stop_loss_percent", "values": [5, 8]}
+	]`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	nums, strs, err := readGridFile(path)
+	if err != nil {
+		t.Fatalf("readGridFile: %v", err)
+	}
+	if len(nums) != 1 || nums[0].Path != "strategy_risk.stop_loss_percent" {
+		t.Fatalf("numeric: %+v", nums)
+	}
+	if len(strs) != 1 || strs[0].Path != "htf_filter.mode" {
+		t.Fatalf("string: %+v", strs)
+	}
+	if !reflect.DeepEqual(strs[0].Values, []string{"ema", "ichimoku"}) {
+		t.Fatalf("string values: %v", strs[0].Values)
+	}
+}
+
+func TestReadGridFile_RejectsMixedAxis(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "grid.json")
+	content := `[{"path": "htf_filter.mode", "values": ["ema", 42]}]`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, _, err := readGridFile(path); err == nil {
+		t.Fatal("expected error for mixed-type axis")
+	}
+}
+
 func TestResolveWalkForwardGrid_FileAndInlineAreMutuallyExclusive(t *testing.T) {
-	_, err := resolveWalkForwardGrid(paramFlags{"foo=1,2"}, "some.json")
+	_, _, err := resolveWalkForwardGrid(paramFlags{"foo=1,2"}, "some.json")
 	if err == nil {
 		t.Fatal("expected error when both --grid and --grid-file are set")
 	}
 }
 
 func TestResolveWalkForwardGrid_EmptyIsNil(t *testing.T) {
-	got, err := resolveWalkForwardGrid(nil, "")
+	nums, strs, err := resolveWalkForwardGrid(nil, "")
 	if err != nil {
 		t.Fatalf("no-args should be allowed: %v", err)
 	}
-	if got != nil {
-		t.Fatalf("expected nil (baseline-only); got %+v", got)
+	if nums != nil || strs != nil {
+		t.Fatalf("expected nil (baseline-only); got nums=%v strs=%v", nums, strs)
 	}
 }
 

--- a/backend/internal/interfaces/api/handler/backtest_walkforward.go
+++ b/backend/internal/interfaces/api/handler/backtest_walkforward.go
@@ -35,9 +35,10 @@ type runWalkForwardRequest struct {
 	OutOfSampleMonths int    `json:"outOfSampleMonths"` // default 3
 	StepMonths        int    `json:"stepMonths"`        // default 3
 
-	BaseProfile   string                  `json:"baseProfile" binding:"required"`
-	ParameterGrid []bt.ParameterOverride  `json:"parameterGrid"`
-	Objective     string                  `json:"objective"` // "return" | "sharpe" | "profit_factor"
+	BaseProfile         string                         `json:"baseProfile" binding:"required"`
+	ParameterGrid       []bt.ParameterOverride         `json:"parameterGrid"`
+	ParameterStringGrid []bt.ParameterStringOverride   `json:"parameterStringGrid"`
+	Objective           string                         `json:"objective"` // "return" | "sharpe" | "profit_factor"
 
 	PDCACycleID    string  `json:"pdcaCycleId,omitempty"`
 	Hypothesis     string  `json:"hypothesis,omitempty"`
@@ -99,7 +100,7 @@ func (h *BacktestHandler) RunWalkForward(c *gin.Context) {
 		return
 	}
 
-	grid, err := bt.ExpandGrid(req.ParameterGrid)
+	combinations, err := bt.ExpandCombinedGrid(req.ParameterGrid, req.ParameterStringGrid)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
@@ -125,6 +126,15 @@ func (h *BacktestHandler) RunWalkForward(c *gin.Context) {
 	// out as HTTP 500.
 	for _, ov := range req.ParameterGrid {
 		if _, err := bt.ApplyOverrides(entity.StrategyProfile{}, map[string]float64{ov.Path: 0}); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+	}
+	// Same pre-validation for string-valued paths. Probe with a known-good
+	// value ("" is accepted by every supported path) to isolate path
+	// errors from value errors.
+	for _, ov := range req.ParameterStringGrid {
+		if _, err := bt.ApplyStringOverrides(entity.StrategyProfile{}, map[string]string{ov.Path: ""}); err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
 		}
@@ -173,7 +183,7 @@ func (h *BacktestHandler) RunWalkForward(c *gin.Context) {
 	input := bt.WalkForwardInput{
 		BaseProfile:    *baseProfile,
 		Windows:        windows,
-		Grid:           grid,
+		Combinations:   combinations,
 		Objective:      req.Objective,
 		PDCACycleID:    req.PDCACycleID,
 		Hypothesis:     req.Hypothesis,

--- a/backend/internal/usecase/backtest/walkforward.go
+++ b/backend/internal/usecase/backtest/walkforward.go
@@ -16,6 +16,25 @@ type ParameterOverride struct {
 	Values []float64 `json:"values"`
 }
 
+// ParameterStringOverride declares one string-valued parameter axis.
+// String axes run alongside ParameterOverride in the combined grid but
+// route to ApplyStringOverrides at combo-apply time. Kept as a separate
+// shape so the numeric API contract (including the bestParameters /
+// parameters fields persisted in the WFO envelope and rendered by the
+// frontend) stays as map[string]float64 for every existing caller.
+type ParameterStringOverride struct {
+	Path   string   `json:"path"`
+	Values []string `json:"values"`
+}
+
+// GridCombination is one expanded grid cell. Numeric and String are
+// applied in sequence (ApplyOverrides → ApplyStringOverrides) so either
+// axis can participate in the same grid.
+type GridCombination struct {
+	Numeric map[string]float64
+	String  map[string]string
+}
+
 // WalkForwardWindow is one (in-sample, out-of-sample) slice of the walk-
 // forward schedule. The in-sample window is used to select best grid
 // parameters; the out-of-sample window is used to score them.
@@ -122,21 +141,45 @@ func addMonthsClamped(t time.Time, months int) time.Time {
 		t.Hour(), t.Minute(), t.Second(), t.Nanosecond(), t.Location())
 }
 
-// ExpandGrid computes the full cartesian product of the supplied
-// parameter axes. An empty slice returns exactly one empty combination
-// so callers can always iterate it (baseline-only sweeps just work).
+// ExpandGrid computes the full cartesian product of the supplied numeric
+// parameter axes. An empty slice returns exactly one empty combination so
+// callers can always iterate it (baseline-only sweeps just work).
+//
+// Kept for backwards compatibility with callers that only use numeric
+// axes. For mixed numeric+string grids, use ExpandCombinedGrid.
 func ExpandGrid(overrides []ParameterOverride) ([]map[string]float64, error) {
-	if len(overrides) == 0 {
-		return []map[string]float64{{}}, nil
+	combos, err := ExpandCombinedGrid(overrides, nil)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]map[string]float64, 0, len(combos))
+	for _, c := range combos {
+		out = append(out, c.Numeric)
+	}
+	return out, nil
+}
+
+// ExpandCombinedGrid computes the cartesian product of numeric and
+// string parameter axes. Combinations are produced in a deterministic
+// order (numeric axes before string axes, right-most index varying
+// fastest) so grid-rank comparisons between runs stay stable.
+//
+// Duplicate paths — whether within numeric, within string, or across
+// the two — are rejected: a later axis would silently overwrite an
+// earlier one when applied to the profile, producing a visible combo
+// count greater than distinct combos and a scoring signal that is not
+// what the caller asked for.
+func ExpandCombinedGrid(numeric []ParameterOverride, strs []ParameterStringOverride) ([]GridCombination, error) {
+	if len(numeric) == 0 && len(strs) == 0 {
+		return []GridCombination{{
+			Numeric: map[string]float64{},
+			String:  map[string]string{},
+		}}, nil
 	}
 
-	// Reject duplicate paths up-front: a later axis would silently overwrite
-	// the earlier one in the combo map, producing visible combo count >
-	// distinct combos and a scoring signal that is not what the caller
-	// asked for.
-	seenPaths := make(map[string]struct{}, len(overrides))
+	seenPaths := make(map[string]struct{}, len(numeric)+len(strs))
 	total := 1
-	for _, o := range overrides {
+	for _, o := range numeric {
 		if o.Path == "" {
 			return nil, fmt.Errorf("walk-forward: override path must not be empty")
 		}
@@ -149,30 +192,68 @@ func ExpandGrid(overrides []ParameterOverride) ([]map[string]float64, error) {
 		}
 		total *= len(o.Values)
 	}
+	for _, o := range strs {
+		if o.Path == "" {
+			return nil, fmt.Errorf("walk-forward: override path must not be empty")
+		}
+		if _, dup := seenPaths[o.Path]; dup {
+			return nil, fmt.Errorf("walk-forward: duplicate override path %q", o.Path)
+		}
+		seenPaths[o.Path] = struct{}{}
+		if len(o.Values) == 0 {
+			return nil, fmt.Errorf("walk-forward: override %q has no values", o.Path)
+		}
+		for _, v := range o.Values {
+			if v == "" {
+				return nil, fmt.Errorf("walk-forward: override %q has empty string value", o.Path)
+			}
+		}
+		total *= len(o.Values)
+	}
 	if total > MaxWalkForwardGridSize {
 		return nil, fmt.Errorf("walk-forward: grid size %d exceeds MAX_GRID_SIZE=%d",
 			total, MaxWalkForwardGridSize)
 	}
 
-	out := make([]map[string]float64, 0, total)
-	indices := make([]int, len(overrides))
+	out := make([]GridCombination, 0, total)
+	nIdx := make([]int, len(numeric))
+	sIdx := make([]int, len(strs))
 	for {
-		combo := make(map[string]float64, len(overrides))
-		for i, o := range overrides {
-			combo[o.Path] = o.Values[indices[i]]
+		combo := GridCombination{
+			Numeric: make(map[string]float64, len(numeric)),
+			String:  make(map[string]string, len(strs)),
+		}
+		for i, o := range numeric {
+			combo.Numeric[o.Path] = o.Values[nIdx[i]]
+		}
+		for i, o := range strs {
+			combo.String[o.Path] = o.Values[sIdx[i]]
 		}
 		out = append(out, combo)
 
-		j := len(overrides) - 1
-		for j >= 0 {
-			indices[j]++
-			if indices[j] < len(overrides[j].Values) {
+		// Advance the combined index (string axes first from the right,
+		// then numeric axes) so string mode swaps hold the numeric cell
+		// steady for one full string pass before stepping numeric.
+		advanced := false
+		for j := len(strs) - 1; j >= 0; j-- {
+			sIdx[j]++
+			if sIdx[j] < len(strs[j].Values) {
+				advanced = true
 				break
 			}
-			indices[j] = 0
-			j--
+			sIdx[j] = 0
 		}
-		if j < 0 {
+		if !advanced {
+			for j := len(numeric) - 1; j >= 0; j-- {
+				nIdx[j]++
+				if nIdx[j] < len(numeric[j].Values) {
+					advanced = true
+					break
+				}
+				nIdx[j] = 0
+			}
+		}
+		if !advanced {
 			break
 		}
 	}
@@ -195,6 +276,9 @@ func ExpandGrid(overrides []ParameterOverride) ([]map[string]float64, error) {
 //   signal_rules.breakout.{volume_ratio_min,adx_min}
 //   stance_rules.{rsi_oversold,rsi_overbought,sma_convergence_threshold,breakout_volume_ratio}
 //   htf_filter.alignment_boost
+//
+// String-valued axes (e.g. htf_filter.mode) live on a separate path via
+// ApplyStringOverrides so the numeric API contract stays purely float64.
 func ApplyOverrides(base entity.StrategyProfile, overrides map[string]float64) (entity.StrategyProfile, error) {
 	out := base
 	for path, value := range overrides {
@@ -246,6 +330,52 @@ func ApplyOverrides(base entity.StrategyProfile, overrides map[string]float64) (
 		default:
 			return entity.StrategyProfile{}, fmt.Errorf("walk-forward: unsupported override path %q", path)
 		}
+	}
+	return out, nil
+}
+
+// ApplyStringOverrides returns a deep copy of base with the requested
+// dot-separated string-valued fields set to their override values.
+//
+// Supported override paths (keep this comment in lockstep with the switch
+// below — unknown paths error out, so the switch is the authoritative list):
+//   htf_filter.mode   values: "" | "ema" | "ichimoku"
+//
+// The allowed values for each path are enforced here at the override
+// boundary rather than in StrategyProfile.Validate() so pre-existing
+// profiles that stored a blank or legacy string keep loading, but a WFO
+// grid with a typo fails fast instead of silently running "ema".
+func ApplyStringOverrides(base entity.StrategyProfile, overrides map[string]string) (entity.StrategyProfile, error) {
+	out := base
+	for path, value := range overrides {
+		switch path {
+		case "htf_filter.mode":
+			switch value {
+			case "", "ema", "ichimoku":
+				out.HTFFilter.Mode = value
+			default:
+				return entity.StrategyProfile{}, fmt.Errorf(
+					"walk-forward: unsupported value %q for %q (want \"\", \"ema\", or \"ichimoku\")",
+					value, path)
+			}
+		default:
+			return entity.StrategyProfile{}, fmt.Errorf("walk-forward: unsupported string override path %q", path)
+		}
+	}
+	return out, nil
+}
+
+// ApplyCombination applies both numeric and string overrides from one
+// expanded grid cell. Convenience wrapper used by WalkForwardRunner so
+// the runner doesn't have to thread two maps through every call site.
+func ApplyCombination(base entity.StrategyProfile, combo GridCombination) (entity.StrategyProfile, error) {
+	out, err := ApplyOverrides(base, combo.Numeric)
+	if err != nil {
+		return entity.StrategyProfile{}, err
+	}
+	out, err = ApplyStringOverrides(out, combo.String)
+	if err != nil {
+		return entity.StrategyProfile{}, err
 	}
 	return out, nil
 }

--- a/backend/internal/usecase/backtest/walkforward_runner.go
+++ b/backend/internal/usecase/backtest/walkforward_runner.go
@@ -17,12 +17,16 @@ import (
 // loading. The callback receives the resolved (profile, is/oos timestamps)
 // and returns a ready-to-run backtest pair.
 type WalkForwardInput struct {
-	BaseProfile    entity.StrategyProfile
-	Windows        []WalkForwardWindow
-	Grid           []map[string]float64 // pre-expanded combinations
-	Objective      string               // "return" | "sharpe" | "profit_factor"
-	PDCACycleID    string
-	Hypothesis     string
+	BaseProfile entity.StrategyProfile
+	Windows     []WalkForwardWindow
+	// Grid is the legacy numeric-only pre-expanded grid. New callers that
+	// also use string axes (e.g. htf_filter.mode) should populate
+	// Combinations instead. When both are set, Combinations wins.
+	Grid         []map[string]float64
+	Combinations []GridCombination
+	Objective    string // "return" | "sharpe" | "profit_factor"
+	PDCACycleID  string
+	Hypothesis   string
 	ParentResultID *string
 
 	// RunWindow is called per (window, param-combination) for the IS phase
@@ -44,22 +48,24 @@ const (
 // WalkForwardWindowResult is the per-window output: the best grid combo
 // chosen on IS, every grid combo's IS summary, and the unbiased OOS result.
 type WalkForwardWindowResult struct {
-	Index          int                   `json:"index"`
-	InSampleFrom   int64                 `json:"inSampleFrom"`
-	InSampleTo     int64                 `json:"inSampleTo"`
-	OOSFrom        int64                 `json:"oosFrom"`
-	OOSTo          int64                 `json:"oosTo"`
-	BestParameters map[string]float64    `json:"bestParameters"`
-	ISResults      []WalkForwardISResult `json:"isResults"`
-	OOSResult      entity.BacktestResult `json:"oosResult"`
+	Index                int                   `json:"index"`
+	InSampleFrom         int64                 `json:"inSampleFrom"`
+	InSampleTo           int64                 `json:"inSampleTo"`
+	OOSFrom              int64                 `json:"oosFrom"`
+	OOSTo                int64                 `json:"oosTo"`
+	BestParameters       map[string]float64    `json:"bestParameters"`
+	BestStringParameters map[string]string     `json:"bestStringParameters,omitempty"`
+	ISResults            []WalkForwardISResult `json:"isResults"`
+	OOSResult            entity.BacktestResult `json:"oosResult"`
 }
 
 // WalkForwardISResult records a single IS run per grid combination.
 type WalkForwardISResult struct {
-	Parameters map[string]float64     `json:"parameters"`
-	Summary    entity.BacktestSummary `json:"summary"`
-	Score      float64                `json:"score"`
-	ResultID   string                 `json:"resultId,omitempty"`
+	Parameters       map[string]float64     `json:"parameters"`
+	StringParameters map[string]string      `json:"stringParameters,omitempty"`
+	Summary          entity.BacktestSummary `json:"summary"`
+	Score            float64                `json:"score"`
+	ResultID         string                 `json:"resultId,omitempty"`
 }
 
 // WalkForwardResult is the envelope returned by Run. Individual per-window
@@ -105,8 +111,17 @@ func (r *WalkForwardRunner) Run(ctx context.Context, in WalkForwardInput) (*Walk
 	if len(in.Windows) == 0 {
 		return nil, fmt.Errorf("walk-forward: at least one window is required")
 	}
-	if len(in.Grid) == 0 {
-		return nil, fmt.Errorf("walk-forward: grid must contain at least one combination (use [{}] for baseline-only)")
+	// Prefer Combinations (supports mixed numeric+string axes) and fall
+	// back to Grid for existing callers. Both empty = invalid.
+	combos := in.Combinations
+	if len(combos) == 0 {
+		if len(in.Grid) == 0 {
+			return nil, fmt.Errorf("walk-forward: grid must contain at least one combination (use [{}] for baseline-only)")
+		}
+		combos = make([]GridCombination, 0, len(in.Grid))
+		for _, g := range in.Grid {
+			combos = append(combos, GridCombination{Numeric: g, String: map[string]string{}})
+		}
 	}
 	if in.RunWindow == nil {
 		return nil, fmt.Errorf("walk-forward: RunWindow callback is required")
@@ -119,16 +134,16 @@ func (r *WalkForwardRunner) Run(ctx context.Context, in WalkForwardInput) (*Walk
 	windowResults := make([]WalkForwardWindowResult, len(in.Windows))
 
 	for wi, w := range in.Windows {
-		isResults := make([]WalkForwardISResult, len(in.Grid))
+		isResults := make([]WalkForwardISResult, len(combos))
 		var mu sync.Mutex
 
 		g, gctx := errgroup.WithContext(ctx)
 		g.SetLimit(maxP)
-		for gi, combo := range in.Grid {
+		for gi, combo := range combos {
 			gi := gi
 			combo := combo
 			g.Go(func() error {
-				profile, err := ApplyOverrides(in.BaseProfile, combo)
+				profile, err := ApplyCombination(in.BaseProfile, combo)
 				if err != nil {
 					return fmt.Errorf("window %d combo %d: %w", wi, gi, err)
 				}
@@ -142,10 +157,11 @@ func (r *WalkForwardRunner) Run(ctx context.Context, in WalkForwardInput) (*Walk
 				score := SelectByObjective(res.Summary, in.Objective)
 				mu.Lock()
 				isResults[gi] = WalkForwardISResult{
-					Parameters: combo,
-					Summary:    res.Summary,
-					Score:      score,
-					ResultID:   res.ID,
+					Parameters:       combo.Numeric,
+					StringParameters: combo.String,
+					Summary:          res.Summary,
+					Score:            score,
+					ResultID:         res.ID,
 				}
 				mu.Unlock()
 				return nil
@@ -162,10 +178,10 @@ func (r *WalkForwardRunner) Run(ctx context.Context, in WalkForwardInput) (*Walk
 				bestIdx = i
 			}
 		}
-		bestCombo := isResults[bestIdx].Parameters
+		bestCombo := combos[bestIdx]
 
 		// OOS run with the winning combo.
-		bestProfile, err := ApplyOverrides(in.BaseProfile, bestCombo)
+		bestProfile, err := ApplyCombination(in.BaseProfile, bestCombo)
 		if err != nil {
 			return nil, fmt.Errorf("window %d apply best combo: %w", wi, err)
 		}
@@ -178,14 +194,15 @@ func (r *WalkForwardRunner) Run(ctx context.Context, in WalkForwardInput) (*Walk
 		}
 
 		windowResults[wi] = WalkForwardWindowResult{
-			Index:          w.Index,
-			InSampleFrom:   w.InSampleFrom.UnixMilli(),
-			InSampleTo:     w.InSampleTo.UnixMilli(),
-			OOSFrom:        w.OOSFrom.UnixMilli(),
-			OOSTo:          w.OOSTo.UnixMilli(),
-			BestParameters: bestCombo,
-			ISResults:      isResults,
-			OOSResult:      *oosResult,
+			Index:                w.Index,
+			InSampleFrom:         w.InSampleFrom.UnixMilli(),
+			InSampleTo:           w.InSampleTo.UnixMilli(),
+			OOSFrom:              w.OOSFrom.UnixMilli(),
+			OOSTo:                w.OOSTo.UnixMilli(),
+			BestParameters:       bestCombo.Numeric,
+			BestStringParameters: bestCombo.String,
+			ISResults:            isResults,
+			OOSResult:            *oosResult,
 		}
 	}
 

--- a/backend/internal/usecase/backtest/walkforward_test.go
+++ b/backend/internal/usecase/backtest/walkforward_test.go
@@ -296,6 +296,175 @@ func TestApplyOverrides_UnknownPathReturnsError(t *testing.T) {
 	}
 }
 
+// -------------- string overrides / combined grid --------------
+
+func TestApplyStringOverrides_HTFMode(t *testing.T) {
+	base := entity.StrategyProfile{HTFFilter: entity.HTFFilterConfig{Mode: "ema"}}
+	got, err := ApplyStringOverrides(base, map[string]string{"htf_filter.mode": "ichimoku"})
+	if err != nil {
+		t.Fatalf("ApplyStringOverrides: %v", err)
+	}
+	if got.HTFFilter.Mode != "ichimoku" {
+		t.Fatalf("Mode = %q, want ichimoku", got.HTFFilter.Mode)
+	}
+	if base.HTFFilter.Mode != "ema" {
+		t.Fatalf("base mutated: %q", base.HTFFilter.Mode)
+	}
+}
+
+func TestApplyStringOverrides_AllowedValues(t *testing.T) {
+	base := entity.StrategyProfile{}
+	for _, v := range []string{"", "ema", "ichimoku"} {
+		if _, err := ApplyStringOverrides(base, map[string]string{"htf_filter.mode": v}); err != nil {
+			t.Fatalf("value %q unexpectedly rejected: %v", v, err)
+		}
+	}
+}
+
+func TestApplyStringOverrides_RejectsBadValue(t *testing.T) {
+	base := entity.StrategyProfile{}
+	_, err := ApplyStringOverrides(base, map[string]string{"htf_filter.mode": "bollinger"})
+	if err == nil {
+		t.Fatal("expected error on unknown mode value")
+	}
+}
+
+func TestApplyStringOverrides_RejectsUnknownPath(t *testing.T) {
+	base := entity.StrategyProfile{}
+	_, err := ApplyStringOverrides(base, map[string]string{"strategy_risk.label": "foo"})
+	if err == nil {
+		t.Fatal("expected error on unknown string override path")
+	}
+}
+
+func TestApplyCombination_NumericAndString(t *testing.T) {
+	base := entity.StrategyProfile{
+		Risk:      entity.StrategyRiskConfig{StopLossPercent: 5},
+		HTFFilter: entity.HTFFilterConfig{Mode: "ema"},
+	}
+	got, err := ApplyCombination(base, GridCombination{
+		Numeric: map[string]float64{"strategy_risk.stop_loss_percent": 14},
+		String:  map[string]string{"htf_filter.mode": "ichimoku"},
+	})
+	if err != nil {
+		t.Fatalf("ApplyCombination: %v", err)
+	}
+	if got.Risk.StopLossPercent != 14 {
+		t.Fatalf("StopLossPercent = %v", got.Risk.StopLossPercent)
+	}
+	if got.HTFFilter.Mode != "ichimoku" {
+		t.Fatalf("Mode = %q", got.HTFFilter.Mode)
+	}
+}
+
+func TestExpandCombinedGrid_NumericOnly(t *testing.T) {
+	got, err := ExpandCombinedGrid([]ParameterOverride{
+		{Path: "strategy_risk.stop_loss_percent", Values: []float64{3, 5}},
+	}, nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("want 2 combos, got %d", len(got))
+	}
+	for _, c := range got {
+		if len(c.String) != 0 {
+			t.Fatalf("numeric-only grid produced string entries: %+v", c.String)
+		}
+	}
+}
+
+func TestExpandCombinedGrid_StringOnly(t *testing.T) {
+	got, err := ExpandCombinedGrid(nil, []ParameterStringOverride{
+		{Path: "htf_filter.mode", Values: []string{"ema", "ichimoku"}},
+	})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("want 2 combos, got %d", len(got))
+	}
+	seen := map[string]bool{}
+	for _, c := range got {
+		seen[c.String["htf_filter.mode"]] = true
+	}
+	if !seen["ema"] || !seen["ichimoku"] {
+		t.Fatalf("missing string values: %+v", seen)
+	}
+}
+
+func TestExpandCombinedGrid_MixedCartesianProduct(t *testing.T) {
+	got, err := ExpandCombinedGrid(
+		[]ParameterOverride{
+			{Path: "strategy_risk.stop_loss_percent", Values: []float64{4, 14}},
+		},
+		[]ParameterStringOverride{
+			{Path: "htf_filter.mode", Values: []string{"ema", "ichimoku"}},
+		},
+	)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(got) != 4 {
+		t.Fatalf("want 4 combos (2x2), got %d", len(got))
+	}
+	type key struct {
+		sl   float64
+		mode string
+	}
+	seen := map[key]bool{}
+	for _, c := range got {
+		k := key{c.Numeric["strategy_risk.stop_loss_percent"], c.String["htf_filter.mode"]}
+		if seen[k] {
+			t.Fatalf("duplicate combo: %+v", k)
+		}
+		seen[k] = true
+	}
+	for _, sl := range []float64{4, 14} {
+		for _, m := range []string{"ema", "ichimoku"} {
+			if !seen[key{sl, m}] {
+				t.Fatalf("missing combo sl=%v mode=%s", sl, m)
+			}
+		}
+	}
+}
+
+func TestExpandCombinedGrid_EmptyBothIsBaseline(t *testing.T) {
+	got, err := ExpandCombinedGrid(nil, nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("want 1 baseline combo, got %d", len(got))
+	}
+	if len(got[0].Numeric) != 0 || len(got[0].String) != 0 {
+		t.Fatalf("baseline combo should be empty: %+v", got[0])
+	}
+}
+
+// TestExpandCombinedGrid_RejectsDuplicateAcrossTypes locks in the same
+// contract ExpandGrid enforces for duplicate paths: even if one axis is
+// numeric and the other is string, sharing a Path would silently let
+// ApplyStringOverrides overwrite ApplyOverrides for that field.
+func TestExpandCombinedGrid_RejectsDuplicateAcrossTypes(t *testing.T) {
+	_, err := ExpandCombinedGrid(
+		[]ParameterOverride{{Path: "htf_filter.mode", Values: []float64{0, 1}}},
+		[]ParameterStringOverride{{Path: "htf_filter.mode", Values: []string{"ema", "ichimoku"}}},
+	)
+	if err == nil {
+		t.Fatal("expected error on duplicate path across numeric + string axes")
+	}
+}
+
+func TestExpandCombinedGrid_RejectsEmptyStringValue(t *testing.T) {
+	_, err := ExpandCombinedGrid(nil, []ParameterStringOverride{
+		{Path: "htf_filter.mode", Values: []string{"ema", ""}},
+	})
+	if err == nil {
+		t.Fatal("expected error on empty string value")
+	}
+}
+
 // -------------- objective --------------
 
 func TestSelectByObjective(t *testing.T) {

--- a/backend/profiles/experiment_2026-04-22_healthy_sl12_tr25.json
+++ b/backend/profiles/experiment_2026-04-22_healthy_sl12_tr25.json
@@ -1,0 +1,55 @@
+{
+  "name": "experiment_2026-04-22_healthy_sl12_tr25",
+  "description": "healthy_v3 with SL=12% + trailing_atr_multiplier=2.5. Healthy SL replacement for v5 promotion candidacy.",
+  "indicators": {
+    "sma_short": 20,
+    "sma_long": 50,
+    "rsi_period": 14,
+    "macd_fast": 12,
+    "macd_slow": 26,
+    "macd_signal": 9,
+    "bb_period": 20,
+    "bb_multiplier": 2.0,
+    "atr_period": 14
+  },
+  "stance_rules": {
+    "rsi_oversold": 32,
+    "rsi_overbought": 68,
+    "sma_convergence_threshold": 0.002,
+    "bb_squeeze_lookback": 5,
+    "breakout_volume_ratio": 1.5
+  },
+  "signal_rules": {
+    "trend_follow": {
+      "enabled": true,
+      "require_macd_confirm": false,
+      "require_ema_cross": true,
+      "rsi_buy_max": 62,
+      "rsi_sell_min": 38
+    },
+    "contrarian": {
+      "enabled": true,
+      "rsi_entry": 32,
+      "rsi_exit": 68,
+      "macd_histogram_limit": 10
+    },
+    "breakout": {
+      "enabled": true,
+      "volume_ratio_min": 1.5,
+      "require_macd_confirm": true
+    }
+  },
+  "strategy_risk": {
+    "stop_loss_percent": 12,
+    "take_profit_percent": 4,
+    "stop_loss_atr_multiplier": 0,
+    "max_position_amount": 100000,
+    "max_daily_loss": 50000,
+    "trailing_atr_multiplier": 2.5
+  },
+  "htf_filter": {
+    "enabled": true,
+    "block_counter_trend": false,
+    "alignment_boost": 0.1
+  }
+}

--- a/backend/profiles/experiment_2026-04-22_healthy_sl5_tr15.json
+++ b/backend/profiles/experiment_2026-04-22_healthy_sl5_tr15.json
@@ -1,0 +1,55 @@
+{
+  "name": "experiment_2026-04-22_healthy_sl5_tr15",
+  "description": "healthy_v3 with SL=5% + trailing_atr_multiplier=1.5. Healthy SL replacement for v5 promotion candidacy.",
+  "indicators": {
+    "sma_short": 20,
+    "sma_long": 50,
+    "rsi_period": 14,
+    "macd_fast": 12,
+    "macd_slow": 26,
+    "macd_signal": 9,
+    "bb_period": 20,
+    "bb_multiplier": 2.0,
+    "atr_period": 14
+  },
+  "stance_rules": {
+    "rsi_oversold": 32,
+    "rsi_overbought": 68,
+    "sma_convergence_threshold": 0.002,
+    "bb_squeeze_lookback": 5,
+    "breakout_volume_ratio": 1.5
+  },
+  "signal_rules": {
+    "trend_follow": {
+      "enabled": true,
+      "require_macd_confirm": false,
+      "require_ema_cross": true,
+      "rsi_buy_max": 62,
+      "rsi_sell_min": 38
+    },
+    "contrarian": {
+      "enabled": true,
+      "rsi_entry": 32,
+      "rsi_exit": 68,
+      "macd_histogram_limit": 10
+    },
+    "breakout": {
+      "enabled": true,
+      "volume_ratio_min": 1.5,
+      "require_macd_confirm": true
+    }
+  },
+  "strategy_risk": {
+    "stop_loss_percent": 5,
+    "take_profit_percent": 4,
+    "stop_loss_atr_multiplier": 0,
+    "max_position_amount": 100000,
+    "max_daily_loss": 50000,
+    "trailing_atr_multiplier": 1.5
+  },
+  "htf_filter": {
+    "enabled": true,
+    "block_counter_trend": false,
+    "alignment_boost": 0.1
+  }
+}

--- a/backend/profiles/experiment_2026-04-22_healthy_sl5_tr20.json
+++ b/backend/profiles/experiment_2026-04-22_healthy_sl5_tr20.json
@@ -1,0 +1,55 @@
+{
+  "name": "experiment_2026-04-22_healthy_sl5_tr20",
+  "description": "healthy_v3 with SL=5% + trailing_atr_multiplier=2.0. Healthy SL replacement for v5 promotion candidacy.",
+  "indicators": {
+    "sma_short": 20,
+    "sma_long": 50,
+    "rsi_period": 14,
+    "macd_fast": 12,
+    "macd_slow": 26,
+    "macd_signal": 9,
+    "bb_period": 20,
+    "bb_multiplier": 2.0,
+    "atr_period": 14
+  },
+  "stance_rules": {
+    "rsi_oversold": 32,
+    "rsi_overbought": 68,
+    "sma_convergence_threshold": 0.002,
+    "bb_squeeze_lookback": 5,
+    "breakout_volume_ratio": 1.5
+  },
+  "signal_rules": {
+    "trend_follow": {
+      "enabled": true,
+      "require_macd_confirm": false,
+      "require_ema_cross": true,
+      "rsi_buy_max": 62,
+      "rsi_sell_min": 38
+    },
+    "contrarian": {
+      "enabled": true,
+      "rsi_entry": 32,
+      "rsi_exit": 68,
+      "macd_histogram_limit": 10
+    },
+    "breakout": {
+      "enabled": true,
+      "volume_ratio_min": 1.5,
+      "require_macd_confirm": true
+    }
+  },
+  "strategy_risk": {
+    "stop_loss_percent": 5,
+    "take_profit_percent": 4,
+    "stop_loss_atr_multiplier": 0,
+    "max_position_amount": 100000,
+    "max_daily_loss": 50000,
+    "trailing_atr_multiplier": 2.0
+  },
+  "htf_filter": {
+    "enabled": true,
+    "block_counter_trend": false,
+    "alignment_boost": 0.1
+  }
+}

--- a/backend/profiles/experiment_2026-04-22_healthy_sl8_tr20.json
+++ b/backend/profiles/experiment_2026-04-22_healthy_sl8_tr20.json
@@ -1,0 +1,55 @@
+{
+  "name": "experiment_2026-04-22_healthy_sl8_tr20",
+  "description": "healthy_v3 with SL=8% + trailing_atr_multiplier=2.0. Healthy SL replacement for v5 promotion candidacy.",
+  "indicators": {
+    "sma_short": 20,
+    "sma_long": 50,
+    "rsi_period": 14,
+    "macd_fast": 12,
+    "macd_slow": 26,
+    "macd_signal": 9,
+    "bb_period": 20,
+    "bb_multiplier": 2.0,
+    "atr_period": 14
+  },
+  "stance_rules": {
+    "rsi_oversold": 32,
+    "rsi_overbought": 68,
+    "sma_convergence_threshold": 0.002,
+    "bb_squeeze_lookback": 5,
+    "breakout_volume_ratio": 1.5
+  },
+  "signal_rules": {
+    "trend_follow": {
+      "enabled": true,
+      "require_macd_confirm": false,
+      "require_ema_cross": true,
+      "rsi_buy_max": 62,
+      "rsi_sell_min": 38
+    },
+    "contrarian": {
+      "enabled": true,
+      "rsi_entry": 32,
+      "rsi_exit": 68,
+      "macd_histogram_limit": 10
+    },
+    "breakout": {
+      "enabled": true,
+      "volume_ratio_min": 1.5,
+      "require_macd_confirm": true
+    }
+  },
+  "strategy_risk": {
+    "stop_loss_percent": 8,
+    "take_profit_percent": 4,
+    "stop_loss_atr_multiplier": 0,
+    "max_position_amount": 100000,
+    "max_daily_loss": 50000,
+    "trailing_atr_multiplier": 2.0
+  },
+  "htf_filter": {
+    "enabled": true,
+    "block_counter_trend": false,
+    "alignment_boost": 0.1
+  }
+}

--- a/backend/profiles/experiment_2026-04-22_healthy_sl8_tr30.json
+++ b/backend/profiles/experiment_2026-04-22_healthy_sl8_tr30.json
@@ -1,0 +1,55 @@
+{
+  "name": "experiment_2026-04-22_healthy_sl8_tr30",
+  "description": "healthy_v3 with SL=8% + trailing_atr_multiplier=3.0. Healthy SL replacement for v5 promotion candidacy.",
+  "indicators": {
+    "sma_short": 20,
+    "sma_long": 50,
+    "rsi_period": 14,
+    "macd_fast": 12,
+    "macd_slow": 26,
+    "macd_signal": 9,
+    "bb_period": 20,
+    "bb_multiplier": 2.0,
+    "atr_period": 14
+  },
+  "stance_rules": {
+    "rsi_oversold": 32,
+    "rsi_overbought": 68,
+    "sma_convergence_threshold": 0.002,
+    "bb_squeeze_lookback": 5,
+    "breakout_volume_ratio": 1.5
+  },
+  "signal_rules": {
+    "trend_follow": {
+      "enabled": true,
+      "require_macd_confirm": false,
+      "require_ema_cross": true,
+      "rsi_buy_max": 62,
+      "rsi_sell_min": 38
+    },
+    "contrarian": {
+      "enabled": true,
+      "rsi_entry": 32,
+      "rsi_exit": 68,
+      "macd_histogram_limit": 10
+    },
+    "breakout": {
+      "enabled": true,
+      "volume_ratio_min": 1.5,
+      "require_macd_confirm": true
+    }
+  },
+  "strategy_risk": {
+    "stop_loss_percent": 8,
+    "take_profit_percent": 4,
+    "stop_loss_atr_multiplier": 0,
+    "max_position_amount": 100000,
+    "max_daily_loss": 50000,
+    "trailing_atr_multiplier": 3.0
+  },
+  "htf_filter": {
+    "enabled": true,
+    "block_counter_trend": false,
+    "alignment_boost": 0.1
+  }
+}

--- a/backend/profiles/experiment_2026-04-22_healthy_v4_atr.json
+++ b/backend/profiles/experiment_2026-04-22_healthy_v4_atr.json
@@ -1,0 +1,55 @@
+{
+  "name": "experiment_2026-04-22_healthy_v4_atr",
+  "description": "healthy_v3 candidate with SL=20 replaced by static SL=8 + ATR trailing (multiplier=2.0). Base profile for WFO cycle 28 Path 1.",
+  "indicators": {
+    "sma_short": 20,
+    "sma_long": 50,
+    "rsi_period": 14,
+    "macd_fast": 12,
+    "macd_slow": 26,
+    "macd_signal": 9,
+    "bb_period": 20,
+    "bb_multiplier": 2.0,
+    "atr_period": 14
+  },
+  "stance_rules": {
+    "rsi_oversold": 32,
+    "rsi_overbought": 68,
+    "sma_convergence_threshold": 0.002,
+    "bb_squeeze_lookback": 5,
+    "breakout_volume_ratio": 1.5
+  },
+  "signal_rules": {
+    "trend_follow": {
+      "enabled": true,
+      "require_macd_confirm": false,
+      "require_ema_cross": true,
+      "rsi_buy_max": 62,
+      "rsi_sell_min": 38
+    },
+    "contrarian": {
+      "enabled": true,
+      "rsi_entry": 32,
+      "rsi_exit": 68,
+      "macd_histogram_limit": 10
+    },
+    "breakout": {
+      "enabled": true,
+      "volume_ratio_min": 1.5,
+      "require_macd_confirm": true
+    }
+  },
+  "strategy_risk": {
+    "stop_loss_percent": 8,
+    "take_profit_percent": 4,
+    "stop_loss_atr_multiplier": 0,
+    "max_position_amount": 100000,
+    "max_daily_loss": 50000,
+    "trailing_atr_multiplier": 2.0
+  },
+  "htf_filter": {
+    "enabled": true,
+    "block_counter_trend": false,
+    "alignment_boost": 0.1
+  }
+}

--- a/backend/profiles/experiment_2026-04-22_sl10_tf60_35.json
+++ b/backend/profiles/experiment_2026-04-22_sl10_tf60_35.json
@@ -1,0 +1,55 @@
+{
+  "name": "experiment_2026-04-22_sl10_tf60_35",
+  "description": "narrow sweep around winner: SL=10 TR=2.5 around sl12_tf60_35_tp4",
+  "indicators": {
+    "sma_short": 20,
+    "sma_long": 50,
+    "rsi_period": 14,
+    "macd_fast": 12,
+    "macd_slow": 26,
+    "macd_signal": 9,
+    "bb_period": 20,
+    "bb_multiplier": 2.0,
+    "atr_period": 14
+  },
+  "stance_rules": {
+    "rsi_oversold": 32,
+    "rsi_overbought": 68,
+    "sma_convergence_threshold": 0.002,
+    "bb_squeeze_lookback": 5,
+    "breakout_volume_ratio": 1.5
+  },
+  "signal_rules": {
+    "trend_follow": {
+      "enabled": true,
+      "require_macd_confirm": false,
+      "require_ema_cross": true,
+      "rsi_buy_max": 60,
+      "rsi_sell_min": 35
+    },
+    "contrarian": {
+      "enabled": true,
+      "rsi_entry": 32,
+      "rsi_exit": 68,
+      "macd_histogram_limit": 10
+    },
+    "breakout": {
+      "enabled": true,
+      "volume_ratio_min": 1.5,
+      "require_macd_confirm": true
+    }
+  },
+  "strategy_risk": {
+    "stop_loss_percent": 10,
+    "take_profit_percent": 4,
+    "stop_loss_atr_multiplier": 0,
+    "max_position_amount": 100000,
+    "max_daily_loss": 50000,
+    "trailing_atr_multiplier": 2.5
+  },
+  "htf_filter": {
+    "enabled": true,
+    "block_counter_trend": false,
+    "alignment_boost": 0.1
+  }
+}

--- a/backend/profiles/experiment_2026-04-22_sl12_rsi65_28.json
+++ b/backend/profiles/experiment_2026-04-22_sl12_rsi65_28.json
@@ -1,0 +1,55 @@
+{
+  "name": "experiment_2026-04-22_sl12_rsi65_28",
+  "description": "Combined: healthy_v3 base + SL=12 + trailing_atr=2.5 + rsi_overbought=65 + rsi_oversold=28. Path1+Path2 intersection.",
+  "indicators": {
+    "sma_short": 20,
+    "sma_long": 50,
+    "rsi_period": 14,
+    "macd_fast": 12,
+    "macd_slow": 26,
+    "macd_signal": 9,
+    "bb_period": 20,
+    "bb_multiplier": 2.0,
+    "atr_period": 14
+  },
+  "stance_rules": {
+    "rsi_oversold": 28,
+    "rsi_overbought": 65,
+    "sma_convergence_threshold": 0.002,
+    "bb_squeeze_lookback": 5,
+    "breakout_volume_ratio": 1.5
+  },
+  "signal_rules": {
+    "trend_follow": {
+      "enabled": true,
+      "require_macd_confirm": false,
+      "require_ema_cross": true,
+      "rsi_buy_max": 62,
+      "rsi_sell_min": 38
+    },
+    "contrarian": {
+      "enabled": true,
+      "rsi_entry": 32,
+      "rsi_exit": 68,
+      "macd_histogram_limit": 10
+    },
+    "breakout": {
+      "enabled": true,
+      "volume_ratio_min": 1.5,
+      "require_macd_confirm": true
+    }
+  },
+  "strategy_risk": {
+    "stop_loss_percent": 12,
+    "take_profit_percent": 4,
+    "stop_loss_atr_multiplier": 0,
+    "max_position_amount": 100000,
+    "max_daily_loss": 50000,
+    "trailing_atr_multiplier": 2.5
+  },
+  "htf_filter": {
+    "enabled": true,
+    "block_counter_trend": false,
+    "alignment_boost": 0.1
+  }
+}

--- a/backend/profiles/experiment_2026-04-22_sl12_rsi72_28.json
+++ b/backend/profiles/experiment_2026-04-22_sl12_rsi72_28.json
@@ -1,0 +1,55 @@
+{
+  "name": "experiment_2026-04-22_sl12_rsi72_28",
+  "description": "Combined: healthy_v3 base + SL=12 + trailing_atr=2.5 + rsi_overbought=72 + rsi_oversold=28. Path1+Path2 intersection.",
+  "indicators": {
+    "sma_short": 20,
+    "sma_long": 50,
+    "rsi_period": 14,
+    "macd_fast": 12,
+    "macd_slow": 26,
+    "macd_signal": 9,
+    "bb_period": 20,
+    "bb_multiplier": 2.0,
+    "atr_period": 14
+  },
+  "stance_rules": {
+    "rsi_oversold": 28,
+    "rsi_overbought": 72,
+    "sma_convergence_threshold": 0.002,
+    "bb_squeeze_lookback": 5,
+    "breakout_volume_ratio": 1.5
+  },
+  "signal_rules": {
+    "trend_follow": {
+      "enabled": true,
+      "require_macd_confirm": false,
+      "require_ema_cross": true,
+      "rsi_buy_max": 62,
+      "rsi_sell_min": 38
+    },
+    "contrarian": {
+      "enabled": true,
+      "rsi_entry": 32,
+      "rsi_exit": 68,
+      "macd_histogram_limit": 10
+    },
+    "breakout": {
+      "enabled": true,
+      "volume_ratio_min": 1.5,
+      "require_macd_confirm": true
+    }
+  },
+  "strategy_risk": {
+    "stop_loss_percent": 12,
+    "take_profit_percent": 4,
+    "stop_loss_atr_multiplier": 0,
+    "max_position_amount": 100000,
+    "max_daily_loss": 50000,
+    "trailing_atr_multiplier": 2.5
+  },
+  "htf_filter": {
+    "enabled": true,
+    "block_counter_trend": false,
+    "alignment_boost": 0.1
+  }
+}

--- a/backend/profiles/experiment_2026-04-22_sl12_rsi72_32.json
+++ b/backend/profiles/experiment_2026-04-22_sl12_rsi72_32.json
@@ -1,0 +1,55 @@
+{
+  "name": "experiment_2026-04-22_sl12_rsi72_32",
+  "description": "Combined: healthy_v3 base + SL=12 + trailing_atr=2.5 + rsi_overbought=72 + rsi_oversold=32. Path1+Path2 intersection.",
+  "indicators": {
+    "sma_short": 20,
+    "sma_long": 50,
+    "rsi_period": 14,
+    "macd_fast": 12,
+    "macd_slow": 26,
+    "macd_signal": 9,
+    "bb_period": 20,
+    "bb_multiplier": 2.0,
+    "atr_period": 14
+  },
+  "stance_rules": {
+    "rsi_oversold": 32,
+    "rsi_overbought": 72,
+    "sma_convergence_threshold": 0.002,
+    "bb_squeeze_lookback": 5,
+    "breakout_volume_ratio": 1.5
+  },
+  "signal_rules": {
+    "trend_follow": {
+      "enabled": true,
+      "require_macd_confirm": false,
+      "require_ema_cross": true,
+      "rsi_buy_max": 62,
+      "rsi_sell_min": 38
+    },
+    "contrarian": {
+      "enabled": true,
+      "rsi_entry": 32,
+      "rsi_exit": 68,
+      "macd_histogram_limit": 10
+    },
+    "breakout": {
+      "enabled": true,
+      "volume_ratio_min": 1.5,
+      "require_macd_confirm": true
+    }
+  },
+  "strategy_risk": {
+    "stop_loss_percent": 12,
+    "take_profit_percent": 4,
+    "stop_loss_atr_multiplier": 0,
+    "max_position_amount": 100000,
+    "max_daily_loss": 50000,
+    "trailing_atr_multiplier": 2.5
+  },
+  "htf_filter": {
+    "enabled": true,
+    "block_counter_trend": false,
+    "alignment_boost": 0.1
+  }
+}

--- a/backend/profiles/experiment_2026-04-22_sl12_tf60_35_macd.json
+++ b/backend/profiles/experiment_2026-04-22_sl12_tf60_35_macd.json
@@ -1,0 +1,55 @@
+{
+  "name": "experiment_2026-04-22_sl12_tf60_35_macd",
+  "description": "try require_macd_confirm=true vs healthy_v3 default false",
+  "indicators": {
+    "sma_short": 20,
+    "sma_long": 50,
+    "rsi_period": 14,
+    "macd_fast": 12,
+    "macd_slow": 26,
+    "macd_signal": 9,
+    "bb_period": 20,
+    "bb_multiplier": 2.0,
+    "atr_period": 14
+  },
+  "stance_rules": {
+    "rsi_oversold": 32,
+    "rsi_overbought": 68,
+    "sma_convergence_threshold": 0.002,
+    "bb_squeeze_lookback": 5,
+    "breakout_volume_ratio": 1.5
+  },
+  "signal_rules": {
+    "trend_follow": {
+      "enabled": true,
+      "require_macd_confirm": true,
+      "require_ema_cross": true,
+      "rsi_buy_max": 60,
+      "rsi_sell_min": 35
+    },
+    "contrarian": {
+      "enabled": true,
+      "rsi_entry": 32,
+      "rsi_exit": 68,
+      "macd_histogram_limit": 10
+    },
+    "breakout": {
+      "enabled": true,
+      "volume_ratio_min": 1.5,
+      "require_macd_confirm": true
+    }
+  },
+  "strategy_risk": {
+    "stop_loss_percent": 12,
+    "take_profit_percent": 4,
+    "stop_loss_atr_multiplier": 0,
+    "max_position_amount": 100000,
+    "max_daily_loss": 50000,
+    "trailing_atr_multiplier": 2.5
+  },
+  "htf_filter": {
+    "enabled": true,
+    "block_counter_trend": false,
+    "alignment_boost": 0.1
+  }
+}

--- a/backend/profiles/experiment_2026-04-22_sl12_tf60_35_noblock.json
+++ b/backend/profiles/experiment_2026-04-22_sl12_tf60_35_noblock.json
@@ -1,0 +1,55 @@
+{
+  "name": "experiment_2026-04-22_sl12_tf60_35_noblock",
+  "description": "try block_counter_trend=true vs healthy_v3 default false",
+  "indicators": {
+    "sma_short": 20,
+    "sma_long": 50,
+    "rsi_period": 14,
+    "macd_fast": 12,
+    "macd_slow": 26,
+    "macd_signal": 9,
+    "bb_period": 20,
+    "bb_multiplier": 2.0,
+    "atr_period": 14
+  },
+  "stance_rules": {
+    "rsi_oversold": 32,
+    "rsi_overbought": 68,
+    "sma_convergence_threshold": 0.002,
+    "bb_squeeze_lookback": 5,
+    "breakout_volume_ratio": 1.5
+  },
+  "signal_rules": {
+    "trend_follow": {
+      "enabled": true,
+      "require_macd_confirm": false,
+      "require_ema_cross": true,
+      "rsi_buy_max": 60,
+      "rsi_sell_min": 35
+    },
+    "contrarian": {
+      "enabled": true,
+      "rsi_entry": 32,
+      "rsi_exit": 68,
+      "macd_histogram_limit": 10
+    },
+    "breakout": {
+      "enabled": true,
+      "volume_ratio_min": 1.5,
+      "require_macd_confirm": true
+    }
+  },
+  "strategy_risk": {
+    "stop_loss_percent": 12,
+    "take_profit_percent": 4,
+    "stop_loss_atr_multiplier": 0,
+    "max_position_amount": 100000,
+    "max_daily_loss": 50000,
+    "trailing_atr_multiplier": 2.5
+  },
+  "htf_filter": {
+    "enabled": true,
+    "block_counter_trend": true,
+    "alignment_boost": 0.1
+  }
+}

--- a/backend/profiles/experiment_2026-04-22_sl12_tf60_35_tp4.json
+++ b/backend/profiles/experiment_2026-04-22_sl12_tf60_35_tp4.json
@@ -1,0 +1,55 @@
+{
+  "name": "experiment_2026-04-22_sl12_tf60_35_tp4",
+  "description": "healthy_v3 + SL=12 + trailing_atr=2.5 + trend_follow(buy_max=60, sell_min=35) + TP=4. Cycle30 winner refinement.",
+  "indicators": {
+    "sma_short": 20,
+    "sma_long": 50,
+    "rsi_period": 14,
+    "macd_fast": 12,
+    "macd_slow": 26,
+    "macd_signal": 9,
+    "bb_period": 20,
+    "bb_multiplier": 2.0,
+    "atr_period": 14
+  },
+  "stance_rules": {
+    "rsi_oversold": 32,
+    "rsi_overbought": 68,
+    "sma_convergence_threshold": 0.002,
+    "bb_squeeze_lookback": 5,
+    "breakout_volume_ratio": 1.5
+  },
+  "signal_rules": {
+    "trend_follow": {
+      "enabled": true,
+      "require_macd_confirm": false,
+      "require_ema_cross": true,
+      "rsi_buy_max": 60,
+      "rsi_sell_min": 35
+    },
+    "contrarian": {
+      "enabled": true,
+      "rsi_entry": 32,
+      "rsi_exit": 68,
+      "macd_histogram_limit": 10
+    },
+    "breakout": {
+      "enabled": true,
+      "volume_ratio_min": 1.5,
+      "require_macd_confirm": true
+    }
+  },
+  "strategy_risk": {
+    "stop_loss_percent": 12,
+    "take_profit_percent": 4,
+    "stop_loss_atr_multiplier": 0,
+    "max_position_amount": 100000,
+    "max_daily_loss": 50000,
+    "trailing_atr_multiplier": 2.5
+  },
+  "htf_filter": {
+    "enabled": true,
+    "block_counter_trend": false,
+    "alignment_boost": 0.1
+  }
+}

--- a/backend/profiles/experiment_2026-04-22_sl12_tf60_40_tp12.json
+++ b/backend/profiles/experiment_2026-04-22_sl12_tf60_40_tp12.json
@@ -1,0 +1,55 @@
+{
+  "name": "experiment_2026-04-22_sl12_tf60_40_tp12",
+  "description": "healthy_v3 + SL=12 + trailing_atr=2.5 + trend_follow(buy_max=60, sell_min=40) + TP=12. Cycle30 winner refinement.",
+  "indicators": {
+    "sma_short": 20,
+    "sma_long": 50,
+    "rsi_period": 14,
+    "macd_fast": 12,
+    "macd_slow": 26,
+    "macd_signal": 9,
+    "bb_period": 20,
+    "bb_multiplier": 2.0,
+    "atr_period": 14
+  },
+  "stance_rules": {
+    "rsi_oversold": 32,
+    "rsi_overbought": 68,
+    "sma_convergence_threshold": 0.002,
+    "bb_squeeze_lookback": 5,
+    "breakout_volume_ratio": 1.5
+  },
+  "signal_rules": {
+    "trend_follow": {
+      "enabled": true,
+      "require_macd_confirm": false,
+      "require_ema_cross": true,
+      "rsi_buy_max": 60,
+      "rsi_sell_min": 40
+    },
+    "contrarian": {
+      "enabled": true,
+      "rsi_entry": 32,
+      "rsi_exit": 68,
+      "macd_histogram_limit": 10
+    },
+    "breakout": {
+      "enabled": true,
+      "volume_ratio_min": 1.5,
+      "require_macd_confirm": true
+    }
+  },
+  "strategy_risk": {
+    "stop_loss_percent": 12,
+    "take_profit_percent": 12,
+    "stop_loss_atr_multiplier": 0,
+    "max_position_amount": 100000,
+    "max_daily_loss": 50000,
+    "trailing_atr_multiplier": 2.5
+  },
+  "htf_filter": {
+    "enabled": true,
+    "block_counter_trend": false,
+    "alignment_boost": 0.1
+  }
+}

--- a/backend/profiles/experiment_2026-04-22_sl12_tf60_40_tp20.json
+++ b/backend/profiles/experiment_2026-04-22_sl12_tf60_40_tp20.json
@@ -1,0 +1,55 @@
+{
+  "name": "experiment_2026-04-22_sl12_tf60_40_tp20",
+  "description": "healthy_v3 + SL=12 + trailing_atr=2.5 + trend_follow(buy_max=60, sell_min=40) + TP=20. Cycle30 winner refinement.",
+  "indicators": {
+    "sma_short": 20,
+    "sma_long": 50,
+    "rsi_period": 14,
+    "macd_fast": 12,
+    "macd_slow": 26,
+    "macd_signal": 9,
+    "bb_period": 20,
+    "bb_multiplier": 2.0,
+    "atr_period": 14
+  },
+  "stance_rules": {
+    "rsi_oversold": 32,
+    "rsi_overbought": 68,
+    "sma_convergence_threshold": 0.002,
+    "bb_squeeze_lookback": 5,
+    "breakout_volume_ratio": 1.5
+  },
+  "signal_rules": {
+    "trend_follow": {
+      "enabled": true,
+      "require_macd_confirm": false,
+      "require_ema_cross": true,
+      "rsi_buy_max": 60,
+      "rsi_sell_min": 40
+    },
+    "contrarian": {
+      "enabled": true,
+      "rsi_entry": 32,
+      "rsi_exit": 68,
+      "macd_histogram_limit": 10
+    },
+    "breakout": {
+      "enabled": true,
+      "volume_ratio_min": 1.5,
+      "require_macd_confirm": true
+    }
+  },
+  "strategy_risk": {
+    "stop_loss_percent": 12,
+    "take_profit_percent": 20,
+    "stop_loss_atr_multiplier": 0,
+    "max_position_amount": 100000,
+    "max_daily_loss": 50000,
+    "trailing_atr_multiplier": 2.5
+  },
+  "htf_filter": {
+    "enabled": true,
+    "block_counter_trend": false,
+    "alignment_boost": 0.1
+  }
+}

--- a/backend/profiles/experiment_2026-04-22_sl12_tf60_40_tp4.json
+++ b/backend/profiles/experiment_2026-04-22_sl12_tf60_40_tp4.json
@@ -1,0 +1,55 @@
+{
+  "name": "experiment_2026-04-22_sl12_tf60_40_tp4",
+  "description": "healthy_v3 + SL=12 + trailing_atr=2.5 + trend_follow(buy_max=60, sell_min=40) + TP=4. Cycle30 winner refinement.",
+  "indicators": {
+    "sma_short": 20,
+    "sma_long": 50,
+    "rsi_period": 14,
+    "macd_fast": 12,
+    "macd_slow": 26,
+    "macd_signal": 9,
+    "bb_period": 20,
+    "bb_multiplier": 2.0,
+    "atr_period": 14
+  },
+  "stance_rules": {
+    "rsi_oversold": 32,
+    "rsi_overbought": 68,
+    "sma_convergence_threshold": 0.002,
+    "bb_squeeze_lookback": 5,
+    "breakout_volume_ratio": 1.5
+  },
+  "signal_rules": {
+    "trend_follow": {
+      "enabled": true,
+      "require_macd_confirm": false,
+      "require_ema_cross": true,
+      "rsi_buy_max": 60,
+      "rsi_sell_min": 40
+    },
+    "contrarian": {
+      "enabled": true,
+      "rsi_entry": 32,
+      "rsi_exit": 68,
+      "macd_histogram_limit": 10
+    },
+    "breakout": {
+      "enabled": true,
+      "volume_ratio_min": 1.5,
+      "require_macd_confirm": true
+    }
+  },
+  "strategy_risk": {
+    "stop_loss_percent": 12,
+    "take_profit_percent": 4,
+    "stop_loss_atr_multiplier": 0,
+    "max_position_amount": 100000,
+    "max_daily_loss": 50000,
+    "trailing_atr_multiplier": 2.5
+  },
+  "htf_filter": {
+    "enabled": true,
+    "block_counter_trend": false,
+    "alignment_boost": 0.1
+  }
+}

--- a/backend/profiles/experiment_2026-04-22_sl12_tf60_40_tp8.json
+++ b/backend/profiles/experiment_2026-04-22_sl12_tf60_40_tp8.json
@@ -1,0 +1,55 @@
+{
+  "name": "experiment_2026-04-22_sl12_tf60_40_tp8",
+  "description": "healthy_v3 + SL=12 + trailing_atr=2.5 + trend_follow(buy_max=60, sell_min=40) + TP=8. Cycle30 winner refinement.",
+  "indicators": {
+    "sma_short": 20,
+    "sma_long": 50,
+    "rsi_period": 14,
+    "macd_fast": 12,
+    "macd_slow": 26,
+    "macd_signal": 9,
+    "bb_period": 20,
+    "bb_multiplier": 2.0,
+    "atr_period": 14
+  },
+  "stance_rules": {
+    "rsi_oversold": 32,
+    "rsi_overbought": 68,
+    "sma_convergence_threshold": 0.002,
+    "bb_squeeze_lookback": 5,
+    "breakout_volume_ratio": 1.5
+  },
+  "signal_rules": {
+    "trend_follow": {
+      "enabled": true,
+      "require_macd_confirm": false,
+      "require_ema_cross": true,
+      "rsi_buy_max": 60,
+      "rsi_sell_min": 40
+    },
+    "contrarian": {
+      "enabled": true,
+      "rsi_entry": 32,
+      "rsi_exit": 68,
+      "macd_histogram_limit": 10
+    },
+    "breakout": {
+      "enabled": true,
+      "volume_ratio_min": 1.5,
+      "require_macd_confirm": true
+    }
+  },
+  "strategy_risk": {
+    "stop_loss_percent": 12,
+    "take_profit_percent": 8,
+    "stop_loss_atr_multiplier": 0,
+    "max_position_amount": 100000,
+    "max_daily_loss": 50000,
+    "trailing_atr_multiplier": 2.5
+  },
+  "htf_filter": {
+    "enabled": true,
+    "block_counter_trend": false,
+    "alignment_boost": 0.1
+  }
+}

--- a/backend/profiles/experiment_2026-04-22_sl12_tfbuy65.json
+++ b/backend/profiles/experiment_2026-04-22_sl12_tfbuy65.json
@@ -1,0 +1,55 @@
+{
+  "name": "experiment_2026-04-22_sl12_tfbuy65",
+  "description": "SL=12 + trailing_atr=2.5 + trend_follow rsi_buy_max=65 (wider entry).",
+  "indicators": {
+    "sma_short": 20,
+    "sma_long": 50,
+    "rsi_period": 14,
+    "macd_fast": 12,
+    "macd_slow": 26,
+    "macd_signal": 9,
+    "bb_period": 20,
+    "bb_multiplier": 2.0,
+    "atr_period": 14
+  },
+  "stance_rules": {
+    "rsi_oversold": 32,
+    "rsi_overbought": 68,
+    "sma_convergence_threshold": 0.002,
+    "bb_squeeze_lookback": 5,
+    "breakout_volume_ratio": 1.5
+  },
+  "signal_rules": {
+    "trend_follow": {
+      "enabled": true,
+      "require_macd_confirm": false,
+      "require_ema_cross": true,
+      "rsi_buy_max": 65,
+      "rsi_sell_min": 35
+    },
+    "contrarian": {
+      "enabled": true,
+      "rsi_entry": 32,
+      "rsi_exit": 68,
+      "macd_histogram_limit": 10
+    },
+    "breakout": {
+      "enabled": true,
+      "volume_ratio_min": 1.5,
+      "require_macd_confirm": true
+    }
+  },
+  "strategy_risk": {
+    "stop_loss_percent": 12,
+    "take_profit_percent": 4,
+    "stop_loss_atr_multiplier": 0,
+    "max_position_amount": 100000,
+    "max_daily_loss": 50000,
+    "trailing_atr_multiplier": 2.5
+  },
+  "htf_filter": {
+    "enabled": true,
+    "block_counter_trend": false,
+    "alignment_boost": 0.1
+  }
+}

--- a/backend/profiles/experiment_2026-04-22_sl12_tr20_tf60_35.json
+++ b/backend/profiles/experiment_2026-04-22_sl12_tr20_tf60_35.json
@@ -1,0 +1,55 @@
+{
+  "name": "experiment_2026-04-22_sl12_tr20_tf60_35",
+  "description": "narrow sweep around winner: SL=12 TR=2.0 around sl12_tf60_35_tp4",
+  "indicators": {
+    "sma_short": 20,
+    "sma_long": 50,
+    "rsi_period": 14,
+    "macd_fast": 12,
+    "macd_slow": 26,
+    "macd_signal": 9,
+    "bb_period": 20,
+    "bb_multiplier": 2.0,
+    "atr_period": 14
+  },
+  "stance_rules": {
+    "rsi_oversold": 32,
+    "rsi_overbought": 68,
+    "sma_convergence_threshold": 0.002,
+    "bb_squeeze_lookback": 5,
+    "breakout_volume_ratio": 1.5
+  },
+  "signal_rules": {
+    "trend_follow": {
+      "enabled": true,
+      "require_macd_confirm": false,
+      "require_ema_cross": true,
+      "rsi_buy_max": 60,
+      "rsi_sell_min": 35
+    },
+    "contrarian": {
+      "enabled": true,
+      "rsi_entry": 32,
+      "rsi_exit": 68,
+      "macd_histogram_limit": 10
+    },
+    "breakout": {
+      "enabled": true,
+      "volume_ratio_min": 1.5,
+      "require_macd_confirm": true
+    }
+  },
+  "strategy_risk": {
+    "stop_loss_percent": 12,
+    "take_profit_percent": 4,
+    "stop_loss_atr_multiplier": 0,
+    "max_position_amount": 100000,
+    "max_daily_loss": 50000,
+    "trailing_atr_multiplier": 2.0
+  },
+  "htf_filter": {
+    "enabled": true,
+    "block_counter_trend": false,
+    "alignment_boost": 0.1
+  }
+}

--- a/backend/profiles/experiment_2026-04-22_sl12_tr30_tf60_35.json
+++ b/backend/profiles/experiment_2026-04-22_sl12_tr30_tf60_35.json
@@ -1,0 +1,55 @@
+{
+  "name": "experiment_2026-04-22_sl12_tr30_tf60_35",
+  "description": "narrow sweep around winner: SL=12 TR=3.0 around sl12_tf60_35_tp4",
+  "indicators": {
+    "sma_short": 20,
+    "sma_long": 50,
+    "rsi_period": 14,
+    "macd_fast": 12,
+    "macd_slow": 26,
+    "macd_signal": 9,
+    "bb_period": 20,
+    "bb_multiplier": 2.0,
+    "atr_period": 14
+  },
+  "stance_rules": {
+    "rsi_oversold": 32,
+    "rsi_overbought": 68,
+    "sma_convergence_threshold": 0.002,
+    "bb_squeeze_lookback": 5,
+    "breakout_volume_ratio": 1.5
+  },
+  "signal_rules": {
+    "trend_follow": {
+      "enabled": true,
+      "require_macd_confirm": false,
+      "require_ema_cross": true,
+      "rsi_buy_max": 60,
+      "rsi_sell_min": 35
+    },
+    "contrarian": {
+      "enabled": true,
+      "rsi_entry": 32,
+      "rsi_exit": 68,
+      "macd_histogram_limit": 10
+    },
+    "breakout": {
+      "enabled": true,
+      "volume_ratio_min": 1.5,
+      "require_macd_confirm": true
+    }
+  },
+  "strategy_risk": {
+    "stop_loss_percent": 12,
+    "take_profit_percent": 4,
+    "stop_loss_atr_multiplier": 0,
+    "max_position_amount": 100000,
+    "max_daily_loss": 50000,
+    "trailing_atr_multiplier": 3.0
+  },
+  "htf_filter": {
+    "enabled": true,
+    "block_counter_trend": false,
+    "alignment_boost": 0.1
+  }
+}

--- a/backend/profiles/experiment_2026-04-22_sl13_tf60_35.json
+++ b/backend/profiles/experiment_2026-04-22_sl13_tf60_35.json
@@ -1,0 +1,55 @@
+{
+  "name": "experiment_2026-04-22_sl13_tf60_35",
+  "description": "SL grid finetune around sl15 winner.",
+  "indicators": {
+    "sma_short": 20,
+    "sma_long": 50,
+    "rsi_period": 14,
+    "macd_fast": 12,
+    "macd_slow": 26,
+    "macd_signal": 9,
+    "bb_period": 20,
+    "bb_multiplier": 2.0,
+    "atr_period": 14
+  },
+  "stance_rules": {
+    "rsi_oversold": 32,
+    "rsi_overbought": 68,
+    "sma_convergence_threshold": 0.002,
+    "bb_squeeze_lookback": 5,
+    "breakout_volume_ratio": 1.5
+  },
+  "signal_rules": {
+    "trend_follow": {
+      "enabled": true,
+      "require_macd_confirm": false,
+      "require_ema_cross": true,
+      "rsi_buy_max": 60,
+      "rsi_sell_min": 35
+    },
+    "contrarian": {
+      "enabled": true,
+      "rsi_entry": 32,
+      "rsi_exit": 68,
+      "macd_histogram_limit": 10
+    },
+    "breakout": {
+      "enabled": true,
+      "volume_ratio_min": 1.5,
+      "require_macd_confirm": true
+    }
+  },
+  "strategy_risk": {
+    "stop_loss_percent": 13,
+    "take_profit_percent": 4,
+    "stop_loss_atr_multiplier": 0,
+    "max_position_amount": 100000,
+    "max_daily_loss": 50000,
+    "trailing_atr_multiplier": 2.5
+  },
+  "htf_filter": {
+    "enabled": true,
+    "block_counter_trend": false,
+    "alignment_boost": 0.1
+  }
+}

--- a/backend/profiles/experiment_2026-04-22_sl14_slatr20.json
+++ b/backend/profiles/experiment_2026-04-22_sl14_slatr20.json
@@ -1,0 +1,55 @@
+{
+  "name": "experiment_2026-04-22_sl14_slatr20",
+  "description": "sl14_tf60_35 + stop_loss_atr_multiplier=2.0. Take the deeper of %SL and ATR-based SL so low-vol regimes don't over-trigger and high-vol (2022) gets wider exit.",
+  "indicators": {
+    "sma_short": 20,
+    "sma_long": 50,
+    "rsi_period": 14,
+    "macd_fast": 12,
+    "macd_slow": 26,
+    "macd_signal": 9,
+    "bb_period": 20,
+    "bb_multiplier": 2.0,
+    "atr_period": 14
+  },
+  "stance_rules": {
+    "rsi_oversold": 32,
+    "rsi_overbought": 68,
+    "sma_convergence_threshold": 0.002,
+    "bb_squeeze_lookback": 5,
+    "breakout_volume_ratio": 1.5
+  },
+  "signal_rules": {
+    "trend_follow": {
+      "enabled": true,
+      "require_macd_confirm": false,
+      "require_ema_cross": true,
+      "rsi_buy_max": 60,
+      "rsi_sell_min": 35
+    },
+    "contrarian": {
+      "enabled": true,
+      "rsi_entry": 32,
+      "rsi_exit": 68,
+      "macd_histogram_limit": 10
+    },
+    "breakout": {
+      "enabled": true,
+      "volume_ratio_min": 1.5,
+      "require_macd_confirm": true
+    }
+  },
+  "strategy_risk": {
+    "stop_loss_percent": 14,
+    "take_profit_percent": 4,
+    "stop_loss_atr_multiplier": 2.0,
+    "max_position_amount": 100000,
+    "max_daily_loss": 50000,
+    "trailing_atr_multiplier": 2.5
+  },
+  "htf_filter": {
+    "enabled": true,
+    "block_counter_trend": false,
+    "alignment_boost": 0.1
+  }
+}

--- a/backend/profiles/experiment_2026-04-22_sl14_slatr30.json
+++ b/backend/profiles/experiment_2026-04-22_sl14_slatr30.json
@@ -1,0 +1,55 @@
+{
+  "name": "experiment_2026-04-22_sl14_slatr30",
+  "description": "sl14_tf60_35 + stop_loss_atr_multiplier=3.0. Take the deeper of %SL and ATR-based SL so low-vol regimes don't over-trigger and high-vol (2022) gets wider exit.",
+  "indicators": {
+    "sma_short": 20,
+    "sma_long": 50,
+    "rsi_period": 14,
+    "macd_fast": 12,
+    "macd_slow": 26,
+    "macd_signal": 9,
+    "bb_period": 20,
+    "bb_multiplier": 2.0,
+    "atr_period": 14
+  },
+  "stance_rules": {
+    "rsi_oversold": 32,
+    "rsi_overbought": 68,
+    "sma_convergence_threshold": 0.002,
+    "bb_squeeze_lookback": 5,
+    "breakout_volume_ratio": 1.5
+  },
+  "signal_rules": {
+    "trend_follow": {
+      "enabled": true,
+      "require_macd_confirm": false,
+      "require_ema_cross": true,
+      "rsi_buy_max": 60,
+      "rsi_sell_min": 35
+    },
+    "contrarian": {
+      "enabled": true,
+      "rsi_entry": 32,
+      "rsi_exit": 68,
+      "macd_histogram_limit": 10
+    },
+    "breakout": {
+      "enabled": true,
+      "volume_ratio_min": 1.5,
+      "require_macd_confirm": true
+    }
+  },
+  "strategy_risk": {
+    "stop_loss_percent": 14,
+    "take_profit_percent": 4,
+    "stop_loss_atr_multiplier": 3.0,
+    "max_position_amount": 100000,
+    "max_daily_loss": 50000,
+    "trailing_atr_multiplier": 2.5
+  },
+  "htf_filter": {
+    "enabled": true,
+    "block_counter_trend": false,
+    "alignment_boost": 0.1
+  }
+}

--- a/backend/profiles/experiment_2026-04-22_sl14_slatr40.json
+++ b/backend/profiles/experiment_2026-04-22_sl14_slatr40.json
@@ -1,0 +1,55 @@
+{
+  "name": "experiment_2026-04-22_sl14_slatr40",
+  "description": "sl14_tf60_35 + stop_loss_atr_multiplier=4.0. Take the deeper of %SL and ATR-based SL so low-vol regimes don't over-trigger and high-vol (2022) gets wider exit.",
+  "indicators": {
+    "sma_short": 20,
+    "sma_long": 50,
+    "rsi_period": 14,
+    "macd_fast": 12,
+    "macd_slow": 26,
+    "macd_signal": 9,
+    "bb_period": 20,
+    "bb_multiplier": 2.0,
+    "atr_period": 14
+  },
+  "stance_rules": {
+    "rsi_oversold": 32,
+    "rsi_overbought": 68,
+    "sma_convergence_threshold": 0.002,
+    "bb_squeeze_lookback": 5,
+    "breakout_volume_ratio": 1.5
+  },
+  "signal_rules": {
+    "trend_follow": {
+      "enabled": true,
+      "require_macd_confirm": false,
+      "require_ema_cross": true,
+      "rsi_buy_max": 60,
+      "rsi_sell_min": 35
+    },
+    "contrarian": {
+      "enabled": true,
+      "rsi_entry": 32,
+      "rsi_exit": 68,
+      "macd_histogram_limit": 10
+    },
+    "breakout": {
+      "enabled": true,
+      "volume_ratio_min": 1.5,
+      "require_macd_confirm": true
+    }
+  },
+  "strategy_risk": {
+    "stop_loss_percent": 14,
+    "take_profit_percent": 4,
+    "stop_loss_atr_multiplier": 4.0,
+    "max_position_amount": 100000,
+    "max_daily_loss": 50000,
+    "trailing_atr_multiplier": 2.5
+  },
+  "htf_filter": {
+    "enabled": true,
+    "block_counter_trend": false,
+    "alignment_boost": 0.1
+  }
+}

--- a/backend/profiles/experiment_2026-04-22_sl14_tf60_35.json
+++ b/backend/profiles/experiment_2026-04-22_sl14_tf60_35.json
@@ -1,0 +1,55 @@
+{
+  "name": "experiment_2026-04-22_sl14_tf60_35",
+  "description": "SL grid finetune around sl15 winner.",
+  "indicators": {
+    "sma_short": 20,
+    "sma_long": 50,
+    "rsi_period": 14,
+    "macd_fast": 12,
+    "macd_slow": 26,
+    "macd_signal": 9,
+    "bb_period": 20,
+    "bb_multiplier": 2.0,
+    "atr_period": 14
+  },
+  "stance_rules": {
+    "rsi_oversold": 32,
+    "rsi_overbought": 68,
+    "sma_convergence_threshold": 0.002,
+    "bb_squeeze_lookback": 5,
+    "breakout_volume_ratio": 1.5
+  },
+  "signal_rules": {
+    "trend_follow": {
+      "enabled": true,
+      "require_macd_confirm": false,
+      "require_ema_cross": true,
+      "rsi_buy_max": 60,
+      "rsi_sell_min": 35
+    },
+    "contrarian": {
+      "enabled": true,
+      "rsi_entry": 32,
+      "rsi_exit": 68,
+      "macd_histogram_limit": 10
+    },
+    "breakout": {
+      "enabled": true,
+      "volume_ratio_min": 1.5,
+      "require_macd_confirm": true
+    }
+  },
+  "strategy_risk": {
+    "stop_loss_percent": 14,
+    "take_profit_percent": 4,
+    "stop_loss_atr_multiplier": 0,
+    "max_position_amount": 100000,
+    "max_daily_loss": 50000,
+    "trailing_atr_multiplier": 2.5
+  },
+  "htf_filter": {
+    "enabled": true,
+    "block_counter_trend": false,
+    "alignment_boost": 0.1
+  }
+}

--- a/backend/profiles/experiment_2026-04-22_sl14_tf60_35_htfblock.json
+++ b/backend/profiles/experiment_2026-04-22_sl14_tf60_35_htfblock.json
@@ -1,0 +1,55 @@
+{
+  "name": "experiment_2026-04-22_sl14_tf60_35_htfblock",
+  "description": "sl14_tf60_35 with htf_filter.block_counter_trend=true, to make htf_filter.mode actually affect trading so the Ichimoku grid can discriminate.",
+  "indicators": {
+    "sma_short": 20,
+    "sma_long": 50,
+    "rsi_period": 14,
+    "macd_fast": 12,
+    "macd_slow": 26,
+    "macd_signal": 9,
+    "bb_period": 20,
+    "bb_multiplier": 2.0,
+    "atr_period": 14
+  },
+  "stance_rules": {
+    "rsi_oversold": 32,
+    "rsi_overbought": 68,
+    "sma_convergence_threshold": 0.002,
+    "bb_squeeze_lookback": 5,
+    "breakout_volume_ratio": 1.5
+  },
+  "signal_rules": {
+    "trend_follow": {
+      "enabled": true,
+      "require_macd_confirm": false,
+      "require_ema_cross": true,
+      "rsi_buy_max": 60,
+      "rsi_sell_min": 35
+    },
+    "contrarian": {
+      "enabled": true,
+      "rsi_entry": 32,
+      "rsi_exit": 68,
+      "macd_histogram_limit": 10
+    },
+    "breakout": {
+      "enabled": true,
+      "volume_ratio_min": 1.5,
+      "require_macd_confirm": true
+    }
+  },
+  "strategy_risk": {
+    "stop_loss_percent": 14,
+    "take_profit_percent": 4,
+    "stop_loss_atr_multiplier": 0,
+    "max_position_amount": 100000,
+    "max_daily_loss": 50000,
+    "trailing_atr_multiplier": 2.5
+  },
+  "htf_filter": {
+    "enabled": true,
+    "block_counter_trend": true,
+    "alignment_boost": 0.1
+  }
+}

--- a/backend/profiles/experiment_2026-04-22_sl14_tf60_35_htfblock_ema.json
+++ b/backend/profiles/experiment_2026-04-22_sl14_tf60_35_htfblock_ema.json
@@ -1,0 +1,56 @@
+{
+  "name": "experiment_2026-04-22_sl14_tf60_35_htfblock_ema",
+  "description": "sl14_tf60_35 with htf_filter.block_counter_trend=true, to make htf_filter.mode actually affect trading so the Ichimoku grid can discriminate.",
+  "indicators": {
+    "sma_short": 20,
+    "sma_long": 50,
+    "rsi_period": 14,
+    "macd_fast": 12,
+    "macd_slow": 26,
+    "macd_signal": 9,
+    "bb_period": 20,
+    "bb_multiplier": 2.0,
+    "atr_period": 14
+  },
+  "stance_rules": {
+    "rsi_oversold": 32,
+    "rsi_overbought": 68,
+    "sma_convergence_threshold": 0.002,
+    "bb_squeeze_lookback": 5,
+    "breakout_volume_ratio": 1.5
+  },
+  "signal_rules": {
+    "trend_follow": {
+      "enabled": true,
+      "require_macd_confirm": false,
+      "require_ema_cross": true,
+      "rsi_buy_max": 60,
+      "rsi_sell_min": 35
+    },
+    "contrarian": {
+      "enabled": true,
+      "rsi_entry": 32,
+      "rsi_exit": 68,
+      "macd_histogram_limit": 10
+    },
+    "breakout": {
+      "enabled": true,
+      "volume_ratio_min": 1.5,
+      "require_macd_confirm": true
+    }
+  },
+  "strategy_risk": {
+    "stop_loss_percent": 14,
+    "take_profit_percent": 4,
+    "stop_loss_atr_multiplier": 0,
+    "max_position_amount": 100000,
+    "max_daily_loss": 50000,
+    "trailing_atr_multiplier": 2.5
+  },
+  "htf_filter": {
+    "enabled": true,
+    "block_counter_trend": true,
+    "alignment_boost": 0.1,
+    "mode": "ema"
+  }
+}

--- a/backend/profiles/experiment_2026-04-22_sl14_tf60_35_htfblock_ichimoku.json
+++ b/backend/profiles/experiment_2026-04-22_sl14_tf60_35_htfblock_ichimoku.json
@@ -1,0 +1,56 @@
+{
+  "name": "experiment_2026-04-22_sl14_tf60_35_htfblock_ichimoku",
+  "description": "sl14_tf60_35 with htf_filter.block_counter_trend=true, to make htf_filter.mode actually affect trading so the Ichimoku grid can discriminate.",
+  "indicators": {
+    "sma_short": 20,
+    "sma_long": 50,
+    "rsi_period": 14,
+    "macd_fast": 12,
+    "macd_slow": 26,
+    "macd_signal": 9,
+    "bb_period": 20,
+    "bb_multiplier": 2.0,
+    "atr_period": 14
+  },
+  "stance_rules": {
+    "rsi_oversold": 32,
+    "rsi_overbought": 68,
+    "sma_convergence_threshold": 0.002,
+    "bb_squeeze_lookback": 5,
+    "breakout_volume_ratio": 1.5
+  },
+  "signal_rules": {
+    "trend_follow": {
+      "enabled": true,
+      "require_macd_confirm": false,
+      "require_ema_cross": true,
+      "rsi_buy_max": 60,
+      "rsi_sell_min": 35
+    },
+    "contrarian": {
+      "enabled": true,
+      "rsi_entry": 32,
+      "rsi_exit": 68,
+      "macd_histogram_limit": 10
+    },
+    "breakout": {
+      "enabled": true,
+      "volume_ratio_min": 1.5,
+      "require_macd_confirm": true
+    }
+  },
+  "strategy_risk": {
+    "stop_loss_percent": 14,
+    "take_profit_percent": 4,
+    "stop_loss_atr_multiplier": 0,
+    "max_position_amount": 100000,
+    "max_daily_loss": 50000,
+    "trailing_atr_multiplier": 2.5
+  },
+  "htf_filter": {
+    "enabled": true,
+    "block_counter_trend": true,
+    "alignment_boost": 0.1,
+    "mode": "ichimoku"
+  }
+}

--- a/backend/profiles/experiment_2026-04-22_sl14_tf60_40.json
+++ b/backend/profiles/experiment_2026-04-22_sl14_tf60_40.json
@@ -1,0 +1,55 @@
+{
+  "name": "experiment_2026-04-22_sl14_tf60_40",
+  "description": "FINAL v5 candidate: healthy_v3 base + SL=14 + trailing_atr=2.5 + trend_follow(buy_max=60, sell_min=40). WFO cycle34 sell_min=40 is IS winner in 2/3 windows (robust choice).",
+  "indicators": {
+    "sma_short": 20,
+    "sma_long": 50,
+    "rsi_period": 14,
+    "macd_fast": 12,
+    "macd_slow": 26,
+    "macd_signal": 9,
+    "bb_period": 20,
+    "bb_multiplier": 2.0,
+    "atr_period": 14
+  },
+  "stance_rules": {
+    "rsi_oversold": 32,
+    "rsi_overbought": 68,
+    "sma_convergence_threshold": 0.002,
+    "bb_squeeze_lookback": 5,
+    "breakout_volume_ratio": 1.5
+  },
+  "signal_rules": {
+    "trend_follow": {
+      "enabled": true,
+      "require_macd_confirm": false,
+      "require_ema_cross": true,
+      "rsi_buy_max": 60,
+      "rsi_sell_min": 40
+    },
+    "contrarian": {
+      "enabled": true,
+      "rsi_entry": 32,
+      "rsi_exit": 68,
+      "macd_histogram_limit": 10
+    },
+    "breakout": {
+      "enabled": true,
+      "volume_ratio_min": 1.5,
+      "require_macd_confirm": true
+    }
+  },
+  "strategy_risk": {
+    "stop_loss_percent": 14,
+    "take_profit_percent": 4,
+    "stop_loss_atr_multiplier": 0,
+    "max_position_amount": 100000,
+    "max_daily_loss": 50000,
+    "trailing_atr_multiplier": 2.5
+  },
+  "htf_filter": {
+    "enabled": true,
+    "block_counter_trend": false,
+    "alignment_boost": 0.1
+  }
+}

--- a/backend/profiles/experiment_2026-04-22_sl15_tf60_35.json
+++ b/backend/profiles/experiment_2026-04-22_sl15_tf60_35.json
@@ -1,0 +1,55 @@
+{
+  "name": "experiment_2026-04-22_sl15_tf60_35",
+  "description": "narrow sweep around winner: SL=15 TR=2.5 around sl12_tf60_35_tp4",
+  "indicators": {
+    "sma_short": 20,
+    "sma_long": 50,
+    "rsi_period": 14,
+    "macd_fast": 12,
+    "macd_slow": 26,
+    "macd_signal": 9,
+    "bb_period": 20,
+    "bb_multiplier": 2.0,
+    "atr_period": 14
+  },
+  "stance_rules": {
+    "rsi_oversold": 32,
+    "rsi_overbought": 68,
+    "sma_convergence_threshold": 0.002,
+    "bb_squeeze_lookback": 5,
+    "breakout_volume_ratio": 1.5
+  },
+  "signal_rules": {
+    "trend_follow": {
+      "enabled": true,
+      "require_macd_confirm": false,
+      "require_ema_cross": true,
+      "rsi_buy_max": 60,
+      "rsi_sell_min": 35
+    },
+    "contrarian": {
+      "enabled": true,
+      "rsi_entry": 32,
+      "rsi_exit": 68,
+      "macd_histogram_limit": 10
+    },
+    "breakout": {
+      "enabled": true,
+      "volume_ratio_min": 1.5,
+      "require_macd_confirm": true
+    }
+  },
+  "strategy_risk": {
+    "stop_loss_percent": 15,
+    "take_profit_percent": 4,
+    "stop_loss_atr_multiplier": 0,
+    "max_position_amount": 100000,
+    "max_daily_loss": 50000,
+    "trailing_atr_multiplier": 2.5
+  },
+  "htf_filter": {
+    "enabled": true,
+    "block_counter_trend": false,
+    "alignment_boost": 0.1
+  }
+}

--- a/backend/profiles/experiment_2026-04-22_sl16_tf60_35.json
+++ b/backend/profiles/experiment_2026-04-22_sl16_tf60_35.json
@@ -1,0 +1,55 @@
+{
+  "name": "experiment_2026-04-22_sl16_tf60_35",
+  "description": "SL grid finetune around sl15 winner.",
+  "indicators": {
+    "sma_short": 20,
+    "sma_long": 50,
+    "rsi_period": 14,
+    "macd_fast": 12,
+    "macd_slow": 26,
+    "macd_signal": 9,
+    "bb_period": 20,
+    "bb_multiplier": 2.0,
+    "atr_period": 14
+  },
+  "stance_rules": {
+    "rsi_oversold": 32,
+    "rsi_overbought": 68,
+    "sma_convergence_threshold": 0.002,
+    "bb_squeeze_lookback": 5,
+    "breakout_volume_ratio": 1.5
+  },
+  "signal_rules": {
+    "trend_follow": {
+      "enabled": true,
+      "require_macd_confirm": false,
+      "require_ema_cross": true,
+      "rsi_buy_max": 60,
+      "rsi_sell_min": 35
+    },
+    "contrarian": {
+      "enabled": true,
+      "rsi_entry": 32,
+      "rsi_exit": 68,
+      "macd_histogram_limit": 10
+    },
+    "breakout": {
+      "enabled": true,
+      "volume_ratio_min": 1.5,
+      "require_macd_confirm": true
+    }
+  },
+  "strategy_risk": {
+    "stop_loss_percent": 16,
+    "take_profit_percent": 4,
+    "stop_loss_atr_multiplier": 0,
+    "max_position_amount": 100000,
+    "max_daily_loss": 50000,
+    "trailing_atr_multiplier": 2.5
+  },
+  "htf_filter": {
+    "enabled": true,
+    "block_counter_trend": false,
+    "alignment_boost": 0.1
+  }
+}

--- a/backend/profiles/experiment_2026-04-22_sl17_tf60_35.json
+++ b/backend/profiles/experiment_2026-04-22_sl17_tf60_35.json
@@ -1,0 +1,55 @@
+{
+  "name": "experiment_2026-04-22_sl17_tf60_35",
+  "description": "SL grid finetune around sl15 winner.",
+  "indicators": {
+    "sma_short": 20,
+    "sma_long": 50,
+    "rsi_period": 14,
+    "macd_fast": 12,
+    "macd_slow": 26,
+    "macd_signal": 9,
+    "bb_period": 20,
+    "bb_multiplier": 2.0,
+    "atr_period": 14
+  },
+  "stance_rules": {
+    "rsi_oversold": 32,
+    "rsi_overbought": 68,
+    "sma_convergence_threshold": 0.002,
+    "bb_squeeze_lookback": 5,
+    "breakout_volume_ratio": 1.5
+  },
+  "signal_rules": {
+    "trend_follow": {
+      "enabled": true,
+      "require_macd_confirm": false,
+      "require_ema_cross": true,
+      "rsi_buy_max": 60,
+      "rsi_sell_min": 35
+    },
+    "contrarian": {
+      "enabled": true,
+      "rsi_entry": 32,
+      "rsi_exit": 68,
+      "macd_histogram_limit": 10
+    },
+    "breakout": {
+      "enabled": true,
+      "volume_ratio_min": 1.5,
+      "require_macd_confirm": true
+    }
+  },
+  "strategy_risk": {
+    "stop_loss_percent": 17,
+    "take_profit_percent": 4,
+    "stop_loss_atr_multiplier": 0,
+    "max_position_amount": 100000,
+    "max_daily_loss": 50000,
+    "trailing_atr_multiplier": 2.5
+  },
+  "htf_filter": {
+    "enabled": true,
+    "block_counter_trend": false,
+    "alignment_boost": 0.1
+  }
+}

--- a/backend/profiles/experiment_2026-04-22_sl18_tf60_35.json
+++ b/backend/profiles/experiment_2026-04-22_sl18_tf60_35.json
@@ -1,0 +1,55 @@
+{
+  "name": "experiment_2026-04-22_sl18_tf60_35",
+  "description": "SL grid finetune around sl15 winner.",
+  "indicators": {
+    "sma_short": 20,
+    "sma_long": 50,
+    "rsi_period": 14,
+    "macd_fast": 12,
+    "macd_slow": 26,
+    "macd_signal": 9,
+    "bb_period": 20,
+    "bb_multiplier": 2.0,
+    "atr_period": 14
+  },
+  "stance_rules": {
+    "rsi_oversold": 32,
+    "rsi_overbought": 68,
+    "sma_convergence_threshold": 0.002,
+    "bb_squeeze_lookback": 5,
+    "breakout_volume_ratio": 1.5
+  },
+  "signal_rules": {
+    "trend_follow": {
+      "enabled": true,
+      "require_macd_confirm": false,
+      "require_ema_cross": true,
+      "rsi_buy_max": 60,
+      "rsi_sell_min": 35
+    },
+    "contrarian": {
+      "enabled": true,
+      "rsi_entry": 32,
+      "rsi_exit": 68,
+      "macd_histogram_limit": 10
+    },
+    "breakout": {
+      "enabled": true,
+      "volume_ratio_min": 1.5,
+      "require_macd_confirm": true
+    }
+  },
+  "strategy_risk": {
+    "stop_loss_percent": 18,
+    "take_profit_percent": 4,
+    "stop_loss_atr_multiplier": 0,
+    "max_position_amount": 100000,
+    "max_daily_loss": 50000,
+    "trailing_atr_multiplier": 2.5
+  },
+  "htf_filter": {
+    "enabled": true,
+    "block_counter_trend": false,
+    "alignment_boost": 0.1
+  }
+}

--- a/backend/profiles/experiment_2026-04-22_sl4_only.json
+++ b/backend/profiles/experiment_2026-04-22_sl4_only.json
@@ -1,0 +1,58 @@
+{
+  "name": "experiment_2026-04-22_sl4_only",
+  "description": "cycle24 SL=4 alone (TP=v4b 4). 3/4 window IS winner.",
+  "indicators": {
+    "sma_short": 20,
+    "sma_long": 50,
+    "rsi_period": 14,
+    "macd_fast": 12,
+    "macd_slow": 26,
+    "macd_signal": 9,
+    "bb_period": 20,
+    "bb_multiplier": 2.0,
+    "atr_period": 14
+  },
+  "stance_rules": {
+    "rsi_oversold": 25,
+    "rsi_overbought": 75,
+    "sma_convergence_threshold": 0.001,
+    "bb_squeeze_lookback": 5,
+    "breakout_volume_ratio": 1.5
+  },
+  "signal_rules": {
+    "trend_follow": {
+      "enabled": true,
+      "require_macd_confirm": true,
+      "require_ema_cross": true,
+      "rsi_buy_max": 60,
+      "rsi_sell_min": 40,
+      "adx_min": 28
+    },
+    "contrarian": {
+      "enabled": true,
+      "rsi_entry": 30,
+      "rsi_exit": 70,
+      "macd_histogram_limit": 10,
+      "adx_max": 0
+    },
+    "breakout": {
+      "enabled": true,
+      "volume_ratio_min": 1.5,
+      "require_macd_confirm": true,
+      "adx_min": 0
+    }
+  },
+  "strategy_risk": {
+    "stop_loss_percent": 4,
+    "take_profit_percent": 4,
+    "stop_loss_atr_multiplier": 0,
+    "trailing_atr_multiplier": 0,
+    "max_position_amount": 100000,
+    "max_daily_loss": 50000
+  },
+  "htf_filter": {
+    "enabled": true,
+    "block_counter_trend": true,
+    "alignment_boost": 0.1
+  }
+}

--- a/backend/profiles/experiment_2026-04-22_sl4_tp5.json
+++ b/backend/profiles/experiment_2026-04-22_sl4_tp5.json
@@ -1,0 +1,58 @@
+{
+  "name": "experiment_2026-04-22_sl4_tp5",
+  "description": "cycle24: SL grid picked SL=4 in 3/4 windows on 3yr LTC WFO; cycle25: TP grid picked TP=5 in 2/4 windows. Combined candidate.",
+  "indicators": {
+    "sma_short": 20,
+    "sma_long": 50,
+    "rsi_period": 14,
+    "macd_fast": 12,
+    "macd_slow": 26,
+    "macd_signal": 9,
+    "bb_period": 20,
+    "bb_multiplier": 2.0,
+    "atr_period": 14
+  },
+  "stance_rules": {
+    "rsi_oversold": 25,
+    "rsi_overbought": 75,
+    "sma_convergence_threshold": 0.001,
+    "bb_squeeze_lookback": 5,
+    "breakout_volume_ratio": 1.5
+  },
+  "signal_rules": {
+    "trend_follow": {
+      "enabled": true,
+      "require_macd_confirm": true,
+      "require_ema_cross": true,
+      "rsi_buy_max": 60,
+      "rsi_sell_min": 40,
+      "adx_min": 28
+    },
+    "contrarian": {
+      "enabled": true,
+      "rsi_entry": 30,
+      "rsi_exit": 70,
+      "macd_histogram_limit": 10,
+      "adx_max": 0
+    },
+    "breakout": {
+      "enabled": true,
+      "volume_ratio_min": 1.5,
+      "require_macd_confirm": true,
+      "adx_min": 0
+    }
+  },
+  "strategy_risk": {
+    "stop_loss_percent": 4,
+    "take_profit_percent": 5,
+    "stop_loss_atr_multiplier": 0,
+    "trailing_atr_multiplier": 0,
+    "max_position_amount": 100000,
+    "max_daily_loss": 50000
+  },
+  "htf_filter": {
+    "enabled": true,
+    "block_counter_trend": true,
+    "alignment_boost": 0.1
+  }
+}

--- a/backend/profiles/experiment_2026-04-22_sl6_tr20_tp6_tf60_35.json
+++ b/backend/profiles/experiment_2026-04-22_sl6_tr20_tp6_tf60_35.json
@@ -1,0 +1,55 @@
+{
+  "name": "experiment_2026-04-22_sl6_tr20_tp6_tf60_35",
+  "description": "sl6 + tr2.0 + tp6. Widen TP so trailing can fire.",
+  "indicators": {
+    "sma_short": 20,
+    "sma_long": 50,
+    "rsi_period": 14,
+    "macd_fast": 12,
+    "macd_slow": 26,
+    "macd_signal": 9,
+    "bb_period": 20,
+    "bb_multiplier": 2.0,
+    "atr_period": 14
+  },
+  "stance_rules": {
+    "rsi_oversold": 32,
+    "rsi_overbought": 68,
+    "sma_convergence_threshold": 0.002,
+    "bb_squeeze_lookback": 5,
+    "breakout_volume_ratio": 1.5
+  },
+  "signal_rules": {
+    "trend_follow": {
+      "enabled": true,
+      "require_macd_confirm": false,
+      "require_ema_cross": true,
+      "rsi_buy_max": 60,
+      "rsi_sell_min": 35
+    },
+    "contrarian": {
+      "enabled": true,
+      "rsi_entry": 32,
+      "rsi_exit": 68,
+      "macd_histogram_limit": 10
+    },
+    "breakout": {
+      "enabled": true,
+      "volume_ratio_min": 1.5,
+      "require_macd_confirm": true
+    }
+  },
+  "strategy_risk": {
+    "stop_loss_percent": 6,
+    "take_profit_percent": 6,
+    "stop_loss_atr_multiplier": 0,
+    "max_position_amount": 100000,
+    "max_daily_loss": 50000,
+    "trailing_atr_multiplier": 2.0
+  },
+  "htf_filter": {
+    "enabled": true,
+    "block_counter_trend": false,
+    "alignment_boost": 0.1
+  }
+}

--- a/backend/profiles/experiment_2026-04-22_sl6_tr30_tp6_tf60_35.json
+++ b/backend/profiles/experiment_2026-04-22_sl6_tr30_tp6_tf60_35.json
@@ -1,0 +1,55 @@
+{
+  "name": "experiment_2026-04-22_sl6_tr30_tp6_tf60_35",
+  "description": "sl6 + tr3.0 + tp6. Widen TP so trailing can fire.",
+  "indicators": {
+    "sma_short": 20,
+    "sma_long": 50,
+    "rsi_period": 14,
+    "macd_fast": 12,
+    "macd_slow": 26,
+    "macd_signal": 9,
+    "bb_period": 20,
+    "bb_multiplier": 2.0,
+    "atr_period": 14
+  },
+  "stance_rules": {
+    "rsi_oversold": 32,
+    "rsi_overbought": 68,
+    "sma_convergence_threshold": 0.002,
+    "bb_squeeze_lookback": 5,
+    "breakout_volume_ratio": 1.5
+  },
+  "signal_rules": {
+    "trend_follow": {
+      "enabled": true,
+      "require_macd_confirm": false,
+      "require_ema_cross": true,
+      "rsi_buy_max": 60,
+      "rsi_sell_min": 35
+    },
+    "contrarian": {
+      "enabled": true,
+      "rsi_entry": 32,
+      "rsi_exit": 68,
+      "macd_histogram_limit": 10
+    },
+    "breakout": {
+      "enabled": true,
+      "volume_ratio_min": 1.5,
+      "require_macd_confirm": true
+    }
+  },
+  "strategy_risk": {
+    "stop_loss_percent": 6,
+    "take_profit_percent": 6,
+    "stop_loss_atr_multiplier": 0,
+    "max_position_amount": 100000,
+    "max_daily_loss": 50000,
+    "trailing_atr_multiplier": 3.0
+  },
+  "htf_filter": {
+    "enabled": true,
+    "block_counter_trend": false,
+    "alignment_boost": 0.1
+  }
+}

--- a/backend/profiles/experiment_2026-04-22_sl8_tr20_tp6_tf60_35.json
+++ b/backend/profiles/experiment_2026-04-22_sl8_tr20_tp6_tf60_35.json
@@ -1,0 +1,55 @@
+{
+  "name": "experiment_2026-04-22_sl8_tr20_tp6_tf60_35",
+  "description": "sl8 + tr2.0 + tp6. Widen TP so trailing can fire.",
+  "indicators": {
+    "sma_short": 20,
+    "sma_long": 50,
+    "rsi_period": 14,
+    "macd_fast": 12,
+    "macd_slow": 26,
+    "macd_signal": 9,
+    "bb_period": 20,
+    "bb_multiplier": 2.0,
+    "atr_period": 14
+  },
+  "stance_rules": {
+    "rsi_oversold": 32,
+    "rsi_overbought": 68,
+    "sma_convergence_threshold": 0.002,
+    "bb_squeeze_lookback": 5,
+    "breakout_volume_ratio": 1.5
+  },
+  "signal_rules": {
+    "trend_follow": {
+      "enabled": true,
+      "require_macd_confirm": false,
+      "require_ema_cross": true,
+      "rsi_buy_max": 60,
+      "rsi_sell_min": 35
+    },
+    "contrarian": {
+      "enabled": true,
+      "rsi_entry": 32,
+      "rsi_exit": 68,
+      "macd_histogram_limit": 10
+    },
+    "breakout": {
+      "enabled": true,
+      "volume_ratio_min": 1.5,
+      "require_macd_confirm": true
+    }
+  },
+  "strategy_risk": {
+    "stop_loss_percent": 8,
+    "take_profit_percent": 6,
+    "stop_loss_atr_multiplier": 0,
+    "max_position_amount": 100000,
+    "max_daily_loss": 50000,
+    "trailing_atr_multiplier": 2.0
+  },
+  "htf_filter": {
+    "enabled": true,
+    "block_counter_trend": false,
+    "alignment_boost": 0.1
+  }
+}

--- a/docs/pdca/2026-04-22_cycle24-27.md
+++ b/docs/pdca/2026-04-22_cycle24-27.md
@@ -1,0 +1,134 @@
+# PDCA cycle24–27 — SL / TP grid on 3yr LTC (v5 promotion search)
+
+**Date:** 2026-04-22
+**Baseline:** `profiles/production.json` (v4b, promoted 2026-04-21 via #117)
+**Goal:** fulfill the cycle23 next-step "grid over `strategy_risk.stop_loss_percent` (3–8) on the 12/6/6 schedule" and see if any combined SL/TP candidate beats v4b well enough to promote as v5.
+
+## Enablers
+
+- **#116** — WFO handler threads `strategy_risk.take_profit_percent` into per-window RiskConfig. Without this the TP axis silently no-ops.
+- **#117** — v4b is the current `production.json` baseline.
+- **#130** — `ApplyOverrides` accepts `strategy_risk.*` paths from the WFO grid.
+- Prior cycle 22–23 (PR-7 Stoch gate): rejected as v5 candidate. This cycle revisits the open TODO "grid over `strategy_risk.stop_loss_percent` (3–8) on the 12/6/6 schedule".
+
+## Baseline — production v4b on LTC 1yr/2yr/3yr
+
+POST `/backtest/run-multi` with `profileName=production`, `tradeAmount=0.1`, `pdcaCycleId=2026-04-22_cycle24_baseline`.
+
+| label | id | TotalReturn | MaxDrawdown | Trades | BiweeklyWinRate |
+|---|---|---:|---:|---:|---:|
+| 1yr (2024) | `01KPS98PGMH1YEM5MSV86PTTMY` | −3.28% | 6.11% | 1,793 | 48.66 |
+| 2yr (2023–2024) | `01KPS98RC09D5ZPR5Z73SS3FVQ` | +17.25% | 6.15% | 6,825 | 53.22 |
+| 3yr (2022–2024) | `01KPS98RZZGYKBV2A8XF35TR31` | +27.74% | **21.21%** ❌ | 11,166 | 39.85 |
+
+Aggregate id: `01KPS98RZZ5ERR1STP5Q87VX1W`. `aggregate.geomMeanReturn=+13.15%`, `worstReturn=-3.28%`, `robustnessScore=+0.0027`.
+
+> Note: 3yr DD `21.21%` exceeds the 20% hard constraint. The PR #117 promotion note recorded 3yr DD `<9%` (different cost assumptions — spread 0.1 + carry 0.04 slippage 0 are now the API defaults). Treat `21.21%` as today's apples-to-apples baseline; it is the number any v5 candidate must beat.
+
+## Cycle 24 — `strategy_risk.stop_loss_percent` grid [3,4,5,6,7,8]
+
+```bash
+POST /backtest/walk-forward \
+  {"data":"data/candles_LTC_JPY_PT15M.csv","dataHtf":"data/candles_LTC_JPY_PT1H.csv",
+   "from":"2022-01-01","to":"2025-01-01","inSampleMonths":12,"outOfSampleMonths":6,"stepMonths":6,
+   "baseProfile":"production","objective":"return",
+   "parameterGrid":[{"path":"strategy_risk.stop_loss_percent","values":[3,4,5,6,7,8]}],
+   "pdcaCycleId":"2026-04-22_cycle24_sl_grid"}
+```
+
+WFO id: `01KPS9AA6S3ZFZ8DEWV9BPDKJ4`
+
+| # | IS window | OOS window | IS-best SL | OOS Return | OOS DD | Trades |
+|---|---|---|---:|---:|---:|---:|
+| 0 | 2022‑01..2022‑12 | 2022‑12..2023‑06 | **6** | +14.55% | 7.08% | 2,336 |
+| 1 | 2022‑07..2023‑06 | 2023‑06..2023‑12 | **4** | +5.74% | 3.12% | 2,687 |
+| 2 | 2023‑01..2023‑12 | 2023‑12..2024‑06 | **4** | −3.26% | 4.23% | 942 |
+| 3 | 2023‑07..2024‑06 | 2024‑06..2024‑12 | **4** | −0.31% | 2.89% | 844 |
+
+Aggregate OOS: geomMean **+3.96%** / worst −3.26% / best +14.55% / worstDD 7.08% / robustness −0.0285.
+
+**Observation.** SL=4 wins 3/4 IS windows (and the 3 most recent). SL=5 (v4b default) never wins. SL=6 only wins on the oldest 2022 IS window where low SL starved the strategy of exits. Aggregate geomMean +3.96% vastly exceeds cycle23 baseline geomMean +0.42%.
+
+## Cycle 25 — `strategy_risk.take_profit_percent` grid [2,3,4,5,6]
+
+Same schedule, TP axis only (SL held at v4b default 5).
+
+WFO id: `01KPSB4W17GD55N8BV9CZRCWGF`
+
+| # | IS-best TP | OOS Return | OOS DD |
+|---|---:|---:|---:|
+| 0 | 5 | +17.04% | 6.06% |
+| 1 | 5 | +5.83% | 3.57% |
+| 2 | 6 | −4.97% | 5.61% |
+| 3 | 4 | +0.19% | 3.08% |
+
+Aggregate OOS: geomMean **+4.21%** / worst −4.97% / best +17.04% / worstDD 6.06% / robustness −0.0397.
+
+**Observation.** TP=5 wins the 2 oldest windows, TP=6 wins window 2, **TP=4 (v4b default) still wins the most recent window #3**. TP alone gives a slightly higher geomMean than SL alone but a worse worst-case. The regime shift in the 2024 OOS is not fixed by TP tuning.
+
+## Cycle 26 — joint SL × TP grid [3,4,5,6] × [3,4,5,6]
+
+WFO id: `01KPSB74XHAH4EEAAB8NJAFSQH`
+
+Per-window best combos:
+
+| # | IS-best (SL,TP) | OOS Return | OOS DD |
+|---|---|---:|---:|
+| 0 | 6,6 | +19.77% | 7.10% |
+| 1 | 6,6 | +5.77% | 4.01% |
+| 2 | 6,6 | −4.93% | 5.61% |
+| 3 | **4,4** | −0.31% | 2.89% |
+
+Aggregate OOS: geomMean **+4.68%** / worst −4.93% / worstDD 7.10% / robustness −0.0462.
+
+**Observation.** The three older windows all pick SL=6/TP=6 (highest IS return but IS DD ≈ 24.5%). The most recent window picks v4b's SL=4/TP=4. This is the classic **regime curve-fit** pattern: aggregate geomMean is the highest of the three cycles, but the combo winner disagrees between old and new regimes, and the IS DD violates the 20% rule at the IS level (OOS DD is still fine). **Do not promote SL=6/TP=6** on the strength of a 3/4 majority that excludes the most recent year.
+
+## Cycle 27 — candidate validation multi-period
+
+Two promotion candidates surfaced:
+
+1. **Candidate A — SL=4 only** (TP stays at v4b 4). cycle24 IS winner 3/4 windows, most recent 3 windows.
+2. **Candidate B — SL=4 + TP=5** (cycle24 + cycle25 single-axis winners).
+
+Both ran as `run-multi` with `parentResultId=01KPS98RZZGYKBV2A8XF35TR31` (3yr baseline).
+
+| label | v4b baseline | Candidate A (SL=4) | Candidate B (SL=4, TP=5) |
+|---|---:|---:|---:|
+| 1yr Return | −3.28% | −3.50% | −4.29% |
+| 1yr DD | 6.11% | 5.66% | 5.88% |
+| 2yr Return | +17.25% | **+17.82%** | +17.27% |
+| 2yr DD | 6.15% | 5.18% | 5.56% |
+| 3yr Return | +27.74% | +33.19% | **+41.91%** |
+| 3yr DD | **21.21% ❌** | **15.56% ✅** | **15.13% ✅** |
+| aggregate geomMean | +13.15% | +14.84% | **+16.78%** |
+| aggregate worstReturn | −3.28% | −3.50% | −4.29% |
+| aggregate robustnessScore | +0.0027 | **−0.0021** (lowest stddev) | −0.0209 |
+
+Result IDs:
+- Candidate A aggregate `01KPSBBGK8BHZGJ6RJ8CB59QBJ` / 1yr `01KPSBB9V7HTQ5JPVQYB192Z6F` / 2yr `01KPSBBF336GX5S4VG9C64Q5AZ` / 3yr `01KPSBBGK8EQKNN6JQKNRVK7HD`
+- Candidate B aggregate `01KPSB9RGPBJP016YME4FZYDF3` / 1yr `01KPSB9HCBHY8K8ERR047QEVTG` / 2yr `01KPSB9PZD1XV85WGWEQQ8NSFH` / 3yr `01KPSB9RGPTACVPV3T2N6B2G93`
+- Experimental profiles committed: `backend/profiles/experiment_2026-04-22_sl4_only.json`, `backend/profiles/experiment_2026-04-22_sl4_tp5.json`
+
+## Conclusion
+
+**Both candidates are legitimate v5 promotion candidates and both beat v4b on the 20% DD constraint.** Candidate A is the safer choice (smallest stddev, consistent with most-recent-window IS pick in cycle26), Candidate B has the higher geomMean but wider OOS distribution.
+
+**Neither candidate fixes the 1yr 2024 LTC negativity.** Consistent with cycle22–23's finding that 2024 is a structurally hard regime for 15m LTC. 1yr negativity is the one reason v5 promotion is not mechanical yet — per `docs/pdca/README.md` rules we want 1yr/2yr/3yr all > 0.
+
+### Recommendation to the next PDCA cycle
+
+1. **Keep SL=4 as the next baseline axis.** It won 3/4 IS windows alone and also appeared as the most-recent-window winner in the joint grid.
+2. **TP=5 is a plus-alpha but not required.** Aggregate geomMean gain is +1.9pp (A→B) at the cost of larger return stddev and worse 1yr.
+3. **Do NOT promote SL=6/TP=6** despite its +4.68% aggregate — that combo was voted down by the most recent window and would re-introduce the regime drift that PR #118 explicitly flagged.
+4. Next axis candidates to test **on Candidate A (SL=4) as the new parent**:
+   - `htf_filter.mode=ichimoku` (requires ApplyOverrides string-type path; cycle23's remaining open TODO).
+   - `contrarian.adx_max` / `trend_follow.adx_min` retune now that SL=4 changes exit dynamics.
+   - `strategy_risk.stop_loss_atr_multiplier` (ATR-based SL) — might handle the 2024 regime where % stops over/under-stop in low vol.
+5. A promotion PR is still premature. The DD fix alone is worth committing experimental profiles; v5 `production.json` promotion should wait until at least 1 of the next two cycles turns 1yr positive without giving back DD.
+
+## Links
+
+- Prior cycle: `docs/pdca/2026-04-22_cycle22-23.md`
+- v4b promotion: `docs/pdca/2026-04-21_promotion_v4.md` (#117)
+- PDCA parent issue: #118 (still open — awaits a 1yr/2yr/3yr all-positive candidate)
+- cycle23 open TODOs fulfilled: SL grid (this cycle); still open: `htf_filter.mode=ichimoku` string override path.

--- a/docs/pdca/2026-04-22_cycle28-37.md
+++ b/docs/pdca/2026-04-22_cycle28-37.md
@@ -1,0 +1,233 @@
+# PDCA cycle28–37 — 15-minute sprint on healthy_v3 lineage
+
+**Date:** 2026-04-22 10:16–10:33 JST
+**Parent cycles:** `2026-04-22_cycle22-23.md` (PR-7 Stoch gate rejected), `2026-04-22_cycle24-27.md` (SL/TP grid on v4b — healthy_v3 completely outclassed both v4b and my cycle24-27 candidates)
+**Trigger:** discovered in cycle24-27 that `experiment_2026-04-21_healthy_v3.json` crushes v4b on 2023-04..2026-03 windows (gM +14.63% vs v4b +1.08%, 1yr/2yr/3yr all positive). healthy_v3 was rolled back in promotion_v3.md because SL=20 is "unhealthy". This sprint replaces the unhealthy SL while beating or matching healthy_v3.
+
+## Sprint methodology
+
+Ran **10 cycles in ~15 minutes** leveraging the `compose.yaml` bindmount for `backend/profiles` (no rebuild needed). Parallel WFO runs in background + foreground validation via `run-multi`.
+
+## Path 1 — ATR trailing replacement (cycle28 Path 1)
+
+Goal: replace healthy_v3's `stop_loss_percent=20` with a tighter static SL + `trailing_atr_multiplier`.
+
+**Finding 1 (critical):** with `take_profit_percent=4` (healthy_v3 default), **`trailing_atr_multiplier` is dead code** — TP fires first and trailing never engages. WFO confirmed: SL=12 with TR=0/1.5/2/3 gave identical IS returns. Trailing only activates if TP is widened.
+
+**WFO 4x4 grid** (SL × TR) on base `healthy_v4_atr`, 2023-04..2026-03, 12/6/6:
+
+| window | IS winner | OOS |
+|---|---|---:|
+| w0 2023-03..2024-03 / OS ..09 | SL=12/TR=0 | −2.33% |
+| w1 2023-09..2024-09 / OS ..03 | SL=5/TR=0 | −9.64% |
+| w2 2024-03..2025-03 / OS ..09 | SL=20/TR=0 | +6.22% |
+
+Aggregate OOS gM −2.13%. Disappointing.
+
+**Fixed-candidate validation** (`run-multi` 1yr/2yr/3yr 2023-04..2026-03):
+
+| profile | gM | worst | 1yr | 2yr | 3yr |
+|---|---:|---:|---:|---:|---:|
+| healthy_v3 (baseline) | **+14.63%** | +9.62% | +9.62% | +9.91% | +25.01% |
+| sl5_tr15 | +2.68% | −6.09% | +5.54% | −6.09% | +9.22% |
+| sl5_tr20 | +2.74% | −6.00% | +5.54% | −6.00% | +9.31% |
+| sl8_tr20 | +8.30% | +1.02% | +8.97% | +1.02% | +15.39% |
+| sl8_tr30 | +8.30% | +1.02% | +8.97% | +1.02% | +15.39% |
+| **sl12_tr25** | **+10.44%** | +3.65% | +8.89% | +3.65% | +19.37% |
+
+`sl12_tr25` is the first candidate to reach 1/2/3yr all > 0 with a tighter (healthier) SL than healthy_v3.
+
+## Path 2 — RSI WFO on healthy_v3 itself (cycle28 Path 2 / cycle30)
+
+**RSI overbought/oversold grid** [65,68,72] × [28,32,35] on healthy_v3 base:
+
+| window | IS winner |
+|---|---|
+| w0 | OB=72/OS=28 |
+| w1 | OB=72/OS=32 |
+| w2 | OB=65/OS=28 |
+
+**trend_follow RSI grid** [60,62,65] × [35,38,40] on healthy_v3 base:
+
+| window | IS winner |
+|---|---|
+| w0 | rsi_buy_max=60 / rsi_sell_min=40 |
+| w1 | rsi_buy_max=60 / rsi_sell_min=40 |
+| w2 | rsi_buy_max=60 / rsi_sell_min=35 |
+
+**`rsi_buy_max=60` is IS winner in 3/3 windows** (vs healthy_v3's 62). Robust finding.
+
+## Cycle 31 — combined Path1 × Path2
+
+Base: SL=12 + trailing_atr=2.5 + trend_follow(60, 40 or 35) × TP axis.
+
+| profile | gM | worst | 1yr | 2yr | 3yr |
+|---|---:|---:|---:|---:|---:|
+| sl12_tf60_40_tp4 | +8.39% | +1.26% | +6.57% | +1.26% | +18.01% |
+| sl12_tf60_40_tp8 | +8.51% | −1.55% | +6.07% | −1.55% | +22.34% |
+| sl12_tf60_40_tp12 | +7.22% | −3.79% | +5.52% | −3.79% | +21.43% |
+| sl12_tf60_40_tp20 | +8.21% | −2.81% | +4.42% | −2.81% | +24.87% |
+| **sl12_tf60_35_tp4** | **+13.59%** | **+8.23%** | +8.23% | +8.65% | +24.64% |
+
+`sl12_tf60_35_tp4` nearly matches healthy_v3 with healthier SL. **First candidate with worst-period > healthy_v3 (+8.23% vs +9.62% — same order).**
+
+## Cycle 32 — narrow sweep / ablation
+
+| profile | gM | worst | 1yr | 2yr | 3yr |
+|---|---:|---:|---:|---:|---:|
+| sl10_tf60_35 | +11.61% | +6.01% | +7.97% | +6.01% | +21.47% |
+| **sl15_tf60_35** | **+16.17%** | **+9.17%** | +9.17% | +12.24% | **+27.96%** |
+| sl12_tr20_tf60_35 | +13.59% | +8.23% | +8.23% | +8.65% | +24.64% |
+| sl12_tr30_tf60_35 | +13.59% | +8.23% | +8.23% | +8.65% | +24.64% |
+| sl12_tf60_35_noblock (block_counter_trend=true) | +0.33% | −8.71% | +3.20% | −8.71% | +7.19% |
+| sl12_tf60_35_macd (require_macd_confirm=true) | +8.16% | +0.63% | +5.89% | +0.63% | +18.73% |
+
+**Ablation confirms healthy_v3 findings:** `block_counter_trend=false` and `require_macd_confirm=false` are load-bearing (reversing them drops gM by 13pp / 5pp respectively).
+
+**`sl15_tf60_35` beats healthy_v3** (gM +16.17% vs +14.63%) with **SL=15 vs healthy_v3's unhealthy SL=20**.
+
+## Cycle 33 — SL plateau confirmation
+
+SL grid [13,14,15,16,17,18] all with tf60_35:
+
+| SL | gM | worst | 1yr | 2yr | 3yr | DD_3yr |
+|---:|---:|---:|---:|---:|---:|---:|
+| 13 | +15.66% | +8.68% | +8.68% | +11.64% | +27.54% | 6.04% |
+| **14** | **+16.22%** | **+9.26%** | **+9.26%** | **+12.23%** | **+28.03%** | **6.01%** |
+| 15 | +16.17% | +9.17% | +9.17% | +12.24% | +27.96% | 6.04% |
+| 16 | +16.41% | +8.96% | +8.96% | +12.77% | +28.40% | 6.08% |
+| 17 | +16.17% | +8.80% | +8.80% | +12.52% | +28.06% | 6.13% |
+| 18 | +16.55% | +8.97% | +8.97% | +13.06% | +28.51% | 5.97% |
+
+SL=13..18 forms a plateau (gM ±0.5pp). **Health-first pick: SL=14** (tighter than healthy_v3 SL=20 while matching best performance).
+
+## Cycle 34 — final WFO on winner region
+
+WFO on `sl14_tf60_35` base, grid SL × rsi_sell_min = [12,14,16,18] × [35,38,40]:
+
+| window | IS winner |
+|---|---|
+| w0 | SL=12 / sell_min=40 |
+| w1 | SL=12 / sell_min=40 |
+| w2 | SL=18 / sell_min=35 |
+
+**`sell_min=40` wins 2/3 windows.** My `sl14_tf60_35` validation used sell_min=35 (w2-only winner — curve-fit to recent window).
+
+## Cycle 35 — robustness to 2022 bear regime
+
+**Critical sanity check** revealed the whole healthy_v3 lineage **overfits to 2023-04 onward** — testing on the 2022-01..2025-01 window (includes 2022 LTC crash) shows catastrophe:
+
+| profile | new3yr (2023-04..2026-03) | old3yr (2022-01..2025-01) |
+|---|---:|---:|
+| sl14_slatr20/30/40 | +28.03% / DD 6.01% | **−57.97%** / DD 91.06% 🚨 |
+| sl6_tr20_tp6 | +14.39% / DD 15.53% | +28.31% / DD 24.51% |
+| **sl6_tr30_tp6_tf60_35** | **+14.69%** / DD 15.57% | **+28.30%** / DD 24.51% |
+| sl8_tr20_tp6 | +16.25% / DD 15.43% | +0.52% / DD 37.40% |
+
+**`sl6_tr30_tp6_tf60_35`** is the only candidate that survives both regimes. SL=6 is tight enough to cut 2022 losses; TP=6 + trailing_atr=3.0 allows trailing to actually engage on winners.
+
+Trade-off: 3yr_new drops from +27.96% → +14.69% (pays a 13pp tax to survive the bear market).
+
+## Cycle 36 — `sl6_tr30_tp6_tf60_35` full multi-period
+
+| period | Return | DD | Trades | PF |
+|---|---:|---:|---:|---:|
+| 1yr_2025 (2025-04..2026-03) | +6.38% | 4.30% | 3755 | 1.168 |
+| 1yr_2024 (2024..2025) | **−7.32%** | 8.70% | 4119 | 0.861 |
+| 1yr_2023 (2023..2024) | +0.06% | 24.74% | 6602 | 1.001 |
+| 1yr_2022 (2022-10..2023-10) | **+37.99%** | 24.51% | 9955 | 1.303 |
+| 2yr (2024-04..2026-03) | −3.88% | 15.03% | 7944 | 0.964 |
+| 3yr_new (2023-04..2026-03) | +14.69% | 15.57% | 13930 | 1.097 |
+| 3yr_old (2022-01..2025-01) | +28.30% | 24.51% | 15098 | 1.153 |
+
+Aggregate gM +9.81% / worst −7.32% / robust −0.0595.
+
+**Insight:** +14.69% on new3yr is entirely from 2025 1yr (+6.38%) + 2023 1yr (+0.06%) + trailing residual. The big +37.99% on 2022 carries the old3yr. 2024 regime is **structurally a losing year** for all tested lineages.
+
+## Cycle 37 — WFO-robust final pick
+
+`sl14_tf60_40` (WFO 2/3 winner) validated:
+
+| period | Return | DD |
+|---|---:|---:|
+| 1yr_2025 | +7.44% | 4.87% |
+| 2yr | +5.19% | 10.17% |
+| 3yr (2023-04..2026-03) | +21.80% | 8.77% |
+| old3yr (2022-01..2025-01) | **−57.74%** | 91.06% 🚨 |
+
+Same 2022-regime blow-up as sl14_tf60_35. WFO-robust choice does not fix the regime fragility.
+
+## Final ranking
+
+### Best profiles by context
+
+| rank | profile | strength | weakness | verdict |
+|---|---|---|---|---|
+| 1 | **experiment_2026-04-22_sl14_tf60_35** | highest healthy-period gM (+16.22%), all 1yr/2yr/3yr > 0 on 2023-04..2026-03, DD 5-7%, healthier SL=14 | blows up on 2022 bear (-57.97%) | **best candidate IF market will not repeat 2022-style crash; otherwise reject** |
+| 2 | **experiment_2026-04-22_sl14_tf60_40** | WFO-robust (2/3 windows), gM +14.63% | same 2022 blow-up | less exposed to curve-fit than #1 within healthy period, same bear fragility |
+| 3 | **experiment_2026-04-22_sl6_tr30_tp6_tf60_35** | only candidate positive in BOTH regimes, healthy SL=6 with trailing_atr=3.0 actually firing | 2024 is −7.32%, worse peak gM (+9.81% aggregate) | **best if prioritising regime robustness over peak return** |
+| 4 | healthy_v3 (existing) | healthy-period gM +14.63%, known good | unhealthy SL=20, same 2022 fragility as #1/#2 | reference baseline |
+
+### Recommendation
+
+**Two v5 promotion candidates to escalate to the user / ATR review:**
+
+- **Aggressive candidate: `sl14_tf60_35`** — if the assumption is "past 3 years representative of the forward regime", this beats healthy_v3 on everything, with SL dropped from 20 → 14.
+- **Defensive candidate: `sl6_tr30_tp6_tf60_35`** — if the assumption is "2022-style bear can recur", this is the only lineage that survived. SL=6 is fully healthy, trailing_atr actually engages.
+
+**Neither should be auto-promoted.** Both carry hidden assumptions; the user should decide which regime hypothesis to bet on before committing `production.json`.
+
+## Artifacts
+
+### Committed profiles (all in `backend/profiles/`)
+
+Path 1 sweep:
+- `experiment_2026-04-22_healthy_v4_atr.json`
+- `experiment_2026-04-22_healthy_sl5_tr15.json`, `_sl5_tr20.json`, `_sl8_tr20.json`, `_sl8_tr30.json`, `_sl12_tr25.json`
+
+Combined candidates:
+- `experiment_2026-04-22_sl12_rsi72_28.json`, `_sl12_rsi65_28.json`, `_sl12_rsi72_32.json`
+- `experiment_2026-04-22_sl12_tfbuy65.json`
+- `experiment_2026-04-22_sl12_tf60_40_tp{4,8,12,20}.json`
+- `experiment_2026-04-22_sl12_tf60_35_tp4.json`
+- `experiment_2026-04-22_sl10_tf60_35.json`, `_sl15_tf60_35.json`
+- `experiment_2026-04-22_sl12_tr20_tf60_35.json`, `_sl12_tr30_tf60_35.json`
+- `experiment_2026-04-22_sl12_tf60_35_noblock.json`, `_sl12_tf60_35_macd.json`
+- `experiment_2026-04-22_sl{13,14,16,17,18}_tf60_35.json`
+- `experiment_2026-04-22_sl14_slatr{20,30,40}.json`
+- `experiment_2026-04-22_sl6_tr20_tp6_tf60_35.json`, `_sl6_tr30_tp6_tf60_35.json`, `_sl8_tr20_tp6_tf60_35.json`
+- `experiment_2026-04-22_sl14_tf60_40.json`
+
+### WFO result IDs
+
+- cycle28 Path 1 (ATR grid): `01KPSC89PKDVBWH2PJRGXT4CDA`
+- cycle28 Path 2 (stance RSI): `01KPSC7KY46NNCRVFACHS1YG63`
+- cycle29 (SL × TP): `01KPSCEHY180DYM544J2Z0VY56`
+- cycle30 (trend_follow RSI): `01KPSCE0EDT8Q4Y329EE20Z5NF`
+- cycle34 (SL × sell_min): `01KPSCXGYN3VW37MY1Z6BZYXV8`
+
+### key multi-period result IDs
+
+- **sl14_tf60_35 (aggressive winner):** extended validation `01KPSCWD0NNM315D8F3QJJQXP2`
+- **sl6_tr30_tp6 (defensive winner):** full multi-period `01KPSD1ZSAMP2Y54DVN6D4F2G0`
+- sl14_tf60_40 (WFO robust pick): `01KPSD3MTYA4AGGD0HMF64YX4P`
+
+## Lessons (for next PDCA author)
+
+1. **Always test on 2022-01..2025-01 alongside healthy_v3 windows.** The healthy_v3 lineage is invisibly curve-fit to 2023-04 onward.
+2. **`trailing_atr_multiplier` requires `take_profit_percent` to be wider than the typical reached profit** to engage. With TP=4 on LTC 15m, trailing never fires. Inspect `byExitReason.trailing_stop.trades` before claiming trailing is the answer.
+3. **The `stop_loss_percent` plateau on healthy_v3 lineage is 13..18** — picking the tightest (SL=14) maximizes healthiness at no return cost within the 2023-04..2026-03 regime.
+4. **`block_counter_trend=false` and `require_macd_confirm=false` are load-bearing.** Turning either back on drops gM by 5–13pp on the healthy_v3 lineage.
+5. **No combination of SL/TP/trailing/RSI on this strategy family wins on both 2022 bear and 2024 range simultaneously.** Escaping this requires a new axis — regime classifier (PR-5 in Phase A) or Ichimoku HTF filter (PR-8 string override).
+
+## Open questions for next cycle
+
+- Implement `htf_filter.mode=ichimoku` WFO support (string override path).
+- Build a regime detector (PR-5) and conditionally switch between sl14_tf60_35 (bull) and sl6_tr30_tp6 (bear).
+- Investigate why 2024 range is structurally losing despite all tuning.
+
+## Links
+
+- Parent cycle: `docs/pdca/2026-04-22_cycle24-27.md`
+- promotion_v3 (explains healthy_v3 rollback): `docs/pdca/2026-04-21_promotion_v3.md`
+- PDCA parent issue: #118

--- a/docs/pdca/2026-04-22_cycle38.md
+++ b/docs/pdca/2026-04-22_cycle38.md
@@ -1,0 +1,110 @@
+# PDCA cycle38 — Ichimoku HTF via WFO string override
+
+**Date:** 2026-04-22
+**Parent:** `docs/pdca/2026-04-22_cycle28-37.md` (v5 candidate hunt, two finalists `sl14_tf60_35` and `sl6_tr30_tp6_tf60_35`)
+**Question:** does `htf_filter.mode=ichimoku` rescue the `sl14_tf60_35` blow-up on the 2022 LTC bear regime?
+
+## Enabler — PR feat/wfo-string-override (this PR)
+
+`ApplyOverrides` previously only accepted `map[string]float64`, so WFO grids could not vary `htf_filter.mode` (a string axis). This cycle is the first use case. The PR adds:
+
+- `ParameterStringOverride{Path, Values []string}` mirror of the numeric axis type.
+- `ExpandCombinedGrid(numeric, strs)` — cartesian product across numeric and string axes with duplicate-path and size-cap checks shared with the numeric path.
+- `ApplyStringOverrides(base, map[string]string)` — allow-listed paths (currently `htf_filter.mode` → `"" | "ema" | "ichimoku"`), with value validation at the override boundary.
+- `ApplyCombination(base, GridCombination)` — applies both sides in sequence.
+- `WalkForwardInput.Combinations []GridCombination` as the preferred input field. The legacy `Grid []map[string]float64` stays supported for existing callers.
+- `WalkForwardWindowResult.BestStringParameters` + `WalkForwardISResult.StringParameters`, both omitempty so older persisted envelopes keep unmarshalling.
+- HTTP `parameterStringGrid` field + pre-validation; CLI `--grid` auto-detects numeric vs. string values; JSON grid-file format unchanged (numeric `[...]` or string `[...]` values discriminate automatically).
+
+Tests added: 11 new cases covering apply, expand, combined, duplicate-across-types, and CLI + file round-trip.
+
+## Cycle 38a — Ichimoku on `sl14_tf60_35` with its default `block_counter_trend=false`
+
+WFO 12/6/6 on 2023-04..2026-03, grid `htf_filter.mode=[ema, ichimoku]`.
+
+WFO id: `01KPSXAW8H96PS4W2C0QZF4M6S`. Aggregate OOS: gM +2.96% / worst −1.76% / robust −0.0045.
+
+```
+  w0 best_mode=ema   oos −1.76% dd 4.05% trades 1980
+  w1 best_mode=ema   oos +4.83% dd 5.31% trades 2207
+  w2 best_mode=ema   oos +5.99% dd 5.04% trades 2018
+
+IS per-window:
+  w0 ema:      isRet +15.65% trades 5981
+  w0 ichimoku: isRet +15.65% trades 5981   ← identical
+  w1 ema:      isRet  −5.03% trades 4002
+  w1 ichimoku: isRet  −5.03% trades 4002   ← identical
+  w2 ema:      isRet  +2.96% trades 4189
+  w2 ichimoku: isRet  +2.96% trades 4189   ← identical
+```
+
+**Observation — mode is a silent no-op when `block_counter_trend=false`.** Reading the strategy code (`usecase/strategy.go:227+`), `htfTrendDirection(mode, ...)` produces the direction, but with `BlockCounterTrend=false` the only consumer is the confidence `AlignmentBoost` which does not affect trade entry, only the score written to the signal. Identical trade counts confirm: same trades, same exits, same returns.
+
+This is exactly the silent-wiring trap PDCA cycle08/09 originally diagnosed. The difference here is that the wiring *exists* (PR-8), it just has no trade-affecting consumer unless counter-trend blocking is turned on.
+
+## Cycle 38b — enable `block_counter_trend=true` to make mode actually drive trades
+
+Created `experiment_2026-04-22_sl14_tf60_35_htfblock` = sl14_tf60_35 with `block_counter_trend=true`. Re-ran the same grid.
+
+WFO id: `01KPSXDBPNV5DJ771Y4777XHP3`. Aggregate OOS: gM **−1.80%** / worst −4.52% / robust −0.0470.
+
+```
+  w0 best_mode=ema      oos −4.52% dd  6.36% trades 1714
+  w1 best_mode=ichimoku oos −2.99% dd 10.35% trades 1651
+  w2 best_mode=ichimoku oos +2.25% dd  5.40% trades 1773
+
+IS per-window (trade counts differ now — mode is wired):
+  w0 ema:      isRet +18.31% trades 5649
+  w0 ichimoku: isRet +17.66% trades 5670
+  w1 ema:      isRet  −7.56% trades 3432
+  w1 ichimoku: isRet  −6.90% trades 3478
+  w2 ema:      isRet  −9.25% trades 3337
+  w2 ichimoku: isRet  −6.02% trades 3400
+```
+
+Ichimoku narrowly wins 2/3 IS windows. Marginal but real. However the *absolute* IS/OOS numbers collapse versus the `block=false` baseline: +18% → ~0% band. **Counter-trend blocking (regardless of mode) is what destroys the strategy.**
+
+## Cycle 38c — validate on 2022 bear regime
+
+The question that matters: does Ichimoku HTF rescue `sl14_tf60_35` on the 2022 bear regime where `block=false` blew up (−57.97%)?
+
+Ran `run-multi` on new3yr (2023-04..2026-03) + old3yr (2022-01..2025-01) for four variants:
+
+| profile | new3yr | old3yr | old3yr DD |
+|---|---:|---:|---:|
+| sl14_tf60_35 (baseline, block=false, mode=ema) | **+28.03%** | −57.97% | 91.06% |
+| healthy_v3 (block=false, mode=ema) | +25.01% | −66.61% | 98.31% |
+| sl14_tf60_35 + block=true + mode=ema | +10.48% | −64.13% | 91.06% |
+| **sl14_tf60_35 + block=true + mode=ichimoku** | +15.51% | **−59.32%** | 91.06% |
+
+**Ichimoku HTF marginally reduces old3yr blow-up** (−64.13% → −59.32%) but pays +12.5pp in new3yr return to do so (+28.03% → +15.51%). The 2022 bear is still a catastrophic loss (−59%, DD 91%); the improvement is noise-level relative to the regime magnitude.
+
+## Conclusion
+
+**Choice A (Ichimoku HTF via WFO) does not fix the 2022 regime problem.** The healthy_v3 lineage's performance is load-bearing on `block_counter_trend=false`, and turning it back on — with any mode — destroys returns. Ichimoku is a marginally better HTF detector than SMA-cross but operates in a domain (confidence-only when block=false; severe return drag when block=true) that does not touch the actual failure mode (2022 trend direction vs. stop depth).
+
+The PR-8 wiring now has a proper WFO dial and should be kept for future lineages or regime-conditional use, but **the 2022 problem requires a different axis — regime detection (choice B).**
+
+## Decision for v5 promotion
+
+- Do **not** promote any cycle38 variant. None beats `sl14_tf60_35` baseline on new3yr.
+- Keep cycle28-37 finalists as the two regime-specialised candidates (`sl14_tf60_35` aggressive, `sl6_tr30_tp6_tf60_35` defensive) pending choice B.
+
+## Next cycle
+
+- **Choice B: Regime classifier + profile router.** Build the lightest possible regime detector (ADX + ATR/price percentile) and a `ProfileRouter` that selects `sl14_tf60_35` in bull-trend and `sl6_tr30_tp6_tf60_35` in bear-trend / volatile. Target: new3yr stays near +25%, old3yr turns from −58% to > 0%.
+
+## Artifacts
+
+- Merged PR: `feat/wfo-string-override` (adds the entire string-override infrastructure; cycle38a was the first real use).
+- Experiment profiles (all in `backend/profiles/`):
+  - `experiment_2026-04-22_sl14_tf60_35_htfblock.json` (block_counter_trend=true)
+  - `experiment_2026-04-22_sl14_tf60_35_htfblock_ema.json` (WFO winner picked in w0)
+  - `experiment_2026-04-22_sl14_tf60_35_htfblock_ichimoku.json` (WFO winner picked in w1/w2)
+- WFO envelope IDs: `01KPSXAW8H96PS4W2C0QZF4M6S` (38a, silent-no-op), `01KPSXDBPNV5DJ771Y4777XHP3` (38b, block=true).
+
+## Links
+
+- Parent: `docs/pdca/2026-04-22_cycle28-37.md`
+- Infrastructure PR: `feat/wfo-string-override` (this cycle)
+- Next TODO: regime classifier design (see agent-guide "未実装 Phase A / C" section — PR-5 regime classification).

--- a/docs/pdca/agent-guide.md
+++ b/docs/pdca/agent-guide.md
@@ -405,7 +405,10 @@ A. 多くは期間不足（< 14 日）か、トレード数不足でカバレッ
 
 - 2026-04-21 v4b で **3yr +9.56% / aggregate geomMean +1.15%** に到達。1yr/2yr はまだマイナス。
 - 2026-04-22 cycle22-23（`docs/pdca/2026-04-22_cycle22-23.md`）で PR-7 Stoch gate を 3yr LTC 12/6/6 WFO で評価 → **gate=0 (無効) が 4/4 窓で勝者**、robustness は baseline を下回る。**PR-7 単体では v5 promotion 候補にならない**。
-- 次候補: PR-8 Ichimoku HTF mode（`htf_filter.mode=ichimoku`） / `strategy_risk.stop_loss_percent` grid on 3yr。
+- 2026-04-22 cycle24-27（`docs/pdca/2026-04-22_cycle24-27.md`）で `strategy_risk.stop_loss_percent` grid [3..8] を 3yr LTC 12/6/6 で評価 → **SL=4 が IS 3/4 窓で勝者**（v4b default の SL=5 は 0/4）。TP grid [2..6] は TP=5 が IS 2/4 窓で勝者だが最新窓は v4b の TP=4。実験 profile `experiment_2026-04-22_sl4_only.json` / `..._sl4_tp5.json` を commit 済み。multi-period 比較は **3yr DD が 21.21% → 15〜16% に改善**し初めて 20% 制約を満たすが、**1yr 2024 regime は依然マイナス**で v5 promotion 候補は未成立。
+- 2026-04-22 cycle28-37（`docs/pdca/2026-04-22_cycle28-37.md`、**15 分連続スプリント**）で `healthy_v3` 系譜を徹底探索。発見: (1) **healthy_v3 は 2023-04〜2026-03 の単一 regime に curve-fit**（2022 熊相場では −58% 破綻）。(2) `trailing_atr_multiplier` は `TP=4` の healthy_v3 では dead code（TP 先打ち）。(3) `rsi_buy_max=60` が trend_follow IS 3/3 窓勝者（healthy_v3 default 62 より頑健）。(4) `block_counter_trend=false` と `require_macd_confirm=false` は load-bearing — 両方 healthy_v3 の勝因。最終候補 2 本: **攻撃型 `experiment_2026-04-22_sl14_tf60_35`** (gM +16.22%, healthy_v3 超え, SL=14 健全化)、**防御型 `experiment_2026-04-22_sl6_tr30_tp6_tf60_35`** (2022/2023-26 両 regime 生存、SL=6 健全、trailing 発火)。どちらも単独 promotion せず、regime 判定（PR-5）or Ichimoku HTF（PR-8 string override）が次の真の解。
+- 次候補: `htf_filter.mode=ichimoku` WFO string override 対応、regime classifier で攻撃/防御 profile 切替。
+- 2026-04-22 cycle38（`docs/pdca/2026-04-22_cycle38.md`、**PR feat/wfo-string-override**）で WFO string override を実装済 (`parameterStringGrid` / `ApplyStringOverrides` / `ExpandCombinedGrid`) + Ichimoku HTF mode を cycle28-37 の `sl14_tf60_35` base で検証 → **Ichimoku は 2022 regime を救わない**。 `block_counter_trend=true` にしないと mode が sil-no-op、true にすると全 regime で壊滅。healthy_v3 家系は block=false 依存で HTF filter では 2022 問題に届かない。**Choice A (Ichimoku WFO) は reject、Choice B (Regime classifier) に進む** のが次の自然な一歩。
 
 ### 配線確認テストの継続
 


### PR DESCRIPTION
## Summary
- Adds `ParameterStringOverride` + `ExpandCombinedGrid` so one WFO run can mix numeric and string axes. Cycle22-23 left `htf_filter.mode` as the one unreachable axis; this closes that gap.
- Adds `ApplyStringOverrides` with a typed allow-list (`htf_filter.mode → "" | "ema" | "ichimoku"`), so a typo fails at the 400 boundary instead of silently running EMA.
- Extends `WalkForwardInput.Combinations` + `BestStringParameters` / `StringParameters` on the window/IS records. Legacy `Grid []map[string]float64` is kept and auto-wrapped into `Combinations` with empty `String` maps, so every pre-PR caller works unchanged.
- HTTP request accepts `parameterStringGrid` alongside the existing `parameterGrid`; CLI `--grid` auto-detects numeric vs. string values per axis; `--grid-file` infers type from JSON value shape and rejects mixed-type axes.

## First use case — cycle38 Ichimoku HTF evaluation

Ran `htf_filter.mode=[ema, ichimoku]` WFO on `sl14_tf60_35` (the v5 candidate from cycle28-37). Three findings, all captured in `docs/pdca/2026-04-22_cycle38.md`:

1. **Silent-no-op when `block_counter_trend=false`**. The wiring in `strategy.go` only reads `mode` for the optional `AlignmentBoost` confidence boost — with blocking off, ema and ichimoku produce identical trade counts. This PR makes that ergonomic to discover (previously it took two hand-written profiles).
2. **Wiring works with `block=true`.** IS trade counts diverge per mode; Ichimoku narrowly wins 2/3 IS windows.
3. **Ichimoku does not rescue 2022 bear regime.** `sl14_tf60_35` baseline: new3yr +28.03% / old3yr −57.97%. With `block=true+ichimoku`: new3yr +15.51% / old3yr −59.32%. Marginal improvement, catastrophic cost on the healthy period. Not a v5 promotion candidate.

The infrastructure is still worth merging: cycle38 would have taken another silent-no-op debugging cycle without it, and regime-conditional profiles (choice B) will reuse the string-axis machinery for the router configuration.

## Test plan
- [x] `go test ./... -race -count=1` in `backend/` — all pass.
- [x] 11 new unit tests:
  - `ApplyStringOverrides` — allowed values, unknown path, bad value.
  - `ExpandCombinedGrid` — numeric-only, string-only, mixed cartesian product, duplicate-across-types rejection, empty-string value rejection, empty-both baseline.
  - `ApplyCombination` — applies both sides in sequence.
  - CLI `parseGridInline` — numeric, string, mixed axes; `readGridFile` — string axis, mixed-axis rejection.
- [x] Cycle38 smoke-run via HTTP + `parameterStringGrid` against live Docker backend.
- [x] Existing WFO tests (`TestExpandGrid_*`, `TestApplyOverrides_*`, `WalkForwardRunner` suite) unchanged and green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)