### PR TITLE
feat(api): profile picker endpoints + profileOverride for edit-and-run (PR-12 part 1)

### DIFF
--- a/backend/internal/infrastructure/strategyprofile/loader.go
+++ b/backend/internal/infrastructure/strategyprofile/loader.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
+	"strings"
 
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
 )
@@ -18,6 +20,59 @@ type Loader struct {
 // NewLoader returns a Loader rooted at baseDir.
 func NewLoader(baseDir string) *Loader {
 	return &Loader{baseDir: baseDir}
+}
+
+// ProfileSummary is the shape returned by Loader.List. It intentionally
+// carries only the metadata the FE picker needs — the full StrategyProfile
+// is fetched lazily via Load(name) when the user actually selects one.
+type ProfileSummary struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	// IsRouter is true when the profile carries a regime_routing block
+	// (StrategyProfile.HasRouting). Surfaced to the FE so the picker can
+	// disable the "edit-and-run" path for router profiles, which cannot
+	// be run standalone without resolving children.
+	IsRouter bool `json:"isRouter"`
+}
+
+// List enumerates every `<baseDir>/*.json` profile and returns a summary
+// for each one. Files that fail to decode or validate are skipped (with
+// a best-effort inclusion using the filename as Name) so a single bad
+// profile does not hide the rest of the directory from the UI. The
+// result is sorted by Name for deterministic FE ordering.
+func (l *Loader) List() ([]ProfileSummary, error) {
+	entries, err := os.ReadDir(l.baseDir)
+	if err != nil {
+		return nil, fmt.Errorf("strategyprofile: list %q: %w", l.baseDir, err)
+	}
+	out := make([]ProfileSummary, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasSuffix(name, ".json") {
+			continue
+		}
+		base := strings.TrimSuffix(name, ".json")
+		profile, err := l.Load(base)
+		if err != nil {
+			// Still surface the entry so the UI can signal a bad profile;
+			// the description field carries the error text.
+			out = append(out, ProfileSummary{
+				Name:        base,
+				Description: fmt.Sprintf("(load error: %v)", err),
+			})
+			continue
+		}
+		out = append(out, ProfileSummary{
+			Name:        profile.Name,
+			Description: profile.Description,
+			IsRouter:    profile.HasRouting(),
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out, nil
 }
 
 // Load resolves `<baseDir>/<name>.json`, decodes it, and validates the

--- a/backend/internal/infrastructure/strategyprofile/loader_test.go
+++ b/backend/internal/infrastructure/strategyprofile/loader_test.go
@@ -218,3 +218,58 @@ func TestParseProfile_UnknownField(t *testing.T) {
 		t.Fatal("expected error for unknown field, got nil")
 	}
 }
+
+// TestLoader_List returns the metadata summary for every *.json file in
+// the base directory, sorted by name, and skips non-JSON files + sub-
+// directories. Invalid profiles are still included (with an error
+// description) so the FE picker can surface the problem instead of
+// silently dropping the row.
+func TestLoader_List(t *testing.T) {
+	tmp := t.TempDir()
+	// Two valid profiles + one bad (validation fails) + one non-JSON file
+	// that must be ignored.
+	writeProfile(t, tmp, "alpha", strings.Replace(validProfileJSON, `"ltc_aggressive_v3"`, `"alpha"`, 1))
+	writeProfile(t, tmp, "beta", strings.Replace(validProfileJSON, `"ltc_aggressive_v3"`, `"beta"`, 1))
+	badJSON := strings.Replace(validProfileJSON, `"atr_period": 14`, `"atr_period": -1`, 1)
+	writeProfile(t, tmp, "gamma_broken", badJSON)
+	// Non-JSON should be ignored.
+	if err := os.WriteFile(filepath.Join(tmp, "notes.txt"), []byte("ignore me"), 0o644); err != nil {
+		t.Fatalf("write txt: %v", err)
+	}
+
+	loader := NewLoader(tmp)
+	summaries, err := loader.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(summaries) != 3 {
+		t.Fatalf("expected 3 summaries (alpha, beta, gamma_broken), got %d: %+v", len(summaries), summaries)
+	}
+	// Sorted by name.
+	if summaries[0].Name != "alpha" || summaries[1].Name != "beta" {
+		t.Errorf("unexpected ordering: %+v", summaries)
+	}
+	if summaries[2].Name != "gamma_broken" {
+		t.Errorf("broken profile should still appear with filename as Name, got %q", summaries[2].Name)
+	}
+	if !strings.Contains(summaries[2].Description, "load error") {
+		t.Errorf("broken profile description should flag load error, got %q", summaries[2].Description)
+	}
+}
+
+// TestLoader_List_EmptyDir returns an empty slice (not nil) so the FE
+// does not crash on a fresh install with no profiles yet.
+func TestLoader_List_EmptyDir(t *testing.T) {
+	tmp := t.TempDir()
+	loader := NewLoader(tmp)
+	summaries, err := loader.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if summaries == nil {
+		t.Error("expected empty slice, got nil")
+	}
+	if len(summaries) != 0 {
+		t.Errorf("expected 0 summaries, got %d", len(summaries))
+	}
+}

--- a/backend/internal/interfaces/api/handler/backtest.go
+++ b/backend/internal/interfaces/api/handler/backtest.go
@@ -114,6 +114,15 @@ type runBacktestRequest struct {
 	PDCACycleID    string  `json:"pdcaCycleId,omitempty"`
 	Hypothesis     string  `json:"hypothesis,omitempty"`
 	ParentResultID *string `json:"parentResultId,omitempty"`
+
+	// PR-12: FE "edit & run" flow. When set, ProfileOverride supersedes
+	// ProfileName for the strategy-construction path: the supplied
+	// StrategyProfile is used directly (after Validate) instead of
+	// loading a preset from disk. ProfileName is still recorded on the
+	// result so the saved row shows which preset the user started from.
+	// Router profiles are rejected here (the picker UI hides them from
+	// edit-and-run) — editing a router without children is out of scope.
+	ProfileOverride *entity.StrategyProfile `json:"profileOverride,omitempty"`
 }
 
 func (h *BacktestHandler) Run(c *gin.Context) {
@@ -135,10 +144,27 @@ func (h *BacktestHandler) Run(c *gin.Context) {
 	if baseDir == "" {
 		baseDir = defaultProfilesBaseDir
 	}
-	profile, loadErr := loadProfileForRequest(baseDir, req.ProfileName)
-	if loadErr != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": loadErr.Error()})
-		return
+	var profile *entity.StrategyProfile
+	if req.ProfileOverride != nil {
+		// PR-12: caller-supplied profile from the FE edit-and-run form.
+		// Validate up-front so the error surfaces as 400 with the same
+		// message shape as a preset that fails loadProfileForRequest.
+		if err := req.ProfileOverride.Validate(); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid profileOverride: " + err.Error()})
+			return
+		}
+		if req.ProfileOverride.HasRouting() {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "profileOverride must not carry regime_routing (router editing is out of scope for edit-and-run)"})
+			return
+		}
+		profile = req.ProfileOverride
+	} else {
+		var loadErr error
+		profile, loadErr = loadProfileForRequest(baseDir, req.ProfileName)
+		if loadErr != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": loadErr.Error()})
+			return
+		}
 	}
 
 	// Apply profile defaults to zero-valued individual fields so spec §8.2's

