### PR TITLE
docs(pdca): cycle41 — Donchian sweep rejects gate on LTC 15m

### DIFF
--- a/backend/profiles/experiment_2026-04-22_sl14_tf60_35_donchian10.json
+++ b/backend/profiles/experiment_2026-04-22_sl14_tf60_35_donchian10.json
@@ -1,0 +1,56 @@
+{
+  "name": "experiment_2026-04-22_sl14_tf60_35_donchian10",
+  "description": "sl14_tf60_35 v5 base + Donchian(10) breakout gate. cycle41 winner of 4/10 WFO windows (period=10 on the 2024 chop windows 3/6/7/8). Kept in repo as audit trail for the cycle41 reject.",
+  "indicators": {
+    "sma_short": 20,
+    "sma_long": 50,
+    "rsi_period": 14,
+    "macd_fast": 12,
+    "macd_slow": 26,
+    "macd_signal": 9,
+    "bb_period": 20,
+    "bb_multiplier": 2.0,
+    "atr_period": 14
+  },
+  "stance_rules": {
+    "rsi_oversold": 32,
+    "rsi_overbought": 68,
+    "sma_convergence_threshold": 0.002,
+    "bb_squeeze_lookback": 5,
+    "breakout_volume_ratio": 1.5
+  },
+  "signal_rules": {
+    "trend_follow": {
+      "enabled": true,
+      "require_macd_confirm": false,
+      "require_ema_cross": true,
+      "rsi_buy_max": 60,
+      "rsi_sell_min": 35
+    },
+    "contrarian": {
+      "enabled": true,
+      "rsi_entry": 32,
+      "rsi_exit": 68,
+      "macd_histogram_limit": 10
+    },
+    "breakout": {
+      "enabled": true,
+      "volume_ratio_min": 1.5,
+      "require_macd_confirm": true,
+      "donchian_period": 10
+    }
+  },
+  "strategy_risk": {
+    "stop_loss_percent": 14,
+    "take_profit_percent": 4,
+    "stop_loss_atr_multiplier": 0,
+    "max_position_amount": 100000,
+    "max_daily_loss": 50000,
+    "trailing_atr_multiplier": 2.5
+  },
+  "htf_filter": {
+    "enabled": true,
+    "block_counter_trend": false,
+    "alignment_boost": 0.1
+  }
+}

