### PR TITLE
feat(indicator): add Donchian Channel + breakout gate (PR-11)

### DIFF
--- a/backend/internal/domain/entity/indicator.go
+++ b/backend/internal/domain/entity/indicator.go
@@ -42,6 +42,15 @@ type IndicatorSet struct {
 	// they could not be computed (yields cleaner payloads during warmup).
 	Ichimoku *IchimokuSnapshot `json:"ichimoku,omitempty"`
 
+	// PR-11: Donchian Channel (N-bar high/low). nil when insufficient
+	// history is available (need at least N bars for the 20-bar default).
+	// Donchian20Upper/Lower bound the most recent 20 bars inclusive of the
+	// current bar so `lastPrice > Donchian20Upper` is a direct upside
+	// breakout probe for the configurable strategy's breakout stance.
+	Donchian20Upper  *float64 `json:"donchian20Upper"`
+	Donchian20Lower  *float64 `json:"donchian20Lower"`
+	Donchian20Middle *float64 `json:"donchian20Middle"`
+
 	Timestamp int64 `json:"timestamp"`
 }
 

--- a/backend/internal/domain/entity/strategy_config.go
+++ b/backend/internal/domain/entity/strategy_config.go
@@ -96,6 +96,15 @@ type BreakoutConfig struct {
 	RequireMACDConfirm bool    `json:"require_macd_confirm"`
 	// PR-6: breakout fires only when ADX >= ADXMin (0 = gate disabled).
 	ADXMin float64 `json:"adx_min"`
+	// PR-11: Donchian Channel confirmation. DonchianPeriod > 0 activates
+	// the gate; a typical value is 20 (~5 hours on 15m bars). When active:
+	//   - BUY  requires lastPrice > Donchian(period).Upper
+	//   - SELL requires lastPrice < Donchian(period).Lower
+	// The gate is orthogonal to the existing BB-width/volume gates — BB
+	// detects mean-reversion squeeze-and-release while Donchian detects
+	// range-of-N breakout; both must agree before a signal fires. Missing
+	// Donchian (warmup) treats the gate as a fail, matching ADX/Stoch.
+	DonchianPeriod int `json:"donchian_period,omitempty"`
 }
 
 // HTFFilterConfig configures the higher-timeframe trend filter.
@@ -306,6 +315,12 @@ func (p StrategyProfile) Validate() error {
 	}
 	if p.Risk.TakeProfitPercent < 0 {
 		errs = append(errs, fmt.Errorf("strategy_risk.take_profit_percent must be >= 0 (got %v)", p.Risk.TakeProfitPercent))
+	}
+
+	// PR-11: negative Donchian period would compute NaN indefinitely; 0
+	// disables the gate and is the safe default.
+	if p.SignalRules.Breakout.DonchianPeriod < 0 {
+		errs = append(errs, fmt.Errorf("signal_rules.breakout.donchian_period must be >= 0 (got %d)", p.SignalRules.Breakout.DonchianPeriod))
 	}
 
 	// regime_routing.overrides without a default is also flagged — a

--- a/backend/internal/infrastructure/indicator/donchian.go
+++ b/backend/internal/infrastructure/indicator/donchian.go
@@ -1,0 +1,43 @@
+package indicator
+
+import "math"
+
+// Donchian computes the Donchian Channel (highest high, lowest low, and their
+// midpoint) over the most recent `period` bars.
+//
+// Returns (upper, lower, middle) where:
+//   - upper:  highest high within the last `period` bars (inclusive of the
+//     current bar — callers wanting the "N-prior bars excluding today"
+//     convention should pass highs[:len-1] / lows[:len-1]).
+//   - lower:  lowest low within the same window.
+//   - middle: arithmetic midpoint (upper+lower)/2.
+//
+// NaN is returned for all three when period <= 0, the input slices have
+// mismatched lengths, or there are fewer than `period` bars available.
+//
+// The caller's intended use is a breakout gate on top of the existing BB-based
+// breakout: `lastPrice > upper` → upside confirmation, `lastPrice < lower` →
+// downside confirmation. Keeping the inclusive-of-current-bar convention makes
+// that comparison direct without the caller having to slice the input again.
+func Donchian(highs, lows []float64, period int) (upper, lower, middle float64) {
+	if period <= 0 {
+		return math.NaN(), math.NaN(), math.NaN()
+	}
+	if len(highs) != len(lows) || len(highs) < period {
+		return math.NaN(), math.NaN(), math.NaN()
+	}
+
+	start := len(highs) - period
+	upper = math.Inf(-1)
+	lower = math.Inf(1)
+	for i := start; i < len(highs); i++ {
+		if highs[i] > upper {
+			upper = highs[i]
+		}
+		if lows[i] < lower {
+			lower = lows[i]
+		}
+	}
+	middle = (upper + lower) / 2
+	return upper, lower, middle
+}

