### PR TITLE
fix(backtest): inherit Risk from default child for routing profiles

### DIFF
--- a/backend/cmd/backtest/main.go
+++ b/backend/cmd/backtest/main.go
@@ -140,7 +140,7 @@ func runCommand(args []string) error {
 		return err
 	}
 
-	input, err := buildRunInput(f, profile)
+	input, err := buildRunInput(f, resolveRiskProfile(profile, profilesBaseDir))
 	if err != nil {
 		return err
 	}
@@ -185,6 +185,31 @@ func visitedFlagNames(fs *flag.FlagSet) map[string]bool {
 		set[ff.Name] = true
 	})
 	return set
+}
+
+// resolveRiskProfile mirrors the HTTP handler helper of the same name:
+// for a router profile (RegimeRouting.Default set) the router itself
+// has no Risk fields, so fall back to the *default child*'s Risk so
+// the run's SL/TP/ATR settings track at least one of the routed
+// strategies. See the handler-side resolveRiskProfile for the full
+// rationale and the part E (per-regime risk) limitation note.
+//
+// On any loader error we silently fall back to the router profile
+// (downstream legacy defaults will apply); the strategy builder will
+// reject the bad child later with a clearer error.
+func resolveRiskProfile(profile *entity.StrategyProfile, baseDir string) *entity.StrategyProfile {
+	if profile == nil || !profile.HasRouting() {
+		return profile
+	}
+	defaultName := profile.RegimeRouting.Default
+	if defaultName == "" {
+		return profile
+	}
+	child, err := loadProfileIfSet(defaultName, baseDir)
+	if err != nil || child == nil {
+		return profile
+	}
+	return child
 }
 
 // loadProfileIfSet loads a StrategyProfile from <baseDir>/<name>.json if

