### PR TITLE
feat(wfo)+docs(pdca): cycle43 — bb_squeeze_lookback axis is a silent no-op

### DIFF
--- a/backend/internal/usecase/backtest/walkforward.go
+++ b/backend/internal/usecase/backtest/walkforward.go
@@ -277,7 +277,7 @@ func ExpandCombinedGrid(numeric []ParameterOverride, strs []ParameterStringOverr
 //	signal_rules.breakout.{volume_ratio_min,adx_min,donchian_period,cmf_buy_min,cmf_sell_max}
 //	// signal_rules.trend_follow.require_obv_alignment is a bool and is set
 //	// directly on the profile; it is not an ApplyOverrides axis.
-//	stance_rules.{rsi_oversold,rsi_overbought,sma_convergence_threshold,breakout_volume_ratio}
+//	stance_rules.{rsi_oversold,rsi_overbought,sma_convergence_threshold,breakout_volume_ratio,bb_squeeze_lookback}
 //	htf_filter.alignment_boost
 //	regime_routing.detector_config.trend_adx_min
 //	regime_routing.detector_config.volatile_atr_percent_min
@@ -355,6 +355,20 @@ func ApplyOverrides(base entity.StrategyProfile, overrides map[string]float64) (
 			out.StanceRules.SMAConvergenceThreshold = value
 		case "stance_rules.breakout_volume_ratio":
 			out.StanceRules.BreakoutVolumeRatio = value
+		case "stance_rules.bb_squeeze_lookback":
+			// BBSqueezeLookback is an int; reject fractional grid values
+			// so a typo surfaces at the WFO boundary rather than silently
+			// truncating into a different lookback. 0 disables the
+			// squeeze-release breakout stance entirely — matching the
+			// ">= 0 accepted" convention used by the other int axes so
+			// the handler's 0-value path probe still succeeds.
+			if value != float64(int(value)) {
+				return entity.StrategyProfile{}, fmt.Errorf("walk-forward: stance_rules.bb_squeeze_lookback must be an integer (got %v)", value)
+			}
+			if value < 0 {
+				return entity.StrategyProfile{}, fmt.Errorf("walk-forward: stance_rules.bb_squeeze_lookback must be >= 0 (got %v)", value)
+			}
+			out.StanceRules.BBSqueezeLookback = int(value)
 		case "htf_filter.alignment_boost":
 			out.HTFFilter.AlignmentBoost = value
 		case "regime_routing.detector_config.trend_adx_min",

--- a/backend/internal/usecase/backtest/walkforward_test.go
+++ b/backend/internal/usecase/backtest/walkforward_test.go
@@ -428,6 +428,65 @@ func TestApplyOverrides_BreakoutDonchianPeriod(t *testing.T) {
 	})
 }
 
+// TestApplyOverrides_BBSqueezeLookback is the cycle43 wiring guard. The
+// lookback is an int and must reject fractional values + non-positive
+// lookbacks to keep the grid signal honest.
+func TestApplyOverrides_BBSqueezeLookback(t *testing.T) {
+	t.Run("integer value sets the field", func(t *testing.T) {
+		base := entity.StrategyProfile{
+			StanceRules: entity.StanceRulesConfig{BBSqueezeLookback: 5},
+		}
+		got, err := ApplyOverrides(base, map[string]float64{
+			"stance_rules.bb_squeeze_lookback": 7,
+		})
+		if err != nil {
+			t.Fatalf("ApplyOverrides: %v", err)
+		}
+		if got.StanceRules.BBSqueezeLookback != 7 {
+			t.Errorf("BBSqueezeLookback = %d, want 7", got.StanceRules.BBSqueezeLookback)
+		}
+	})
+
+	t.Run("fractional value is rejected", func(t *testing.T) {
+		base := entity.StrategyProfile{}
+		_, err := ApplyOverrides(base, map[string]float64{
+			"stance_rules.bb_squeeze_lookback": 5.5,
+		})
+		if err == nil {
+			t.Fatal("expected error on fractional bb_squeeze_lookback")
+		}
+	})
+
+	t.Run("zero is accepted (disables squeeze lookback)", func(t *testing.T) {
+		// 0 matches the donchian_period / hysteresis_bars convention so
+		// the handler's "pre-probe path with value=0" path validation
+		// still works; downstream the stance resolver treats 0 as "no
+		// squeeze window" which yields HOLD, not a crash.
+		base := entity.StrategyProfile{
+			StanceRules: entity.StanceRulesConfig{BBSqueezeLookback: 5},
+		}
+		got, err := ApplyOverrides(base, map[string]float64{
+			"stance_rules.bb_squeeze_lookback": 0,
+		})
+		if err != nil {
+			t.Fatalf("ApplyOverrides should accept 0, got error: %v", err)
+		}
+		if got.StanceRules.BBSqueezeLookback != 0 {
+			t.Errorf("BBSqueezeLookback = %d, want 0", got.StanceRules.BBSqueezeLookback)
+		}
+	})
+
+	t.Run("negative value is rejected", func(t *testing.T) {
+		base := entity.StrategyProfile{}
+		_, err := ApplyOverrides(base, map[string]float64{
+			"stance_rules.bb_squeeze_lookback": -1,
+		})
+		if err == nil {
+			t.Fatal("negative value should be rejected")
+		}
+	})
+}
+
 // TestApplyOverrides_BreakoutCMF is the PR-9 wiring guard for CMF gates.
 // CMF is bounded in [-1, 1]; the BUY gate must stay in [0, 1] and the
 // SELL gate must stay in [-1, 0], otherwise a grid axis could silently