--- a/backend/internal/infrastructure/indicator/donchian_test.go
+++ b/backend/internal/infrastructure/indicator/donchian_test.go
@@ -1,0 +1,92 @@
+package indicator
+
+import (
+	"math"
+	"testing"
+)
+
+func TestDonchian_BasicRange(t *testing.T) {
+	highs := []float64{10, 12, 14, 11, 13, 15, 12, 10, 11, 16, 14}
+	lows := []float64{8, 9, 10, 9, 10, 11, 9, 7, 8, 12, 11}
+
+	// Donchian(5) over the last 5 bars: highs[6..10] = {12,10,11,16,14}, lows = {9,7,8,12,11}
+	// Upper = 16, Lower = 7, Middle = (16+7)/2 = 11.5
+	upper, lower, middle := Donchian(highs, lows, 5)
+
+	if upper != 16 {
+		t.Errorf("upper: want 16, got %v", upper)
+	}
+	if lower != 7 {
+		t.Errorf("lower: want 7, got %v", lower)
+	}
+	if middle != 11.5 {
+		t.Errorf("middle: want 11.5, got %v", middle)
+	}
+}
+
+func TestDonchian_ExcludesCurrentBar(t *testing.T) {
+	// Donchian breakout conventions vary. We use the "inclusive of current"
+	// convention so the caller can compare lastPrice > upper directly to
+	// detect an upside breakout on the current bar.
+	highs := []float64{5, 6, 7, 8, 100}
+	lows := []float64{1, 2, 3, 4, 50}
+
+	upper, lower, middle := Donchian(highs, lows, 5)
+	if upper != 100 || lower != 1 || middle != 50.5 {
+		t.Errorf("inclusive window: got upper=%v lower=%v middle=%v, want 100/1/50.5", upper, lower, middle)
+	}
+}
+
+func TestDonchian_PeriodEqualsLength(t *testing.T) {
+	highs := []float64{10, 12, 14}
+	lows := []float64{8, 9, 10}
+
+	upper, lower, middle := Donchian(highs, lows, 3)
+	if upper != 14 || lower != 8 || middle != 11 {
+		t.Errorf("full-window: got upper=%v lower=%v middle=%v, want 14/8/11", upper, lower, middle)
+	}
+}
+
+func TestDonchian_InsufficientData(t *testing.T) {
+	highs := []float64{10, 12}
+	lows := []float64{8, 9}
+
+	upper, lower, middle := Donchian(highs, lows, 5)
+	if !math.IsNaN(upper) || !math.IsNaN(lower) || !math.IsNaN(middle) {
+		t.Errorf("insufficient data: want NaN triplet, got %v / %v / %v", upper, lower, middle)
+	}
+}
+
+func TestDonchian_MismatchedLengths(t *testing.T) {
+	highs := []float64{10, 12, 14, 11}
+	lows := []float64{8, 9, 10} // shorter
+
+	upper, lower, middle := Donchian(highs, lows, 3)
+	if !math.IsNaN(upper) || !math.IsNaN(lower) || !math.IsNaN(middle) {
+		t.Errorf("mismatched lengths: want NaN triplet, got %v / %v / %v", upper, lower, middle)
+	}
+}
+
+func TestDonchian_InvalidPeriod(t *testing.T) {
+	highs := []float64{10, 12, 14}
+	lows := []float64{8, 9, 10}
+
+	for _, p := range []int{0, -1} {
+		upper, lower, middle := Donchian(highs, lows, p)
+		if !math.IsNaN(upper) || !math.IsNaN(lower) || !math.IsNaN(middle) {
+			t.Errorf("period=%d: want NaN triplet, got %v / %v / %v", p, upper, lower, middle)
+		}
+	}
+}
+
+func TestDonchian_FlatWindow(t *testing.T) {
+	// If the window is perfectly flat, upper == lower == middle and no
+	// breakout is possible. Make sure we do not NaN out on the edge.
+	highs := []float64{5, 5, 5, 5, 5}
+	lows := []float64{5, 5, 5, 5, 5}
+
+	upper, lower, middle := Donchian(highs, lows, 5)
+	if upper != 5 || lower != 5 || middle != 5 {
+		t.Errorf("flat window: want 5/5/5, got %v/%v/%v", upper, lower, middle)
+	}
+}

