### PR TITLE
feat(regime): add Regime entity + RegimeDetector usecase (PR-5 part A)

### DIFF
--- a/backend/internal/domain/entity/regime.go
+++ b/backend/internal/domain/entity/regime.go
@@ -1,0 +1,45 @@
+package entity
+
+// Regime is the high-level market state the Strategy layer can branch on.
+// The four labels correspond one-to-one to the regimes the PDCA cycle28-37
+// finalists were specialised for: bull-trend / bear-trend favour the
+// aggressive sl14_tf60_35 lineage, range / volatile favour the defensive
+// sl6_tr30_tp6_tf60_35 lineage. RegimeUnknown is emitted while indicators
+// are still warming up so callers can fall through to a baseline profile
+// instead of guessing a side.
+type Regime string
+
+const (
+	RegimeUnknown   Regime = ""
+	RegimeBullTrend Regime = "bull-trend"
+	RegimeBearTrend Regime = "bear-trend"
+	RegimeRange     Regime = "range"
+	RegimeVolatile  Regime = "volatile"
+)
+
+// IsKnown reports whether r is a real regime label (not the warmup-only
+// RegimeUnknown sentinel). Centralised so callers do not hard-code the
+// "" comparison.
+func (r Regime) IsKnown() bool {
+	return r != RegimeUnknown
+}
+
+// RegimeClassification is one detector emission. ADXValue / ATRPercent /
+// CloudPosition are the raw inputs the detector saw, copied into the
+// snapshot so logs and tests can explain *why* a Regime was chosen
+// without re-deriving from the IndicatorSet (which may have been
+// discarded by the time logs are read).
+//
+// Confidence is 0..1: 1.0 means every classifier dimension agreed,
+// lower values mean the regime is the best-of-N pick but the call is
+// close. Strategy callers can use it to widen the safety margin (e.g.
+// reduce trade size when confidence < 0.5) but the routing decision
+// itself is binary on Regime.
+type RegimeClassification struct {
+	Regime        Regime  `json:"regime"`
+	Confidence    float64 `json:"confidence"`
+	ADXValue      float64 `json:"adxValue"`
+	ATRPercent    float64 `json:"atrPercent"`    // ATR / lastPrice * 100, in % units
+	CloudPosition string  `json:"cloudPosition"` // "above" | "below" | "inside" | "" when Ichimoku missing
+	Timestamp     int64   `json:"timestamp"`
+}

