### PR TITLE
feat(indicator): add OBV + CMF with trend/breakout gates (PR-9)

### DIFF
--- a/backend/internal/domain/entity/indicator.go
+++ b/backend/internal/domain/entity/indicator.go
@@ -51,6 +51,14 @@ type IndicatorSet struct {
 	Donchian20Lower  *float64 `json:"donchian20Lower"`
 	Donchian20Middle *float64 `json:"donchian20Middle"`
 
+	// PR-9: Volume-based oscillators. OBV is a cumulative scalar whose
+	// absolute value is meaningless; OBVSlope20 is (OBV_now − OBV_{−20})
+	// and carries the gate signal (positive = net buying volume over the
+	// last 20 bars). CMF20 is bounded in [-1, 1]. Both nil during warmup.
+	OBV        *float64 `json:"obv"`
+	OBVSlope20 *float64 `json:"obvSlope20"`
+	CMF20      *float64 `json:"cmf20"`
+
 	Timestamp int64 `json:"timestamp"`
 }
 

--- a/backend/internal/domain/entity/strategy_config.go
+++ b/backend/internal/domain/entity/strategy_config.go
@@ -70,6 +70,12 @@ type TrendFollowConfig struct {
 	RSISellMin         float64 `json:"rsi_sell_min"`
 	// PR-6: trend_follow fires only when ADX >= ADXMin (0 = gate disabled).
 	ADXMin float64 `json:"adx_min"`
+	// PR-9: OBV slope confirmation. When RequireOBVAlignment is true, a
+	// trend-follow BUY requires OBVSlope20 > 0 (net buying volume over the
+	// last 20 bars) and SELL requires OBVSlope20 < 0. Missing OBVSlope20
+	// fails the gate, matching the ADX/Stoch convention. Defaults to false
+	// so existing profiles are bit-identical.
+	RequireOBVAlignment bool `json:"require_obv_alignment,omitempty"`
 }
 
 // ContrarianConfig configures the contrarian signal generator.
@@ -105,6 +111,13 @@ type BreakoutConfig struct {
 	// range-of-N breakout; both must agree before a signal fires. Missing
 	// Donchian (warmup) treats the gate as a fail, matching ADX/Stoch.
 	DonchianPeriod int `json:"donchian_period,omitempty"`
+	// PR-9: CMF confirmation. CMFBuyMin > 0 activates the BUY gate
+	// (breakout BUY requires CMF20 >= CMFBuyMin); CMFSellMax < 0
+	// activates the SELL gate (SELL requires CMF20 <= CMFSellMax). Both
+	// default to 0 so existing profiles are bit-identical. CMF is
+	// bounded in [-1, 1]; typical active values ~ ±0.1.
+	CMFBuyMin  float64 `json:"cmf_buy_min,omitempty"`
+	CMFSellMax float64 `json:"cmf_sell_max,omitempty"`
 }
 
 // HTFFilterConfig configures the higher-timeframe trend filter.
