### PR TITLE
docs(pdca): handoff for the 2026-04-22 session (cycle22-cycle40)

### DIFF
--- a/docs/pdca/2026-04-22_handoff.md
+++ b/docs/pdca/2026-04-22_handoff.md
@@ -1,0 +1,227 @@
+# Handoff — 2026-04-22 セッション
+
+このドキュメントは 2026-04-22 のセッション (cycle22 から cycle40) を引き継ぐためのものです。次のセッションを開始する人 (人間 or 別 Claude) が、5 分でこのセッションの「いまどこにいるか」「何が決まっているか」「次に何を選ぶか」を把握できることを目的にしています。
+
+---
+
+## 1. このセッションで起きたこと（時系列サマリ）
+
+| ID | 内容 | 結果 |
+|---|---|---|
+| cycle22-23 | PR-7 Stoch gate を WFO で評価 | reject (gate=0 が IS 4/4 勝者) |
+| cycle24-27 | v4b production の SL/TP grid WFO + multi-period validation | SL=4 が IS 3/4 勝者、ただし 1yr 2024 がマイナスで v5 候補にならず |
+| cycle28-37 | **15 分連続 PDCA スプリント** で healthy_v3 系譜を徹底探索。10+ サイクル | 2 つの finalist を抽出: `sl14_tf60_35` (攻撃) / `sl6_tr30_tp6_tf60_35` (防御) |
+| PR #132 | WFO に string-valued grid axis (`htf_filter.mode`) を追加 | merged |
+| cycle38 | Ichimoku HTF mode を string-grid で WFO 評価 | reject (block_counter_trend=true で全 regime 壊滅、2022 救済できず) |
+| PR #133 | `RegimeDetector` entity + usecase | merged |
+| PR #134 | `ProfileRouter` + `RegimeRoutingConfig` schema | merged |
+| PR #135 | runner / handler / CLI 配線 + 3 wiring-confirmation テスト | merged |
+| PR #136 | router risk-from-default-child fix | merged |
+| cycle39 | 4 router variants validation | reject (全 variant が default 子と byte-identical) |
+| PR #138 | `detector_config` を schema に追加 + WFO override path | merged |
+| cycle40 | detector threshold sweep (20 cells) + real LTC 15m regime histogram | **regime routing を LTC 15m で hard-reject** |
+
+最新 main コミット: `98218ff` (PR #139, cycle40 docs)。
+
+---
+
+## 2. **いまユーザを待っている意思決定**
+
+セッションは「**A / B どちらに進むか**」をユーザに聞いた状態で終わっています。次セッションは必ずこの選択から再開してください。
+
+### (A) cycle28-37 finalist の v5 promotion (XS, 1-2h)
+2 候補:
+- **`experiment_2026-04-22_sl14_tf60_35`** — 攻撃型。gM **+16.22%** on 2023-04..2026-03、worst +9.26%、3yr DD 6.01%。**ただし 2022 bear で −57.97% 破綻**。
+- **`experiment_2026-04-22_sl6_tr30_tp6_tf60_35`** — 防御型。2022/2023-26 両方プラス、worst **−7.32%** (2024 chop)、gM +6.88%、3yr DD 24.5% (20% 制約をやや超過)。
+
+実装手順は §6 参照。
+
+### (B) 別 indicator 軸を試行 (M, 3-5h + cycle41 PDCA)
+- **PR-9 (OBV / CMF)** — 出来高ベース指標、ADX が見逃すパターンを捕捉する可能性。LTC は出来高薄いので有効か未知数。
+- **PR-11 (Donchian Channel)** — N 期間 high/low breakout。cycle28-37 で BREAKOUT stance のロジックは弱いまま、新軸として有望。
+
+このセッションでの推奨は **A → B の順**。理由:
+1. v4b より大幅に良い候補が手元にあるので production を進めない理由がない
+2. 撤退が早いほど本番運用フィードバックが回る
+3. B は仮説段階で結果が読めない、A は確定数値で promotion 可能
+
+---
+
+## 3. PR-5 (Regime Routing) の最終結論
+
+**LTC 15m で regime routing は構造的に有効化不可能**。3 つの独立した証拠 (`docs/pdca/2026-04-22_cycle40.md` 詳細):
+
+1. **WFO sweep**: 20 cells (5 ADX × 4 ATR%) すべて byte-identical
+2. **Diagnostic routers**: range が 90% 発火するのに sl6 (default) と同じ → PR-5 part E (per-regime SL/TP) が未実装で SL/TP exit を override が変えられない
+3. **Real LTC 15m histogram** (120k bars 全期間):
+   - defaults: range 99.9% / volatile 0.1% / **directional 0%**
+   - loose ADX10: range 89.7% / volatile 10.3% / **directional 0%**
+   - tight ADX50: range 100% / volatile 0% / **directional 0%**
+
+**3 年以上の LTC 15m データで bull-trend / bear-trend が 1 bar も発火しない**。ADX が 15m timeframe で trend threshold を越えない。
+
+**Decision**: regime-routing は撤退。infrastructure (PR #133/134/135/136/138) は main に残し、別 asset/timeframe (BTC 1h / ETH 4h) や別指標軸のために温存。**LTC 15m に対しては死んだコードパス**として扱う。
+
+---
+
+## 4. 現状の production / 候補 profile
+
+### Production (main にある現在の `production.json`)
+**`production.json` は 2026-04-21 v4b promotion から変わっていません**。
+- gM +1.15% on multi-period (1yr/2yr/3yr)
+- 1yr/2yr マイナス、3yr +9.56%
+- 3yr DD 21.21% (20% 制約超過)
+
+### このセッションで作成した候補 profile (全 47 ファイル)
+- **cycle28-37 finalist 2 本**: `sl14_tf60_35.json` / `sl6_tr30_tp6_tf60_35.json`
+- **cycle28-37 探索系列 30+ 本**: SL grid / TP grid / RSI grid / TF buy max grid / ablation 等
+- **router 系列 6 本**: cycle39/40 の router_v5{a,b,c,d}, router_cycle40, router_diag_{bull,bear,range,volatile}
+- **smoke fixture 1 本**: `router_smoke_bad.json` (loader 400 path 用の故障 fixture)
+
+すべて `backend/profiles/experiment_2026-04-22_*.json`。
+
+### 重要な flat profile (history)
+- `experiment_2026-04-21_healthy_v3.json` — promotion_v3 で rollback された unhealthy SL=20 候補。cycle28-37 探索の起点
+- v4b 促進前の `experiment_2026-04-21_LGb` 等もリポジトリに残存
+
+---
+
+## 5. 残った技術的課題 (load-bearing for B 経路 or 後の PDCA)
+
+### PR-5 part E (deferred): tickRiskHandler refactor
+**規模**: L (1 日)。
+**内容**: `tickRiskHandler` が現状 run 開始時に 1 つの `RiskConfig` を fix して全 tick で使う。これを **active strategy の RiskConfig per Evaluate に同期** する refactor。
+**なぜ必要か**: cycle40 の diagnostic で「range は 90% 発火しているが SL/TP は default 子のまま」という限界が確認された。**Regime routing を別 asset で蘇らせるとき必須**。
+**いま blocking しているか**: LTC 15m では regime 自体が emit されないので E を実装しても結果は変わらない → 別 asset に移ったとき初めて値打ちが出る。
+
+### Frontend に regime info が表示されていない
+- WFO 結果 envelope に `bestStringParameters` / `bestParameters` の `regime_routing.detector_config.*` paths が入るが FE 側のレンダリングは未実装
+- cycle40 で regime routing を撤退したので緊急性低
+
+### `infrastructure/strategyprofile/Loader` の `MaxDepth` 強制テストが builder 側に依存している
+PR #134 で BuildStrategyFromProfile が depth-1 enforce、entity.Validate は profile-local なので depth は見れない。両方 work するが、loader 側に depth check を移動する余地あり (今は不要)。
+
+---
+
+## 6. (A) を選んだ場合の実装手順
+
+PDCA pattern に従う:
+
+### 6.1 promotion record を書く
+ファイル: `docs/pdca/2026-04-22_promotion_v5.md`
+
+書くべき内容 (`docs/pdca/2026-04-21_promotion_v4.md` を template に):
+1. どちらの finalist を選んだか (sl14 攻撃 or sl6 防御)
+2. multi-period 数字の最終確認 (1yr_2025 / 1yr_2024 / 2yr / new3yr / old3yr の表)
+3. v4b との差分要約 (なぜ v5 になるか)
+4. **Known limitation を明文化**:
+   - sl14 を選んだ場合: "2022 級の bear regime には対応不可"
+   - sl6 を選んだ場合: "2024 chop regime で −7.32%、3yr DD 24.5% で 20% 制約を僅かに超過"
+5. roll-back plan: `git restore backend/profiles/production.json` + `docker compose up --build -d backend`
+
+### 6.2 production.json を上書き
+```bash
+cp backend/profiles/experiment_2026-04-22_sl14_tf60_35.json backend/profiles/production.json
+# または sl6_tr30_tp6_tf60_35.json
+```
+**注意**: `name` フィールドを `production` に書き換えるのを忘れない。`description` も v5 promotion record を指す形に書き換える (例: `"Promoted from experiment_2026-04-22_sl14_tf60_35 on 2026-04-22 — see docs/pdca/2026-04-22_promotion_v5.md for the full rationale and 2022-regime caveat."`)。
+
+### 6.3 production.json の Validate を確認
+```bash
+cd backend && go test ./internal/usecase/strategy/... -run TestConfigurableStrategy_EquivalentToDefault -v
+```
+**この test は production.json == DefaultStrategy という不変条件を強制する**。promotion で破壊される可能性が高い。テストを更新するか、テストの不変条件自体が時代遅れなら削除する判断が必要 (cycle28-37 で healthy_v3 を rollback したのもこの不変条件が理由だった)。
+
+### 6.4 docker rebuild + smoke
+```bash
+docker compose up -d --build backend
+curl -s -X POST 'http://localhost:38080/api/v1/backtest/run-multi' \
+  -d '{...production smoke run...}'
+```
+
+### 6.5 PR
+- branch: `promote/v5-{aggressive|defensive}-finalist`
+- title: `feat(production): promote v5 — sl{14|6}_tf60_35 finalist with 2{022|024}-regime caveat`
+- body: promotion_v5.md の内容 + multi-period 表 + caveat
+
+---
+
+## 7. (B) を選んだ場合の出発点
+
+### PR-9 (OBV/CMF)
+1. `backend/internal/infrastructure/indicator/obv.go` + `cmf.go` を新規作成 (既存 `adx.go`, `stochastics.go` が template)
+2. `IndicatorSet` に `OBV` / `CMF` フィールド追加
+3. `usecase/indicator.go` で計算
+4. `domain/entity/strategy_config.go` の `SignalRulesConfig` に OBV/CMF gate 追加
+5. `usecase/strategy.go` の `StrategyEngineOptions` に threshold 追加
+6. `usecase/strategy/configurable_strategy.go` で profile → options mapping 追加
+7. `walkforward.go` の `ApplyOverrides` に対応 path 追加
+8. **配線確認テスト** (cycle08/09 silent-no-op trap 防止) — cycle28-37 agent-guide §配線確認テストの継続 参照
+
+### PR-11 (Donchian Channel)
+PR-9 と同じパターン。Donchian は実装シンプル (N 期間 high/low) なので時間は短い。**BREAKOUT stance のロジック改善** に直結するので cycle28-37 の弱点を補える可能性。
+
+両方とも実装後の cycle41 PDCA で「単体追加 → grid sweep → multi-period validation」の典型 PDCA workflow。
+
+---
+
+## 8. このセッションで触ったコードと commit
+
+### Merged PR (新規 7 本 + 既存 1 本)
+| PR | branch | 内容 |
+|---|---|---|
+| #132 | feat/wfo-string-override | WFO `parameterStringGrid` 対応 (`htf_filter.mode`) |
+| #133 | feat/regime-detector | `RegimeDetector` entity + usecase + 19 tests |
+| #134 | feat/regime-routing | `ProfileRouter` + `RegimeRoutingConfig` schema + 22 tests |
+| #135 | feat/regime-routing-runner-wiring | runner / handler / CLI 配線 + 3 wiring tests |
+| #136 | fix/regime-router-risk-from-default-child | router profile が default 子 Risk を継承 |
+| #137 | docs/cycle39-router-validation | cycle39 結果 + 4 router profile |
+| #138 | feat/regime-detector-config-in-schema | `detector_config` schema + WFO override path + 15 tests |
+| #139 | docs/cycle40-detector-sweep-rejects-routing | cycle40 結果 + 5 diagnostic profile + real-stream test |
+
+### このセッション新規コミット行数の概算
+- code: ~1500 行 (PR #132-#138)
+- tests: ~1100 行 (新規 60+ テストケース)
+- docs: ~1000 行 (4 サイクル markdown)
+- profiles: 47 JSON ファイル
+
+---
+
+## 9. 復元すべき context (新セッション開始時に読むべき順)
+
+1. **このファイル** (`docs/pdca/2026-04-22_handoff.md`)
+2. `docs/pdca/agent-guide.md` (§v5 promotion (#118) の現況 + 配線確認テストの継続)
+3. `docs/pdca/README.md` (PDCA 運用ガイド全体)
+4. **直近 4 サイクル**: `2026-04-22_cycle24-27.md` → `cycle28-37.md` → `cycle38.md` → `cycle39.md` → `cycle40.md`
+5. **インフラ理解が必要なら**: PR #133-#138 の commit message (どれも詳細な rationale を書いてある)
+
+---
+
+## 10. 個人的注意事項 (次セッション 開始時の罠)
+
+- **`compose.yaml` の bindmount で `backend/profiles` は live**。Docker rebuild が必要なのは **Go コード変更時のみ**。profile JSON 追加だけなら rebuild 不要 (cycle28-37 の sprint で発見、agent-guide にも記載済み)
+- **`tradeAmount=1.0` は 10x exposure**。LTC backtest のデフォは `0.1`。ratio 間違えると DD が 10x 膨れて全数値が見当外れになる。cycle24 baseline で一度ハマった
+- **`production.json == DefaultStrategy` 不変条件のテスト**が `usecase/strategy/configurable_strategy_test.go::TestConfigurableStrategy_EquivalentToDefault` にある。promotion で必ず破壊されるので **test 更新が PR の一部** になる
+- **WFO の `MaxWalkForwardGridSize=100`** 制約。グリッドが 100 を超えると 400 エラー (cycle40 で 5×4=20 に絞ったのはこの理由)
+- **Detector 関連 PR 全部に同じ wiring-confirmation pattern** を入れた (`TestRouterWiring_*` / `TestBacktestRunner_RouterStrategyChangesResult` / `TestBuildStrategyFromProfile_ThreadsDetectorConfig`)。新指標を追加する PR は同じパターンに従うこと
+
+---
+
+## 11. このセッションで明示的にユーザに確認した重要決定
+
+1. ✅ **15 分連続 PDCA をユーザが許可** → cycle28-37 sprint 実行
+2. ✅ **"続けて"** で何度も承認 → PR #132-#139 順次 merge
+3. ✅ **Choice A (Ichimoku WFO) と Choice B (Regime classifier) のうち A → 失敗 → B 選択** → PR-5 全工程
+4. ✅ **PR-5 part D で risk-fix の選択肢 4 つから A (default 子 Risk 継承) を選択** → PR #136
+5. ✅ **cycle40 結果 hard-reject 受領 → A/B 次の選択肢提示** ← **ここでセッション終了**
+
+---
+
+## 12. 開いている (未 merge の) PR / branch
+
+セッション終了時点で **open PR は 0 本**、**ローカルに残っている branch は main のみ**。すべてクリーン。
+
+---
+
+セッション終了時刻: 2026-04-22 17:55+ JST
+最後のコミット: `98218ff docs(pdca): cycle40 — detector sweep + regime histogram hard-rejects regime routing on LTC 15m (#139)`


### PR DESCRIPTION
## Summary
セッション引き継ぎ書。次のセッション（人 or 別 Claude）が 5 分で「いまどこにいるか」「何が決まっているか」「次に何を選ぶか」を把握できるように。

## このセッションで起きたこと（要約）
- cycle22-cycle40 の 19+ サイクル PDCA を実行
- PR #132-#139 の 8 本を merge (PR-5 全工程 A/B/C/risk-fix/F + WFO string-grid + cycle39/40 docs)
- **PR-5 (Regime Routing) を LTC 15m で hard-reject** — 3 年以上のデータで bull-trend / bear-trend が 1 bar も発火しないことを確定
- インフラ自体は main に残し、別 asset/timeframe で再利用可能な形で温存

## 次のセッションで待っている意思決定
ユーザに **A / B どちらに進むか** を聞いた状態でセッション終了:

- **(A) cycle28-37 finalist の v5 promotion** — `sl14_tf60_35` (攻撃) or `sl6_tr30_tp6_tf60_35` (防御)
- **(B) 別 indicator 軸を試行** — PR-9 (OBV/CMF) or PR-11 (Donchian)

詳細・実装手順・トラップは ${'`'}docs/pdca/2026-04-22_handoff.md${'`'} 全文に記載。

## Test plan
- [x] 純 docs 追加、コード変更なし
- [x] 既存テストへの影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)