--- a/backend/internal/interfaces/api/handler/backtest_test.go
+++ b/backend/internal/interfaces/api/handler/backtest_test.go
@@ -1019,3 +1019,161 @@ func TestBacktestHandler_ListResults_NoFilters(t *testing.T) {
 		t.Errorf("expected all filters zero, got %+v", repo.lastFilter)
 	}
 }
+
+// TestBacktestHandler_Run_ProfileOverride_UsesSuppliedProfile is the PR-12
+// edit-and-run wiring guard. When the request carries `profileOverride`,
+// the handler must use its values (not load a preset from disk) for
+// strategy construction, risk defaults, and bb_squeeze_lookback.
+func TestBacktestHandler_Run_ProfileOverride_UsesSuppliedProfile(t *testing.T) {
+	// No profiles on disk — this proves the override path does not require
+	// a preset to exist.
+	router, _, _ := newRunRouter(t, t.TempDir())
+	csvPath := makeCSVForRunTests(t)
+
+	// Minimal valid StrategyProfile (same shape as validProfileJSON in the
+	// strategyprofile loader tests).
+	override := map[string]any{
+		"name":        "edit_and_run",
+		"description": "Inline profile from FE",
+		"indicators": map[string]any{
+			"sma_short":     10,
+			"sma_long":      30,
+			"rsi_period":    14,
+			"macd_fast":     12,
+			"macd_slow":     26,
+			"macd_signal":   9,
+			"bb_period":     20,
+			"bb_multiplier": 2.0,
+			"atr_period":    14,
+		},
+		"stance_rules": map[string]any{
+			"rsi_oversold":              25.0,
+			"rsi_overbought":            75.0,
+			"sma_convergence_threshold": 0.001,
+			"bb_squeeze_lookback":       5,
+			"breakout_volume_ratio":     1.5,
+		},
+		"signal_rules": map[string]any{
+			"trend_follow": map[string]any{
+				"enabled":              true,
+				"require_macd_confirm": true,
+				"require_ema_cross":    true,
+				"rsi_buy_max":          70.0,
+				"rsi_sell_min":         30.0,
+			},
+			"contrarian": map[string]any{
+				"enabled":              true,
+				"rsi_entry":            30.0,
+				"rsi_exit":             70.0,
+				"macd_histogram_limit": 10.0,
+			},
+			"breakout": map[string]any{
+				"enabled":              true,
+				"volume_ratio_min":     1.5,
+				"require_macd_confirm": true,
+			},
+		},
+		"strategy_risk": map[string]any{
+			"stop_loss_percent":        5.0,
+			"take_profit_percent":      10.0,
+			"stop_loss_atr_multiplier": 0.0,
+			"max_position_amount":      100000.0,
+			"max_daily_loss":           50000.0,
+		},
+		"htf_filter": map[string]any{
+			"enabled":             true,
+			"block_counter_trend": true,
+			"alignment_boost":     0.1,
+		},
+	}
+	body := runRequestBody(t, csvPath, map[string]any{
+		"profileName":     "edit_and_run", // just for audit labelling
+		"profileOverride": override,
+	})
+	w := postRun(t, router, body)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var got entity.BacktestResult
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	// The ProfileName label from the request should still be persisted so
+	// the UI can show "which preset did they start from".
+	if got.ProfileName != "edit_and_run" {
+		t.Errorf("ProfileName = %q, want %q", got.ProfileName, "edit_and_run")
+	}
+}
+
+// TestBacktestHandler_Run_ProfileOverride_ValidationFailure_400 is the
+// counterpart: an override that fails Validate() (here: negative
+// atr_period) must come back as 400, not 500.
+func TestBacktestHandler_Run_ProfileOverride_ValidationFailure_400(t *testing.T) {
+	router, _, _ := newRunRouter(t, t.TempDir())
+	csvPath := makeCSVForRunTests(t)
+
+	override := map[string]any{
+		"name": "bad_profile",
+		"indicators": map[string]any{
+			"sma_short":     10,
+			"sma_long":      30,
+			"rsi_period":    14,
+			"macd_fast":     12,
+			"macd_slow":     26,
+			"macd_signal":   9,
+			"bb_period":     20,
+			"bb_multiplier": 2.0,
+			"atr_period":    -1, // invalid — Validate rejects negative periods
+		},
+		"stance_rules": map[string]any{
+			"rsi_oversold":              25.0,
+			"rsi_overbought":            75.0,
+			"sma_convergence_threshold": 0.001,
+			"bb_squeeze_lookback":       5,
+			"breakout_volume_ratio":     1.5,
+		},
+		"signal_rules":  map[string]any{},
+		"strategy_risk": map[string]any{},
+		"htf_filter":    map[string]any{},
+	}
+	body := runRequestBody(t, csvPath, map[string]any{"profileOverride": override})
+	w := postRun(t, router, body)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid override, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "atr_period") {
+		t.Errorf("expected error to mention atr_period, got %s", w.Body.String())
+	}
+}
+
+// TestBacktestHandler_Run_ProfileOverride_RejectsRouter ensures that the
+// FE cannot edit-and-run a regime_routing profile — resolving its children
+// against a live profiles dir is out of scope for PR-12.
+func TestBacktestHandler_Run_ProfileOverride_RejectsRouter(t *testing.T) {
+	router, _, _ := newRunRouter(t, t.TempDir())
+	csvPath := makeCSVForRunTests(t)
+
+	override := map[string]any{
+		"name":          "router_profile",
+		"description":   "routing",
+		"indicators":    map[string]any{"sma_short": 10, "sma_long": 30, "rsi_period": 14, "macd_fast": 12, "macd_slow": 26, "macd_signal": 9, "bb_period": 20, "bb_multiplier": 2.0, "atr_period": 14},
+		"stance_rules":  map[string]any{"rsi_oversold": 25.0, "rsi_overbought": 75.0, "sma_convergence_threshold": 0.001, "bb_squeeze_lookback": 5, "breakout_volume_ratio": 1.5},
+		"signal_rules":  map[string]any{},
+		"strategy_risk": map[string]any{},
+		"htf_filter":    map[string]any{},
+		"regime_routing": map[string]any{
+			"default": "some_child",
+		},
+	}
+	body := runRequestBody(t, csvPath, map[string]any{"profileOverride": override})
+	w := postRun(t, router, body)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for router override, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "regime_routing") {
+		t.Errorf("expected error to mention regime_routing, got %s", w.Body.String())
+	}
+}