--- a/backend/internal/usecase/regime/detector.go
+++ b/backend/internal/usecase/regime/detector.go
@@ -1,0 +1,316 @@
+// Package regime classifies the current market state into one of the four
+// labels strategy routing branches on (bull-trend / bear-trend / range /
+// volatile / unknown). The detector reads from the existing IndicatorSet
+// — no new indicator calculation — so a regime emission is "free" once a
+// pipeline tick has produced the indicators it already produces today.
+//
+// Why a separate package: the Strategy port can later wire a router that
+// owns one detector and N strategies, but the classifier itself must
+// stay free of any Strategy/profile imports. Putting it under usecase/
+// keeps it side-effect free and unit-testable without spinning up a
+// backtest runner.
+//
+// The classification is deliberately rule-based (no learning) so the
+// behaviour is auditable from the PDCA cycle records and a single
+// thresholds change can be diffed and rolled back. See
+// docs/pdca/2026-04-22_cycle28-37.md for the regime decomposition that
+// motivated the four-label space.
+package regime
+
+import (
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+)
+
+// Config bundles the thresholds and hysteresis depth so the routing
+// layer can tune them per profile pair without recompiling. All fields
+// are zero-default safe — a Detector built with Config{} uses the
+// defaults documented next to each field.
+type Config struct {
+	// TrendADXMin is the ADX value at or above which a directional
+	// regime (bull-trend / bear-trend) becomes eligible. Below this, the
+	// market is treated as ranging or volatile. Default 20 (Wilder's
+	// "trend present" threshold).
+	TrendADXMin float64
+
+	// VolatileATRPercentMin is the ATR/price threshold (in percent
+	// units, e.g. 2.5 = 2.5%) at or above which a non-trending bar is
+	// classified as volatile rather than range. Default 2.5%, calibrated
+	// against the LTC 15m 2022 crash window where ATR/price routinely
+	// exceeded 3% while ADX stayed in the 15-20 chop band.
+	VolatileATRPercentMin float64
+
+	// HysteresisBars is the minimum number of consecutive bars a new
+	// candidate regime must persist before the detector switches to it.
+	// 0 disables hysteresis. Default 3 (one strategy bar = one tick;
+	// 3 bars on 15m candles = 45 minutes minimum dwell time).
+	HysteresisBars int
+}
+
+// DefaultConfig returns the production-tuned thresholds. Unit tests
+// build their own Config so a future tuning change does not silently
+// break the test fixtures.
+func DefaultConfig() Config {
+	return Config{
+		TrendADXMin:           20,
+		VolatileATRPercentMin: 2.5,
+		HysteresisBars:        3,
+	}
+}
+
+// Detector is stateful: the hysteresis logic needs to remember the
+// committed regime and how many bars the current candidate has
+// persisted for. One Detector per backtest run / live pipeline.
+type Detector struct {
+	cfg Config
+
+	committed  entity.Regime
+	candidate  entity.Regime
+	candidateN int
+}
+
+// NewDetector builds a Detector with the supplied Config. Zero-valued
+// Config fields fall back to DefaultConfig values.
+func NewDetector(cfg Config) *Detector {
+	d := DefaultConfig()
+	if cfg.TrendADXMin > 0 {
+		d.TrendADXMin = cfg.TrendADXMin
+	}
+	if cfg.VolatileATRPercentMin > 0 {
+		d.VolatileATRPercentMin = cfg.VolatileATRPercentMin
+	}
+	if cfg.HysteresisBars > 0 {
+		d.HysteresisBars = cfg.HysteresisBars
+	}
+	return &Detector{cfg: d, committed: entity.RegimeUnknown}
+}
+
+// Classify reads the supplied indicator snapshots and returns the
+// committed regime (after hysteresis). lastPrice is the close used to
+// normalise ATR into a percentage and to read Ichimoku cloud position.
+//
+// The Ichimoku snapshot, when present, comes from the higher timeframe;
+// when nil the detector falls back to SMA20/SMA50 cross for direction.
+// This matches the existing htfTrendDirection convention so a regime
+// router can reuse the same higher-TF wiring the HTF filter uses.
+//
+// When critical inputs (ADX or ATR) are missing the classifier emits
+// RegimeUnknown so callers can route to a baseline profile rather than
+// guessing a direction during warmup.
+func (d *Detector) Classify(indicators entity.IndicatorSet, higherTF *entity.IndicatorSet, lastPrice float64) entity.RegimeClassification {
+	out := entity.RegimeClassification{
+		Timestamp:     indicators.Timestamp,
+		CloudPosition: classifyCloudPosition(higherTF, lastPrice),
+	}
+
+	// ADX and ATR are the load-bearing inputs. If either is missing the
+	// classifier cannot speak — committing Unknown also resets the
+	// candidate counter so the next valid bar starts the dwell clock
+	// from one, not from a stale partial count.
+	if indicators.ADX14 == nil || indicators.ATR14 == nil || lastPrice <= 0 {
+		d.committed = entity.RegimeUnknown
+		d.candidate = entity.RegimeUnknown
+		d.candidateN = 0
+		out.Regime = entity.RegimeUnknown
+		return out
+	}
+
+	adx := *indicators.ADX14
+	atrPct := *indicators.ATR14 / lastPrice * 100
+	out.ADXValue = adx
+	out.ATRPercent = atrPct
+
+	candidate, conf := d.classifyOnce(indicators, higherTF, lastPrice, adx, atrPct, out.CloudPosition)
+	out.Confidence = conf
+
+	committed := d.applyHysteresis(candidate)
+	out.Regime = committed
+	return out
+}
+
+// classifyOnce produces a regime from one bar's inputs, ignoring
+// hysteresis. Split out so the test suite can exercise the rule logic
+// without juggling Detector state.
+//
+// Confidence is a coarse 4-step ladder (0.25 / 0.5 / 0.75 / 1.0) rather
+// than a continuous score: it captures "barely qualified" vs. "every
+// dimension agreed" without the false precision a continuous score
+// would imply for a hand-tuned classifier.
+func (d *Detector) classifyOnce(
+	indicators entity.IndicatorSet,
+	higherTF *entity.IndicatorSet,
+	lastPrice, adx, atrPct float64,
+	cloud string,
+) (entity.Regime, float64) {
+	trendStrong := adx >= d.cfg.TrendADXMin
+	highVol := atrPct >= d.cfg.VolatileATRPercentMin
+
+	if trendStrong {
+		direction := classifyDirection(indicators, higherTF, cloud)
+		switch direction {
+		case "up":
+			conf := 0.5
+			if cloud == "above" {
+				conf += 0.25
+			}
+			if adx >= d.cfg.TrendADXMin*1.5 {
+				conf += 0.25
+			}
+			if conf > 1.0 {
+				conf = 1.0
+			}
+			return entity.RegimeBullTrend, conf
+		case "down":
+			conf := 0.5
+			if cloud == "below" {
+				conf += 0.25
+			}
+			if adx >= d.cfg.TrendADXMin*1.5 {
+				conf += 0.25
+			}
+			if conf > 1.0 {
+				conf = 1.0
+			}
+			return entity.RegimeBearTrend, conf
+		}
+		// Direction was undetermined despite trend strength — treat as
+		// volatile/range based on ATR rather than guessing a direction.
+	}
+
+	if highVol {
+		conf := 0.5
+		if atrPct >= d.cfg.VolatileATRPercentMin*1.5 {
+			conf += 0.25
+		}
+		if !trendStrong {
+			conf += 0.25
+		}
+		if conf > 1.0 {
+			conf = 1.0
+		}
+		return entity.RegimeVolatile, conf
+	}
+
+	conf := 0.5
+	if adx < d.cfg.TrendADXMin*0.75 {
+		conf += 0.25
+	}
+	if atrPct < d.cfg.VolatileATRPercentMin*0.75 {
+		conf += 0.25
+	}
+	if conf > 1.0 {
+		conf = 1.0
+	}
+	return entity.RegimeRange, conf
+}
+
+// applyHysteresis decides whether to commit the new candidate. The rule
+// is intentionally asymmetric: switching INTO a regime requires
+// HysteresisBars consecutive matches; switching to RegimeUnknown is
+// never throttled because warmup loss should be reflected immediately.
+func (d *Detector) applyHysteresis(candidate entity.Regime) entity.Regime {
+	if !candidate.IsKnown() {
+		d.committed = entity.RegimeUnknown
+		d.candidate = entity.RegimeUnknown
+		d.candidateN = 0
+		return entity.RegimeUnknown
+	}
+
+	// First-ever real classification: commit immediately so the very
+	// first non-warmup bar already routes (no dead window where the
+	// detector is "thinking").
+	if !d.committed.IsKnown() {
+		d.committed = candidate
+		d.candidate = candidate
+		d.candidateN = 1
+		return d.committed
+	}
+
+	if candidate == d.committed {
+		// Reaffirmation: keep the committed regime, reset the dwell
+		// counter so a brief opposite blip does not chip away at the
+		// switch threshold.
+		d.candidate = candidate
+		d.candidateN = 0
+		return d.committed
+	}
+
+	if candidate == d.candidate {
+		d.candidateN++
+	} else {
+		d.candidate = candidate
+		d.candidateN = 1
+	}
+	if d.candidateN >= d.cfg.HysteresisBars {
+		d.committed = candidate
+		d.candidateN = 0
+	}
+	return d.committed
+}
+
+// Reset puts the Detector back into the warmup state. Used when a
+// backtest runner starts a new window so the previous window's hysteresis
+// state does not bleed into the new one.
+func (d *Detector) Reset() {
+	d.committed = entity.RegimeUnknown
+	d.candidate = entity.RegimeUnknown
+	d.candidateN = 0
+}
+
+// Committed exposes the current committed regime without taking a new
+// classification. Useful for tests and for the router to peek at
+// state without forcing a re-classify.
+func (d *Detector) Committed() entity.Regime { return d.committed }
+
+// classifyCloudPosition returns "above" / "below" / "inside" when the
+// higher-timeframe Ichimoku snapshot is complete enough, or the empty
+// string when it is missing or warming up. The semantics intentionally
+// mirror htfTrendDirection in usecase/strategy.go.
+func classifyCloudPosition(higherTF *entity.IndicatorSet, lastPrice float64) string {
+	if higherTF == nil || higherTF.Ichimoku == nil {
+		return ""
+	}
+	ic := higherTF.Ichimoku
+	if ic.SenkouA == nil || ic.SenkouB == nil {
+		return ""
+	}
+	upper := *ic.SenkouA
+	lower := *ic.SenkouB
+	if lower > upper {
+		upper, lower = lower, upper
+	}
+	switch {
+	case lastPrice > upper:
+		return "above"
+	case lastPrice < lower:
+		return "below"
+	default:
+		return "inside"
+	}
+}
+
+// classifyDirection picks between "up" / "down" / "" using Ichimoku
+// cloud position when available, falling back to higher-TF SMA20/SMA50
+// cross, falling back to primary-TF SMA cross. Returns the empty
+// string when no source has enough data — the caller treats that as
+// "trend strong but undirected" and routes to volatile/range instead.
+func classifyDirection(indicators entity.IndicatorSet, higherTF *entity.IndicatorSet, cloud string) string {
+	switch cloud {
+	case "above":
+		return "up"
+	case "below":
+		return "down"
+	}
+	if higherTF != nil && higherTF.SMA20 != nil && higherTF.SMA50 != nil {
+		if *higherTF.SMA20 > *higherTF.SMA50 {
+			return "up"
+		}
+		return "down"
+	}
+	if indicators.SMA20 != nil && indicators.SMA50 != nil {
+		if *indicators.SMA20 > *indicators.SMA50 {
+			return "up"
+		}
+		return "down"
+	}
+	return ""
+}