--- a/backend/internal/usecase/backtest/handler.go
+++ b/backend/internal/usecase/backtest/handler.go
@@ -590,6 +590,13 @@ func calculateIndicatorSet(symbolID int64, candles []entity.Candle) entity.Indic
 		result.Ichimoku = snap
 	}
 
+	// PR-11: Donchian Channel (20-bar default). Mirror the live pipeline;
+	// nil until 20 bars of history are available.
+	donU, donL, donM := indicator.Donchian(highs, lows, 20)
+	result.Donchian20Upper = floatToPtr(donU)
+	result.Donchian20Lower = floatToPtr(donL)
+	result.Donchian20Middle = floatToPtr(donM)
+
 	// Volume indicators
 	volumes := make([]float64, n)
 	for i, c := range candles {

--- a/backend/internal/usecase/backtest/walkforward.go
+++ b/backend/internal/usecase/backtest/walkforward.go
@@ -274,7 +274,7 @@ func ExpandCombinedGrid(numeric []ParameterOverride, strs []ParameterStringOverr
 //	strategy_risk.max_daily_loss
 //	signal_rules.trend_follow.{rsi_buy_max,rsi_sell_min,adx_min}
 //	signal_rules.contrarian.{rsi_entry,rsi_exit,macd_histogram_limit,adx_max,stoch_entry_max,stoch_exit_min}
-//	signal_rules.breakout.{volume_ratio_min,adx_min}
+//	signal_rules.breakout.{volume_ratio_min,adx_min,donchian_period}
 //	stance_rules.{rsi_oversold,rsi_overbought,sma_convergence_threshold,breakout_volume_ratio}
 //	htf_filter.alignment_boost
 //	regime_routing.detector_config.trend_adx_min
@@ -321,6 +321,17 @@ func ApplyOverrides(base entity.StrategyProfile, overrides map[string]float64) (
 			out.SignalRules.Breakout.VolumeRatioMin = value
 		case "signal_rules.breakout.adx_min":
 			out.SignalRules.Breakout.ADXMin = value
+		case "signal_rules.breakout.donchian_period":
+			// Period is an int; a fractional grid value would silently
+			// truncate, mirroring the existing "no silent rounding"
+			// contract used for regime_routing.detector_config.hysteresis_bars.
+			if value != float64(int(value)) {
+				return entity.StrategyProfile{}, fmt.Errorf("walk-forward: signal_rules.breakout.donchian_period must be an integer (got %v)", value)
+			}
+			if value < 0 {
+				return entity.StrategyProfile{}, fmt.Errorf("walk-forward: signal_rules.breakout.donchian_period must be >= 0 (got %v)", value)
+			}
+			out.SignalRules.Breakout.DonchianPeriod = int(value)
 		case "stance_rules.rsi_oversold":
 			out.StanceRules.RSIOversold = value
 		case "stance_rules.rsi_overbought":

--- a/backend/internal/usecase/backtest/walkforward_test.go
+++ b/backend/internal/usecase/backtest/walkforward_test.go
@@ -372,6 +372,62 @@ func TestApplyOverrides_RegimeDetectorConfig(t *testing.T) {
 	})
 }
 
+// TestApplyOverrides_BreakoutDonchianPeriod is the PR-11 wiring guard:
+// grid axes sweeping Donchian lookback (20 / 40 / 60 etc.) must land on
+// SignalRules.Breakout.DonchianPeriod as an int, and fractional values
+// must be rejected so an off-by-0.5 in a grid spec fails loudly.
+func TestApplyOverrides_BreakoutDonchianPeriod(t *testing.T) {
+	t.Run("integer value sets the field", func(t *testing.T) {
+		base := entity.StrategyProfile{}
+		got, err := ApplyOverrides(base, map[string]float64{
+			"signal_rules.breakout.donchian_period": 20,
+		})
+		if err != nil {
+			t.Fatalf("ApplyOverrides: %v", err)
+		}
+		if got.SignalRules.Breakout.DonchianPeriod != 20 {
+			t.Errorf("DonchianPeriod = %d, want 20", got.SignalRules.Breakout.DonchianPeriod)
+		}
+	})
+
+	t.Run("zero disables the gate", func(t *testing.T) {
+		base := entity.StrategyProfile{
+			SignalRules: entity.SignalRulesConfig{
+				Breakout: entity.BreakoutConfig{DonchianPeriod: 20},
+			},
+		}
+		got, err := ApplyOverrides(base, map[string]float64{
+			"signal_rules.breakout.donchian_period": 0,
+		})
+		if err != nil {
+			t.Fatalf("ApplyOverrides: %v", err)
+		}
+		if got.SignalRules.Breakout.DonchianPeriod != 0 {
+			t.Errorf("DonchianPeriod = %d, want 0 (gate disabled)", got.SignalRules.Breakout.DonchianPeriod)
+		}
+	})
+
+	t.Run("fractional value is rejected", func(t *testing.T) {
+		base := entity.StrategyProfile{}
+		_, err := ApplyOverrides(base, map[string]float64{
+			"signal_rules.breakout.donchian_period": 20.5,
+		})
+		if err == nil {
+			t.Fatal("expected error on fractional donchian_period (silent truncation would corrupt the grid signal)")
+		}
+	})
+
+	t.Run("negative value is rejected", func(t *testing.T) {
+		base := entity.StrategyProfile{}
+		_, err := ApplyOverrides(base, map[string]float64{
+			"signal_rules.breakout.donchian_period": -1,
+		})
+		if err == nil {
+			t.Fatal("expected error on negative donchian_period")
+		}
+	})
+}
+
 // -------------- string overrides / combined grid --------------
 
 func TestApplyStringOverrides_HTFMode(t *testing.T) {

--- a/backend/internal/usecase/indicator.go
+++ b/backend/internal/usecase/indicator.go
@@ -89,6 +89,14 @@ func (c *IndicatorCalculator) Calculate(ctx context.Context, symbolID int64, int
 		result.Ichimoku = snap
 	}
 
+	// PR-11: Donchian Channel (20-bar default). Mirror the other range-of-N
+	// indicators — NaN until 20 bars of history are available; toPtr
+	// collapses that into nil pointers for downstream gates.
+	donU, donL, donM := indicator.Donchian(highs, lows, 20)
+	result.Donchian20Upper = toPtr(donU)
+	result.Donchian20Lower = toPtr(donL)
+	result.Donchian20Middle = toPtr(donM)
+
 	// Volume indicators
 	volumes := make([]float64, n)
 	for i, cd := range candles {

--- a/backend/internal/usecase/strategy.go
+++ b/backend/internal/usecase/strategy.go
@@ -84,6 +84,20 @@ type StrategyEngineOptions struct {
 	ContrarianStochEntryMax float64
 	ContrarianStochExitMin  float64
 
+	// PR-11: Donchian confirmation on breakout signals. When
+	// BreakoutDonchianPeriod > 0, the breakout stance additionally requires
+	// lastPrice > Donchian20Upper (BUY) or lastPrice < Donchian20Lower
+	// (SELL). Typical value: 20 (matches the IndicatorSet's default
+	// Donchian20 fields). 0 keeps the legacy BB-only breakout.
+	//
+	// Note: the live pipeline currently computes Donchian with period=20
+	// only; setting BreakoutDonchianPeriod to any other positive value
+	// still activates the gate but will compare against the same
+	// Donchian20Upper/Lower pair. Exposing per-bar arbitrary periods is
+	// out of scope for PR-11 — the gate is the cheap win; period tuning
+	// can be a follow-up once WFO tells us Donchian20 helps at all.
+	BreakoutDonchianPeriod int
+
 	// defaulted tracks whether applyDefaults has already been called so we
 	// don't flip booleans to true twice (e.g. on a caller that explicitly
 	// wants them false).
@@ -419,7 +433,25 @@ func (e *StrategyEngine) EvaluateAt(ctx context.Context, indicators entity.Indic
 				return adxBlock("breakout: ADX below threshold"), nil
 			}
 		}
-		return e.evaluateBreakout(indicators.SymbolID, lastPrice, indicators.BBUpper, indicators.BBLower, indicators.BBMiddle, indicators.VolumeRatio, indicators.Histogram, nowUnix), nil
+		sig := e.evaluateBreakout(indicators.SymbolID, lastPrice, indicators.BBUpper, indicators.BBLower, indicators.BBMiddle, indicators.VolumeRatio, indicators.Histogram, nowUnix)
+		// PR-11: Donchian confirmation. Applies only when a direction was
+		// actually emitted — HOLD passes through unchanged. BUY requires
+		// lastPrice > Donchian20Upper; SELL requires lastPrice <
+		// Donchian20Lower. Missing Donchian (warmup) fails the gate,
+		// matching the ADX / Stochastics convention.
+		if e.options.BreakoutDonchianPeriod > 0 && sig != nil {
+			switch sig.Action {
+			case entity.SignalActionBuy:
+				if indicators.Donchian20Upper == nil || lastPrice <= *indicators.Donchian20Upper {
+					return adxBlock("breakout: price below Donchian upper"), nil
+				}
+			case entity.SignalActionSell:
+				if indicators.Donchian20Lower == nil || lastPrice >= *indicators.Donchian20Lower {
+					return adxBlock("breakout: price above Donchian lower"), nil
+				}
+			}
+		}
+		return sig, nil
 	default:
 		return &entity.Signal{
 			SymbolID:  indicators.SymbolID,

--- a/backend/internal/usecase/strategy/configurable_strategy.go
+++ b/backend/internal/usecase/strategy/configurable_strategy.go
@@ -78,6 +78,7 @@ func NewConfigurableStrategy(profile *entity.StrategyProfile) (*ConfigurableStra
 		BreakoutVolumeRatio:        profile.SignalRules.Breakout.VolumeRatioMin,
 		BreakoutRequireMACDConfirm: profile.SignalRules.Breakout.RequireMACDConfirm,
 		BreakoutADXMin:             profile.SignalRules.Breakout.ADXMin, // PR-6
+		BreakoutDonchianPeriod:     profile.SignalRules.Breakout.DonchianPeriod, // PR-11
 
 		// HTF filter
 		HTFEnabled:           profile.HTFFilter.Enabled,

--- a/backend/internal/usecase/strategy/donchian_gate_test.go
+++ b/backend/internal/usecase/strategy/donchian_gate_test.go
@@ -1,0 +1,245 @@
+package strategy
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+)
+
+// TestConfigurableStrategy_DonchianGateBlocksBreakoutBuy is the PR-11 wiring
+// confirmation test. With DonchianPeriod > 0 and lastPrice at or below
+// Donchian20Upper, a breakout BUY must be blocked with a reason citing
+// Donchian. Guards against the silent-no-op trap (cycle08 pattern) where a
+// profile field compiles cleanly but never influences a signal decision.
+func TestConfigurableStrategy_DonchianGateBlocksBreakoutBuy(t *testing.T) {
+	profile := productionProfile(t)
+	profile.SignalRules.Breakout.Enabled = true
+	profile.SignalRules.Breakout.DonchianPeriod = 20
+	// Keep other breakout gates permissive so only the Donchian gate can fire.
+	profile.SignalRules.Breakout.ADXMin = 0
+	profile.SignalRules.Breakout.RequireMACDConfirm = false
+
+	s, err := NewConfigurableStrategy(profile)
+	if err != nil {
+		t.Fatalf("NewConfigurableStrategy: %v", err)
+	}
+
+	// IndicatorSet that would fire a breakout BUY (squeeze released, price
+	// above BB upper with volume) but whose lastPrice is exactly equal to
+	// the Donchian20 upper — the gate uses strict `>` so equality blocks.
+	// BBUpper is 118 (breakout threshold) and Donchian is 125 (gate block).
+	ind := makeBreakoutBuyReadyIndicators()
+	lastPrice := 120.0
+	don := 125.0 // strictly above lastPrice, so gate blocks
+	ind.Donchian20Upper = &don
+
+	sig, err := s.Evaluate(context.Background(), &ind, nil, lastPrice, time.Now())
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if sig == nil {
+		t.Fatalf("nil signal")
+	}
+	if sig.Action != entity.SignalActionHold {
+		t.Fatalf("expected HOLD when price <= Donchian upper, got %v (reason=%q)", sig.Action, sig.Reason)
+	}
+	if !containsSubstring(sig.Reason, "Donchian") {
+		t.Fatalf("expected reason to mention Donchian, got %q", sig.Reason)
+	}
+}
+
+// TestConfigurableStrategy_DonchianGateAllowsBreakoutBuy: when lastPrice is
+// strictly above Donchian20Upper, the gate passes and the breakout BUY fires.
+func TestConfigurableStrategy_DonchianGateAllowsBreakoutBuy(t *testing.T) {
+	profile := productionProfile(t)
+	profile.SignalRules.Breakout.Enabled = true
+	profile.SignalRules.Breakout.DonchianPeriod = 20
+	profile.SignalRules.Breakout.ADXMin = 0
+	profile.SignalRules.Breakout.RequireMACDConfirm = false
+
+	s, err := NewConfigurableStrategy(profile)
+	if err != nil {
+		t.Fatalf("NewConfigurableStrategy: %v", err)
+	}
+
+	ind := makeBreakoutBuyReadyIndicators()
+	lastPrice := 125.0
+	don := 120.0 // lastPrice strictly above Donchian upper
+	ind.Donchian20Upper = &don
+
+	sig, err := s.Evaluate(context.Background(), &ind, nil, lastPrice, time.Now())
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if sig == nil {
+		t.Fatalf("nil signal")
+	}
+	if sig.Action != entity.SignalActionBuy {
+		t.Fatalf("expected breakout BUY, got %v (reason=%q)", sig.Action, sig.Reason)
+	}
+}
+
+// TestConfigurableStrategy_DonchianGateMissingDonchianCountsAsFail is the
+// nil-indicator edge: a profile that activates the gate must NOT emit a BUY
+// when Donchian20Upper is nil (warmup). Matches the ADX / Stoch convention.
+func TestConfigurableStrategy_DonchianGateMissingDonchianCountsAsFail(t *testing.T) {
+	profile := productionProfile(t)
+	profile.SignalRules.Breakout.Enabled = true
+	profile.SignalRules.Breakout.DonchianPeriod = 20
+	profile.SignalRules.Breakout.ADXMin = 0
+	profile.SignalRules.Breakout.RequireMACDConfirm = false
+
+	s, err := NewConfigurableStrategy(profile)
+	if err != nil {
+		t.Fatalf("NewConfigurableStrategy: %v", err)
+	}
+
+	ind := makeBreakoutBuyReadyIndicators()
+	ind.Donchian20Upper = nil // warmup
+
+	sig, err := s.Evaluate(context.Background(), &ind, nil, 125.0, time.Now())
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if sig.Action != entity.SignalActionHold {
+		t.Fatalf("expected HOLD on nil Donchian, got %v", sig.Action)
+	}
+	if !containsSubstring(sig.Reason, "Donchian") {
+		t.Fatalf("expected Donchian block reason, got %q", sig.Reason)
+	}
+}
+
+// TestConfigurableStrategy_DonchianGateZeroIsDisabled: the default 0-value on
+// DonchianPeriod must not touch the signal path. A breakout BUY scenario with
+// Donchian20Upper set high enough to block (if the gate were on) must still
+// emit BUY when the gate is 0.
+func TestConfigurableStrategy_DonchianGateZeroIsDisabled(t *testing.T) {
+	profile := productionProfile(t)
+	profile.SignalRules.Breakout.Enabled = true
+	profile.SignalRules.Breakout.DonchianPeriod = 0 // gate disabled
+	profile.SignalRules.Breakout.ADXMin = 0
+	profile.SignalRules.Breakout.RequireMACDConfirm = false
+
+	s, err := NewConfigurableStrategy(profile)
+	if err != nil {
+		t.Fatalf("NewConfigurableStrategy: %v", err)
+	}
+
+	ind := makeBreakoutBuyReadyIndicators()
+	// Even though Donchian20Upper > lastPrice (would block if the gate were
+	// active), the gate is disabled so BUY must still fire.
+	don := 999.0
+	ind.Donchian20Upper = &don
+
+	sig, err := s.Evaluate(context.Background(), &ind, nil, 125.0, time.Now())
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if sig.Action != entity.SignalActionBuy {
+		t.Fatalf("gate=0 should pass through; expected BUY, got %v (reason=%q)", sig.Action, sig.Reason)
+	}
+}
+
+// TestConfigurableStrategy_DonchianGateBlocksBreakoutSell mirrors the BUY
+// gate for the SELL direction. lastPrice at or above Donchian20Lower must
+// block a breakout SELL when the gate is active.
+func TestConfigurableStrategy_DonchianGateBlocksBreakoutSell(t *testing.T) {
+	profile := productionProfile(t)
+	profile.SignalRules.Breakout.Enabled = true
+	profile.SignalRules.Breakout.DonchianPeriod = 20
+	profile.SignalRules.Breakout.ADXMin = 0
+	profile.SignalRules.Breakout.RequireMACDConfirm = false
+
+	s, err := NewConfigurableStrategy(profile)
+	if err != nil {
+		t.Fatalf("NewConfigurableStrategy: %v", err)
+	}
+
+	ind := makeBreakoutSellReadyIndicators()
+	lastPrice := 80.0
+	don := 80.0 // equal — gate uses strict `<`
+	ind.Donchian20Lower = &don
+
+	sig, err := s.Evaluate(context.Background(), &ind, nil, lastPrice, time.Now())
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if sig == nil {
+		t.Fatalf("nil signal")
+	}
+	if sig.Action != entity.SignalActionHold {
+		t.Fatalf("expected HOLD when price >= Donchian lower, got %v (reason=%q)", sig.Action, sig.Reason)
+	}
+	if !containsSubstring(sig.Reason, "Donchian") {
+		t.Fatalf("expected reason to mention Donchian, got %q", sig.Reason)
+	}
+}
+
+// makeBreakoutBuyReadyIndicators builds an IndicatorSet that falls into the
+// BREAKOUT stance (RecentSqueeze released upward with volume) and would fire
+// a BUY from evaluateBreakout when evaluated at lastPrice=120. Only Donchian
+// decisions can intervene in tests that set DonchianPeriod > 0.
+//
+// BB upper is 118 so the caller's lastPrice=120 is strictly above; callers
+// vary Donchian20Upper to probe the gate.
+func makeBreakoutBuyReadyIndicators() entity.IndicatorSet {
+	sma20 := 110.0
+	sma50 := 105.0
+	ema12 := 112.0
+	ema26 := 109.0
+	rsi := 55.0
+	hist := 2.0
+	bbUpper := 118.0
+	bbLower := 100.0
+	bbMiddle := 110.0
+	volRatio := 2.0 // above default BreakoutVolumeRatio=1.5
+	squeeze := true
+	return entity.IndicatorSet{
+		SymbolID:      10,
+		SMA20:         &sma20,
+		SMA50:         &sma50,
+		EMA12:         &ema12,
+		EMA26:         &ema26,
+		RSI14:         &rsi,
+		Histogram:     &hist,
+		BBUpper:       &bbUpper,
+		BBLower:       &bbLower,
+		BBMiddle:      &bbMiddle,
+		VolumeRatio:   &volRatio,
+		RecentSqueeze: &squeeze,
+		Timestamp:     time.Now().Unix(),
+	}
+}
+
+// makeBreakoutSellReadyIndicators mirrors the BUY helper for the SELL
+// direction. BB lower is 82 so lastPrice=80 is strictly below.
+func makeBreakoutSellReadyIndicators() entity.IndicatorSet {
+	sma20 := 95.0
+	sma50 := 100.0
+	ema12 := 93.0
+	ema26 := 97.0
+	rsi := 45.0
+	hist := -2.0
+	bbUpper := 100.0
+	bbLower := 82.0
+	bbMiddle := 90.0
+	volRatio := 2.0
+	squeeze := true
+	return entity.IndicatorSet{
+		SymbolID:      10,
+		SMA20:         &sma20,
+		SMA50:         &sma50,
+		EMA12:         &ema12,
+		EMA26:         &ema26,
+		RSI14:         &rsi,
+		Histogram:     &hist,
+		BBUpper:       &bbUpper,
+		BBLower:       &bbLower,
+		BBMiddle:      &bbMiddle,
+		VolumeRatio:   &volRatio,
+		RecentSqueeze: &squeeze,
+		Timestamp:     time.Now().Unix(),
+	}
+}


### PR DESCRIPTION
## Summary

- Add Donchian Channel (20-bar high/low) indicator: `internal/infrastructure/indicator/donchian.go`
- Wire `Donchian20Upper/Lower/Middle` through `IndicatorSet` and compute in both the live (`usecase/indicator.go`) and backtest (`usecase/backtest/handler.go`) pipelines
- Extend `BreakoutConfig` with `donchian_period` (int, 0 = disabled) and thread it through `ConfigurableStrategy` → `StrategyEngineOptions.BreakoutDonchianPeriod`
- Apply the gate in `StrategyEngine.EvaluateAt` case `MarketStanceBreakout`: BUY requires lastPrice > Donchian20Upper, SELL requires lastPrice < Donchian20Lower, missing Donchian fails the gate (same convention as ADX/Stoch)
- Expose `signal_rules.breakout.donchian_period` in `ApplyOverrides` for WFO sweeps, rejecting fractional/negative values
- 7 indicator unit tests, 5 wiring-confirmation gate tests, 4 WFO override tests

## Design choice

Donchian is **additive** to the existing BB-width/volume breakout gate, not a replacement. BB detects mean-reversion squeeze-and-release; Donchian detects range-of-N breakout. Both must agree before a signal fires when the gate is active. This is the smallest-blast-radius way to add Donchian as a WFO axis without rewriting the BREAKOUT stance rules.

`DonchianPeriod=0` keeps the legacy BB-only breakout so every existing profile (including `production.json` / v5 sl14) is bit-identical under this change — confirmed by full `go test ./... -race -count=1` green.

Per-bar arbitrary periods are intentionally out of scope: the live calculator computes `Donchian(highs, lows, 20)` and the gate compares against that single `Donchian20Upper/Lower` pair. If WFO tells us Donchian helps at all, period tuning can be a follow-up.

## Wiring-confirmation tests

Following the cycle08/09 silent-no-op pattern (profile field compiles cleanly but never changes a signal), every new option has a direct assertion:

- `TestConfigurableStrategy_DonchianGateBlocksBreakoutBuy` — gate active, price below Donchian upper → HOLD with reason mentioning Donchian
- `TestConfigurableStrategy_DonchianGateAllowsBreakoutBuy` — gate active, price above Donchian upper → BUY fires
- `TestConfigurableStrategy_DonchianGateMissingDonchianCountsAsFail` — nil Donchian during warmup → HOLD
- `TestConfigurableStrategy_DonchianGateZeroIsDisabled` — gate=0 keeps BUY path unchanged even with adversarial Donchian20Upper
- `TestConfigurableStrategy_DonchianGateBlocksBreakoutSell` — mirror for SELL direction
- `TestApplyOverrides_BreakoutDonchianPeriod/*` — 4 subtests covering int / zero / fractional-rejected / negative-rejected

## Next cycle (cycle41)

WFO sweep `signal_rules.breakout.donchian_period ∈ {10, 20, 30, 40}` on the v5 sl14 base on LTC 15m, to measure whether the gate prunes losing breakouts or just cuts signal volume. BREAKOUT stance was the weakest leg of cycle28-37's final ranking — if Donchian confirmation helps here, the v5 promotion has a clean axis to iterate on without needing a regime-router rescue.

## Test plan

- [ ] CI: backend `go test ./...` green
- [ ] CI: frontend `pnpm test` green
- [ ] Post-merge: `POST /backtest/walk-forward` with `parameterGrid: [{"path": "signal_rules.breakout.donchian_period", "values": [10, 20, 30, 40]}]` on the sl14 base and compare OOS geomMean against sl14 baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)