--- a/docs/pdca/2026-04-22_cycle41.md
+++ b/docs/pdca/2026-04-22_cycle41.md
@@ -1,0 +1,110 @@
+# PDCA Cycle 41 — Donchian Channel breakout gate on v5 sl14
+
+**Date**: 2026-04-22
+**Parent**: `2026-04-22_handoff.md` §7 "(B) PR-11 Donchian"
+**PR**: #142 (indicator + gate + WFO override path) → merged as `76b9b6a`
+**Verdict**: **reject** — Donchian gate does not improve v5 sl14 on LTC 15m.
+
+---
+
+## Hypothesis
+
+cycle28-37 concluded "BREAKOUT stance logic is weak — new axis required". Donchian Channel (N-bar high/low) is a classic breakout confirmation axis that is orthogonal to the existing BB-squeeze/volume gate:
+
+- BB breakout: mean-reversion squeeze-and-release (volatility contraction → expansion)
+- Donchian breakout: range-of-N extreme
+
+If Donchian prunes losing breakouts (false breakouts where BB+volume fire but the move does not make a new N-bar high/low), adding the gate should improve worst/DD while sacrificing some signal volume.
+
+## Method
+
+WFO sweep on `experiment_2026-04-22_sl14_tf60_35` (the v5 production base) with `signal_rules.breakout.donchian_period ∈ {0, 10, 20, 30, 40}`. 10 windows, IS=6mo / OOS=3mo / step=3mo, 2023-04-01 to 2026-04-01, LTC 15m, tradeAmount=1.0, objective=return.
+
+Result ID: `01KPTAJW09E4M89QS5180SKKZG`.
+
+Multi-period validation on the closest-to-winner (`donchian_period=10`): `01KPTANP4PW900450S4CPVD6SQ`.
+
+## Results
+
+### WFO IS winners per window
+
+| window | OOS period | IS winner |
+|---:|---|---:|
+| 0 | 2023-10 → 2024-01 | **period=0** |
+| 1 | 2024-01 → 2024-04 | **period=0** |
+| 2 | 2024-04 → 2024-07 | **period=0** |
+| 3 | 2024-07 → 2024-10 | **period=10** |
+| 4 | 2024-10 → 2025-01 | **period=0** |
+| 5 | 2025-01 → 2025-04 | **period=0** |
+| 6 | 2025-04 → 2025-07 | **period=10** |
+| 7 | 2025-07 → 2025-10 | **period=10** |
+| 8 | 2025-10 → 2026-01 | **period=10** |
+| 9 | 2026-01 → 2026-04 | **period=0** |
+
+**period=0 (gate disabled) wins 6/10 windows. period=10 wins 4/10. period ∈ {20, 30, 40} wins 0/10 windows** — across all 10 windows, period=10/20/30/40 produced bit-identical IS returns and trade counts, meaning the longer-Donchian branches are not actually varying the signal set relative to period=10.
+
+### Aggregate OOS
+
+- **geomMeanReturn**: +0.77%
+- **worstReturn**: −1.74%
+- **bestReturn**: +5.64%
+- **worstDrawdown**: 5.02%
+- **allPositive**: false
+- **robustnessScore**: −0.0159
+
+For comparison, v5 sl14 alone on 3yr runs gM +28% with DD 6% — the sweep's aggregate is a worse fit on every axis, because the grid mechanically picks period=10 (a HOLD filter) on half the windows.
+
+### Multi-period validation of period=10
+
+| period | v5 sl14 baseline | **sl14 + donchian10** | Δ |
+|---|---:|---:|---:|
+| 1yr Return | +9.33% | **+8.79%** | −0.54pp |
+| 2yr Return | +12.30% | **+12.11%** | −0.19pp |
+| 3yr Return | +28.11% | **+27.24%** | −0.87pp |
+| 3yr DD | 6.01% | 6.32% | +0.31pp |
+| 3yr Trades | 13,963 | **13,102** | −861 |
+
+**Return down on every window. DD up. Trades down. No dimension where Donchian helps.**
+
+## Why the gate does not help
+
+Three observations from the WFO table:
+
+1. **period ∈ {10, 20, 30, 40} produce identical IS results.** Because Donchian(10) is a subset of Donchian(20): if lastPrice > Donchian20Upper (period=20 gate open), it is also > Donchian10Upper (period=10 gate open). The converse is not guaranteed, but on LTC 15m the two conditions coincide so often that trades/return/PF match to 10+ decimal places. **Period is not a meaningful axis here.**
+2. **period=0 wins the bull-trend windows (4, 5) and the recovery window (9).** When the market actually trends, BB+volume already catches the right breakouts; Donchian just filters out some that would have been profitable.
+3. **period=10 wins the 2024 chop windows (3, 6, 7, 8).** In range-bound tape the Donchian gate is slightly useful at screening out BB breakouts that immediately reverse — but the advantage is small (few hundred bps on isRet) and does not survive into the multi-period test.
+
+The cycle28-37 lesson "no combination of SL/TP/trailing/RSI wins on both 2022 bear and 2024 range" extends to Donchian. **Donchian is not the BREAKOUT-stance rescue axis** we were hoping for.
+
+## Decision
+
+**Reject.** Keep `experiment_2026-04-22_sl14_tf60_35_donchian10.json` in-tree for audit-trail purposes only; do not promote. `production.json` stays on v5 sl14 as merged in PR #141.
+
+The PR-11 Donchian infrastructure (indicator, gate, WFO override path, 16 tests) stays in `main` — it is dead code for LTC 15m but may be useful on a different asset/timeframe pair (e.g., BTC 1h where Donchian breakouts are historically the textbook trend-following trigger). **Same fate as the PR-5 regime routing code** — infra preserved, live policy unchanged.
+
+## Lessons for the next PDCA author
+
+1. **Overlapping indicators collapse grid axes.** If you add a gate whose `period` variants produce the same filter set on the tested asset, WFO will collapse those variants into a single effective cell and the grid signal is zero. Sanity-check by pre-running two distant periods on a short window and comparing `totalTrades` — if they match to the same integer, the axis is not informative.
+2. **BREAKOUT stance is "last-mile strategic value" on LTC 15m.** Every BREAKOUT-centric PR on this asset has rejected (PR-5 regime routing, PR-7 Stoch, PR-11 Donchian). Future PRs for LTC 15m should either target a different stance (TREND_FOLLOW refinements, CONTRARIAN gates) or accept that the BREAKOUT contribution is already at its ceiling for this tape.
+3. **Infrastructure-first still pays.** PR-11 is a clean merge with green CI and zero policy change because `donchian_period=0` is bit-identical to pre-PR behaviour. Keep adding axes this way: the infra cost is small, reject cycles are cheap, and when an axis finally fits a different asset the pipework is already there.
+
+## Next cycle candidates
+
+- **PR-9 (OBV / CMF)** — volume-based oscillators. LTC 15m volume is thin, so the prior is "will not help", but the hypothesis is untested.
+- **Re-examine BB squeeze lookback.** `bb_squeeze_lookback=5` is a stance-rule parameter that has never been grid-swept. Lightweight PDCA candidate.
+- **Asset / timeframe diversification.** Port the v5 sl14 profile to BTC 1h / ETH 1h and see whether the 2022 bear failure still manifests. If regime-routing comes back it has to be on an asset where the detector actually emits multiple regimes (cycle40 proved LTC 15m does not).
+
+## Result IDs
+
+| run | id |
+|---|---|
+| Donchian WFO sweep (5 × 10 windows) | `01KPTAJW09E4M89QS5180SKKZG` |
+| donchian10 multi-period validation | `01KPTANP4PW900450S4CPVD6SQ` |
+| v5 sl14 baseline multi-period (from promotion_v5.md) | `01KPT7SYZYRYCC595N0VVT4BZK` |
+
+## Related
+
+- PR #142 — Donchian infrastructure
+- `docs/pdca/2026-04-22_promotion_v5.md` — v5 sl14 production baseline
+- `docs/pdca/2026-04-22_cycle28-37.md` — BREAKOUT stance weakness (Lesson 5)
+- `docs/pdca/2026-04-22_cycle40.md` — regime-routing reject (same "infra kept, policy unchanged" outcome)


