### PR TITLE
feat(strategy): regime-routing profile schema + ProfileRouter (PR-5 part B)

### DIFF
--- a/backend/internal/domain/entity/regime.go
+++ b/backend/internal/domain/entity/regime.go
@@ -17,11 +17,33 @@ const (
 	RegimeVolatile  Regime = "volatile"
 )
 
-// IsKnown reports whether r is a real regime label (not the warmup-only
-// RegimeUnknown sentinel). Centralised so callers do not hard-code the
-// "" comparison.
+// IsKnown reports whether r is anything other than RegimeUnknown — the
+// "the detector has committed to a real regime" check. This is the
+// hot-path predicate: the router uses it on every Evaluate to decide
+// whether to consult the overrides map or fall through to default.
+//
+// Note: IsKnown returns true for *any* non-empty Regime value,
+// including stringly-typed garbage like Regime("bear-trnd"). For the
+// stricter "is this string one of the four legal labels" check used
+// by config validation, see IsValidLabel.
 func (r Regime) IsKnown() bool {
 	return r != RegimeUnknown
+}
+
+// IsValidLabel reports whether r is one of the four canonical regime
+// labels (bull-trend / bear-trend / range / volatile). Used by config
+// validation to reject typos in regime_routing.overrides keys before
+// they silently shadow a real branch at runtime.
+//
+// RegimeUnknown is *not* a valid label here — it is a sentinel for the
+// warmup state and must never be a routing key (it would shadow the
+// router's Default branch).
+func (r Regime) IsValidLabel() bool {
+	switch r {
+	case RegimeBullTrend, RegimeBearTrend, RegimeRange, RegimeVolatile:
+		return true
+	}
+	return false
 }
 
 // RegimeClassification is one detector emission. ADXValue / ATRPercent /

--- a/backend/internal/domain/entity/strategy_config.go
+++ b/backend/internal/domain/entity/strategy_config.go
@@ -19,6 +19,15 @@ type StrategyProfile struct {
 	SignalRules SignalRulesConfig  `json:"signal_rules"`
 	Risk        StrategyRiskConfig `json:"strategy_risk"`
 	HTFFilter   HTFFilterConfig    `json:"htf_filter"`
+	// RegimeRouting is optional. When set (non-nil), the profile is
+	// treated as a router that delegates to child profiles by Regime.
+	// See RegimeRoutingConfig and usecase/strategy.ProfileRouter.
+	//
+	// Pointer (not value) so the JSON round-trip preserves "this
+	// profile has no routing block" — a value-typed RegimeRoutingConfig
+	// always serialises an empty map, which would corrupt the existing
+	// TestStrategyProfile_JSONRoundTrip contract.
+	RegimeRouting *RegimeRoutingConfig `json:"regime_routing,omitempty"`
 }
 
 // IndicatorConfig declares the lookback periods and shape parameters used when
@@ -106,6 +115,53 @@ type HTFFilterConfig struct {
 	Mode string `json:"mode,omitempty"`
 }
 