--- a/docs/pdca/2026-04-22_cycle43.md
+++ b/docs/pdca/2026-04-22_cycle43.md
@@ -1,0 +1,81 @@
+# PDCA Cycle 43 — `bb_squeeze_lookback` is a silent no-op; axis capture without fix
+
+**Date**: 2026-04-22
+**Parent**: `2026-04-22_cycle42.md` §"Next cycle candidates" → bb_squeeze_lookback grid
+**Verdict**: **reject sweep, discovered upstream bug**. The `stance_rules.bb_squeeze_lookback` profile field is not plumbed into the indicator calculators — it is a **silent no-op** (cycle08-class bug). cycle43 wires the WFO path for the field and documents the no-op; the actual fix is deferred to a follow-up (cycle44 candidate).
+
+---
+
+## Hypothesis
+
+cycle42 listed `bb_squeeze_lookback` as the low-priority cycle candidate: "stance-rule parameter; grid-sweep has never been run". All existing profiles carry `bb_squeeze_lookback=5`, and cycle28-37 Lesson 4 observed that `RecentSqueeze` semantics were load-bearing on the healthy_v3 lineage. If the 5-bar default is suboptimal, a sweep of `{3, 5, 7, 10, 15}` should reveal it.
+
+## Method
+
+1. Add `stance_rules.bb_squeeze_lookback` to `ApplyOverrides` (int-valued axis, `>= 0` allowed to match the donchian_period / hysteresis_bars handler-probe convention).
+2. Add `TestApplyOverrides_BBSqueezeLookback` covering integer/fractional/zero/negative.
+3. WFO sweep on `experiment_2026-04-22_sl14_tf60_35` with `bb_squeeze_lookback ∈ {3, 5, 7, 10, 15}`, 10 windows, IS=6mo / OOS=3mo / step=3mo, 2023-04..2026-04, LTC 15m.
+
+Result ID: `01KPTC9CFX0TEBSPH6Y8NPWWFA`.
+
+## Result: silent no-op
+
+**Every lookback value produced bit-identical IS results on every window** (return matched to 15+ decimal places, trade counts equal to the integer). Example, window 0:
+
+| lookback | isRet | isTrades |
+|---:|---:|---:|
+| 3 | 0.19087123723865185 | 3961 |
+| 5 | 0.19087123723865185 | 3961 |
+| 7 | 0.19087123723865185 | 3961 |
+| 10 | 0.19087123723865185 | 3961 |
+| 15 | 0.19087123723865185 | 3961 |
+
+Aggregate OOS: gM +0.86% / worst −1.74% / worstDD 5.04% / allPositive=false / robustnessScore −0.0150. Practically identical to the baseline v5 sl14 3yr result because the axis had no effect.
+
+## Root cause
+
+`backend/internal/usecase/backtest/handler.go:620` hardcodes the lookback window used to compute `RecentSqueeze`:
+
+```go
+// RecentSqueeze: check if any of the last 5 candles had BBBandwidth < 0.02
+if n >= 20 {
+    recentSqueeze := false
+    lookback := 5 // ← HARDCODED — should be profile.StanceRules.BBSqueezeLookback
+    ...
+}
+```
+
+The same pattern exists in `backend/internal/usecase/indicator.go:107` for the live pipeline. The field `StanceRulesConfig.BBSqueezeLookback` is declared in `strategy_config.go:53` and is part of the on-disk profile JSON, but nothing reads it when computing indicators. ApplyOverrides writes it, `ConfigurableStrategy.Validate` accepts it, but it is never threaded into the calculator that actually needs it.
+
+**This is the cycle08 silent-no-op pattern** — the exact failure mode that motivated the wiring-confirmation test convention in PR-6 / PR-7 / PR-9 / PR-11. `bb_squeeze_lookback` predates that convention and never received a guard.
+
+## Decision
+
+1. **Do not interpret cycle43 WFO results as a signal.** Every value is identical, so the sweep carries zero information about the best lookback.
+2. **Keep the ApplyOverrides path + the 4-subcase test.** The path itself is cheap and safe (zero/negative rejection keeps the grid boundary clean), and it becomes meaningful the moment the hardcoded `5` is removed.
+3. **File cycle44 candidate: "thread `profile.StanceRules.BBSqueezeLookback` through both calculators"**. Scope: ~20 lines across `indicator.go` + `backtest/handler.go`, plus a wiring-confirmation test on `RecentSqueeze` to prevent a re-regression. Re-run cycle43's sweep after the fix.
+4. **`production.json` stays on v5 sl14** (PR #141). No policy change possible from cycle43.
+
+## Lessons for the next PDCA author
+
+1. **Legacy profile fields can silently no-op.** The wiring-confirmation convention (one test per profile knob that proves the signal path is affected) is retroactive: any pre-PR-6 field needs the same audit. Quick check — grep for each `StanceRulesConfig` / `SignalRulesConfig` field name in the non-entity code; if it appears only in `entity/`, `walkforward.go`, and schema tests, it is probably dead wiring.
+2. **A bit-identical WFO grid is a bug alarm.** Cycle41 hit this with Donchian (different reason: indicator logic collapsed the period axis on 15m data). Cycle43 hits it again with the lookback. Rule: any time `isTrades` matches across grid cells to the *integer*, stop interpreting the sweep and find the reason.
+3. **Handler-probe validation constrains zero-permitting axes.** The handler in `backtest_walkforward.go` pre-probes every override path with `{path: 0}` to surface 400-errors early. Any int override that rejects 0 will crash the handler before the grid expands. Either widen the validation to `>= 0` (chosen here) or update the handler probe.
+
+## Next cycle candidates
+
+- **cycle44 (high priority)**: wire `BBSqueezeLookback` into `indicator.Calculate` + `backtest.handler.ComputeIndicators`, add `TestRecentSqueeze_UsesProfileLookback` wiring guard, re-run cycle43's sweep.
+- **Asset diversification** (still top overall priority from cycle42): v5 sl14 on BTC 1h / ETH 1h.
+
+## Result IDs
+
+| run | id |
+|---|---|
+| bb_squeeze_lookback WFO sweep | `01KPTC9CFX0TEBSPH6Y8NPWWFA` |
+| v5 sl14 baseline (reference) | `01KPT7SYZYRYCC595N0VVT4BZK` |
+
+## Related
+
+- PR #141 (v5 sl14 production baseline)
+- `docs/pdca/2026-04-22_cycle42.md` — CMF borderline, OBV reject
+- cycle08 (original silent-no-op incident that motivated the wiring-confirmation pattern)


### PR DESCRIPTION
## Summary

- Add `stance_rules.bb_squeeze_lookback` to `ApplyOverrides` (int axis, `>= 0` to match the handler 0-probe pattern used by `donchian_period` / `hysteresis_bars`).
- 4-subcase wiring test (`TestApplyOverrides_BBSqueezeLookback`).
- **Finding**: the WFO sweep on `{3, 5, 7, 10, 15}` against v5 sl14 produces bit-identical IS results on every window — the profile field is a silent no-op. `usecase/backtest/handler.go:620` and `usecase/indicator.go:107` hardcode `lookback := 5` instead of reading `profile.StanceRules.BBSqueezeLookback`.

## Why merge this anyway

The new path is harmless today (the field is still dead wiring) and becomes immediately meaningful the moment cycle44 threads the profile into both calculators. Leaving the WFO path out would either (a) require another PR after the fix, or (b) invite a future agent to write the same override-path code from scratch. Merging now captures the audit trail at discovery time.

## Scope of the follow-up (cycle44 candidate)

~20 lines across:
- `backend/internal/usecase/indicator.go` — replace hardcoded `lookback := 5` with `lookback := profile.StanceRules.BBSqueezeLookback` (with a safe default when the field is zero for older profiles).
- `backend/internal/usecase/backtest/handler.go` — mirror the same change.
- Plumbing change: `Calculate` / `ComputeIndicators` would need access to the current profile. The simplest route is to pass the lookback value into the call site rather than threading the full profile.
- New `TestRecentSqueeze_UsesProfileLookback` wiring guard.
- Re-run cycle43's WFO sweep; expect non-identical IS returns this time.

## Lesson captured for the next author

Any time a WFO sweep returns bit-identical IS returns / trade counts across grid cells, **it is a wiring bug alarm, not a legitimate "flat surface"**. cycle41 (Donchian) and cycle43 (lookback) both hit this — different underlying reasons but the same detection signature.

## Result IDs

- WFO sweep (bit-identical): `01KPTC9CFX0TEBSPH6Y8NPWWFA`

## Test plan

- [ ] CI: backend `go test ./...` green
- [ ] CI: frontend `pnpm test` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)