@@ -321,6 +334,16 @@ func (p StrategyProfile) Validate() error {
 	// disables the gate and is the safe default.
 	if p.SignalRules.Breakout.DonchianPeriod < 0 {
 		errs = append(errs, fmt.Errorf("signal_rules.breakout.donchian_period must be >= 0 (got %d)", p.SignalRules.Breakout.DonchianPeriod))
+	}
+
+	// PR-9: CMF gate bounds. CMF is in [-1, 1], so any value outside that
+	// range either never fires (CMFBuyMin > 1) or always fires (CMFBuyMin
+	// < -1), both silent no-ops. Reject to fail loudly.
+	if p.SignalRules.Breakout.CMFBuyMin < 0 || p.SignalRules.Breakout.CMFBuyMin > 1 {
+		errs = append(errs, fmt.Errorf("signal_rules.breakout.cmf_buy_min must be in [0, 1] (got %v)", p.SignalRules.Breakout.CMFBuyMin))
+	}
+	if p.SignalRules.Breakout.CMFSellMax < -1 || p.SignalRules.Breakout.CMFSellMax > 0 {
+		errs = append(errs, fmt.Errorf("signal_rules.breakout.cmf_sell_max must be in [-1, 0] (got %v)", p.SignalRules.Breakout.CMFSellMax))
 	}
 
 	// regime_routing.overrides without a default is also flagged — a

--- a/backend/internal/infrastructure/indicator/cmf.go
+++ b/backend/internal/infrastructure/indicator/cmf.go
@@ -1,0 +1,49 @@
+package indicator
+
+import "math"
+
+// CMF computes the Chaikin Money Flow oscillator over the most recent
+// `period` bars. Standard period = 20. Result is bounded in [-1, 1]:
+//
+//	>0 = net buying pressure over the window
+//	<0 = net selling pressure
+//	0  = balanced or dead (no volume / flat bars)
+//
+// Formula:
+//
+//	MFM_i = ((close_i - low_i) - (high_i - close_i)) / (high_i - low_i)
+//	MFV_i = MFM_i * volume_i
+//	CMF   = sum(MFV over window) / sum(volume over window)
+//
+// Edge cases handled:
+//   - high == low (flat bar): MFM treated as 0 so the bar contributes no
+//     signal rather than NaN-ing the whole window. Matches the standard
+//     Chaikin convention.
+//   - sum(volume over window) == 0: return 0 to avoid divide-by-zero. The
+//     caller's intent ("gate on CMF") is satisfied by a neutral reading.
+//   - insufficient history, mismatched lengths, period <= 0: NaN.
+func CMF(highs, lows, closes, volumes []float64, period int) float64 {
+	if period <= 0 {
+		return math.NaN()
+	}
+	n := len(closes)
+	if n != len(highs) || n != len(lows) || n != len(volumes) || n < period {
+		return math.NaN()
+	}
+
+	start := n - period
+	var sumMFV, sumVol float64
+	for i := start; i < n; i++ {
+		rng := highs[i] - lows[i]
+		var mfm float64
+		if rng > 0 {
+			mfm = ((closes[i] - lows[i]) - (highs[i] - closes[i])) / rng
+		}
+		sumMFV += mfm * volumes[i]
+		sumVol += volumes[i]
+	}
+	if sumVol == 0 {
+		return 0
+	}
+	return sumMFV / sumVol
+}

--- a/backend/internal/infrastructure/indicator/cmf_test.go
+++ b/backend/internal/infrastructure/indicator/cmf_test.go
@@ -1,0 +1,111 @@
+package indicator
+
+import (
+	"math"
+	"testing"
+)
+
+func TestCMF_AllBuyingPressure(t *testing.T) {
+	// Close == high for every bar -> MFM = 1 for every bar -> CMF = 1.
+	highs := []float64{10, 11, 12, 13, 14}
+	lows := []float64{9, 10, 11, 12, 13}
+	closes := []float64{10, 11, 12, 13, 14}
+	volumes := []float64{100, 100, 100, 100, 100}
+
+	got := CMF(highs, lows, closes, volumes, 3)
+	// Last 3 bars: MFM=1 for each; CMF = (300)/300 = 1.0
+	if math.Abs(got-1.0) > 1e-9 {
+		t.Errorf("want CMF=1.0, got %v", got)
+	}
+}
+
+func TestCMF_AllSellingPressure(t *testing.T) {
+	// Close == low for every bar -> MFM = -1 -> CMF = -1.
+	highs := []float64{10, 11, 12, 13, 14}
+	lows := []float64{9, 10, 11, 12, 13}
+	closes := []float64{9, 10, 11, 12, 13}
+	volumes := []float64{100, 100, 100, 100, 100}
+
+	got := CMF(highs, lows, closes, volumes, 3)
+	if math.Abs(got-(-1.0)) > 1e-9 {
+		t.Errorf("want CMF=-1.0, got %v", got)
+	}
+}
+
+func TestCMF_Neutral(t *testing.T) {
+	// Close in the middle every bar -> MFM = 0 -> CMF = 0.
+	highs := []float64{10, 11, 12, 13, 14}
+	lows := []float64{8, 9, 10, 11, 12}
+	closes := []float64{9, 10, 11, 12, 13} // midpoint
+	volumes := []float64{100, 100, 100, 100, 100}
+
+	got := CMF(highs, lows, closes, volumes, 3)
+	if math.Abs(got) > 1e-9 {
+		t.Errorf("want CMF≈0, got %v", got)
+	}
+}
+
+func TestCMF_FlatBarPassedThroughAsZero(t *testing.T) {
+	// A perfectly flat bar (high==low) has no information. We treat MFM as
+	// 0 for that bar so CMF does not NaN out on a single dead candle.
+	highs := []float64{10, 5, 12}
+	lows := []float64{9, 5, 11}
+	closes := []float64{10, 5, 12}
+	volumes := []float64{100, 100, 100}
+
+	got := CMF(highs, lows, closes, volumes, 3)
+	if math.IsNaN(got) {
+		t.Errorf("flat bar in the window should not produce NaN; got NaN")
+	}
+}
+
+func TestCMF_InsufficientData(t *testing.T) {
+	highs := []float64{10, 11}
+	lows := []float64{9, 10}
+	closes := []float64{10, 11}
+	volumes := []float64{100, 100}
+
+	got := CMF(highs, lows, closes, volumes, 5)
+	if !math.IsNaN(got) {
+		t.Errorf("insufficient bars should return NaN, got %v", got)
+	}
+}
+
+func TestCMF_InvalidPeriod(t *testing.T) {
+	highs := []float64{10, 11, 12}
+	lows := []float64{9, 10, 11}
+	closes := []float64{10, 11, 12}
+	volumes := []float64{100, 100, 100}
+
+	for _, p := range []int{0, -1} {
+		got := CMF(highs, lows, closes, volumes, p)
+		if !math.IsNaN(got) {
+			t.Errorf("period=%d should return NaN, got %v", p, got)
+		}
+	}
+}
+
+func TestCMF_MismatchedLengths(t *testing.T) {
+	highs := []float64{10, 11, 12}
+	lows := []float64{9, 10}
+	closes := []float64{10, 11, 12}
+	volumes := []float64{100, 100, 100}
+
+	got := CMF(highs, lows, closes, volumes, 3)
+	if !math.IsNaN(got) {
+		t.Errorf("mismatched lengths should return NaN, got %v", got)
+	}
+}
+
+func TestCMF_ZeroVolumeWindow(t *testing.T) {
+	// Sum of volumes is zero — avoids divide-by-zero by returning 0 (neutral).
+	highs := []float64{10, 11, 12}
+	lows := []float64{9, 10, 11}
+	closes := []float64{10, 10.5, 11}
+	volumes := []float64{0, 0, 0}
+
+	got := CMF(highs, lows, closes, volumes, 3)
+	if got != 0 {
+		t.Errorf("zero-volume window should return 0, got %v", got)
+	}
+}

--- a/backend/internal/infrastructure/indicator/obv.go
+++ b/backend/internal/infrastructure/indicator/obv.go
@@ -1,0 +1,65 @@
+package indicator
+
+import "math"
+
+// OBV computes On-Balance Volume as a single cumulative scalar anchored at
+// zero on the first input bar. Direction rule:
+//
+//	close[i] > close[i-1] -> OBV += volume[i]
+//	close[i] < close[i-1] -> OBV -= volume[i]
+//	close[i] == close[i-1] -> OBV unchanged
+//
+// Returns NaN on fewer than 2 bars or on mismatched input lengths.
+//
+// OBV's absolute value is meaningless (zero is arbitrary), so callers should
+// consume it through OBVSlope or compare to a prior OBV reading rather than
+// against a static threshold.
+func OBV(closes, volumes []float64) float64 {
+	if len(closes) < 2 || len(closes) != len(volumes) {
+		return math.NaN()
+	}
+	obv := 0.0
+	for i := 1; i < len(closes); i++ {
+		switch {
+		case closes[i] > closes[i-1]:
+			obv += volumes[i]
+		case closes[i] < closes[i-1]:
+			obv -= volumes[i]
+		}
+	}
+	return obv
+}
+
+// OBVSlope returns (OBV_now − OBV_{n−window}) where OBV is the running
+// cumulative volume series defined in OBV. A positive result means buying
+// volume has exceeded selling volume over the last `window` bars; a negative
+// result means the reverse. The magnitude is volume-scaled, so callers
+// threshold it as "slope > 0" / "slope < 0" rather than comparing to an
+// absolute cutoff across assets.
+//
+// Returns NaN when window <= 0, when there are fewer than window+1 bars,
+// or when input slices are mismatched.
+func OBVSlope(closes, volumes []float64, window int) float64 {
+	if window <= 0 {
+		return math.NaN()
+	}
+	n := len(closes)
+	if n != len(volumes) || n < window+1 {
+		return math.NaN()
+	}
+	// Build the OBV series so we can diff against the state `window` bars
+	// back. Implementation is O(n); the live pipeline feeds ~500 bars, so
+	// this stays trivial.
+	series := make([]float64, n)
+	series[0] = 0
+	for i := 1; i < n; i++ {
+		series[i] = series[i-1]
+		switch {
+		case closes[i] > closes[i-1]:
+			series[i] += volumes[i]
+		case closes[i] < closes[i-1]:
+			series[i] -= volumes[i]
+		}
+	}
+	return series[n-1] - series[n-1-window]
+}

--- a/backend/internal/infrastructure/indicator/obv_test.go
+++ b/backend/internal/infrastructure/indicator/obv_test.go
@@ -1,0 +1,112 @@
+package indicator
+
+import (
+	"math"
+	"testing"
+)
+
+func TestOBV_AccumulatesOnUpDays(t *testing.T) {
+	// Close goes up every bar -> volume keeps accumulating positive.
+	closes := []float64{10, 11, 12, 13}
+	volumes := []float64{100, 200, 150, 300}
+
+	got := OBV(closes, volumes)
+	// OBV[0] = 0 (seed), then +200, +150, +300 -> 650
+	want := 650.0
+	if got != want {
+		t.Errorf("want %v, got %v", want, got)
+	}
+}
+
+func TestOBV_SubtractsOnDownDays(t *testing.T) {
+	closes := []float64{10, 9, 8, 7}
+	volumes := []float64{100, 200, 150, 300}
+
+	got := OBV(closes, volumes)
+	// OBV[0] = 0, then -200, -150, -300 -> -650
+	want := -650.0
+	if got != want {
+		t.Errorf("want %v, got %v", want, got)
+	}
+}
+
+func TestOBV_UnchangedOnFlatDays(t *testing.T) {
+	closes := []float64{10, 10, 10, 10}
+	volumes := []float64{100, 200, 150, 300}
+
+	got := OBV(closes, volumes)
+	if got != 0 {
+		t.Errorf("flat closes should leave OBV at 0, got %v", got)
+	}
+}
+
+func TestOBV_MixedDirections(t *testing.T) {
+	closes := []float64{10, 11, 10, 12, 11}
+	volumes := []float64{100, 200, 150, 300, 250}
+
+	got := OBV(closes, volumes)
+	// 0 + 200 (up) - 150 (down) + 300 (up) - 250 (down) = 100
+	want := 100.0
+	if got != want {
+		t.Errorf("want %v, got %v", want, got)
+	}
+}
+
+func TestOBV_InsufficientData(t *testing.T) {
+	got := OBV([]float64{10}, []float64{100})
+	if !math.IsNaN(got) {
+		t.Errorf("single-bar input should return NaN, got %v", got)
+	}
+	if got := OBV(nil, nil); !math.IsNaN(got) {
+		t.Errorf("nil input should return NaN, got %v", got)
+	}
+}
+
+func TestOBV_MismatchedLengths(t *testing.T) {
+	got := OBV([]float64{10, 11, 12}, []float64{100, 200})
+	if !math.IsNaN(got) {
+		t.Errorf("mismatched length should return NaN, got %v", got)
+	}
+}
+
+func TestOBVSlope_UpTrend(t *testing.T) {
+	// OBV history walking up: 0, 200, 350, 650 — slope over last 3 bars is
+	// (650 - 200) / 2 (slope-per-bar basis is not normalized here; we just
+	// want a signed magnitude the gate can threshold).
+	closes := []float64{10, 11, 12, 13}
+	volumes := []float64{100, 200, 150, 300}
+
+	got := OBVSlope(closes, volumes, 3)
+	// OBV_now - OBV_{n-3} = 650 - 0 = 650 (window includes seed=0)
+	if got <= 0 {
+		t.Errorf("expected positive slope, got %v", got)
+	}
+}
+
+func TestOBVSlope_DownTrend(t *testing.T) {
+	closes := []float64{10, 9, 8, 7}
+	volumes := []float64{100, 200, 150, 300}
+
+	got := OBVSlope(closes, volumes, 3)
+	if got >= 0 {
+		t.Errorf("expected negative slope, got %v", got)
+	}
+}
+
+func TestOBVSlope_InsufficientData(t *testing.T) {
+	got := OBVSlope([]float64{10, 11}, []float64{100, 200}, 5)
+	if !math.IsNaN(got) {
+		t.Errorf("insufficient bars should return NaN, got %v", got)
+	}
+}
+
+func TestOBVSlope_InvalidWindow(t *testing.T) {
+	closes := []float64{10, 11, 12}
+	volumes := []float64{100, 200, 150}
+	for _, w := range []int{0, -1} {
+		got := OBVSlope(closes, volumes, w)
+		if !math.IsNaN(got) {
+			t.Errorf("window=%d should return NaN, got %v", w, got)
+		}
+	}
+}

--- a/backend/internal/usecase/backtest/handler.go
+++ b/backend/internal/usecase/backtest/handler.go
@@ -609,6 +609,11 @@ func calculateIndicatorSet(symbolID int64, candles []entity.Candle) entity.Indic
 		result.VolumeRatio = floatToPtr(vr)
 	}
 