--- a/backend/cmd/backtest/walkforward.go
+++ b/backend/cmd/backtest/walkforward.go
@@ -132,6 +132,14 @@ func walkForwardCommand(args []string) error {
 			if err != nil {
 				return nil, err
 			}
+			// For router profiles, pull SL/TP/ATR risk values from
+			// the default child since the router itself carries no
+			// Risk fields. See cmd/backtest/main.go::resolveRiskProfile
+			// for the limitation note.
+			riskProfile := pf
+			if resolved := resolveRiskProfile(&pf, profilesBaseDir); resolved != nil {
+				riskProfile = *resolved
+			}
 			cfg := entity.BacktestConfig{
 				Symbol:           primary.Symbol,
 				SymbolID:         primary.SymbolID,
@@ -148,12 +156,12 @@ func walkForwardCommand(args []string) error {
 				cfg.HigherTFInterval = ""
 			}
 			risk := entity.RiskConfig{
-				MaxPositionAmount:     nonZeroFloat(pf.Risk.MaxPositionAmount, 1_000_000_000.0),
-				MaxDailyLoss:          nonZeroFloat(pf.Risk.MaxDailyLoss, 1_000_000_000.0),
-				StopLossPercent:       pf.Risk.StopLossPercent,
-				StopLossATRMultiplier: pf.Risk.StopLossATRMultiplier,
-				TrailingATRMultiplier: pf.Risk.TrailingATRMultiplier,
-				TakeProfitPercent:     pf.Risk.TakeProfitPercent,
+				MaxPositionAmount:     nonZeroFloat(riskProfile.Risk.MaxPositionAmount, 1_000_000_000.0),
+				MaxDailyLoss:          nonZeroFloat(riskProfile.Risk.MaxDailyLoss, 1_000_000_000.0),
+				StopLossPercent:       riskProfile.Risk.StopLossPercent,
+				StopLossATRMultiplier: riskProfile.Risk.StopLossATRMultiplier,
+				TrailingATRMultiplier: riskProfile.Risk.TrailingATRMultiplier,
+				TakeProfitPercent:     riskProfile.Risk.TakeProfitPercent,
 				InitialCapital:        *initialBalance,
 			}
 			windowRunner := bt.NewBacktestRunner(bt.WithStrategy(strat))

--- a/backend/internal/interfaces/api/handler/backtest.go
+++ b/backend/internal/interfaces/api/handler/backtest.go
@@ -143,8 +143,11 @@ func (h *BacktestHandler) Run(c *gin.Context) {
 
 	// Apply profile defaults to zero-valued individual fields so spec §8.2's
 	// precedence rule holds: profile first, then any non-zero individual
-	// parameter in the request overrides.
-	applyProfileDefaults(&req, profile)
+	// parameter in the request overrides. resolveRiskProfile redirects
+	// router profiles (which carry no Risk of their own) to their
+	// default child's Risk — see resolveRiskProfile for the limitation
+	// notes.
+	applyProfileDefaults(&req, resolveRiskProfile(baseDir, profile))
 
 	// Legacy callers (no profile) still get the historical hard-coded
 	// defaults when individual fields are zero.
@@ -281,6 +284,43 @@ func loadProfileForRequest(baseDir, name string) (*entity.StrategyProfile, error
 		return nil, err
 	}
 	return profile, nil
+}
+
+// resolveRiskProfile returns the profile whose Risk fields should be
+// used to populate per-run RiskConfig defaults.
+//
+// For flat profiles, this is the loaded profile itself. For routing
+// profiles (PR-5 part B), the router's own Risk struct is empty by
+// design — the router only declares routing rules, not exit thresholds.
+// In that case we fall back to the *default child*'s Risk so the run's
+// SL/TP/ATR settings are at least consistent with one of the routed
+// strategies rather than the legacy hard-coded SL=5/TP=10 fallback.
+//
+// Known limitation (tracked as PR-5 part E): per-regime SL/TP
+// differentiation is not yet implemented. The tickRiskHandler in the
+// runner is constructed once per run with one fixed RiskConfig, so
+// even though ProfileRouter swaps signal-generation per regime, every
+// bar's exit logic uses the same SL/TP values. Promotion candidates
+// surfaced before PR-5 part E are therefore "best of {default child
+// risk, router signal mix}" — not "true regime-specialised risk".
+//
+// On any loader error for the child, we silently fall back to the
+// router profile (i.e. legacy defaults will apply downstream). The
+// router's own builder will reject the bad child later with a clearer
+// 400, so we do not need to surface the lookup error here.
+func resolveRiskProfile(baseDir string, profile *entity.StrategyProfile) *entity.StrategyProfile {
+	if profile == nil || !profile.HasRouting() {
+		return profile
+	}
+	defaultName := profile.RegimeRouting.Default
+	if defaultName == "" {
+		return profile
+	}
+	child, err := loadProfileForRequest(baseDir, defaultName)
+	if err != nil || child == nil {
+		return profile
+	}
+	return child
 }
 
 // applyProfileDefaults overlays the profile's risk values onto the request

--- a/backend/internal/interfaces/api/handler/backtest_multi.go
+++ b/backend/internal/interfaces/api/handler/backtest_multi.go
@@ -95,7 +95,11 @@ func (h *BacktestHandler) RunMulti(c *gin.Context) {
 		MaxPositionAmount:     req.MaxPositionAmount,
 		MaxDailyLoss:          req.MaxDailyLoss,
 	}
-	applyProfileDefaults(&shared, profile)
+	// resolveRiskProfile redirects router profiles to their default
+	// child's Risk so per-run SL/TP/ATR defaults match one of the
+	// routed strategies rather than the legacy SL=5/TP=10 fallback.
+	// See resolveRiskProfile for the per-regime SL/TP limitation.
+	applyProfileDefaults(&shared, resolveRiskProfile(baseDir, profile))
 	applyLegacyDefaults(&shared)
 
 	// Load CSVs once and share across all period runs. Each period uses the

--- a/backend/internal/interfaces/api/handler/backtest_test.go
+++ b/backend/internal/interfaces/api/handler/backtest_test.go
@@ -15,13 +15,13 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
-	_ "modernc.org/sqlite"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/repository"
 	btinfra "github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/infrastructure/backtest"
 	csvinfra "github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/infrastructure/csv"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/infrastructure/database"
 	bt "github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/backtest"
+	_ "modernc.org/sqlite"
 )
 
 type mockBacktestResultRepo struct {
@@ -713,6 +713,91 @@ func TestApplyProfileDefaults_IndividualFieldOverrides(t *testing.T) {
 		applyProfileDefaults(req, nil)
 		if req.StopLossPercent != 3 {
 			t.Errorf("StopLossPercent = %v, want 3 (unchanged)", req.StopLossPercent)
+		}
+	})
+}
+
+// TestResolveRiskProfile_RouterFollowsDefaultChild guards the PR-D fix:
+// router profiles carry no Risk fields of their own, so the handler
+// must redirect risk-defaults lookup to the default child before
+// applyProfileDefaults runs. Without this fix every router profile
+// silently fell through to the legacy SL=5/TP=10 hard-coded defaults
+// regardless of which child the router would actually delegate to,
+// producing the cycle39 "all 4 router variants give identical
+// numbers" silent-no-op.
+func TestResolveRiskProfile_RouterFollowsDefaultChild(t *testing.T) {
+	dir := setupProfilesDir(t, map[string][]byte{
+		// Default child carries the real Risk envelope.
+		"router_child_default": []byte(`{
+			"name": "router_child_default",
+			"indicators": {
+				"sma_short": 20, "sma_long": 50, "rsi_period": 14,
+				"macd_fast": 12, "macd_slow": 26, "macd_signal": 9,
+				"bb_period": 20, "bb_multiplier": 2.0, "atr_period": 14
+			},
+			"stance_rules": {"rsi_oversold": 30, "rsi_overbought": 70},
+			"strategy_risk": {
+				"stop_loss_percent": 14,
+				"take_profit_percent": 4,
+				"max_position_amount": 100000,
+				"max_daily_loss": 50000
+			}
+		}`),
+	})
+
+	t.Run("router profile -> default child Risk", func(t *testing.T) {
+		router := &entity.StrategyProfile{
+			Name: "router",
+			RegimeRouting: &entity.RegimeRoutingConfig{
+				Default: "router_child_default",
+			},
+		}
+		got := resolveRiskProfile(dir, router)
+		if got == nil {
+			t.Fatal("resolveRiskProfile returned nil")
+		}
+		if got.Name != "router_child_default" {
+			t.Errorf("got name %q, want router_child_default (router fall-through failed)", got.Name)
+		}
+		if got.Risk.StopLossPercent != 14 {
+			t.Errorf("StopLossPercent = %v, want 14 (child's risk)", got.Risk.StopLossPercent)
+		}
+		if got.Risk.TakeProfitPercent != 4 {
+			t.Errorf("TakeProfitPercent = %v, want 4", got.Risk.TakeProfitPercent)
+		}
+	})
+
+	t.Run("flat profile -> itself unchanged", func(t *testing.T) {
+		flat := &entity.StrategyProfile{
+			Name: "flat",
+			Risk: entity.StrategyRiskConfig{StopLossPercent: 8},
+		}
+		got := resolveRiskProfile(dir, flat)
+		if got != flat {
+			t.Errorf("flat profile must return itself; got %p want %p", got, flat)
+		}
+	})
+
+	t.Run("nil profile -> nil", func(t *testing.T) {
+		if got := resolveRiskProfile(dir, nil); got != nil {
+			t.Errorf("nil input must return nil; got %v", got)
+		}
+	})
+
+	t.Run("router with missing default child -> falls back to router itself", func(t *testing.T) {
+		// resolveRiskProfile silently swallows the loader error and
+		// returns the router. Downstream legacy defaults will then
+		// apply, and the strategy builder will reject the bad child
+		// with a clearer 400 — so this fall-through is safe.
+		router := &entity.StrategyProfile{
+			Name: "router",
+			RegimeRouting: &entity.RegimeRoutingConfig{
+				Default: "this_child_does_not_exist",
+			},
+		}
+		got := resolveRiskProfile(dir, router)
+		if got != router {
+			t.Errorf("missing-child fallback must return the router itself; got %p want %p", got, router)
 		}
 	})
 }

