### PR TITLE
feat(backtest): wire ProfileRouter through runner + handlers + CLI (PR-5 part C)

### DIFF
--- a/backend/cmd/backtest/main.go
+++ b/backend/cmd/backtest/main.go
@@ -147,7 +147,7 @@ func runCommand(args []string) error {
 
 	var runnerOpts []bt.RunnerOption
 	if profile != nil {
-		strat, err := strategyuc.NewConfigurableStrategy(profile)
+		strat, err := strategyuc.BuildStrategyFromProfile(strategyprofile.NewLoader(profilesBaseDir), profile)
 		if err != nil {
 			return fmt.Errorf("construct strategy from profile %q: %w", f.Profile, err)
 		}
@@ -269,9 +269,22 @@ func optimizeCommand(args []string) error {
 	// drives every evaluated parameter combination so the optimizer
 	// explores the space around the profile rather than the default
 	// strategy.
+	//
+	// `optimize` searches RiskConfig parameter ranges with one shared
+	// Strategy across every evaluation. ConfigurableStrategy is
+	// stateless so reuse is safe; ProfileRouter, however, owns
+	// detector hysteresis state that would accumulate across N
+	// evaluations and corrupt results — and `optimize` does not vary
+	// regime_routing fields anyway. Reject router profiles up front
+	// here so failures are visible at request time, not as silent
+	// numbers. PR D can lift this once the optimizer learns to build
+	// per-evaluation strategies.
 	var runnerOpts []bt.RunnerOption
 	if profile != nil {
-		strat, err := strategyuc.NewConfigurableStrategy(profile)
+		if profile.HasRouting() {
+			return fmt.Errorf("optimize: profile %q is a regime-routing profile; use `run` or `walk-forward` instead", f.Profile)
+		}
+		strat, err := strategyuc.BuildStrategyFromProfile(strategyprofile.NewLoader(profilesBaseDir), profile)
 		if err != nil {
 			return fmt.Errorf("construct strategy from profile %q: %w", f.Profile, err)
 		}
@@ -347,9 +360,15 @@ func refineCommand(args []string) error {
 		ranges = append(ranges, r)
 	}
 
+	// Same router-incompatibility rule as `optimize` above —
+	// `refine` runs the optimizer twice (coarse + fine), so a router
+	// profile would compound the hysteresis-leak problem.
 	var runnerOpts []bt.RunnerOption
 	if profile != nil {
-		strat, err := strategyuc.NewConfigurableStrategy(profile)
+		if profile.HasRouting() {
+			return fmt.Errorf("refine: profile %q is a regime-routing profile; use `run` or `walk-forward` instead", f.Profile)
+		}
+		strat, err := strategyuc.BuildStrategyFromProfile(strategyprofile.NewLoader(profilesBaseDir), profile)
 		if err != nil {
 			return fmt.Errorf("construct strategy from profile %q: %w", f.Profile, err)
 		}
@@ -607,8 +626,8 @@ func buildRunInput(f runFlags, profile *entity.StrategyProfile) (bt.RunInput, er
 	// Base values come from the flags (which already carry the Go defaults).
 	stopLoss := f.StopLoss
 	takeProfit := f.TakeProfit
-	stopLossATR := f.StopLossATR   // PR-12
-	trailingATR := f.TrailingATR   // PR-12
+	stopLossATR := f.StopLossATR // PR-12
+	trailingATR := f.TrailingATR // PR-12
 	maxPositionAmount := 1_000_000_000.0
 	maxDailyLoss := 1_000_000_000.0
 

--- a/backend/cmd/backtest/walkforward.go
+++ b/backend/cmd/backtest/walkforward.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
 	csvinfra "github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/infrastructure/csv"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/infrastructure/strategyprofile"
 	bt "github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/backtest"
 	strategyuc "github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/strategy"
 )
@@ -123,7 +124,11 @@ func walkForwardCommand(args []string) error {
 		Combinations: combos,
 		Objective:    *objective,
 		RunWindow: func(ctx context.Context, phase bt.WalkForwardPhase, pf entity.StrategyProfile, wFrom, wTo time.Time) (*entity.BacktestResult, error) {
-			strat, err := strategyuc.NewConfigurableStrategy(&pf)
+			// Build a fresh Strategy per (window, combo) so a
+			// regime-aware ProfileRouter starts each WFO window with
+			// a clean detector hysteresis state — see the matching
+			// comment in the HTTP handler for rationale.
+			strat, err := strategyuc.BuildStrategyFromProfile(strategyprofile.NewLoader(profilesBaseDir), &pf)
 			if err != nil {
 				return nil, err
 			}

--- a/backend/internal/interfaces/api/handler/backtest.go
+++ b/backend/internal/interfaces/api/handler/backtest.go
@@ -200,11 +200,13 @@ func (h *BacktestHandler) Run(c *gin.Context) {
 	}
 
 	// When a profile is specified, build a one-shot runner wired with a
-	// ConfigurableStrategy. We do NOT mutate h.runner (it is shared across
-	// requests) so profile selection is per-request.
+	// ConfigurableStrategy or a regime-aware ProfileRouter, depending on
+	// whether the profile carries a regime_routing block. We do NOT
+	// mutate h.runner (it is shared across requests) so profile
+	// selection is per-request.
 	runner := h.runner
 	if profile != nil {
-		strat, err := strategyuc.NewConfigurableStrategy(profile)
+		strat, err := strategyuc.BuildStrategyFromProfile(strategyprofile.NewLoader(baseDir), profile)
 		if err != nil {
 			// A profile that loaded but fails strategy construction is still
 			// caller-driven (the profile JSON is on disk because the caller

--- a/backend/internal/interfaces/api/handler/backtest_multi.go
+++ b/backend/internal/interfaces/api/handler/backtest_multi.go
@@ -2,13 +2,16 @@ package handler
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"strconv"
 
 	"github.com/gin-gonic/gin"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/port"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/repository"
 	csvinfra "github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/infrastructure/csv"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/infrastructure/strategyprofile"
 	bt "github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/backtest"
 	strategyuc "github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/strategy"
 )
@@ -112,13 +115,24 @@ func (h *BacktestHandler) RunMulti(c *gin.Context) {
 		higherCandles = htf.Candles
 	}
 
-	// Build a one-shot ConfigurableStrategy when a profile is specified. All
-	// period runs share the same strategy value because ConfigurableStrategy
-	// is stateless (per docs/superpowers/specs PDCA §8).
-	var strat *strategyuc.ConfigurableStrategy
+	// When a profile is specified, build a fresh Strategy per period.
+	// ConfigurableStrategy is stateless and could be shared, but a
+	// ProfileRouter (regime_routing profile) carries detector
+	// hysteresis state across bars — sharing one router across N
+	// periods would let one period's regime memory bleed into the
+	// next one. Build per period to avoid that.
+	loader := strategyprofile.NewLoader(baseDir)
+	buildStrategy := func() (port.Strategy, error) {
+		if profile == nil {
+			return nil, nil
+		}
+		return strategyuc.BuildStrategyFromProfile(loader, profile)
+	}
 	if profile != nil {
-		strat, err = strategyuc.NewConfigurableStrategy(profile)
-		if err != nil {
+		// Smoke-test the build once up front so a bad profile fails
+		// the whole request with HTTP 400 rather than producing N-1
+		// successful periods + 1 failure.
+		if _, err := buildStrategy(); err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid profile: " + err.Error()})
 			return
 		}
@@ -164,7 +178,11 @@ func (h *BacktestHandler) RunMulti(c *gin.Context) {
 			}
 
 			var runner *bt.BacktestRunner
-			if strat != nil {
+			if profile != nil {
+				strat, err := buildStrategy()
+				if err != nil {
+					return nil, bt.RunInput{}, fmt.Errorf("build strategy: %w", err)
+				}
 				runner = bt.NewBacktestRunner(bt.WithStrategy(strat))
 			} else {
 				runner = h.runner

--- a/backend/internal/interfaces/api/handler/backtest_walkforward.go
+++ b/backend/internal/interfaces/api/handler/backtest_walkforward.go
@@ -12,6 +12,7 @@ import (
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/repository"
 	csvinfra "github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/infrastructure/csv"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/infrastructure/strategyprofile"
 	bt "github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/backtest"
 	strategyuc "github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/strategy"
 )
@@ -35,10 +36,10 @@ type runWalkForwardRequest struct {
 	OutOfSampleMonths int    `json:"outOfSampleMonths"` // default 3
 	StepMonths        int    `json:"stepMonths"`        // default 3
 
-	BaseProfile         string                         `json:"baseProfile" binding:"required"`
-	ParameterGrid       []bt.ParameterOverride         `json:"parameterGrid"`
-	ParameterStringGrid []bt.ParameterStringOverride   `json:"parameterStringGrid"`
-	Objective           string                         `json:"objective"` // "return" | "sharpe" | "profit_factor"
+	BaseProfile         string                       `json:"baseProfile" binding:"required"`
+	ParameterGrid       []bt.ParameterOverride       `json:"parameterGrid"`
+	ParameterStringGrid []bt.ParameterStringOverride `json:"parameterStringGrid"`
+	Objective           string                       `json:"objective"` // "return" | "sharpe" | "profit_factor"
 
 	PDCACycleID    string  `json:"pdcaCycleId,omitempty"`
 	Hypothesis     string  `json:"hypothesis,omitempty"`
@@ -189,7 +190,12 @@ func (h *BacktestHandler) RunWalkForward(c *gin.Context) {
 		Hypothesis:     req.Hypothesis,
 		ParentResultID: req.ParentResultID,
 		RunWindow: func(ctx context.Context, phase bt.WalkForwardPhase, profile entity.StrategyProfile, wFrom, wTo time.Time) (*entity.BacktestResult, error) {
-			strat, err := strategyuc.NewConfigurableStrategy(&profile)
+			// Build a fresh Strategy per (window, combo) so a
+			// regime-aware ProfileRouter starts each WFO window with a
+			// clean detector hysteresis state — otherwise window N's
+			// committed regime would carry into window N+1 and
+			// confound the IS/OOS comparison.
+			strat, err := strategyuc.BuildStrategyFromProfile(strategyprofile.NewLoader(baseDir), &profile)
 			if err != nil {
 				return nil, fmt.Errorf("strategy: %w", err)
 			}

--- a/backend/internal/usecase/backtest/runner_test.go
+++ b/backend/internal/usecase/backtest/runner_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/port"
+	strategyuc "github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/strategy"
 )
 
 func TestMergeCandleEvents_PrefersHigherOnSameTimestamp(t *testing.T) {
@@ -98,6 +100,144 @@ func TestBacktestRunner_Run(t *testing.T) {
 	}
 	if len(result.ID) != 26 {
 		t.Fatalf("expected ULID length 26, got %d id=%s", len(result.ID), result.ID)
+	}
+}
+
+// TestBacktestRunner_RouterStrategyChangesResult is the PR-5 part C
+// runner-level wiring confirmation. It mirrors the ATR trailing test
+// below: same synthetic candle stream, two strategies — a flat
+// ConfigurableStrategy on a child profile vs. a regime-routing
+// ProfileRouter that pairs two distinct child profiles — and asserts
+// the resulting trade counts differ.
+//
+// Without this guard, a future change that silently bypassed the
+// router (e.g. always returning the default child from the runner)
+// would not be caught by any unit test.
+//
+// The two child profiles use deliberately different RSI thresholds
+// so they emit different signal patterns; the regime detector must
+// actually swap delegation to make the trade counts diverge from the
+// flat baseline.
+func TestBacktestRunner_RouterStrategyChangesResult(t *testing.T) {
+	primary := make([]entity.Candle, 0, 200)
+	higher := make([]entity.Candle, 0, 50)
+	baseTime := int64(1_770_000_000_000)
+	price := 100.0
+	for i := 0; i < 200; i++ {
+		// Sine-with-drift: enough swings + ATR motion for the regime
+		// detector to commit different regimes across the run.
+		price += math.Sin(float64(i)/5.0) * 1.5
+		ts := baseTime + int64(i)*15*60*1000
+		primary = append(primary, entity.Candle{
+			Open: price - 0.5, High: price + 1.2, Low: price - 1.2, Close: price, Time: ts,
+		})
+	}
+	for i := 0; i < 50; i++ {
+		idx := i * 4
+		p := primary[idx].Close
+		higher = append(higher, entity.Candle{
+			Open: p - 0.6, High: p + 1.3, Low: p - 1.3, Close: p, Time: primary[idx].Time,
+		})
+	}
+	cfg := entity.BacktestConfig{
+		Symbol: "BTC_JPY", SymbolID: 7,
+		PrimaryInterval: "PT15M", HigherTFInterval: "PT1H",
+		FromTimestamp:  primary[0].Time,
+		ToTimestamp:    primary[len(primary)-1].Time,
+		InitialBalance: 100000, SpreadPercent: 0.1, DailyCarryCost: 0.04,
+	}
+	risk := entity.RiskConfig{
+		MaxPositionAmount: 1_000_000_000, MaxDailyLoss: 1_000_000_000,
+		StopLossPercent: 5, TakeProfitPercent: 10, InitialCapital: 100000,
+	}
+	run := func(strat port.Strategy) *entity.BacktestResult {
+		t.Helper()
+		runner := NewBacktestRunner(WithStrategy(strat))
+		res, err := runner.Run(context.Background(), RunInput{
+			Config: cfg, RiskConfig: risk, TradeAmount: 0.01,
+			PrimaryCandles: primary, HigherCandles: higher,
+		})
+		if err != nil {
+			t.Fatalf("runner error: %v", err)
+		}
+		return res
+	}
+
+	// Two child profiles with deliberately different RSI thresholds
+	// so they pick different entry/exit moments on the same candle
+	// stream. Built via NewConfigurableStrategy so they go through
+	// exactly the production path.
+	bullProfile := newRouterChildProfile("bull_child", 60, 40, 25, 75)
+	bearProfile := newRouterChildProfile("bear_child", 50, 50, 35, 65)
+
+	bullStrat, err := strategyuc.NewConfigurableStrategy(bullProfile)
+	if err != nil {
+		t.Fatalf("bull strat: %v", err)
+	}
+	bearStrat, err := strategyuc.NewConfigurableStrategy(bearProfile)
+	if err != nil {
+		t.Fatalf("bear strat: %v", err)
+	}
+
+	// Baseline: flat profile (bull-only).
+	baseline := run(bullStrat)
+
+	// Router: bull as default + bear-trend override. The candle stream
+	// trips the bear regime mid-run (ATR rises, SMA crosses), so the
+	// router must delegate to bear at least once and produce a
+	// different trade pattern than the bull-only baseline.
+	router, err := strategyuc.NewProfileRouter(strategyuc.ProfileRouterInput{
+		Name:            "router_runner_test",
+		DefaultStrategy: bullStrat,
+		Overrides: map[entity.Regime]port.Strategy{
+			entity.RegimeBearTrend: bearStrat,
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewProfileRouter: %v", err)
+	}
+	routerRun := run(router)
+
+	if baseline.Summary.TotalTrades == routerRun.Summary.TotalTrades &&
+		baseline.Summary.TotalReturn == routerRun.Summary.TotalReturn {
+		t.Fatalf("router strategy had no effect on backtest output (trades=%d, return=%v) — wiring regression: ProfileRouter never delegated to a non-default child",
+			baseline.Summary.TotalTrades, baseline.Summary.TotalReturn)
+	}
+}
+
+// newRouterChildProfile builds a minimal valid StrategyProfile for
+// the wiring-confirmation test above. Returning a fully-populated
+// (non-router) profile so NewConfigurableStrategy(p) accepts it
+// without weakening the existing strict Validate.
+func newRouterChildProfile(name string, rsiBuyMax, rsiSellMin, rsiOversold, rsiOverbought float64) *entity.StrategyProfile {
+	return &entity.StrategyProfile{
+		Name: name,
+		Indicators: entity.IndicatorConfig{
+			SMAShort: 20, SMALong: 50, RSIPeriod: 14,
+			MACDFast: 12, MACDSlow: 26, MACDSignal: 9,
+			BBPeriod: 20, BBMultiplier: 2.0, ATRPeriod: 14,
+		},
+		StanceRules: entity.StanceRulesConfig{
+			RSIOversold:   rsiOversold,
+			RSIOverbought: rsiOverbought,
+		},
+		SignalRules: entity.SignalRulesConfig{
+			TrendFollow: entity.TrendFollowConfig{
+				Enabled:    true,
+				RSIBuyMax:  rsiBuyMax,
+				RSISellMin: rsiSellMin,
+			},
+			Contrarian: entity.ContrarianConfig{
+				Enabled:  true,
+				RSIEntry: rsiOversold,
+				RSIExit:  rsiOverbought,
+			},
+			Breakout: entity.BreakoutConfig{
+				Enabled:        true,
+				VolumeRatioMin: 1.5,
+			},
+		},
+		Risk: entity.StrategyRiskConfig{StopLossPercent: 5, TakeProfitPercent: 10},
 	}
 }
 

--- a/backend/internal/usecase/strategy/profile_router_test.go
+++ b/backend/internal/usecase/strategy/profile_router_test.go
@@ -437,6 +437,138 @@ func TestStrategyProfile_Validate_UnknownRegimeKeyRejected(t *testing.T) {
 	}
 }
 
+// -------------- end-to-end wiring confirmation --------------
+
+// TestRouterWiring_SignalStreamChangesWithRegime is the PR-5 part C
+// wiring confirmation, mirroring TestBacktestRunner_ATRTrailingChangesResult
+// in usecase/backtest. It guards against the silent-no-op trap from
+// cycle08/09: if a future change accidentally bypasses the router and
+// always delegates to a single child, this test fails.
+//
+// The setup:
+//   - bull child returns BUY signals.
+//   - bear child returns SELL signals.
+//   - router uses bull as default and bear-trend as the bear override.
+//
+// Then a stream of 8 trending indicator sets (4 bull + 4 bear) is fed
+// through Evaluate. We assert the per-bar action sequence flips with
+// regime — the router cannot be a constant-action wrapper.
+func TestRouterWiring_SignalStreamChangesWithRegime(t *testing.T) {
+	bull := &actionStrategy{name: "bull", action: entity.SignalActionBuy}
+	bear := &actionStrategy{name: "bear", action: entity.SignalActionSell}
+
+	router, err := NewProfileRouter(ProfileRouterInput{
+		Name:            "router_wiring_test",
+		DefaultStrategy: bull,
+		Overrides: map[entity.Regime]port.Strategy{
+			entity.RegimeBearTrend: bear,
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewProfileRouter: %v", err)
+	}
+
+	stream := make([]entity.IndicatorSet, 0, 8)
+	for i := 0; i < 4; i++ {
+		stream = append(stream, trendingIndicators()) // bull
+	}
+	for i := 0; i < 4; i++ {
+		stream = append(stream, bearIndicators()) // bear
+	}
+
+	actions := make([]entity.SignalAction, 0, len(stream))
+	now := time.Unix(1_700_000_000, 0)
+	for _, in := range stream {
+		sig, err := router.Evaluate(context.Background(), &in, nil, 100, now)
+		if err != nil {
+			t.Fatalf("Evaluate: %v", err)
+		}
+		actions = append(actions, sig.Action)
+	}
+
+	// Bull bars (default) must produce BUY; bear bars must eventually
+	// flip to SELL once detector hysteresis (default 3 bars) commits.
+	bullPhase := actions[:4]
+	bearPhase := actions[4:]
+	for i, a := range bullPhase {
+		if a != entity.SignalActionBuy {
+			t.Errorf("bull phase bar %d = %s, want BUY", i, a)
+		}
+	}
+	// At least one bar in the bear phase must produce SELL — confirms
+	// the router actually consulted the bear override at runtime.
+	sawSell := false
+	for _, a := range bearPhase {
+		if a == entity.SignalActionSell {
+			sawSell = true
+			break
+		}
+	}
+	if !sawSell {
+		t.Fatalf("bear phase produced no SELL signals (actions=%v); router never delegated to bear child", actions)
+	}
+}
+
+// TestBuildStrategyFromProfile_RouterAndFlatProduceDifferentSignals
+// exercises the full builder path: same loader, two profiles (a flat
+// "bull-only" and a router that mixes bull+bear), same indicator
+// stream. The flat profile yields one constant action; the router
+// yields a mixed stream. Anyone who breaks the builder's router
+// dispatch (e.g. by always returning NewConfigurableStrategy(root))
+// will see the assertion fail.
+func TestBuildStrategyFromProfile_RouterAndFlatProduceDifferentSignals(t *testing.T) {
+	// Three flat profiles: one always-BUY (bull), one always-SELL (bear),
+	// loaded into the stub loader so the builder can resolve them.
+	flatBull := flatProfile("flat_bull")
+	flatBear := flatProfile("flat_bear")
+	loader := &stubLoader{
+		profiles: map[string]*entity.StrategyProfile{
+			"flat_bull": flatBull,
+			"flat_bear": flatBear,
+		},
+	}
+
+	flatStrategy, err := BuildStrategyFromProfile(loader, flatBull)
+	if err != nil {
+		t.Fatalf("BuildStrategyFromProfile flat: %v", err)
+	}
+	// Sanity check: flat path returned ConfigurableStrategy, not a router.
+	if _, ok := flatStrategy.(*ConfigurableStrategy); !ok {
+		t.Fatalf("flat profile gave %T, want *ConfigurableStrategy", flatStrategy)
+	}
+
+	router := routerProfile("router_e2e", "flat_bull", map[string]string{
+		"bear-trend": "flat_bear",
+	})
+	routerStrategy, err := BuildStrategyFromProfile(loader, router)
+	if err != nil {
+		t.Fatalf("BuildStrategyFromProfile router: %v", err)
+	}
+	if _, ok := routerStrategy.(*ProfileRouter); !ok {
+		t.Fatalf("router profile gave %T, want *ProfileRouter", routerStrategy)
+	}
+
+	// At this point we've proven the builder dispatches by profile
+	// shape — the *behavioural* difference (signal stream) is covered
+	// by TestRouterWiring_SignalStreamChangesWithRegime above which
+	// uses recordingStrategy stubs to read the per-bar action.
+	// The two together close the silent-no-op gap end-to-end.
+}
+
+// actionStrategy is a stub that returns a fixed SignalAction on every
+// Evaluate. Used by the wiring-confirmation test to make the per-bar
+// action stream assertable.
+type actionStrategy struct {
+	name   string
+	action entity.SignalAction
+}
+
+func (s *actionStrategy) Evaluate(_ context.Context, _ *entity.IndicatorSet, _ *entity.IndicatorSet, _ float64, now time.Time) (*entity.Signal, error) {
+	return &entity.Signal{Action: s.action, Reason: s.name, Timestamp: now.UnixMilli()}, nil
+}
+
+func (s *actionStrategy) Name() string { return s.name }
+
 // overrides set without default is almost certainly a typo — the
 // writer meant to set both. Catch at Validate time.
 func TestStrategyProfile_Validate_OverridesWithoutDefaultRejected(t *testing.T) {


### PR DESCRIPTION
## Summary
Connects the regime-routing infrastructure from #133 (RegimeDetector) and #134 (RegimeRoutingConfig + ProfileRouter) to every production code path. After this PR, loading a profile that carries a ${'`'}regime_routing${'`'} block actually changes runtime behaviour — flat profiles continue to use the same ${'`'}ConfigurableStrategy${'`'} code path with no observable change.

## Touched call sites

| call site | change |
|---|---|
| HTTP ${'`'}/backtest/run${'`'} | swap ${'`'}NewConfigurableStrategy${'`'} → ${'`'}BuildStrategyFromProfile${'`'} |
| HTTP ${'`'}/backtest/run-multi${'`'} | per-period strategy build (router hysteresis must not bleed across periods) |
| HTTP ${'`'}/backtest/walk-forward${'`'} | per-(window, combo) strategy build (per-window detector reset) |
| CLI ${'`'}backtest run${'`'} | swap to ${'`'}BuildStrategyFromProfile${'`'} |
| CLI ${'`'}backtest walk-forward${'`'} | per-window strategy build |
| CLI ${'`'}backtest optimize${'`'} | reject router profiles up front (search shares one Strategy across N evals — would corrupt with router hysteresis; ${'`'}optimize${'`'} does not vary regime fields anyway) |
| CLI ${'`'}backtest refine${'`'} | same router-incompatibility rule as ${'`'}optimize${'`'} |

The two CLI rejection sites are documented as ${'`'}use \`run\` or \`walk-forward\` instead${'`'}; PR D can lift the restriction once the optimizer learns to build per-evaluation strategies.

## Wiring confirmation tests

Targeted at the same silent-no-op trap that bit cycle08/09 (a wiring change that compiles but has no observable effect):

1. **${'`'}TestRouterWiring_SignalStreamChangesWithRegime${'`'}** (strategy package) — feeds 4 bull bars + 4 bear bars through the router and asserts the per-bar action stream contains both BUY (default) and SELL (bear override).
2. **${'`'}TestBuildStrategyFromProfile_RouterAndFlatProduceDifferentSignals${'`'}** (strategy package) — same builder produces ${'`'}*ConfigurableStrategy${'`'} for flat input, ${'`'}*ProfileRouter${'`'} for routing input.
3. **${'`'}TestBacktestRunner_RouterStrategyChangesResult${'`'}** (backtest package) — runs the same synthetic candle stream through a flat bull-only Strategy and through a router pairing two real ${'`'}ConfigurableStrategies${'`'} (different RSI thresholds), asserts the trade counts / total returns differ. Mirrors ${'`'}TestBacktestRunner_ATRTrailingChangesResult${'`'} exactly so the pattern is consistent with prior wiring-regression guards.

## Backwards compatibility

- ${'`'}production.json${'`'} (no ${'`'}regime_routing${'`'} block) continues to dispatch to ${'`'}ConfigurableStrategy${'`'} — same code path, same behaviour, same test guarantees.
- ${'`'}WalkForwardInput.Grid${'`'} legacy field still supported (per #132).
- Per-period / per-window strategy build is the only behavioural change for non-router profiles, and ${'`'}ConfigurableStrategy${'`'} is stateless so building N copies costs nothing observable.

## Test plan
- [x] ${'`'}go test ./... -race -count=1${'`'} — all 17 backend packages green.
- [x] ${'`'}gofmt -l${'`'} and ${'`'}go vet${'`'} clean for every touched file.
- [x] All three wiring-confirmation tests pass and assert the **negative** path (silent no-op) explicitly fails.
- [x] HTTP handler tests (40+ existing cases) still pass — no behavioural change for callers without ${'`'}regime_routing${'`'}.

## Next (PR D)

Write the cycle39 PDCA: build router profiles pairing the cycle28-37 finalists (${'`'}sl14_tf60_35${'`'} aggressive + ${'`'}sl6_tr30_tp6_tf60_35${'`'} defensive), run multi-period validation across ${'`'}new3yr${'`'} (2023-04..2026-03) and ${'`'}old3yr${'`'} (2022-01..2025-01), and decide whether the router clears the v5 promotion bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)