+	// PR-9: OBV + CMF (volume-based). Mirror the live-pipeline calculator.
+	result.OBV = floatToPtr(indicator.OBV(closes, volumes))
+	result.OBVSlope20 = floatToPtr(indicator.OBVSlope(closes, volumes, 20))
+	result.CMF20 = floatToPtr(indicator.CMF(highs, lows, closes, volumes, 20))
+
 	// RecentSqueeze: check if any of the last 5 candles had BBBandwidth < 0.02
 	if n >= 20 {
 		recentSqueeze := false

--- a/backend/internal/usecase/backtest/walkforward.go
+++ b/backend/internal/usecase/backtest/walkforward.go
@@ -274,7 +274,9 @@ func ExpandCombinedGrid(numeric []ParameterOverride, strs []ParameterStringOverr
 //	strategy_risk.max_daily_loss
 //	signal_rules.trend_follow.{rsi_buy_max,rsi_sell_min,adx_min}
 //	signal_rules.contrarian.{rsi_entry,rsi_exit,macd_histogram_limit,adx_max,stoch_entry_max,stoch_exit_min}
-//	signal_rules.breakout.{volume_ratio_min,adx_min,donchian_period}
+//	signal_rules.breakout.{volume_ratio_min,adx_min,donchian_period,cmf_buy_min,cmf_sell_max}
+//	// signal_rules.trend_follow.require_obv_alignment is a bool and is set
+//	// directly on the profile; it is not an ApplyOverrides axis.
 //	stance_rules.{rsi_oversold,rsi_overbought,sma_convergence_threshold,breakout_volume_ratio}
 //	htf_filter.alignment_boost
 //	regime_routing.detector_config.trend_adx_min
@@ -332,6 +334,19 @@ func ApplyOverrides(base entity.StrategyProfile, overrides map[string]float64) (
 				return entity.StrategyProfile{}, fmt.Errorf("walk-forward: signal_rules.breakout.donchian_period must be >= 0 (got %v)", value)
 			}
 			out.SignalRules.Breakout.DonchianPeriod = int(value)
+		case "signal_rules.breakout.cmf_buy_min":
+			// CMF is bounded in [-1, 1]; BUY gate must stay in [0, 1] so
+			// the grid cannot set an always-on / always-off silent
+			// no-op by going outside the valid CMF range.
+			if value < 0 || value > 1 {
+				return entity.StrategyProfile{}, fmt.Errorf("walk-forward: signal_rules.breakout.cmf_buy_min must be in [0, 1] (got %v)", value)
+			}
+			out.SignalRules.Breakout.CMFBuyMin = value
+		case "signal_rules.breakout.cmf_sell_max":
+			if value < -1 || value > 0 {
+				return entity.StrategyProfile{}, fmt.Errorf("walk-forward: signal_rules.breakout.cmf_sell_max must be in [-1, 0] (got %v)", value)
+			}
+			out.SignalRules.Breakout.CMFSellMax = value
 		case "stance_rules.rsi_oversold":
 			out.StanceRules.RSIOversold = value
 		case "stance_rules.rsi_overbought":

--- a/backend/internal/usecase/backtest/walkforward_test.go
+++ b/backend/internal/usecase/backtest/walkforward_test.go
@@ -428,6 +428,62 @@ func TestApplyOverrides_BreakoutDonchianPeriod(t *testing.T) {
 	})
 }
 