--- a/backend/internal/interfaces/api/handler/profile.go
+++ b/backend/internal/interfaces/api/handler/profile.go
@@ -1,0 +1,83 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+	"os"
+
+	"github.com/gin-gonic/gin"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/infrastructure/strategyprofile"
+)
+
+// ProfileHandler exposes the on-disk strategy profile collection to the
+// frontend so users can pick a preset and read / edit its fields before
+// kicking off a backtest. The handler is read-only; writes (promotion,
+// saving a variant) remain a CLI / git-tracked workflow.
+type ProfileHandler struct {
+	baseDir string
+}
+
+// NewProfileHandler returns a handler rooted at baseDir. Callers typically
+// pass the same baseDir used by the BacktestHandler (see
+// handler.defaultProfilesBaseDir) so profile picker and backtest run share
+// the same view of the filesystem.
+func NewProfileHandler(baseDir string) *ProfileHandler {
+	if baseDir == "" {
+		baseDir = defaultProfilesBaseDir
+	}
+	return &ProfileHandler{baseDir: baseDir}
+}
+
+// List handles GET /api/v1/profiles. Returns an array of
+// strategyprofile.ProfileSummary sorted by name. A directory read error is
+// mapped to 500; per-file load errors are surfaced *inside* the summary so
+// a single bad profile does not hide the rest.
+func (h *ProfileHandler) List(c *gin.Context) {
+	loader := strategyprofile.NewLoader(h.baseDir)
+	summaries, err := loader.List()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	// Return a non-nil empty slice so the FE can iterate unconditionally.
+	if summaries == nil {
+		summaries = []strategyprofile.ProfileSummary{}
+	}
+	c.JSON(http.StatusOK, gin.H{"profiles": summaries})
+}
+
+// Get handles GET /api/v1/profiles/:name. Returns the full StrategyProfile
+// JSON; the FE uses this to populate the inline edit form.
+//
+// 400 on an invalid name shape (regex-rejected by ResolveProfilePath).
+// 404 when the profile file is missing.
+// 422 when the file is present but fails schema / Validate — same split as
+//
+//	the existing loader behaviour, so the FE can distinguish "typo'd name"
+//	from "profile broken".
+func (h *ProfileHandler) Get(c *gin.Context) {
+	name := c.Param("name")
+	loader := strategyprofile.NewLoader(h.baseDir)
+	profile, err := loader.Load(name)
+	if err != nil {
+		switch {
+		case errors.Is(err, strategyprofile.ErrInvalidProfileName):
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		case isNotExist(err):
+			c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+		default:
+			// Decode / validate failures. 422 conveys "your request is
+			// understandable but the referenced resource is unprocessable".
+			c.JSON(http.StatusUnprocessableEntity, gin.H{"error": err.Error()})
+		}
+		return
+	}
+	c.JSON(http.StatusOK, profile)
+}
+
+// isNotExist distinguishes "file missing" (404) from decode / validate
+// failures (422). errors.Is works on wrapped errors because
+// strategyprofile.Load wraps via fmt.Errorf("%w", ...).
+func isNotExist(err error) bool {
+	return errors.Is(err, os.ErrNotExist)
+}