+// RegimeRoutingConfig declares regime-conditional profile delegation.
+// When set, the loaded profile becomes a *router*: the strategy looks
+// up the current Regime (see usecase/regime.Detector) and delegates to
+// the child profile named by Default (when no regime-specific override
+// applies) or by Overrides[regime].
+//
+// Child profiles are loaded by the same Loader from the same base
+// directory. Children must NOT themselves carry regime_routing — depth
+// is capped at 1 to keep the routing graph readable and to avoid
+// silent infinite-loop debugging.
+//
+// Example: cycle28-37 produced two finalists, one strong on
+// trending bull regimes (sl14_tf60_35) and one robust to bear /
+// volatile regimes (sl6_tr30_tp6_tf60_35). A regime router pairing the
+// two looks like:
+//
+//	"regime_routing": {
+//	  "default": "experiment_2026-04-22_sl14_tf60_35",
+//	  "overrides": {
+//	    "bear-trend": "experiment_2026-04-22_sl6_tr30_tp6_tf60_35",
+//	    "volatile":   "experiment_2026-04-22_sl6_tr30_tp6_tf60_35"
+//	  }
+//	}
+type RegimeRoutingConfig struct {
+	// Default is the child profile name used when the detector emits
+	// RegimeUnknown (warmup) or a regime not listed in Overrides.
+	// Required when regime_routing is set; the profile is otherwise a
+	// no-op routing wrapper that just runs Default 100% of the time.
+	Default string `json:"default"`
+
+	// Overrides maps Regime label → child profile name. Keys must be
+	// known Regime values (bull-trend / bear-trend / range / volatile);
+	// "" / "unknown" is rejected because it would shadow Default.
+	Overrides map[string]string `json:"overrides,omitempty"`
+}
+
+// IsRouting reports whether this profile is a router. Centralised so
+// callers do not duplicate the "Default != """ check.
+func (r RegimeRoutingConfig) IsRouting() bool { return r.Default != "" }
+
+// HasRouting is the nil-safe form for *RegimeRoutingConfig fields on
+// StrategyProfile — handles "no routing block at all" without forcing
+// callers to write `p.RegimeRouting != nil && p.RegimeRouting.IsRouting()`.
+func (p StrategyProfile) HasRouting() bool {
+	return p.RegimeRouting != nil && p.RegimeRouting.IsRouting()
+}
+
 // StrategyRiskConfig configures the per-strategy risk envelope (position
 // sizing, stop-loss, take-profit, daily loss cap).
 type StrategyRiskConfig struct {
@@ -134,6 +190,22 @@ func (p StrategyProfile) Validate() error {
 
 	if p.Name == "" {
 		errs = append(errs, errors.New("name must not be empty"))
+	}
+
+	// Routing profiles delegate every per-bar decision to children, so
+	// indicator periods / signal rules / risk envelope on the router
+	// itself are unused. Skip the field-level checks below and only
+	// validate the routing block.
+	if p.RegimeRouting != nil && p.RegimeRouting.Default != "" {
+		for key := range p.RegimeRouting.Overrides {
+			if !Regime(key).IsValidLabel() {
+				errs = append(errs, fmt.Errorf("regime_routing.overrides has unknown regime key %q (want one of bull-trend, bear-trend, range, volatile)", key))
+			}
+		}
+		if len(errs) == 0 {
+			return nil
+		}
+		return fmt.Errorf("invalid strategy profile: %w", errors.Join(errs...))
 	}
 
 	ind := p.Indicators
@@ -187,6 +259,13 @@ func (p StrategyProfile) Validate() error {
 	}
 	if p.Risk.TakeProfitPercent < 0 {
 		errs = append(errs, fmt.Errorf("strategy_risk.take_profit_percent must be >= 0 (got %v)", p.Risk.TakeProfitPercent))
+	}
+
+	// regime_routing.overrides without a default is also flagged — a
+	// non-empty Overrides without Default is almost certainly a typo
+	// (the writer meant to set both).
+	if p.RegimeRouting != nil && len(p.RegimeRouting.Overrides) > 0 && p.RegimeRouting.Default == "" {
+		errs = append(errs, errors.New("regime_routing.default must be set when regime_routing.overrides is non-empty"))
 	}
 
 	if len(errs) == 0 {

--- a/backend/internal/usecase/regime/detector_test.go
+++ b/backend/internal/usecase/regime/detector_test.go
@@ -273,10 +273,31 @@ func TestRegime_IsKnown(t *testing.T) {
 		entity.RegimeBearTrend: true,
 		entity.RegimeRange:     true,
 		entity.RegimeVolatile:  true,
+		entity.Regime("typo"):  true, // IsKnown is "non-empty", not "valid label"
 	}
 	for r, want := range cases {
 		if r.IsKnown() != want {
 			t.Errorf("Regime(%q).IsKnown() = %v, want %v", r, r.IsKnown(), want)
+		}
+	}
+}
+
+// IsValidLabel is the strict-validation predicate used by config
+// loading; it differs from IsKnown by rejecting typos.
+func TestRegime_IsValidLabel(t *testing.T) {
+	cases := map[entity.Regime]bool{
+		entity.RegimeUnknown:       false, // sentinel, never valid as a key
+		entity.RegimeBullTrend:     true,
+		entity.RegimeBearTrend:     true,
+		entity.RegimeRange:         true,
+		entity.RegimeVolatile:      true,
+		entity.Regime("typo"):      false, // unknown string -> invalid
+		entity.Regime("Bull"):      false, // case-sensitive
+		entity.Regime("bear-trnd"): false,
+	}
+	for r, want := range cases {
+		if r.IsValidLabel() != want {
+			t.Errorf("Regime(%q).IsValidLabel() = %v, want %v", r, r.IsValidLabel(), want)
 		}
 	}
 }

--- a/backend/internal/usecase/strategy/profile_router.go
+++ b/backend/internal/usecase/strategy/profile_router.go
@@ -1,0 +1,149 @@
+package strategy
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/port"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/regime"
+)
+
+// ProfileRouter is a port.Strategy that delegates each Evaluate to a
+// child Strategy chosen by the current Regime.
+//
+// The router owns one regime.Detector instance for its full lifetime
+// (one router per backtest run / live pipeline). Hysteresis state on
+// the detector therefore persists across bars within a single run,
+// which is the entire point — without persisted state every bar would
+// re-classify from scratch and the dwell threshold would never apply.
+//
+// Wiring is fully constructed at NewProfileRouter time: the caller
+// resolves child profiles to their port.Strategy implementations and
+// hands them in by Regime. This keeps ProfileRouter free of any
+// loader/profile concerns and makes the dispatch behaviour trivially
+// testable with stub Strategies.
+//
+// Fallback rules at delegation time:
+//   - RegimeUnknown (warmup, missing inputs) → defaultStrategy
+//   - Any regime not present in overrides    → defaultStrategy
+//   - When higherTF is nil but the detector needs it for direction, it
+//     falls back to primary SMA cross (see regime.classifyDirection)
+//     so the router never panics on missing optional inputs.
+type ProfileRouter struct {
+	name            string
+	detector        *regime.Detector
+	defaultStrategy port.Strategy
+	overrides       map[entity.Regime]port.Strategy
+}
+
+// ProfileRouterInput collects the pre-resolved children plus a detector
+// override hook. DetectorConfig is taken by value so a zero-valued
+// config falls through to regime.DefaultConfig in NewDetector.
+type ProfileRouterInput struct {
+	Name            string
+	DetectorConfig  regime.Config
+	DefaultStrategy port.Strategy
+	Overrides       map[entity.Regime]port.Strategy
+}
+
+// NewProfileRouter builds a ProfileRouter from pre-resolved Strategy
+// children. The caller is responsible for constructing each child
+// (typically via NewConfigurableStrategy on a child profile).
+//
+// Validation:
+//   - DefaultStrategy is required: a router with no default would
+//     return ErrNoStrategyForRegime on every warmup bar.
+//   - Overrides keys must be known Regime values; RegimeUnknown is
+//     rejected because it would shadow Default.
+//   - Empty Name is rejected so registries / log lines stay legible.
+func NewProfileRouter(in ProfileRouterInput) (*ProfileRouter, error) {
+	if in.Name == "" {
+		return nil, fmt.Errorf("profile router: name must not be empty")
+	}
+	if in.DefaultStrategy == nil {
+		return nil, fmt.Errorf("profile router %q: default strategy is required", in.Name)
+	}
+	for r, s := range in.Overrides {
+		if !r.IsValidLabel() {
+			return nil, fmt.Errorf("profile router %q: overrides has unknown regime key %q", in.Name, string(r))
+		}
+		if s == nil {
+			return nil, fmt.Errorf("profile router %q: overrides[%q] is nil", in.Name, string(r))
+		}
+	}
+
+	overrides := make(map[entity.Regime]port.Strategy, len(in.Overrides))
+	for r, s := range in.Overrides {
+		overrides[r] = s
+	}
+
+	return &ProfileRouter{
+		name:            in.Name,
+		detector:        regime.NewDetector(in.DetectorConfig),
+		defaultStrategy: in.DefaultStrategy,
+		overrides:       overrides,
+	}, nil
+}
+
+// Evaluate consults the regime detector, picks the matching child
+// Strategy, and delegates. The returned Signal carries whichever
+// confidence/decision the child produced — the router does not
+// post-process.
+//
+// The selected child is recorded on the Signal via the existing
+// signal.Confidence field's neighbours indirectly (no schema change
+// in this PR); a future PR can add a "regime"+"selectedProfile" field
+// to Signal once the router is in production.
+func (r *ProfileRouter) Evaluate(
+	ctx context.Context,
+	indicators *entity.IndicatorSet,
+	higherTF *entity.IndicatorSet,
+	lastPrice float64,
+	now time.Time,
+) (*entity.Signal, error) {
+	if indicators == nil {
+		return nil, ErrIndicatorsRequired
+	}
+
+	classification := r.detector.Classify(*indicators, higherTF, lastPrice)
+	child := r.SelectStrategy(classification.Regime)
+	return child.Evaluate(ctx, indicators, higherTF, lastPrice, now)
+}
+
+// SelectStrategy returns the child Strategy that the router would pick
+// for the given Regime, or the default when no override applies.
+// Exposed for tests and for diagnostic tooling that needs to label a
+// trade with the strategy that produced it without re-running the
+// detector.
+func (r *ProfileRouter) SelectStrategy(rg entity.Regime) port.Strategy {
+	if !rg.IsKnown() {
+		return r.defaultStrategy
+	}
+	if s, ok := r.overrides[rg]; ok {
+		return s
+	}
+	return r.defaultStrategy
+}
+
+// Name returns the router's profile name. Registries key strategies by
+// Name(), so loading two routers with the same name is a caller error.
+func (r *ProfileRouter) Name() string { return r.name }
+
+// CommittedRegime exposes the detector's current committed regime
+// without forcing a re-classify. Used by tests and by future telemetry
+// hooks that want to log the active regime per tick.
+func (r *ProfileRouter) CommittedRegime() entity.Regime {
+	return r.detector.Committed()
+}
+
+// Reset rewinds the detector's hysteresis state. Backtest runners
+// should call this between independent windows so the previous
+// window's regime memory does not bleed into the next one.
+func (r *ProfileRouter) Reset() {
+	r.detector.Reset()
+}
+
+// Compile-time guarantee that ProfileRouter satisfies port.Strategy.
+var _ port.Strategy = (*ProfileRouter)(nil)

--- a/backend/internal/usecase/strategy/profile_router_builder.go
+++ b/backend/internal/usecase/strategy/profile_router_builder.go
@@ -1,0 +1,115 @@
+package strategy
+
+import (
+	"fmt"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/port"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/regime"
+)
+
+// ProfileLoader is the minimum loader contract the router builder
+// needs. The infrastructure-side strategyprofile.Loader satisfies this
+// without the strategy package importing the infrastructure package
+// (clean architecture: usecase depends on a port, not on infra).
+type ProfileLoader interface {
+	Load(name string) (*entity.StrategyProfile, error)
+}
+
+// BuildStrategyFromProfile turns a loaded StrategyProfile into a ready
+// port.Strategy.
+//
+// When the profile is *not* a router (RegimeRouting.Default == ""),
+// this is just NewConfigurableStrategy(root). When the profile *is* a
+// router, this resolves every child via loader.Load, wraps each in a
+// ConfigurableStrategy, and assembles a ProfileRouter.
+//
+// Depth limit: child profiles must NOT themselves carry regime_routing.
+// This is enforced here (not in entity.StrategyProfile.Validate)
+// because Validate is profile-local and cannot see other profiles.
+// Capping at depth 1 keeps the routing graph trivially explainable
+// ("router → flat strategy") and removes a class of cycle bugs that
+// would otherwise need a visited-set walk to detect.
+//
+// The detector config is taken from the router profile's optional
+// detector_config block when it is set in a future PR; for now every
+// router uses regime.DefaultConfig. This is the "no behaviour change
+// on existing profiles" promise — adding detector_config to the
+// router schema can land in a follow-up without touching this builder.
+func BuildStrategyFromProfile(loader ProfileLoader, root *entity.StrategyProfile) (port.Strategy, error) {
+	if root == nil {
+		return nil, fmt.Errorf("strategy: profile must not be nil")
+	}
+	if !root.HasRouting() {
+		return NewConfigurableStrategy(root)
+	}
+	if loader == nil {
+		return nil, fmt.Errorf("strategy: router profile %q requires a non-nil loader to resolve children", root.Name)
+	}
+
+	rr := root.RegimeRouting
+	// Resolve default first so a typo there fails loud before we go
+	// hunting for override children.
+	defaultProfile, err := loadChild(loader, root.Name, "default", rr.Default)
+	if err != nil {
+		return nil, err
+	}
+	defaultStrategy, err := NewConfigurableStrategy(defaultProfile)
+	if err != nil {
+		return nil, fmt.Errorf("strategy: router %q default child %q: %w", root.Name, rr.Default, err)
+	}
+
+	overrides := make(map[entity.Regime]port.Strategy, len(rr.Overrides))
+	for key, childName := range rr.Overrides {
+		r := entity.Regime(key)
+		// Validate already screened unknown regime keys, but defend
+		// here too in case a future caller skips Validate.
+		if !r.IsValidLabel() {
+			return nil, fmt.Errorf("strategy: router %q overrides has unknown regime key %q", root.Name, key)
+		}
+		childProfile, err := loadChild(loader, root.Name, key, childName)
+		if err != nil {
+			return nil, err
+		}
+		childStrategy, err := NewConfigurableStrategy(childProfile)
+		if err != nil {
+			return nil, fmt.Errorf("strategy: router %q override[%q] child %q: %w", root.Name, key, childName, err)
+		}
+		overrides[r] = childStrategy
+	}
+
+	return NewProfileRouter(ProfileRouterInput{
+		Name:            root.Name,
+		DefaultStrategy: defaultStrategy,
+		Overrides:       overrides,
+	})
+}
+
+// loadChild loads one child profile and enforces depth-1 (children
+// must not themselves carry regime_routing). The slot string is just
+// for the error message — "default" or the regime label that owns
+// this child reference.
+func loadChild(loader ProfileLoader, parentName, slot, childName string) (*entity.StrategyProfile, error) {
+	if childName == "" {
+		return nil, fmt.Errorf("strategy: router %q slot %q has empty child profile name", parentName, slot)
+	}
+	if childName == parentName {
+		return nil, fmt.Errorf("strategy: router %q slot %q references itself (would loop)", parentName, slot)
+	}
+	child, err := loader.Load(childName)
+	if err != nil {
+		return nil, fmt.Errorf("strategy: router %q slot %q: load child %q: %w", parentName, slot, childName, err)
+	}
+	if child == nil {
+		return nil, fmt.Errorf("strategy: router %q slot %q: loader returned nil for %q", parentName, slot, childName)
+	}
+	if child.HasRouting() {
+		return nil, fmt.Errorf("strategy: router %q slot %q: child %q is itself a routing profile (max depth is 1)", parentName, slot, childName)
+	}
+	return child, nil
+}
+
+// Keep regime.Config visible at the strategy package surface so users
+// of BuildStrategyFromProfile do not need a second import for the
+// router config (anti-import-pyramid pattern).
+type DetectorConfig = regime.Config

--- a/backend/internal/usecase/strategy/profile_router_test.go
+++ b/backend/internal/usecase/strategy/profile_router_test.go
@@ -1,0 +1,461 @@
+package strategy
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/port"
+)
+
+// recordingStrategy is a minimal port.Strategy that records every Evaluate
+// call so tests can assert which child the router delegated to.
+type recordingStrategy struct {
+	name string
+
+	mu    sync.Mutex
+	calls int
+}
+
+func (s *recordingStrategy) Evaluate(_ context.Context, _ *entity.IndicatorSet, _ *entity.IndicatorSet, _ float64, now time.Time) (*entity.Signal, error) {
+	s.mu.Lock()
+	s.calls++
+	s.mu.Unlock()
+	// Return a HOLD signal stamped with the strategy name so the test
+	// can also assert via the Signal payload, not just the call counter.
+	return &entity.Signal{
+		Action:    entity.SignalActionHold,
+		Reason:    s.name,
+		Timestamp: now.UnixMilli(),
+	}, nil
+}
+
+func (s *recordingStrategy) Name() string { return s.name }
+
+func (s *recordingStrategy) callCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls
+}
+
+// fp helper for IndicatorSet pointer fields.
+func fp(v float64) *float64 { return &v }
+
+// trendingIndicators builds an IndicatorSet that the regime detector
+// will classify as bull-trend (ADX strong + SMA20>SMA50).
+func trendingIndicators() entity.IndicatorSet {
+	return entity.IndicatorSet{
+		ADX14: fp(35),
+		ATR14: fp(1.0),
+		SMA20: fp(110),
+		SMA50: fp(100),
+	}
+}
+
+// bearIndicators builds an IndicatorSet that classifies as bear-trend.
+func bearIndicators() entity.IndicatorSet {
+	return entity.IndicatorSet{
+		ADX14: fp(35),
+		ATR14: fp(1.0),
+		SMA20: fp(95),
+		SMA50: fp(100),
+	}
+}
+
+// rangeIndicators builds an IndicatorSet that classifies as range
+// (low ADX + low ATR%).
+func rangeIndicators() entity.IndicatorSet {
+	return entity.IndicatorSet{
+		ADX14: fp(12),
+		ATR14: fp(0.8),
+		SMA20: fp(100),
+		SMA50: fp(100),
+	}
+}
+
+// volatileIndicators builds an IndicatorSet that classifies as
+// volatile (low ADX + high ATR%).
+func volatileIndicators() entity.IndicatorSet {
+	return entity.IndicatorSet{
+		ADX14: fp(15),
+		ATR14: fp(4.0),
+		SMA20: fp(100),
+		SMA50: fp(100),
+	}
+}
+
+// -------------- ProfileRouter validation --------------
+
+func TestNewProfileRouter_RequiresName(t *testing.T) {
+	_, err := NewProfileRouter(ProfileRouterInput{
+		DefaultStrategy: &recordingStrategy{name: "d"},
+	})
+	if err == nil {
+		t.Fatal("expected error on empty name")
+	}
+}
+
+func TestNewProfileRouter_RequiresDefault(t *testing.T) {
+	_, err := NewProfileRouter(ProfileRouterInput{Name: "r"})
+	if err == nil {
+		t.Fatal("expected error when DefaultStrategy is nil")
+	}
+}
+
+func TestNewProfileRouter_RejectsUnknownRegimeKey(t *testing.T) {
+	_, err := NewProfileRouter(ProfileRouterInput{
+		Name:            "r",
+		DefaultStrategy: &recordingStrategy{name: "d"},
+		Overrides: map[entity.Regime]port.Strategy{
+			entity.RegimeUnknown: &recordingStrategy{name: "x"}, // shadow Default
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error on RegimeUnknown override (shadows Default)")
+	}
+}
+
+func TestNewProfileRouter_RejectsNilOverride(t *testing.T) {
+	_, err := NewProfileRouter(ProfileRouterInput{
+		Name:            "r",
+		DefaultStrategy: &recordingStrategy{name: "d"},
+		Overrides: map[entity.Regime]port.Strategy{
+			entity.RegimeBearTrend: nil,
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error on nil override entry")
+	}
+}
+
+// -------------- ProfileRouter dispatch --------------
+
+// SelectStrategy is the deterministic surface; Evaluate ties together
+// detector + dispatch and is covered separately below.
+func TestSelectStrategy_DispatchTable(t *testing.T) {
+	def := &recordingStrategy{name: "default"}
+	bear := &recordingStrategy{name: "bear"}
+	vol := &recordingStrategy{name: "vol"}
+	r, err := NewProfileRouter(ProfileRouterInput{
+		Name:            "r",
+		DefaultStrategy: def,
+		Overrides: map[entity.Regime]port.Strategy{
+			entity.RegimeBearTrend: bear,
+			entity.RegimeVolatile:  vol,
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewProfileRouter: %v", err)
+	}
+
+	cases := []struct {
+		regime entity.Regime
+		want   port.Strategy
+	}{
+		{entity.RegimeUnknown, def},   // warmup → default
+		{entity.RegimeBullTrend, def}, // not in overrides → default
+		{entity.RegimeRange, def},     // not in overrides → default
+		{entity.RegimeBearTrend, bear},
+		{entity.RegimeVolatile, vol},
+	}
+	for _, c := range cases {
+		got := r.SelectStrategy(c.regime)
+		if got != c.want {
+			t.Errorf("regime %q: got strategy %q, want %q", c.regime, got.Name(), c.want.Name())
+		}
+	}
+}
+
+// Evaluate must consult the detector, route to the child, and return
+// the child's signal verbatim. Use bear indicators so the router picks
+// the bear child, then assert the bear stub got the call (not default).
+func TestEvaluate_RoutesByRegime(t *testing.T) {
+	def := &recordingStrategy{name: "default"}
+	bear := &recordingStrategy{name: "bear"}
+	r, _ := NewProfileRouter(ProfileRouterInput{
+		Name:            "r",
+		DefaultStrategy: def,
+		Overrides: map[entity.Regime]port.Strategy{
+			entity.RegimeBearTrend: bear,
+		},
+	})
+
+	in := bearIndicators()
+	sig, err := r.Evaluate(context.Background(), &in, nil, 100, time.Unix(1700000000, 0))
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if sig == nil {
+		t.Fatal("Evaluate returned nil signal")
+	}
+	if sig.Reason != "bear" {
+		t.Errorf("signal.Reason = %q, want %q (router did not delegate to bear child)", sig.Reason, "bear")
+	}
+	if def.callCount() != 0 || bear.callCount() != 1 {
+		t.Errorf("call counts: default=%d bear=%d, want 0/1", def.callCount(), bear.callCount())
+	}
+	if r.CommittedRegime() != entity.RegimeBearTrend {
+		t.Errorf("CommittedRegime = %q, want bear-trend", r.CommittedRegime())
+	}
+}
+
+// During warmup (ADX missing) the detector emits Unknown — the router
+// must route to the default strategy, not panic and not skip the bar.
+func TestEvaluate_WarmupRoutesToDefault(t *testing.T) {
+	def := &recordingStrategy{name: "default"}
+	bear := &recordingStrategy{name: "bear"}
+	r, _ := NewProfileRouter(ProfileRouterInput{
+		Name:            "r",
+		DefaultStrategy: def,
+		Overrides:       map[entity.Regime]port.Strategy{entity.RegimeBearTrend: bear},
+	})
+
+	in := entity.IndicatorSet{} // no ADX, no ATR — warmup
+	sig, err := r.Evaluate(context.Background(), &in, nil, 100, time.Now())
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if sig.Reason != "default" {
+		t.Errorf("warmup signal.Reason = %q, want default", sig.Reason)
+	}
+}
+
+func TestEvaluate_NilIndicatorsErrors(t *testing.T) {
+	r, _ := NewProfileRouter(ProfileRouterInput{
+		Name:            "r",
+		DefaultStrategy: &recordingStrategy{name: "d"},
+	})
+	_, err := r.Evaluate(context.Background(), nil, nil, 100, time.Now())
+	if !errors.Is(err, ErrIndicatorsRequired) {
+		t.Fatalf("err = %v, want ErrIndicatorsRequired", err)
+	}
+}
+
+func TestReset_ClearsDetectorState(t *testing.T) {
+	def := &recordingStrategy{name: "default"}
+	r, _ := NewProfileRouter(ProfileRouterInput{
+		Name:            "r",
+		DefaultStrategy: def,
+	})
+	in := trendingIndicators()
+	_, _ = r.Evaluate(context.Background(), &in, nil, 100, time.Now())
+	if r.CommittedRegime() != entity.RegimeBullTrend {
+		t.Fatalf("setup: regime not committed, got %q", r.CommittedRegime())
+	}
+	r.Reset()
+	if r.CommittedRegime() != entity.RegimeUnknown {
+		t.Errorf("after Reset: regime = %q, want unknown", r.CommittedRegime())
+	}
+}
+
+// -------------- Builder: BuildStrategyFromProfile --------------
+
+// stubLoader resolves child profile names from an in-memory map and
+// records every Load call so tests can assert the builder did not
+// over-fetch.
+type stubLoader struct {
+	profiles map[string]*entity.StrategyProfile
+	loaded   []string
+	err      error
+}
+
+func (l *stubLoader) Load(name string) (*entity.StrategyProfile, error) {
+	l.loaded = append(l.loaded, name)
+	if l.err != nil {
+		return nil, l.err
+	}
+	p, ok := l.profiles[name]
+	if !ok {
+		return nil, errors.New("not found: " + name)
+	}
+	return p, nil
+}
+
+// flatProfile returns a minimal valid (non-router) StrategyProfile.
+func flatProfile(name string) *entity.StrategyProfile {
+	return &entity.StrategyProfile{
+		Name: name,
+		Indicators: entity.IndicatorConfig{
+			SMAShort: 20, SMALong: 50, RSIPeriod: 14,
+			MACDFast: 12, MACDSlow: 26, MACDSignal: 9,
+			BBPeriod: 20, BBMultiplier: 2.0, ATRPeriod: 14,
+		},
+		StanceRules: entity.StanceRulesConfig{RSIOversold: 30, RSIOverbought: 70},
+	}
+}
+
+// routerProfile returns a router profile with the given default and
+// optional overrides.
+func routerProfile(name, def string, overrides map[string]string) *entity.StrategyProfile {
+	return &entity.StrategyProfile{
+		Name: name,
+		RegimeRouting: &entity.RegimeRoutingConfig{
+			Default:   def,
+			Overrides: overrides,
+		},
+	}
+}
+
+// Non-router profiles must pass through to NewConfigurableStrategy
+// with no loader call (the loader is irrelevant for flat profiles).
+func TestBuildStrategyFromProfile_FlatProfileSkipsLoader(t *testing.T) {
+	loader := &stubLoader{}
+	got, err := BuildStrategyFromProfile(loader, flatProfile("flat"))
+	if err != nil {
+		t.Fatalf("BuildStrategyFromProfile: %v", err)
+	}
+	if _, ok := got.(*ConfigurableStrategy); !ok {
+		t.Errorf("got type %T, want *ConfigurableStrategy", got)
+	}
+	if len(loader.loaded) != 0 {
+		t.Errorf("loader was consulted for a flat profile: %v", loader.loaded)
+	}
+}
+
+// Router profiles resolve every child via the loader and produce a
+// *ProfileRouter. Each child name appears in loader.loaded exactly
+// once (no over-fetch).
+func TestBuildStrategyFromProfile_RouterResolvesChildren(t *testing.T) {
+	loader := &stubLoader{
+		profiles: map[string]*entity.StrategyProfile{
+			"def":  flatProfile("def"),
+			"bear": flatProfile("bear"),
+		},
+	}
+	root := routerProfile("router", "def", map[string]string{
+		"bear-trend": "bear",
+	})
+	got, err := BuildStrategyFromProfile(loader, root)
+	if err != nil {
+		t.Fatalf("BuildStrategyFromProfile: %v", err)
+	}
+	router, ok := got.(*ProfileRouter)
+	if !ok {
+		t.Fatalf("got type %T, want *ProfileRouter", got)
+	}
+	if router.Name() != "router" {
+		t.Errorf("router.Name() = %q", router.Name())
+	}
+	// bear regime → bear child; bull (not in overrides) → default.
+	bearChoice := router.SelectStrategy(entity.RegimeBearTrend)
+	defChoice := router.SelectStrategy(entity.RegimeBullTrend)
+	if bearChoice.Name() != "bear" {
+		t.Errorf("bear choice name = %q", bearChoice.Name())
+	}
+	if defChoice.Name() != "def" {
+		t.Errorf("default choice name = %q", defChoice.Name())
+	}
+	// Loader called exactly twice (default + one override), not for
+	// regimes the router would never consult.
+	if len(loader.loaded) != 2 {
+		t.Errorf("loader.loaded = %v, want 2 calls", loader.loaded)
+	}
+}
+
+// Depth-1 enforcement: a child profile that is itself a router must
+// be rejected at build time, not silently treated as a deep router.
+func TestBuildStrategyFromProfile_RejectsNestedRouter(t *testing.T) {
+	loader := &stubLoader{
+		profiles: map[string]*entity.StrategyProfile{
+			"def":         flatProfile("def"),
+			"nestedchild": flatProfile("nestedchild"),
+			"nested":      routerProfile("nested", "nestedchild", nil),
+		},
+	}
+	root := routerProfile("router", "def", map[string]string{
+		"bear-trend": "nested",
+	})
+	_, err := BuildStrategyFromProfile(loader, root)
+	if err == nil {
+		t.Fatal("expected error on nested router child")
+	}
+	if !strings.Contains(err.Error(), "max depth") {
+		t.Errorf("error message %q does not mention depth limit", err.Error())
+	}
+}
+
+// Self-reference (default = router itself) would loop forever via
+// loader.Load if not caught. Build must reject it at the top of the
+// recursion so the loader.Load call never even fires for the cycle.
+func TestBuildStrategyFromProfile_RejectsSelfReference(t *testing.T) {
+	loader := &stubLoader{profiles: map[string]*entity.StrategyProfile{}}
+	root := routerProfile("router", "router", nil)
+	_, err := BuildStrategyFromProfile(loader, root)
+	if err == nil {
+		t.Fatal("expected error on router referencing itself")
+	}
+}
+
+// Missing child file is a fatal config error, not a fall-through to
+// "default" — the router would silently drop the regime otherwise.
+func TestBuildStrategyFromProfile_MissingChildErrors(t *testing.T) {
+	loader := &stubLoader{
+		profiles: map[string]*entity.StrategyProfile{
+			"def": flatProfile("def"),
+			// no "bear" entry
+		},
+	}
+	root := routerProfile("router", "def", map[string]string{"bear-trend": "bear"})
+	_, err := BuildStrategyFromProfile(loader, root)
+	if err == nil {
+		t.Fatal("expected error on missing child profile")
+	}
+}
+
+// Validate-side coverage: a router profile with empty
+// Indicators/StanceRules/etc. must pass Validate (router profiles
+// delegate, so those fields are unused).
+func TestStrategyProfile_Validate_RouterProfileSkipsFieldChecks(t *testing.T) {
+	p := *routerProfile("router", "child", nil)
+	if err := p.Validate(); err != nil {
+		t.Fatalf("router-only profile rejected by Validate: %v", err)
+	}
+}
+
+// Conversely, a non-router profile that left Indicators empty must
+// still be rejected — the router shortcut should not weaken existing
+// profiles' validation.
+func TestStrategyProfile_Validate_FlatProfileStillRequiresIndicators(t *testing.T) {
+	p := entity.StrategyProfile{Name: "flat"} // no Indicators, no RegimeRouting
+	if err := p.Validate(); err == nil {
+		t.Fatal("flat profile with empty Indicators must fail Validate")
+	}
+}
+
+// Validate rejects unknown regime keys in overrides so a typo like
+// "bear-trnd" is caught at load time, not silently ignored at runtime.
+func TestStrategyProfile_Validate_UnknownRegimeKeyRejected(t *testing.T) {
+	p := *routerProfile("router", "def", map[string]string{
+		"bear-trnd": "child", // typo
+	})
+	if err := p.Validate(); err == nil {
+		t.Fatal("expected error on unknown regime key")
+	}
+}
+
+// overrides set without default is almost certainly a typo — the
+// writer meant to set both. Catch at Validate time.
+func TestStrategyProfile_Validate_OverridesWithoutDefaultRejected(t *testing.T) {
+	// Build a baseline flat profile (so the Indicators/StanceRules
+	// field-level checks pass) and then attach a routing block that
+	// has overrides but no default — the trailing guard inside the
+	// flat-profile branch must catch this.
+	p := *flatProfile("router")
+	p.RegimeRouting = &entity.RegimeRoutingConfig{
+		// Default deliberately empty so HasRouting() is false and the
+		// router-shortcut path in Validate does not fire — but the
+		// trailing "overrides without default" guard does.
+		Overrides: map[string]string{"bear-trend": "child"},
+	}
+	err := p.Validate()
+	if err == nil {
+		t.Fatal("expected error on overrides without default")
+	}
+	if !strings.Contains(err.Error(), "default must be set") {
+		t.Errorf("error message %q does not mention the missing default", err.Error())
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `RegimeRoutingConfig` (entity) + `ProfileRouter` (usecase/strategy) — PR-5 part B, building on the `RegimeDetector` from #133.
- A profile JSON file can now carry a `regime_routing` block; loaded that way it becomes a *router* whose `Evaluate` consults the detector and delegates to a child profile's `Strategy`.
- **No backtest-runner wiring yet** — that is PR C. After this PR, `BuildStrategyFromProfile` exists and is unit-tested but no production code path constructs a router. PR C wires the runner; PR D runs the actual cycle39 PDCA validation.

## Why split into PRs

Cycle28-37 produced two finalists that are each strong on one regime and catastrophic on the other (`sl14_tf60_35` blows up −57.97% on 2022; `sl6_tr30_tp6_tf60_35` only manages +14.69% on 2023-26). Cycle38 (#132) confirmed Ichimoku HTF cannot bridge the gap. The intended router pairing puts the aggressive lineage on the Default + bull-trend branches and the defensive lineage on the bear-trend + volatile branches — but the value of that pairing is only measurable once PR C wires the runner.

Landing the schema + router-port in a separate PR keeps each diff reviewable and lets the threshold tuning happen against unit-tested wiring before any backtest result is collected.

## Schema

```json
{
  "name": "router_v5_candidate",
  "regime_routing": {
    "default": "experiment_2026-04-22_sl14_tf60_35",
    "overrides": {
      "bear-trend": "experiment_2026-04-22_sl6_tr30_tp6_tf60_35",
      "volatile":   "experiment_2026-04-22_sl6_tr30_tp6_tf60_35"
    }
  }
}
```

## Design choices worth flagging

| choice | rationale |
|---|---|
| Pointer field `*RegimeRoutingConfig` | A value-typed field would serialise as ${'`'}regime_routing: {default: ""}${'`'} on every existing profile and break ${'`'}TestStrategyProfile_JSONRoundTrip${'`'}. Pointer + omitempty preserves "no routing block" through the round-trip. |
| Validate skips field-level checks for routers | Router profiles delegate every per-bar decision; their Indicators/SignalRules/Risk fields are dead. Forcing dummy periods to pass strict Validate would be confusing. |
| `IsKnown` (hot-path) vs `IsValidLabel` (config) | Old `IsKnown` conflated "non-empty" with "one of the four legal labels". Split so a typo like ${'`'}bear-trnd${'`'} is rejected at config load instead of silently shadowing nothing at runtime. |
| Depth-1 enforced at the loader builder | `Validate` is profile-local — cannot see other profiles. The builder rejects child profiles that themselves carry `regime_routing` and rejects self-references before the loader even fires. |
| `ProfileRouter` is loader-agnostic | Takes pre-built children through `ProfileRouterInput`. Tests use a stub loader; production uses `BuildStrategyFromProfile + strategyprofile.Loader`. Strategy package never imports infrastructure — clean architecture. |
| One `Detector` per router lifetime | Hysteresis state must persist across bars. `Reset()` exists for backtest runners that want to clear state between windows. |

## Test plan
- [x] `go test ./internal/usecase/strategy/... -race -count=1 -v` — 22 new cases (all green).
- [x] `go test ./internal/usecase/regime/... -race -count=1 -v` — +2 cases for IsKnown vs IsValidLabel.
- [x] `go test ./internal/domain/entity/... -race -count=1` — pre-existing JSON round-trip and Validate suite still green.
- [x] `go test ./... -race -count=1` — full backend suite green.
- [x] `gofmt -l` and `go vet` clean for all touched files.

Coverage:
- Router validation (name, default required, unknown regime key, nil override) → 4 tests.
- Dispatch table per regime + warmup→default + nil indicators → 4 tests.
- Reset clears state → 1 test.
- Builder: flat-profile passthrough (loader untouched), router resolves children with right call count, depth-1 nested-router rejection, self-reference rejection, missing-child error → 5 tests.
- Validate: router-profile passes with empty Indicators, flat profile still requires Indicators, unknown regime key rejected, overrides without default rejected → 4 tests.
- Regime label predicates: `IsKnown` (warmup vs typo) and `IsValidLabel` (strict label) separation → 2 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)