### PR TITLE
fix(fe): 約定 Amount の float 表示ゴミを 2 桁丸めで除去

### DIFF
--- a/frontend/src/components/TradeHistoryTable.tsx
+++ b/frontend/src/components/TradeHistoryTable.tsx
@@ -1,4 +1,5 @@
 import type { TradeHistoryItem } from '../lib/api'
+import { formatAmount } from '../lib/format'
 
 export type TradeHistoryRow = TradeHistoryItem & { currencyPair?: string }
 
@@ -55,7 +56,7 @@ export function TradeHistoryTable({ trades, showCurrencyPair = false }: TradeHis
                   <td className={`px-5 py-4 font-medium ${trade.orderSide === 'BUY' ? 'text-accent-green' : 'text-accent-red'}`}>
                     {trade.orderSide}
                   </td>
-                  <td className="px-5 py-4">{trade.amount}</td>
+                  <td className="px-5 py-4">{formatAmount(trade.amount)}</td>
                   <td className="px-5 py-4">{formatYen(trade.price)}</td>
                   <td className={`px-5 py-4 ${trade.profit >= 0 ? 'text-accent-green' : 'text-accent-red'}`}>
                     {formatYen(trade.profit)}

--- a/frontend/src/lib/format.test.ts
+++ b/frontend/src/lib/format.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { formatAmount } from './format'
+
+describe('formatAmount', () => {
+  it('strips IEEE-754 noise like 0.30000000000000004 → 0.3', () => {
+    expect(formatAmount(0.1 + 0.2)).toBe('0.3')
+  })
+
+  it('renders venue lot-step precision (2 dp) cleanly', () => {
+    expect(formatAmount(0.1)).toBe('0.1')
+    expect(formatAmount(0.2)).toBe('0.2')
+    expect(formatAmount(0.01)).toBe('0.01')
+    expect(formatAmount(1.5)).toBe('1.5')
+  })
+
+  it('rounds beyond 2 dp', () => {
+    expect(formatAmount(0.12345678)).toBe('0.12')
+    expect(formatAmount(0.005)).toBe('0.01')
+  })
+
+  it('renders integers without trailing zeros', () => {
+    expect(formatAmount(5)).toBe('5')
+    expect(formatAmount(0)).toBe('0')
+  })
+
+  it('renders negative values', () => {
+    expect(formatAmount(-0.1 + -0.2)).toBe('-0.3')
+  })
+
+  it('renders a dash for non-finite values', () => {
+    expect(formatAmount(Number.NaN)).toBe('—')
+    expect(formatAmount(Number.POSITIVE_INFINITY)).toBe('—')
+  })
+})

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -1,0 +1,17 @@
+// Shared number formatters. Amount fields (crypto base units) can pick up
+// IEEE-754 tails like 0.30000000000000004 when the backend computes lots
+// via float math (e.g. 0.1 + 0.2 during dynamic sizing). Rendering the raw
+// number surfaces that noise.
+//
+// Rakuten Wallet margin trading lot-step is 0.01 (BTC) or 0.1 (LTC/ETH/BCH),
+// so 2 decimal places is enough to show the real precision without leaking
+// float noise. Trailing zeros and a dangling decimal point are stripped so
+// "0.30" → "0.3" and "5.00" → "5".
+
+const AMOUNT_MAX_FRACTION_DIGITS = 2
+
+export function formatAmount(value: number): string {
+  if (!Number.isFinite(value)) return '—'
+  const fixed = value.toFixed(AMOUNT_MAX_FRACTION_DIGITS)
+  return fixed.replace(/\.?0+$/, '')
+}

--- a/frontend/src/routes/backtest.tsx
+++ b/frontend/src/routes/backtest.tsx
@@ -20,6 +20,7 @@ import type {
   StrategyProfile,
   SummaryBreakdown,
 } from '../lib/api'
+import { formatAmount } from '../lib/format'
 
 export const Route = createFileRoute('/backtest')({ component: BacktestPage })
 
@@ -1227,7 +1228,7 @@ function TradeRow({ trade }: { trade: BacktestTrade }) {
       <td className="px-3 py-2 text-right text-white">
         {trade.exitPrice.toLocaleString('ja-JP')}
       </td>
-      <td className="px-3 py-2 text-right text-white">{trade.amount}</td>
+      <td className="px-3 py-2 text-right text-white">{formatAmount(trade.amount)}</td>
       <td className={`px-3 py-2 text-right font-medium ${pnlColor(trade.pnl)}`}>
         {trade.pnl >= 0 ? '+' : ''}{trade.pnl.toLocaleString('ja-JP', { maximumFractionDigits: 0 })}
       </td>


### PR DESCRIPTION
## Summary
- 取引一覧で Amount が「0.30000000000000004」と表示されるバグを修正
- 原因: IEEE-754 の丸め誤差 (0.1 + 0.2 = 0.30000000000000004) を `{trade.amount}` で直接描画していた
- 修正: 共通フォーマッタ `formatAmount` を追加、小数第2位で丸めて末尾の 0 と trailing dot を除去

## 変更
- `frontend/src/lib/format.ts` 新設（formatAmount）
- `frontend/src/lib/format.test.ts` vitest でケース網羅
- `frontend/src/components/TradeHistoryTable.tsx` (約定履歴テーブル)
- `frontend/src/routes/backtest.tsx` (バックテスト詳細 trade 行)

## 2 桁で十分な理由
楽天ウォレット証拠金取引の最小発注単位 (lot_step) は:
- BTC/JPY: 0.01
- LTC/JPY / ETH/JPY / BCH/JPY: 0.1
- XRP/JPY: 100

いずれも小数 2 桁以内で表現可能。

## Test plan
- [x] `pnpm test` 全 37 件緑 (新規 6 件含む)
- [x] `pnpm build` 緑
- [ ] フロント画面で「取引一覧」を開き、Amount 列に「0.3」「0.5」等で表示されることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)