+// TestApplyOverrides_BreakoutCMF is the PR-9 wiring guard for CMF gates.
+// CMF is bounded in [-1, 1]; the BUY gate must stay in [0, 1] and the
+// SELL gate must stay in [-1, 0], otherwise a grid axis could silently
+// disable itself by landing outside the CMF range.
+func TestApplyOverrides_BreakoutCMF(t *testing.T) {
+	t.Run("buy min sets the field within bounds", func(t *testing.T) {
+		base := entity.StrategyProfile{}
+		got, err := ApplyOverrides(base, map[string]float64{
+			"signal_rules.breakout.cmf_buy_min": 0.15,
+		})
+		if err != nil {
+			t.Fatalf("ApplyOverrides: %v", err)
+		}
+		if got.SignalRules.Breakout.CMFBuyMin != 0.15 {
+			t.Errorf("CMFBuyMin = %v, want 0.15", got.SignalRules.Breakout.CMFBuyMin)
+		}
+	})
+
+	t.Run("sell max sets the field within bounds", func(t *testing.T) {
+		base := entity.StrategyProfile{}
+		got, err := ApplyOverrides(base, map[string]float64{
+			"signal_rules.breakout.cmf_sell_max": -0.15,
+		})
+		if err != nil {
+			t.Fatalf("ApplyOverrides: %v", err)
+		}
+		if got.SignalRules.Breakout.CMFSellMax != -0.15 {
+			t.Errorf("CMFSellMax = %v, want -0.15", got.SignalRules.Breakout.CMFSellMax)
+		}
+	})
+
+	t.Run("buy min rejects out-of-range values", func(t *testing.T) {
+		base := entity.StrategyProfile{}
+		for _, v := range []float64{-0.1, 1.1} {
+			_, err := ApplyOverrides(base, map[string]float64{
+				"signal_rules.breakout.cmf_buy_min": v,
+			})
+			if err == nil {
+				t.Errorf("value %v should be rejected", v)
+			}
+		}
+	})
+
+	t.Run("sell max rejects out-of-range values", func(t *testing.T) {
+		base := entity.StrategyProfile{}
+		for _, v := range []float64{-1.1, 0.1} {
+			_, err := ApplyOverrides(base, map[string]float64{
+				"signal_rules.breakout.cmf_sell_max": v,
+			})
+			if err == nil {
+				t.Errorf("value %v should be rejected", v)
+			}
+		}
+	})
+}
+
 // -------------- string overrides / combined grid --------------
 
 func TestApplyStringOverrides_HTFMode(t *testing.T) {

--- a/backend/internal/usecase/indicator.go
+++ b/backend/internal/usecase/indicator.go
@@ -109,6 +109,13 @@ func (c *IndicatorCalculator) Calculate(ctx context.Context, symbolID int64, int
 		result.VolumeRatio = toPtr(vr)
 	}
 
+	// PR-9: OBV + CMF (volume-based). OBVSlope20 carries the gate signal
+	// (cumulative buying volume over 20 bars); raw OBV is exposed for
+	// diagnostics / frontend charting. CMF20 is bounded in [-1, 1].
+	result.OBV = toPtr(indicator.OBV(prices, volumes))
+	result.OBVSlope20 = toPtr(indicator.OBVSlope(prices, volumes, 20))
+	result.CMF20 = toPtr(indicator.CMF(highs, lows, prices, volumes, 20))
+
 	// RecentSqueeze: check if any of the last 5 candles had BBBandwidth < 0.02
 	if n >= 20 {
 		recentSqueeze := false

--- a/backend/internal/usecase/strategy.go
+++ b/backend/internal/usecase/strategy.go
@@ -98,6 +98,21 @@ type StrategyEngineOptions struct {
 	// can be a follow-up once WFO tells us Donchian20 helps at all.
 	BreakoutDonchianPeriod int
 
+	// PR-9: volume-based gates.
+	//
+	//   TrendFollowRequireOBVAlignment: when true, trend-follow BUY
+	//     requires OBVSlope20 > 0 and SELL requires OBVSlope20 < 0.
+	//     Missing OBVSlope20 fails the gate, matching the
+	//     ADX/Stoch/Donchian convention. Default false = disabled.
+	//
+	//   BreakoutCMFBuyMin / BreakoutCMFSellMax: CMF20 thresholds that
+	//     gate breakout BUY / SELL signals respectively. CMF is bounded
+	//     in [-1, 1]; a typical active pair is (0.1, -0.1). Both default
+	//     to 0 which disables each direction's gate independently.
+	TrendFollowRequireOBVAlignment bool
+	BreakoutCMFBuyMin              float64
+	BreakoutCMFSellMax             float64
+
 	// defaulted tracks whether applyDefaults has already been called so we
 	// don't flip booleans to true twice (e.g. on a caller that explicitly
 	// wants them false).
@@ -387,7 +402,24 @@ func (e *StrategyEngine) EvaluateAt(ctx context.Context, indicators entity.Indic
 				return adxBlock("trend follow: ADX below threshold"), nil
 			}
 		}
-		return e.evaluateTrendFollow(indicators.SymbolID, sma20, sma50, rsi, indicators.EMA12, indicators.EMA26, indicators.Histogram, nowUnix), nil
+		tfSig := e.evaluateTrendFollow(indicators.SymbolID, sma20, sma50, rsi, indicators.EMA12, indicators.EMA26, indicators.Histogram, nowUnix)
+		// PR-9: OBV slope alignment. Applies only when a direction was
+		// actually emitted — HOLD passes through unchanged. BUY requires
+		// OBVSlope20 > 0 (net buying volume); SELL requires OBVSlope20
+		// < 0. Missing OBVSlope20 fails the gate.
+		if e.options.TrendFollowRequireOBVAlignment && tfSig != nil {
+			switch tfSig.Action {
+			case entity.SignalActionBuy:
+				if indicators.OBVSlope20 == nil || *indicators.OBVSlope20 <= 0 {
+					return adxBlock("trend follow: OBV slope not positive"), nil
+				}
+			case entity.SignalActionSell:
+				if indicators.OBVSlope20 == nil || *indicators.OBVSlope20 >= 0 {
+					return adxBlock("trend follow: OBV slope not negative"), nil
+				}
+			}
+		}
+		return tfSig, nil
 	case entity.MarketStanceContrarian:
 		if !e.options.EnableContrarian {
 			return &entity.Signal{
@@ -448,6 +480,22 @@ func (e *StrategyEngine) EvaluateAt(ctx context.Context, indicators entity.Indic
 			case entity.SignalActionSell:
 				if indicators.Donchian20Lower == nil || lastPrice >= *indicators.Donchian20Lower {
 					return adxBlock("breakout: price above Donchian lower"), nil
+				}
+			}
+		}
+		// PR-9: CMF confirmation. BUY requires CMF20 >= BreakoutCMFBuyMin
+		// (net buying pressure); SELL requires CMF20 <= BreakoutCMFSellMax
+		// (net selling pressure). Each direction is independent: a
+		// profile may set only one side. Missing CMF20 fails the gate.
+		if sig != nil {
+			if sig.Action == entity.SignalActionBuy && e.options.BreakoutCMFBuyMin > 0 {
+				if indicators.CMF20 == nil || *indicators.CMF20 < e.options.BreakoutCMFBuyMin {
+					return adxBlock("breakout: CMF below buy threshold"), nil
+				}
+			}
+			if sig.Action == entity.SignalActionSell && e.options.BreakoutCMFSellMax < 0 {
+				if indicators.CMF20 == nil || *indicators.CMF20 > e.options.BreakoutCMFSellMax {
+					return adxBlock("breakout: CMF above sell threshold"), nil
 				}
 			}
 		}

--- a/backend/internal/usecase/strategy/configurable_strategy.go
+++ b/backend/internal/usecase/strategy/configurable_strategy.go
@@ -57,12 +57,13 @@ func NewConfigurableStrategy(profile *entity.StrategyProfile) (*ConfigurableStra
 
 	engineOpts := usecase.StrategyEngineOptions{
 		// Trend-follow
-		EnableTrendFollow:  profile.SignalRules.TrendFollow.Enabled,
-		RSIBuyMax:          profile.SignalRules.TrendFollow.RSIBuyMax,
-		RSISellMin:         profile.SignalRules.TrendFollow.RSISellMin,
-		RequireMACDConfirm: profile.SignalRules.TrendFollow.RequireMACDConfirm,
-		RequireEMACross:    profile.SignalRules.TrendFollow.RequireEMACross,
-		TrendFollowADXMin:  profile.SignalRules.TrendFollow.ADXMin, // PR-6
+		EnableTrendFollow:              profile.SignalRules.TrendFollow.Enabled,
+		RSIBuyMax:                      profile.SignalRules.TrendFollow.RSIBuyMax,
+		RSISellMin:                     profile.SignalRules.TrendFollow.RSISellMin,
+		RequireMACDConfirm:             profile.SignalRules.TrendFollow.RequireMACDConfirm,
+		RequireEMACross:                profile.SignalRules.TrendFollow.RequireEMACross,
+		TrendFollowADXMin:              profile.SignalRules.TrendFollow.ADXMin, // PR-6
+		TrendFollowRequireOBVAlignment: profile.SignalRules.TrendFollow.RequireOBVAlignment, // PR-9
 
 		// Contrarian
 		EnableContrarian:        profile.SignalRules.Contrarian.Enabled,
@@ -77,8 +78,10 @@ func NewConfigurableStrategy(profile *entity.StrategyProfile) (*ConfigurableStra
 		EnableBreakout:             profile.SignalRules.Breakout.Enabled,
 		BreakoutVolumeRatio:        profile.SignalRules.Breakout.VolumeRatioMin,
 		BreakoutRequireMACDConfirm: profile.SignalRules.Breakout.RequireMACDConfirm,
-		BreakoutADXMin:             profile.SignalRules.Breakout.ADXMin, // PR-6
+		BreakoutADXMin:             profile.SignalRules.Breakout.ADXMin,         // PR-6
 		BreakoutDonchianPeriod:     profile.SignalRules.Breakout.DonchianPeriod, // PR-11
+		BreakoutCMFBuyMin:          profile.SignalRules.Breakout.CMFBuyMin,      // PR-9
+		BreakoutCMFSellMax:         profile.SignalRules.Breakout.CMFSellMax,     // PR-9
 
 		// HTF filter
 		HTFEnabled:           profile.HTFFilter.Enabled,

--- a/backend/internal/usecase/strategy/obv_cmf_gate_test.go
+++ b/backend/internal/usecase/strategy/obv_cmf_gate_test.go
@@ -1,0 +1,267 @@
+package strategy
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+)
+
+// TestConfigurableStrategy_OBVAlignmentBlocksTrendFollowBuy verifies the
+// PR-9 wiring: when RequireOBVAlignment is true and OBVSlope20 is negative
+// (net selling volume), a trend-follow BUY must be blocked. Silent-no-op
+// regression guard.
+func TestConfigurableStrategy_OBVAlignmentBlocksTrendFollowBuy(t *testing.T) {
+	profile := productionProfile(t)
+	profile.SignalRules.TrendFollow.RequireOBVAlignment = true
+	// Disable ADX gate so only OBV can block.
+	profile.SignalRules.TrendFollow.ADXMin = 0
+
+	s, err := NewConfigurableStrategy(profile)
+	if err != nil {
+		t.Fatalf("NewConfigurableStrategy: %v", err)
+	}
+
+	ind := makeTrendFollowReadyIndicators()
+	slope := -100.0
+	ind.OBVSlope20 = &slope
+
+	sig, err := s.Evaluate(context.Background(), &ind, nil, 100.0, time.Now())
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if sig.Action != entity.SignalActionHold {
+		t.Fatalf("expected HOLD, got %v (reason=%q)", sig.Action, sig.Reason)
+	}
+	if !containsSubstring(sig.Reason, "OBV") {
+		t.Fatalf("expected OBV in reason, got %q", sig.Reason)
+	}
+}
+
+// TestConfigurableStrategy_OBVAlignmentAllowsTrendFollowBuy: with positive
+// OBVSlope20 the gate passes and BUY fires.
+func TestConfigurableStrategy_OBVAlignmentAllowsTrendFollowBuy(t *testing.T) {
+	profile := productionProfile(t)
+	profile.SignalRules.TrendFollow.RequireOBVAlignment = true
+	profile.SignalRules.TrendFollow.ADXMin = 0
+
+	s, err := NewConfigurableStrategy(profile)
+	if err != nil {
+		t.Fatalf("NewConfigurableStrategy: %v", err)
+	}
+
+	ind := makeTrendFollowReadyIndicators()
+	slope := 100.0
+	ind.OBVSlope20 = &slope
+
+	sig, err := s.Evaluate(context.Background(), &ind, nil, 100.0, time.Now())
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if sig.Action != entity.SignalActionBuy {
+		t.Fatalf("expected BUY, got %v (reason=%q)", sig.Action, sig.Reason)
+	}
+}
+
+// TestConfigurableStrategy_OBVAlignmentMissingCountsAsFail: nil OBVSlope20
+// during warmup fails the gate.
+func TestConfigurableStrategy_OBVAlignmentMissingCountsAsFail(t *testing.T) {
+	profile := productionProfile(t)
+	profile.SignalRules.TrendFollow.RequireOBVAlignment = true
+	profile.SignalRules.TrendFollow.ADXMin = 0
+
+	s, err := NewConfigurableStrategy(profile)
+	if err != nil {
+		t.Fatalf("NewConfigurableStrategy: %v", err)
+	}
+
+	ind := makeTrendFollowReadyIndicators()
+	ind.OBVSlope20 = nil
+
+	sig, err := s.Evaluate(context.Background(), &ind, nil, 100.0, time.Now())
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if sig.Action != entity.SignalActionHold {
+		t.Fatalf("expected HOLD on nil OBVSlope20, got %v", sig.Action)
+	}
+	if !containsSubstring(sig.Reason, "OBV") {
+		t.Fatalf("expected OBV in reason, got %q", sig.Reason)
+	}
+}
+
+// TestConfigurableStrategy_OBVAlignmentFalseIsDisabled: when the toggle is
+// off, an adversarial OBVSlope20 must not affect the BUY path.
+func TestConfigurableStrategy_OBVAlignmentFalseIsDisabled(t *testing.T) {
+	profile := productionProfile(t)
+	profile.SignalRules.TrendFollow.RequireOBVAlignment = false
+	profile.SignalRules.TrendFollow.ADXMin = 0
+
+	s, err := NewConfigurableStrategy(profile)
+	if err != nil {
+		t.Fatalf("NewConfigurableStrategy: %v", err)
+	}
+
+	ind := makeTrendFollowReadyIndicators()
+	slope := -999.0
+	ind.OBVSlope20 = &slope
+
+	sig, err := s.Evaluate(context.Background(), &ind, nil, 100.0, time.Now())
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if sig.Action != entity.SignalActionBuy {
+		t.Fatalf("gate=false should pass through; expected BUY, got %v (reason=%q)", sig.Action, sig.Reason)
+	}
+}
+
+// TestConfigurableStrategy_CMFBuyGateBlocks is the PR-9 CMF wiring guard:
+// when CMFBuyMin > 0 and CMF20 is below the threshold, a breakout BUY is
+// blocked.
+func TestConfigurableStrategy_CMFBuyGateBlocks(t *testing.T) {
+	profile := productionProfile(t)
+	profile.SignalRules.Breakout.Enabled = true
+	profile.SignalRules.Breakout.CMFBuyMin = 0.2
+	profile.SignalRules.Breakout.ADXMin = 0
+	profile.SignalRules.Breakout.RequireMACDConfirm = false
+	profile.SignalRules.Breakout.DonchianPeriod = 0
+
+	s, err := NewConfigurableStrategy(profile)
+	if err != nil {
+		t.Fatalf("NewConfigurableStrategy: %v", err)
+	}
+
+	ind := makeBreakoutBuyReadyIndicators()
+	cmf := 0.05
+	ind.CMF20 = &cmf
+
+	sig, err := s.Evaluate(context.Background(), &ind, nil, 120.0, time.Now())
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if sig.Action != entity.SignalActionHold {
+		t.Fatalf("expected HOLD when CMF below threshold, got %v (reason=%q)", sig.Action, sig.Reason)
+	}
+	if !containsSubstring(sig.Reason, "CMF") {
+		t.Fatalf("expected CMF in reason, got %q", sig.Reason)
+	}
+}
+
+// TestConfigurableStrategy_CMFBuyGateAllows: with CMF above threshold the
+// breakout BUY fires.
+func TestConfigurableStrategy_CMFBuyGateAllows(t *testing.T) {
+	profile := productionProfile(t)
+	profile.SignalRules.Breakout.Enabled = true
+	profile.SignalRules.Breakout.CMFBuyMin = 0.1
+	profile.SignalRules.Breakout.ADXMin = 0
+	profile.SignalRules.Breakout.RequireMACDConfirm = false
+	profile.SignalRules.Breakout.DonchianPeriod = 0
+
+	s, err := NewConfigurableStrategy(profile)
+	if err != nil {
+		t.Fatalf("NewConfigurableStrategy: %v", err)
+	}
+
+	ind := makeBreakoutBuyReadyIndicators()
+	cmf := 0.25
+	ind.CMF20 = &cmf
+
+	sig, err := s.Evaluate(context.Background(), &ind, nil, 120.0, time.Now())
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if sig.Action != entity.SignalActionBuy {
+		t.Fatalf("expected BUY with CMF above threshold, got %v (reason=%q)", sig.Action, sig.Reason)
+	}
+}
+
+// TestConfigurableStrategy_CMFGateZeroIsDisabled: CMFBuyMin=0 must not
+// touch the signal path even when CMF20 is strongly negative.
+func TestConfigurableStrategy_CMFGateZeroIsDisabled(t *testing.T) {
+	profile := productionProfile(t)
+	profile.SignalRules.Breakout.Enabled = true
+	profile.SignalRules.Breakout.CMFBuyMin = 0 // disabled
+	profile.SignalRules.Breakout.ADXMin = 0
+	profile.SignalRules.Breakout.RequireMACDConfirm = false
+	profile.SignalRules.Breakout.DonchianPeriod = 0
+
+	s, err := NewConfigurableStrategy(profile)
+	if err != nil {
+		t.Fatalf("NewConfigurableStrategy: %v", err)
+	}
+
+	ind := makeBreakoutBuyReadyIndicators()
+	cmf := -0.9
+	ind.CMF20 = &cmf
+
+	sig, err := s.Evaluate(context.Background(), &ind, nil, 120.0, time.Now())
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if sig.Action != entity.SignalActionBuy {
+		t.Fatalf("gate=0 should pass through; expected BUY, got %v (reason=%q)", sig.Action, sig.Reason)
+	}
+}
+
+// TestConfigurableStrategy_CMFSellGateBlocks: the SELL-direction mirror of
+// the BUY gate. With CMFSellMax = -0.2 and CMF20 = -0.05, the SELL must be
+// blocked (|CMF| too small = not selling-pressure enough).
+func TestConfigurableStrategy_CMFSellGateBlocks(t *testing.T) {
+	profile := productionProfile(t)
+	profile.SignalRules.Breakout.Enabled = true
+	profile.SignalRules.Breakout.CMFSellMax = -0.2
+	profile.SignalRules.Breakout.ADXMin = 0
+	profile.SignalRules.Breakout.RequireMACDConfirm = false
+	profile.SignalRules.Breakout.DonchianPeriod = 0
+
+	s, err := NewConfigurableStrategy(profile)
+	if err != nil {
+		t.Fatalf("NewConfigurableStrategy: %v", err)
+	}
+
+	ind := makeBreakoutSellReadyIndicators()
+	cmf := -0.05
+	ind.CMF20 = &cmf
+
+	sig, err := s.Evaluate(context.Background(), &ind, nil, 80.0, time.Now())
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if sig.Action != entity.SignalActionHold {
+		t.Fatalf("expected HOLD, got %v (reason=%q)", sig.Action, sig.Reason)
+	}
+	if !containsSubstring(sig.Reason, "CMF") {
+		t.Fatalf("expected CMF in reason, got %q", sig.Reason)
+	}
+}
+
+// TestConfigurableStrategy_CMFGateMissingCountsAsFail: nil CMF20 during
+// warmup fails the gate.
+func TestConfigurableStrategy_CMFGateMissingCountsAsFail(t *testing.T) {
+	profile := productionProfile(t)
+	profile.SignalRules.Breakout.Enabled = true
+	profile.SignalRules.Breakout.CMFBuyMin = 0.1
+	profile.SignalRules.Breakout.ADXMin = 0
+	profile.SignalRules.Breakout.RequireMACDConfirm = false
+	profile.SignalRules.Breakout.DonchianPeriod = 0
+
+	s, err := NewConfigurableStrategy(profile)
+	if err != nil {
+		t.Fatalf("NewConfigurableStrategy: %v", err)
+	}
+
+	ind := makeBreakoutBuyReadyIndicators()
+	ind.CMF20 = nil
+
+	sig, err := s.Evaluate(context.Background(), &ind, nil, 120.0, time.Now())
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if sig.Action != entity.SignalActionHold {
+		t.Fatalf("expected HOLD on nil CMF20, got %v", sig.Action)
+	}
+	if !containsSubstring(sig.Reason, "CMF") {
+		t.Fatalf("expected CMF in reason, got %q", sig.Reason)
+	}
+}


### PR DESCRIPTION
## Summary

Add two volume-based oscillators (OBV and CMF) and wire three independent gates through the `ConfigurableStrategy`:

- **OBV alignment** on the trend-follow stance (BUY requires OBVSlope20 > 0; SELL requires OBVSlope20 < 0)
- **CMF BUY** gate on the breakout stance (`CMF20 >= CMFBuyMin` when `CMFBuyMin > 0`)
- **CMF SELL** gate on the breakout stance (`CMF20 <= CMFSellMax` when `CMFSellMax < 0`)

All three default to disabled, so every existing profile (including v5 sl14 `production.json`) is bit-identical under this change.

## Design choice

OBV is exposed through a **slope delta** (`OBV_now − OBV_{−20}`) rather than the scalar, because OBV's absolute value is meaningless (the zero anchor is arbitrary). The gate reads "net buying volume over the last 20 bars" as a signed magnitude, which is what the trend-follow stance actually wants to know.

CMF is split into **two independent directional knobs** (`cmf_buy_min` and `cmf_sell_max`) so a profile can gate only the BUY side or only the SELL side. This mirrors the contrarian Stoch gate pattern (`stoch_entry_max` / `stoch_exit_min` in PR-7) and keeps WFO axes orthogonal.

Bool toggles (`require_obv_alignment`) are intentionally **not** exposed through `ApplyOverrides` — WFO grids are numeric-axis only by contract. A bool gate is set directly on the base profile; the cycle42 plan is to run two independent WFO sweeps (CMF threshold sweep alone, and a second run with the OBV toggle flipped).

## Wiring-confirmation tests

Following the cycle08/09 silent-no-op pattern, every new option has a direct assertion that signal behaviour changes when the option is active:

### OBV (`obv_cmf_gate_test.go`)
- `TestConfigurableStrategy_OBVAlignmentBlocksTrendFollowBuy`
- `TestConfigurableStrategy_OBVAlignmentAllowsTrendFollowBuy`
- `TestConfigurableStrategy_OBVAlignmentMissingCountsAsFail`
- `TestConfigurableStrategy_OBVAlignmentFalseIsDisabled`

### CMF (`obv_cmf_gate_test.go`)
- `TestConfigurableStrategy_CMFBuyGateBlocks`
- `TestConfigurableStrategy_CMFBuyGateAllows`
- `TestConfigurableStrategy_CMFGateZeroIsDisabled`
- `TestConfigurableStrategy_CMFSellGateBlocks`
- `TestConfigurableStrategy_CMFGateMissingCountsAsFail`

### WFO override (`walkforward_test.go`)
- `TestApplyOverrides_BreakoutCMF/*` — 4 subtests covering buy min set / sell max set / out-of-range rejection for both directions

### Indicator math (`indicator/*_test.go`)
- 10 OBV cases (up/down/flat/mixed/insufficient/mismatched/slope variants)
- 8 CMF cases (buying / selling / neutral / flat bar / insufficient / invalid period / mismatched / zero-volume)

## Next cycle (cycle42)

- Run WFO sweep `signal_rules.breakout.cmf_buy_min ∈ {0, 0.05, 0.1, 0.15, 0.2}` on v5 sl14, measure OOS geomMean
- Separately: toggle `require_obv_alignment` on the v5 sl14 base and re-run multi-period to see whether OBV-aligned-only trend-follow beats unfiltered
- Given LTC 15m is thin-volume, priors are unfavourable (same fate as PR-11 Donchian is the expected outcome). Infrastructure remains useful for cross-asset reuse.

## Test plan

- [ ] CI: backend `go test ./...` green
- [ ] CI: frontend `pnpm test` green
- [ ] Post-merge: cycle42 WFO sweep against the sl14 base

🤖 Generated with [Claude Code](https://claude.com/claude-code)