### PR TITLE
docs(pdca): handoff v2 for the 2026-04-22 session (cycle41-cycle44)

### DIFF
--- a/docs/pdca/2026-04-22_handoff_v2.md
+++ b/docs/pdca/2026-04-22_handoff_v2.md
@@ -1,0 +1,204 @@
+# Handoff v2 — 2026-04-22 セッション後半 (cycle41-cycle44)
+
+前半 (cycle22-40) の引き継ぎ書は `docs/pdca/2026-04-22_handoff.md`。このドキュメントは v5 sl14 promotion 以降 (PR #141-#147) を引き継ぐためのもの。次セッションを 5 分で cold-start できる形で書いた。
+
+---
+
+## 1. TL;DR — 現状
+
+- **production.json は v5 sl14 (aggressive)** (PR #141 で promote 済み)。multi-period gM +16.22% / 3yr DD 6.01%。**Known limit: 2022 bear 相場で −57.97% 破綻**。
+- **PR-11 Donchian と PR-9 OBV/CMF のインフラは本番 main 上にある** が、LTC 15m では reject or borderline で live policy は変わっていない（別 asset 用に温存）。
+- **cycle43 で "silent no-op" を発見、cycle44 で fix**。`stance_rules.bb_squeeze_lookback` は pre-cycle44 では profile フィールドが読まれていなかった。fix 後、**lookback=3 が 2yr/3yr で +1.35pp / +1.62pp 改善、DD -0.28pp**。promote するには 1yr -0.21pp が引っかかるので cycle45 で multi-axis 検証を優先。
+- **cycle28-37 Lesson 4 は invalid**（silent no-op の上で導かれた）。他にも同根拠の lesson がないか re-audit 推奨。
+- **open PR は 0 本**、ローカル branch も docs/handoff-2026-04-22-v2 を除けば clean。
+
+---
+
+## 2. 最新の最明確な "次にやるべきこと"
+
+### cycle45 候補 (high priority、推奨 next action)
+
+**Multi-axis sweep**: `stance_rules.bb_squeeze_lookback ∈ {3, 5, 10}` × `signal_rules.breakout.cmf_buy_min ∈ {0, 0.1}` 2 軸 × 6 セル × 10 windows = 60 runs。MaxWalkForwardGridSize=100 の範囲内。
+
+**仮説**: cycle42 CMF は単軸で microimpact (1yr +0.21pp / 2yr +0.72pp / 3yr -0.24pp)、cycle44 lookback=3 も単軸で modest (1yr -0.21pp / 2yr +1.35pp / 3yr +1.62pp)。両方 BREAKOUT stance 周辺の axis なので **compounding** するかは data が必要。もし combined で 3 指標 (1yr/2yr/3yr) 全てが baseline 超える設定があれば v6 promote 候補。
+
+**実行コマンド例** (WFO):
+```bash
+curl -s -X POST 'http://localhost:38080/api/v1/backtest/walk-forward' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "data": "/app/backend/data/candles_LTC_JPY_PT15M.csv",
+    "dataHtf": "/app/backend/data/candles_LTC_JPY_PT1H.csv",
+    "from": "2023-04-01", "to": "2026-04-01",
+    "inSampleMonths": 6, "outOfSampleMonths": 3, "stepMonths": 3,
+    "baseProfile": "experiment_2026-04-22_sl14_tf60_35",
+    "parameterGrid": [
+      {"path": "stance_rules.bb_squeeze_lookback", "values": [3, 5, 10]},
+      {"path": "signal_rules.breakout.cmf_buy_min", "values": [0, 0.1]}
+    ],
+    "objective": "return",
+    "initialBalance": 1000000,
+    "tradeAmount": 1.0,
+    "pdcaCycleId": "2026-04-22_cycle45_multi_axis"
+  }'
+```
+
+その後、winner 組合せで `run-multi` を実行し baseline と比較。詳細手順は `docs/pdca/2026-04-22_cycle44.md` の "Next cycle candidates" も参照。
+
+### cycle46+ の中期候補
+
+- **Asset / timeframe diversification (高優先)**: v5 sl14 を BTC 1h / ETH 1h / LTC 1h に移植。2022 bear fragility と BREAKOUT 弱さが asset-specific かを確認。regime routing (PR-5 code) と CMF (PR-9) は **別 asset では蘇る可能性**がある。cycle40 の LTC 15m regime histogram 結論を BTC 1h で再計測するのが第一歩。
+- **cycle28-37 全 lesson の re-audit**: Lesson 4 (bb_squeeze_lookback) が invalid だった → 他にも silent no-op に依存した lesson があるかもしれない。特に `stance_rules.*` と `signal_rules.*` の field は retroactive に検査するのが安全 (grep で entity 外の参照がないフィールドを炙り出す)。
+- **`production.json` v5 の live 運用テスト**: 現時点では backtest 数値しか持っていない。手動 bot 起動で 1 週間回して実挙動を観測するのも選択肢 (ただし 2022 級 bear 監視下で)。
+
+---
+
+## 3. このセッションで起きたこと (cycle41-44)
+
+| cycle | PR | 内容 | 結果 |
+|---|---|---|---|
+| cycle41 | #142, #143 | Donchian indicator + breakout gate、WFO sweep | **reject**: period ≥10 が axis collapse (bit-identical)、period=10 multi-period は全 window 悪化 |
+| cycle42 | #144, #145 | OBV + CMF、OBV alignment + CMF sweep | **OBV reject** (2yr −9pp)、**CMF borderline** (±1pp、promote せず) |
+| cycle43 | #146 | bb_squeeze_lookback を WFO path 追加 → silent no-op 発見 | **Discovery**: profile field が実コードに接続されておらず全 sweep が bit-identical |
+| cycle44 | #147 | silent no-op fix + 再 sweep + multi-period | **Fix merged**、lookback=3 が 2yr/3yr で +1.35pp / +1.62pp、DD -0.28pp、1yr -0.21pp。promote は先送り |
+
+前半からの連続番号として PR #141 (v5 sl14 promotion) もこのセッションで merge している。
+
+---
+
+## 4. Merged PRs (このセッション後半)
+
+| PR | branch | 内容 | commit on main |
+|---|---|---|---|
+| #141 | `promote/v5-aggressive-sl14` | production.json を sl14_tf60_35 に promote + promotion_v5.md | `d4123f6` |
+| #142 | `feat/pr11-donchian` | Donchian(20) indicator + breakout gate + 16 tests | `76b9b6a` |
+| #143 | `docs/cycle41-donchian-sweep` | cycle41 Donchian reject | `18cfc29` |
+| #144 | `feat/pr9-obv-cmf` | OBV + CMF indicators + OBV alignment + CMF buy/sell gates + 27 tests | `87ac191` |
+| #145 | `docs/cycle42-obv-cmf-sweep` | cycle42 OBV reject + CMF borderline | `c57e071` |
+| #146 | `feat/cycle43-bb-squeeze-sweep` | bb_squeeze_lookback ApplyOverrides path + 4 tests + silent-no-op discovery doc | `4c56508` |
+| #147 | `fix/cycle44-bb-squeeze-plumbing` | silent no-op fix (handler + calculator + runner + 3 HTTP handlers) + 2 wiring tests + cycle44 doc | `023eb6b` |
+
+---
+
+## 5. Invalidated / 要再検証の過去知見
+
+### cycle28-37 Lesson 4 — 無効
+
+> "`block_counter_trend=false` and `require_macd_confirm=false` are load-bearing. `bb_squeeze_lookback=5` is load-bearing."
+
+cycle44 の silent no-op 修正により **lookback=5 の主張は成り立たない**。実際には lookback=3 が 4/10 windows で勝ち、5 は 0/10。`block_counter_trend=false` と `require_macd_confirm=false` の主張は別メカニズムなので影響はないはずだが、念のため cycle45 の multi-axis sweep で同時に検証する価値あり。
+
+### cycle28-37 の load-bearing 主張一般
+
+cycle28-37 の PDCA は pre-cycle44 で実行されているため、**profile 由来の stance_rules フィールドを動かした箇所は全て silent no-op の可能性**がある。安全な再監査手順:
+
+1. `stance_rules.*` に含まれる field を列挙 (`grep -n "^\s*\S*\s*[a-z_]*\s*\(float64\|int\|string\|bool\)" backend/internal/domain/entity/strategy_config.go`)
+2. 各 field 名を `backend/internal/` 全体に grep
+3. `entity/` と `walkforward.go` と schema test 以外にヒットしないフィールドは silent no-op の可能性
+4. ヒット先が calculator の中ではなく `ApplyOverrides` 自身のみ、も NG
+
+候補: `SMAConvergenceThreshold`, `RSIOversold/Overbought` (stance 判定) など — これらは stance.go で使われているはずだが cycle45 以降で確認推奨。
+
+---
+
+## 6. このセッションで追加された profile (in-tree)
+
+`backend/profiles/experiment_2026-04-22_*` に常駐。次 cycle45 の sweep で base にしたり baseline 比較で使ったりするため保持。
+
+### cycle41-44 起源
+- `experiment_2026-04-22_sl14_tf60_35_donchian10.json` — cycle41 reject (Donchian(10) gate; 4/10 WFO winner)
+- `experiment_2026-04-22_sl14_cmf010.json` — cycle42 borderline (CMF BUY 0.10)
+- `experiment_2026-04-22_sl14_obv.json` — cycle42 reject (require_obv_alignment=true)
+- `experiment_2026-04-22_sl14_bblk3.json` — **cycle44 最有力候補** (bb_squeeze_lookback=3)
+
+### 前半由来
+- `experiment_2026-04-22_sl14_tf60_35.json` — v5 production base (= production.json の内容)
+- `experiment_2026-04-22_sl6_tr30_tp6_tf60_35.json` — defensive v5 代替（2022 bear 対応、手動 rollback 用）
+- その他 cycle28-37 の 30+ 本の sweep profile
+- regime router 系列 6 本 + smoke fixture 1 本（cycle40 reject、別 asset 用に温存）
+
+---
+
+## 7. 新 indicator / gate のまとめ
+
+本セッションで infra に入った指標と、その WFO-path:
+
+| PR | Indicator | IndicatorSet フィールド | WFO path |
+|---|---|---|---|
+| #142 | **Donchian(20)** | `Donchian20Upper/Lower/Middle` | `signal_rules.breakout.donchian_period` (int, 0 = disabled) |
+| #144 | **OBV / OBVSlope(20)** | `OBV`, `OBVSlope20` | (bool) `signal_rules.trend_follow.require_obv_alignment` — **bool axis なので WFO numeric-grid には乗らない**。profile 直接設定。 |
+| #144 | **CMF(20)** | `CMF20` | `signal_rules.breakout.cmf_buy_min` (0..1), `signal_rules.breakout.cmf_sell_max` (-1..0) |
+| #146/#147 | **BB squeeze lookback** (既存の修正) | `RecentSqueeze` (既存) | `stance_rules.bb_squeeze_lookback` (int, 0 = disabled), **cycle44 で実働化** |
+
+各 gate は全て `0` / `false` 初期値で既存挙動を保持する設計。production.json は一切変更せずに新しい axis を足せる構造。
+
+---
+
+## 8. 累積 "dead-for-now, reusable-later" インフラ
+
+**live policy は変わっていない** が将来の asset diversification / regime re-examination で再利用可能なもの:
+
+- **PR-5 regime routing** (cycle40 reject)
+- **PR-11 Donchian** (cycle41 reject)
+- **PR-9 OBV** (cycle42 reject), **PR-9 CMF** (cycle42 borderline)
+
+全て "LTC 15m では効かないが BTC 1h で試す価値あり" のクラス。
+
+---
+
+## 9. 次セッション開始時に読むべき順
+
+1. **このファイル** (`docs/pdca/2026-04-22_handoff_v2.md`)
+2. **前セッション handoff** (`docs/pdca/2026-04-22_handoff.md`) — cycle22-40 の文脈
+3. `docs/pdca/2026-04-22_cycle44.md` — silent no-op 修正と lookback=3 の数字
+4. `docs/pdca/2026-04-22_promotion_v5.md` — v5 production 根拠 + rollback 手順
+5. `docs/pdca/agent-guide.md` — 常用 reference（更新はされていない、一読）
+
+---
+
+## 10. 開いている PR / branch / 未完了作業
+
+- **open PR: 0**
+- **open issue 的な未完了**: なし（全部 merged）
+- **未検証の新 axis**: `require_obv_alignment` の 1yr/2yr/3yr 詳細は cycle42 で測ったが 2yr -9pp なので追加検証は不要
+- **既知の技術的 debt**:
+  - cycle28-37 Lesson 4 の invalidation を受けた再検証は未着手
+  - Frontend 側の `Donchian20Upper/Lower/Middle`, `OBV/OBVSlope20`, `CMF20` の可視化は未実装（backend 側から JSON は出ている）
+
+---
+
+## 11. 個人的注意事項 (次セッション開始時の罠)
+
+前半 handoff の §10 に加えて本セッションで見つけた罠:
+
+- **silent no-op は WFO で検出可能**: `isResults[].summary.totalTrades` が **integer まで完全一致**していたら wiring バグ確定。cycle41 (Donchian) と cycle43 (lookback) で 2 回ハマった。新 axis を追加するたびに sweep 後この一致を確認する癖をつける。
+- **handler のパス probe 規約**: `backtest_walkforward.go:129` は各 override path を `{path: 0}` で probe して 400 エラーを早期発火させる。int axis は `>= 0` 許容にするのが現行ルール（`< 1` で reject すると probe でコケる）。
+- **profile と RunInput の分離**: BacktestRunner は profile 全体を受け取らず、必要な要素だけ `RunInput` に展開される設計。新 profile field を追加したら **4 箇所に配線が要る**: entity → ApplyOverrides → RunInput → 3 HTTP handlers (backtest, multi, walkforward) + optionally runner.go → IndicatorHandler。cycle44 で修正 pattern を固めたのでそれを踏襲。
+- **baseline の same-commit 再測定**: 新 feature PR の multi-period 比較では必ず **fix 後に baseline も再実行** する。cycle44 で「v5 sl14 lookback=5 の数字が fix 前後で bit-identical」を確認してから lookback=3 の δ を報告した。これが信頼性の根拠。
+
+---
+
+## 12. このセッションで明示的にユーザに確認した重要決定
+
+1. ✅ **v5 aggressive (sl14) vs defensive (sl6) → A 選択 (sl14)**。sl6 は profile として保持
+2. ✅ **"mergeして1"** で PR #141 即 merge → その後は `<<autonomous-loop-dynamic>>` で自律続行の合意
+3. ✅ 以降 PR #142-#147 全てユーザ明示 merge or autonomous merge で処理
+4. ✅ cycle41/42/43/44 全て自動的に reject / borderline / fix 判定、production.json は変更せず
+5. ✅ (本ファイル作成前時点で) **cycle45 multi-axis sweep 提案 → 判断保留で自律 loop 続行**
+
+---
+
+## 13. セッション統計
+
+- 開始時 main HEAD: `98218ff` (cycle40 docs)
+- 終了時 main HEAD: `023eb6b` (cycle44 fix) + handoff_v2 commit 予定
+- 新規 commit: 7 PR (141-147) + handoff_v2
+- 新規テスト追加数: ~60+（Donchian 16、OBV/CMF 27、bb_squeeze 6、その他）
+- 新規 in-tree profile: 4 本 (donchian10, cmf010, obv, bblk3)
+- Production v-bump: 1 回 (v4b → v5 sl14)
+- 無効化された過去 lesson: 1 (cycle28-37 Lesson 4)
+
+---
+
+セッション終了時刻（本ファイル作成時点）: 2026-04-22 19:55+ JST
+最後のコードコミット: `023eb6b fix(indicator)+docs(pdca): cycle44 — plumb bb_squeeze_lookback, lookback=3 lifts 2yr/3yr (#147)`


### PR DESCRIPTION
## Summary

Post-v5-promotion handoff covering cycle41 → cycle44. Designed so the next session (human or agent) can cold-start in 5 minutes.

## Key points captured

- **Current production**: v5 sl14 (PR #141). gM +16.22% on 2023-04..2026-03; known 2022-bear fragility.
- **New dead-for-now infrastructure on main**: Donchian (PR-11), OBV/CMF (PR-9). All preserved for future asset/timeframe diversification.
- **cycle43 silent no-op + cycle44 fix** documented with regression-check evidence that production.json is bit-identical pre/post fix.
- **Invalidated prior knowledge**: cycle28-37 Lesson 4 about `bb_squeeze_lookback=5` being load-bearing is no longer valid after cycle44. Flagged as re-audit candidate.
- **Proposed cycle45**: `bb_squeeze_lookback ∈ {3, 5, 10}` × `cmf_buy_min ∈ {0, 0.1}` multi-axis WFO sweep on sl14 v5 base (60 runs within MaxWalkForwardGridSize=100).
- **New in-tree audit-trail profiles**: `sl14_tf60_35_donchian10`, `sl14_cmf010`, `sl14_obv`, `sl14_bblk3`.

## Test plan

- [ ] CI: backend `go test ./...` green (docs-only change, expected)
- [ ] CI: frontend `pnpm test` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)