--- a/backend/internal/usecase/regime/detector_test.go
+++ b/backend/internal/usecase/regime/detector_test.go
@@ -1,0 +1,282 @@
+package regime
+
+import (
+	"testing"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+)
+
+// fp returns a *float64 from a literal. Pointer-based optional fields
+// are everywhere in IndicatorSet; this just keeps the test bodies
+// readable.
+func fp(v float64) *float64 { return &v }
+
+// indicatorsWith builds an IndicatorSet with ADX/ATR set and the rest
+// nil — the two required inputs. SMA20/SMA50 are optional direction
+// inputs, set when the test wants the SMA-cross fallback to fire.
+func indicatorsWith(adx, atr float64) entity.IndicatorSet {
+	return entity.IndicatorSet{
+		ADX14:     fp(adx),
+		ATR14:     fp(atr),
+		Timestamp: 1700000000000,
+	}
+}
+
+func htfWithSMA(sma20, sma50 float64) *entity.IndicatorSet {
+	return &entity.IndicatorSet{SMA20: fp(sma20), SMA50: fp(sma50)}
+}
+
+func htfWithCloud(senkouA, senkouB float64) *entity.IndicatorSet {
+	return &entity.IndicatorSet{
+		Ichimoku: &entity.IchimokuSnapshot{SenkouA: fp(senkouA), SenkouB: fp(senkouB)},
+	}
+}
+
+// -------------- single-bar classification --------------
+
+func TestClassifyOnce_BullTrend_FromCloudAbove(t *testing.T) {
+	d := NewDetector(Config{HysteresisBars: 1}) // disable dwell so we read the first bar
+	got := d.Classify(indicatorsWith(35, 1.0), htfWithCloud(95, 90), 100)
+	if got.Regime != entity.RegimeBullTrend {
+		t.Fatalf("regime = %q, want bull-trend (above strong cloud, ADX 35)", got.Regime)
+	}
+	if got.Confidence < 0.75 {
+		t.Fatalf("confidence = %v, want >= 0.75 (above + ADX strong)", got.Confidence)
+	}
+	if got.CloudPosition != "above" {
+		t.Fatalf("cloud = %q", got.CloudPosition)
+	}
+}
+
+func TestClassifyOnce_BearTrend_FromCloudBelow(t *testing.T) {
+	d := NewDetector(Config{HysteresisBars: 1})
+	got := d.Classify(indicatorsWith(35, 1.0), htfWithCloud(110, 105), 100)
+	if got.Regime != entity.RegimeBearTrend {
+		t.Fatalf("regime = %q, want bear-trend", got.Regime)
+	}
+	if got.CloudPosition != "below" {
+		t.Fatalf("cloud = %q", got.CloudPosition)
+	}
+}
+
+func TestClassifyOnce_BullTrend_FromHTFSMACross_NoCloud(t *testing.T) {
+	d := NewDetector(Config{HysteresisBars: 1})
+	got := d.Classify(indicatorsWith(25, 1.0), htfWithSMA(110, 100), 100)
+	if got.Regime != entity.RegimeBullTrend {
+		t.Fatalf("regime = %q, want bull-trend (SMA20>SMA50 fallback)", got.Regime)
+	}
+	if got.CloudPosition != "" {
+		t.Fatalf("cloud should be empty without ichimoku, got %q", got.CloudPosition)
+	}
+}
+
+func TestClassifyOnce_BearTrend_FromHTFSMACross_NoCloud(t *testing.T) {
+	d := NewDetector(Config{HysteresisBars: 1})
+	got := d.Classify(indicatorsWith(25, 1.0), htfWithSMA(95, 100), 100)
+	if got.Regime != entity.RegimeBearTrend {
+		t.Fatalf("regime = %q, want bear-trend", got.Regime)
+	}
+}
+
+func TestClassifyOnce_Volatile_HighATR_LowADX(t *testing.T) {
+	d := NewDetector(Config{HysteresisBars: 1})
+	got := d.Classify(indicatorsWith(15, 4.0), nil, 100) // ATR 4% on 100 = 4.0
+	if got.Regime != entity.RegimeVolatile {
+		t.Fatalf("regime = %q, want volatile (ATR%% 4.0, ADX 15)", got.Regime)
+	}
+	if got.ATRPercent != 4.0 {
+		t.Fatalf("ATRPercent = %v, want 4.0", got.ATRPercent)
+	}
+}
+
+func TestClassifyOnce_Range_LowATR_LowADX(t *testing.T) {
+	d := NewDetector(Config{HysteresisBars: 1})
+	got := d.Classify(indicatorsWith(12, 0.8), nil, 100)
+	if got.Regime != entity.RegimeRange {
+		t.Fatalf("regime = %q, want range (calm + chop)", got.Regime)
+	}
+	if got.Confidence < 0.75 {
+		t.Fatalf("confidence = %v, deeply-calm range should score >= 0.75", got.Confidence)
+	}
+}
+
+func TestClassifyOnce_Unknown_ADXMissing(t *testing.T) {
+	d := NewDetector(DefaultConfig())
+	in := entity.IndicatorSet{ATR14: fp(1.0)} // no ADX
+	got := d.Classify(in, nil, 100)
+	if got.Regime != entity.RegimeUnknown {
+		t.Fatalf("regime = %q, want unknown when ADX missing", got.Regime)
+	}
+}
+
+func TestClassifyOnce_Unknown_ATRMissing(t *testing.T) {
+	d := NewDetector(DefaultConfig())
+	in := entity.IndicatorSet{ADX14: fp(30)}
+	got := d.Classify(in, nil, 100)
+	if got.Regime != entity.RegimeUnknown {
+		t.Fatalf("regime = %q, want unknown when ATR missing", got.Regime)
+	}
+}
+
+func TestClassifyOnce_Unknown_LastPriceZero(t *testing.T) {
+	d := NewDetector(DefaultConfig())
+	got := d.Classify(indicatorsWith(30, 1.0), nil, 0)
+	if got.Regime != entity.RegimeUnknown {
+		t.Fatalf("regime = %q, want unknown when lastPrice <= 0", got.Regime)
+	}
+}
+
+// classifyOnce direction fallback: ADX strong but no Ichimoku and no
+// SMAs anywhere → no direction → falls through to volatility-based
+// classification rather than guessing a side.
+func TestClassifyOnce_TrendStrongNoDirection_FallsToRangeOrVolatile(t *testing.T) {
+	d := NewDetector(Config{HysteresisBars: 1})
+	got := d.Classify(indicatorsWith(40, 0.5), nil, 100)
+	if got.Regime == entity.RegimeBullTrend || got.Regime == entity.RegimeBearTrend {
+		t.Fatalf("regime = %q; without direction inputs the detector must not guess a side", got.Regime)
+	}
+}
+
+// classifyDirection prefers Ichimoku cloud over SMA cross when both
+// are present, so a contradiction ("cloud above" + "SMA bear cross")
+// resolves to the cloud's direction.
+func TestClassifyOnce_DirectionPrefersCloudOverSMA(t *testing.T) {
+	d := NewDetector(Config{HysteresisBars: 1})
+	htf := &entity.IndicatorSet{
+		SMA20:    fp(95),
+		SMA50:    fp(100),
+		Ichimoku: &entity.IchimokuSnapshot{SenkouA: fp(95), SenkouB: fp(90)}, // cloud below price 100
+	}
+	got := d.Classify(indicatorsWith(35, 1.0), htf, 100)
+	if got.Regime != entity.RegimeBullTrend {
+		t.Fatalf("regime = %q; cloud=above must outvote SMA bear cross", got.Regime)
+	}
+}
+
+// -------------- hysteresis --------------
+
+// Switching from one committed regime to a new candidate must require
+// HysteresisBars consecutive matches; a single-bar opposite blip should
+// not move the committed state.
+func TestApplyHysteresis_RequiresMinimumDwell(t *testing.T) {
+	d := NewDetector(Config{HysteresisBars: 3})
+	// Establish bull-trend baseline.
+	for i := 0; i < 5; i++ {
+		d.Classify(indicatorsWith(30, 1.0), htfWithCloud(95, 90), 100)
+	}
+	if d.Committed() != entity.RegimeBullTrend {
+		t.Fatalf("baseline regime = %q, want bull-trend", d.Committed())
+	}
+	// Single bear-trend bar — must NOT switch yet.
+	d.Classify(indicatorsWith(30, 1.0), htfWithCloud(110, 105), 100)
+	if d.Committed() != entity.RegimeBullTrend {
+		t.Fatalf("regime flipped after 1 opposite bar: got %q", d.Committed())
+	}
+	// Two more bear bars → 3 consecutive → switch.
+	d.Classify(indicatorsWith(30, 1.0), htfWithCloud(110, 105), 100)
+	d.Classify(indicatorsWith(30, 1.0), htfWithCloud(110, 105), 100)
+	if d.Committed() != entity.RegimeBearTrend {
+		t.Fatalf("regime did not switch after 3 consecutive opposite bars: got %q", d.Committed())
+	}
+}
+
+// A single opposite bar surrounded by reaffirmations should leave the
+// committed regime untouched and the candidate counter must reset
+// each time the candidate diverges.
+func TestApplyHysteresis_NonConsecutiveCandidatesResetCounter(t *testing.T) {
+	d := NewDetector(Config{HysteresisBars: 3})
+	for i := 0; i < 5; i++ {
+		d.Classify(indicatorsWith(30, 1.0), htfWithCloud(95, 90), 100)
+	}
+	// bear, bull(reaffirm), bear, bull, bear — never 3 bears in a row.
+	d.Classify(indicatorsWith(30, 1.0), htfWithCloud(110, 105), 100)
+	d.Classify(indicatorsWith(30, 1.0), htfWithCloud(95, 90), 100)
+	d.Classify(indicatorsWith(30, 1.0), htfWithCloud(110, 105), 100)
+	d.Classify(indicatorsWith(30, 1.0), htfWithCloud(95, 90), 100)
+	d.Classify(indicatorsWith(30, 1.0), htfWithCloud(110, 105), 100)
+	if d.Committed() != entity.RegimeBullTrend {
+		t.Fatalf("regime flipped despite no 3 consecutive opposite bars: got %q", d.Committed())
+	}
+}
+
+// First bar after warmup commits immediately — there is no "thinking"
+// dead window between RegimeUnknown and the first real classification.
+func TestApplyHysteresis_FirstRealBarCommitsImmediately(t *testing.T) {
+	d := NewDetector(Config{HysteresisBars: 5})
+	got := d.Classify(indicatorsWith(30, 1.0), htfWithCloud(95, 90), 100)
+	if got.Regime != entity.RegimeBullTrend {
+		t.Fatalf("first real bar did not commit: got %q", got.Regime)
+	}
+}
+
+// Returning to RegimeUnknown (warmup loss / missing inputs) must
+// short-circuit hysteresis so a router does not keep trading on a
+// stale regime when indicators stop arriving.
+func TestApplyHysteresis_UnknownResetsImmediately(t *testing.T) {
+	d := NewDetector(Config{HysteresisBars: 3})
+	d.Classify(indicatorsWith(30, 1.0), htfWithCloud(95, 90), 100)
+	if d.Committed() != entity.RegimeBullTrend {
+		t.Fatalf("setup failed: %q", d.Committed())
+	}
+	d.Classify(entity.IndicatorSet{}, nil, 100) // ADX missing → unknown
+	if d.Committed() != entity.RegimeUnknown {
+		t.Fatalf("regime did not reset to unknown: got %q", d.Committed())
+	}
+}
+
+func TestReset_ClearsAllState(t *testing.T) {
+	d := NewDetector(Config{HysteresisBars: 3})
+	d.Classify(indicatorsWith(30, 1.0), htfWithCloud(95, 90), 100)
+	d.Reset()
+	if d.Committed() != entity.RegimeUnknown {
+		t.Fatalf("Reset did not clear committed: %q", d.Committed())
+	}
+	// After reset, the next bar must commit immediately again (no
+	// stale candidate counter).
+	got := d.Classify(indicatorsWith(30, 1.0), htfWithCloud(110, 105), 100)
+	if got.Regime != entity.RegimeBearTrend {
+		t.Fatalf("post-reset regime = %q, want bear-trend immediately", got.Regime)
+	}
+}
+
+// -------------- config defaults --------------
+
+func TestNewDetector_ZeroConfigUsesDefaults(t *testing.T) {
+	d := NewDetector(Config{})
+	if d.cfg.TrendADXMin != 20 {
+		t.Errorf("TrendADXMin = %v, want 20 default", d.cfg.TrendADXMin)
+	}
+	if d.cfg.VolatileATRPercentMin != 2.5 {
+		t.Errorf("VolatileATRPercentMin = %v, want 2.5 default", d.cfg.VolatileATRPercentMin)
+	}
+	if d.cfg.HysteresisBars != 3 {
+		t.Errorf("HysteresisBars = %v, want 3 default", d.cfg.HysteresisBars)
+	}
+}
+
+func TestNewDetector_PartialConfigOverridesPerField(t *testing.T) {
+	d := NewDetector(Config{TrendADXMin: 30}) // only override one field
+	if d.cfg.TrendADXMin != 30 {
+		t.Errorf("TrendADXMin override lost: %v", d.cfg.TrendADXMin)
+	}
+	if d.cfg.VolatileATRPercentMin != 2.5 {
+		t.Errorf("VolatileATRPercentMin should default: %v", d.cfg.VolatileATRPercentMin)
+	}
+}
+
+// -------------- regime entity --------------
+
+func TestRegime_IsKnown(t *testing.T) {
+	cases := map[entity.Regime]bool{
+		entity.RegimeUnknown:   false,
+		entity.RegimeBullTrend: true,
+		entity.RegimeBearTrend: true,
+		entity.RegimeRange:     true,
+		entity.RegimeVolatile:  true,
+	}
+	for r, want := range cases {
+		if r.IsKnown() != want {
+			t.Errorf("Regime(%q).IsKnown() = %v, want %v", r, r.IsKnown(), want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `entity.Regime` (`bull-trend`/`bear-trend`/`range`/`volatile`/`unknown`) + `RegimeClassification` snapshot.
- Adds `usecase/regime.Detector` that classifies one bar from the existing `IndicatorSet` (ADX, ATR, Ichimoku, SMA20/50). No new indicators are computed — emitting a regime is free per pipeline tick.
- Hysteresis (default 3 bars, ~45min on 15m candles) prevents flapping at threshold boundaries. Switching INTO a regime needs N consecutive matches; falling back to `RegimeUnknown` (warmup loss) is never throttled.
- **No router yet** — this PR is part A of PR-5. PR B adds a config schema for `regime_routing` and a `Strategy`-port `ProfileRouter` that consults this detector.

## Why a separate PR

Cycle28-37 found two finalists that are each strong on one regime and catastrophic on the other (`sl14_tf60_35` blows up −57.97% on 2022; `sl6_tr30_tp6_tf60_35` only manages +14.69% on 2023-26). Cycle38 confirmed Ichimoku HTF cannot bridge the gap. The remaining axis is regime-conditional routing.

Landing the classifier alone — with thresholds tunable via `Config` and 19 unit tests — lets the threshold tuning happen against synthetic golden vectors before any backtest result is wired up. PR B then becomes a pure plumbing change.

## Design choices

| choice | rationale |
|---|---|
| 4 labels | 1:1 map to cycle28-37 finalist pair; small label space keeps router config readable. |
| Reads from existing IndicatorSet only | No new pipeline cost; works under both backtest and live. |
| Direction priority Ichimoku > HTF SMA > primary SMA | Mirrors `htfTrendDirection` in `usecase/strategy.go` so router and HTF filter agree. |
| Default hysteresis 3 bars | 45min dwell on 15m candles — enough to ignore one wick, short enough to react to a real shift. |
| Coarse 0.25 / 0.5 / 0.75 / 1.0 confidence | Avoids implying continuous precision the rule-based model does not have. |
| ADX/ATR missing → RegimeUnknown | Caller routes to baseline profile instead of guessing direction during warmup. |
| Switching to RegimeUnknown not throttled | Warmup loss / missing inputs must be reflected immediately so router does not keep trading on stale regime. |

## Test plan
- [x] `go test ./internal/usecase/regime/... -race -count=1 -v` — 19/19 pass.
- [x] `go test ./... -race -count=1` — full backend suite green.
- [x] `gofmt -l` and `go vet` clean.
- [x] Coverage: each of the 4 regime emissions from each direction source, ADX/ATR/lastPrice missing → unknown, direction priority (Ichimoku vs SMA contradiction), hysteresis dwell threshold, non-consecutive candidate counter reset, first-bar immediate commit, unknown reset, partial Config overrides, `Regime.IsKnown` helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)