--- a/backend/internal/interfaces/api/handler/backtest_walkforward.go
+++ b/backend/internal/interfaces/api/handler/backtest_walkforward.go
@@ -162,7 +162,11 @@ func (h *BacktestHandler) RunWalkForward(c *gin.Context) {
 		Slippage:       req.Slippage,
 		TradeAmount:    req.TradeAmount,
 	}
-	applyProfileDefaults(&shared, baseProfile)
+	// resolveRiskProfile lets a router base profile inherit Risk
+	// defaults from its default child, instead of falling through to
+	// the legacy SL=5/TP=10 hard-coded defaults that would otherwise
+	// override every WFO grid evaluation.
+	applyProfileDefaults(&shared, resolveRiskProfile(baseDir, baseProfile))
 	applyLegacyDefaults(&shared)
 
 	primary, err := csvinfra.LoadCandles(shared.DataPath)


### PR DESCRIPTION
## Summary
PR-5 part C wired ProfileRouter into the runner but cycle39 validation immediately exposed a residual silent-no-op: every router profile (regardless of its child mix) produced identical totalReturn / totalTrades / DD across 4 deliberately-different routing variants.

## Root cause

A router profile's ${'`'}strategy_risk${'`'} block is empty by design — the router only declares routing rules. When the handler loaded a router, ${'`'}applyProfileDefaults${'`'} found no Risk values and let ${'`'}applyLegacyDefaults${'`'} overwrite the request with the historical SL=5/TP=10 fallback. The runner's tickRiskHandler then ran the entire backtest with that one fixed envelope — ${'`'}sl14_tf60_35${'`'}'s SL=14/TP=4 and ${'`'}sl6_tr30_tp6_tf60_35${'`'}'s SL=6/TP=6 were both lost. Same envelope → same exits → same numbers, regardless of which child the router delegated to.