### PR DESCRIPTION
## Summary

- Record cycle41 WFO sweep result: `signal_rules.breakout.donchian_period ∈ {0, 10, 20, 30, 40}` on v5 sl14 base, LTC 15m, 10 windows, 2023-04..2026-04.
- Reject the gate for production use on LTC 15m. Keep PR-11 infrastructure in-tree for future asset/timeframe reuse.
- Add `experiment_2026-04-22_sl14_tf60_35_donchian10.json` as audit-trail profile for the 4-window period=10 winner.

## Key findings

- **period=0 (gate disabled) wins 6/10 windows**; period=10 wins 4/10; period ∈ {20, 30, 40} wins 0/10 (collapse with period=10 — bit-identical IS returns).
- Aggregate OOS: gM **+0.77%** / worst **-1.74%** / allPositive **false**.
- Multi-period validation on period=10 is worse than v5 sl14 on every window:

| window | v5 sl14 baseline | sl14 + donchian10 | Δ |
|---|---:|---:|---:|
| 1yr | +9.33% | +8.79% | -0.54pp |
| 2yr | +12.30% | +12.11% | -0.19pp |
| 3yr | +28.11% | +27.24% | -0.87pp |
| 3yr DD | 6.01% | 6.32% | +0.31pp |

## Decision

**Reject.** `production.json` stays on v5 sl14 (PR #141). The Donchian infra (PR #142) remains in `main` as dead code for LTC 15m but usable on another asset if the BREAKOUT stance becomes load-bearing there.

Same pattern as cycle40 (regime routing): infrastructure preserved, live policy unchanged.

## Next cycle candidates

- PR-9 (OBV / CMF) — volume-based; priors unfavourable on thin-volume LTC but untested.
- `bb_squeeze_lookback` grid-sweep — stance-rule parameter never WFO'd.
- Port v5 sl14 to BTC 1h / ETH 1h to see whether the 2022 fragility and BREAKOUT weakness are asset-specific.

## Result IDs

- WFO sweep: `01KPTAJW09E4M89QS5180SKKZG`
- donchian10 multi-period: `01KPTANP4PW900450S4CPVD6SQ`
- v5 sl14 baseline multi: `01KPT7SYZYRYCC595N0VVT4BZK`

## Test plan

- [ ] CI: backend `go test ./...` green (no code changes outside of a profile JSON; tests cover the schema)
- [ ] CI: frontend `pnpm test` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)