--- a/backend/internal/interfaces/api/handler/profile_test.go
+++ b/backend/internal/interfaces/api/handler/profile_test.go
@@ -1,0 +1,139 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/infrastructure/strategyprofile"
+)
+
+// newProfileRouter mounts just the profile endpoints so tests do not need
+// the full BacktestHandler / sqlite setup.
+func newProfileRouter(t *testing.T, profilesDir string) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	h := NewProfileHandler(profilesDir)
+	r := gin.New()
+	r.GET("/api/v1/profiles", h.List)
+	r.GET("/api/v1/profiles/:name", h.Get)
+	return r
+}
+
+func TestProfileHandler_List_ReturnsSortedSummaries(t *testing.T) {
+	// Two valid profiles in the temp dir; the handler must sort them and
+	// return both with Name / Description / IsRouter populated.
+	profilesDir := setupProfilesDir(t, map[string][]byte{
+		"alpha": readProductionProfileJSON(t),
+		"beta":  readProductionProfileJSON(t),
+	})
+	router := newProfileRouter(t, profilesDir)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/profiles", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body: %s)", w.Code, w.Body.String())
+	}
+
+	var body struct {
+		Profiles []strategyprofile.ProfileSummary `json:"profiles"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v (body=%s)", err, w.Body.String())
+	}
+	if len(body.Profiles) != 2 {
+		t.Fatalf("expected 2 profiles, got %d: %+v", len(body.Profiles), body.Profiles)
+	}
+	// production.json's internal `name` is "production", not "alpha" /
+	// "beta" — Loader.List uses the profile's own name (filename is only
+	// the disk anchor). Both entries therefore come back named
+	// "production"; we assert on Description presence to keep the test
+	// robust against that design choice.
+	for i, p := range body.Profiles {
+		if p.Name == "" {
+			t.Errorf("profile[%d] has empty Name", i)
+		}
+		if p.Description == "" {
+			t.Errorf("profile[%d] has empty Description", i)
+		}
+		if p.IsRouter {
+			t.Errorf("profile[%d] is unexpectedly flagged as a router", i)
+		}
+	}
+}
+
+func TestProfileHandler_List_EmptyDirReturnsEmptyArray(t *testing.T) {
+	// Nothing on disk — the FE expects a non-nil empty array, not a 500.
+	profilesDir := setupProfilesDir(t, nil)
+	router := newProfileRouter(t, profilesDir)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/profiles", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), `"profiles":[]`) {
+		t.Errorf("expected empty profiles array, got %s", w.Body.String())
+	}
+}
+
+func TestProfileHandler_Get_ReturnsFullProfile(t *testing.T) {
+	profilesDir := setupProfilesDir(t, map[string][]byte{
+		"production": readProductionProfileJSON(t),
+	})
+	router := newProfileRouter(t, profilesDir)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/profiles/production", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body: %s)", w.Code, w.Body.String())
+	}
+	var profile entity.StrategyProfile
+	if err := json.Unmarshal(w.Body.Bytes(), &profile); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if profile.Name == "" {
+		t.Error("returned profile has empty Name")
+	}
+	if profile.Indicators.SMAShort == 0 || profile.Indicators.SMALong == 0 {
+		t.Error("indicator periods did not round-trip through /profiles/:name")
+	}
+}
+
+func TestProfileHandler_Get_MissingReturns404(t *testing.T) {
+	profilesDir := setupProfilesDir(t, nil)
+	router := newProfileRouter(t, profilesDir)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/profiles/nonexistent", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404 (body: %s)", w.Code, w.Body.String())
+	}
+}
+
+func TestProfileHandler_Get_InvalidNameReturns400(t *testing.T) {
+	profilesDir := setupProfilesDir(t, nil)
+	router := newProfileRouter(t, profilesDir)
+
+	// URL-escape a traversal attempt so gin's path parser passes it to the
+	// handler unchanged. The profile name allow-list should reject it.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/profiles/bad..name", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 (body: %s)", w.Code, w.Body.String())
+	}
+}

--- a/backend/internal/interfaces/api/router.go
+++ b/backend/internal/interfaces/api/router.go
@@ -141,6 +141,13 @@ func NewRouter(deps Dependencies) *gin.Engine {
 			opts = append(opts, handler.WithWalkForwardRepo(deps.WalkForwardResultRepo))
 		}
 		backtestHandler := handler.NewBacktestHandler(deps.BacktestRunner, deps.BacktestResultRepo, opts...)
+		// PR-12: profile discovery endpoints used by the FE backtest picker.
+		// The same profilesBaseDir default is used so /profiles and
+		// /backtest/run share the same filesystem view.
+		profileHandler := handler.NewProfileHandler("")
+		v1.GET("/profiles", profileHandler.List)
+		v1.GET("/profiles/:name", profileHandler.Get)
+
 		v1.POST("/backtest/run", backtestHandler.Run)
 		v1.GET("/backtest/csv-meta", backtestHandler.CSVMeta)
 		v1.GET("/backtest/results", backtestHandler.ListResults)


### PR DESCRIPTION
## Summary

Backend piece of the FE backtest "edit-and-run" workflow. Adds two read-only profile endpoints and one inline-override field on `POST /backtest/run`.

### New endpoints

- **GET `/api/v1/profiles`** — lists `{name, description, isRouter}` for every `backend/profiles/*.json`. Sorted by name. Broken profiles surface with a `(load error: ...)` description so the FE picker can show the problem instead of silently dropping them.
- **GET `/api/v1/profiles/:name`** — returns the full `StrategyProfile` JSON. 400 / 404 / 422 for invalid-name / missing / broken respectively.

### Run endpoint extension

- `POST /backtest/run` now accepts `profileOverride?: StrategyProfile`. When present it supersedes `profileName` for strategy construction, risk defaults, and `bb_squeeze_lookback` plumbing. The original `profileName` is still saved as the audit label so the results table can show "which preset did this start from".
- Router profiles (`regime_routing` block) are rejected via `profileOverride` — editing a router without resolving children is out of scope for PR-12 (picker UI will disable edit for routers).
- `Validate()` failures on the override surface as HTTP 400 mentioning the offending field.

### Loader change

- `strategyprofile.Loader` gets a `List()` method returning `[]ProfileSummary`. The handler delegates directly.

## Tests

- 2 `Loader.List` cases (sort / empty dir).
- 5 `ProfileHandler` cases (list / empty list / get / missing 404 / invalid-name 400).
- 3 `Run` `profileOverride` cases (valid path / validate-failure 400 / router-rejected 400).

All existing tests unchanged; full `go test ./... -race -count=1` green.

## Next PR

Part 2 wires the FE backtest screen: `useProfiles()` / `useProfile()` hooks, a preset picker, an inline form that binds every `StrategyProfile` field, and the `profileOverride` request path.

## Test plan

- [ ] CI: backend `go test ./...` green
- [ ] CI: frontend `pnpm test` green (no FE changes here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)