## Fix

${'`'}resolveRiskProfile${'`'} (handler-side and CLI-side): when the loaded profile is a router, load the default child and return that child's Risk for downstream ${'`'}applyProfileDefaults${'`'} / ${'`'}RiskConfig${'`'} assembly. Flat profiles pass through unchanged.

| call site | change |
|---|---|
| HTTP ${'`'}/backtest/run${'`'} | redirect ${'`'}applyProfileDefaults${'`'} call site through ${'`'}resolveRiskProfile${'`'} |
| HTTP ${'`'}/backtest/run-multi${'`'} | same redirect |
| HTTP ${'`'}/backtest/walk-forward${'`'} | same redirect (per-window ${'`'}profile.Risk${'`'} fallback through ${'`'}shared.*${'`'} then carries resolved values into every grid evaluation) |
| CLI ${'`'}backtest run${'`'} | parallel ${'`'}resolveRiskProfile${'`'} helper |
| CLI ${'`'}backtest walk-forward${'`'} | per-window risk read goes through resolved child |
| CLI ${'`'}backtest optimize${'`'} / ${'`'}refine${'`'} | already reject router profiles outright (PR C), no change |

## Known limitation (tracked as PR-5 part E)

**Per-regime SL/TP differentiation is still not implemented.** The tickRiskHandler accepts one RiskConfig per run, so even with this fix every bar uses the *default child's* SL/TP — not the *active regime's child's* SL/TP. That upgrade requires the tick risk handler to learn about the active strategy's risk envelope on every Evaluate, which is a larger refactor and stays out of scope here.

Promotion candidates surfaced before part E should be understood as "router signal-mix on the default child's risk envelope" rather than fully regime-specialised risk. The signal-mix half (which RSI/MACD/HTF gates fire per regime) is meaningful PDCA value on its own; the cycle39 results that follow this PR will quantify how much.

## Test plan
- [x] New ${'`'}TestResolveRiskProfile_RouterFollowsDefaultChild${'`'} — 4 branches: router → child Risk, flat → itself, nil → nil, missing child → router fall-back.
- [x] Existing ${'`'}TestApplyProfileDefaults_IndividualFieldOverrides${'`'} unchanged and green (precedence rule unchanged for flat).
- [x] ${'`'}go test ./... -race -count=1${'`'} — all 17 backend packages green.
- [x] gofmt + go vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)