### PR TITLE
fix(api): GET /strategy に現在指標を流して live stance を返す

### DIFF
--- a/backend/internal/interfaces/api/handler/live_snapshot.go
+++ b/backend/internal/interfaces/api/handler/live_snapshot.go
@@ -1,0 +1,75 @@
+package handler
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase"
+)
+
+// symbolProvider is the narrow port live_snapshot uses to read the active
+// trading symbol. Mirrors the PipelineController.SymbolID() method on the
+// router-level interface so the handler layer doesn't depend on the pipeline
+// package directly.
+type symbolProvider interface {
+	SymbolID() int64
+}
+
+// pipelineLiveSnapshot computes the current indicator set + price for the
+// *active* trading symbol. It's intentionally a thin shim so the handler
+// layer does not import the pipeline directly — it only needs SymbolID()
+// from whatever PipelineController the router passes in.
+type pipelineLiveSnapshot struct {
+	symbol    symbolProvider
+	calc      *usecase.IndicatorCalculator
+	market    *usecase.MarketDataService
+	primaryTF string
+}
+
+// NewPipelineLiveSnapshot returns a LiveMarketSnapshot bound to the pipeline's
+// currently-selected symbol. nil-safety: if any of symbol/calc/market is nil,
+// the shim returns an empty IndicatorSet + 0 so the resolver falls back to the
+// legacy warmup branch. primaryTF defaults to "PT15M" when empty (current
+// production interval).
+func NewPipelineLiveSnapshot(
+	symbol symbolProvider,
+	calc *usecase.IndicatorCalculator,
+	market *usecase.MarketDataService,
+	primaryTF string,
+) LiveMarketSnapshot {
+	if primaryTF == "" {
+		primaryTF = "PT15M"
+	}
+	return &pipelineLiveSnapshot{
+		symbol:    symbol,
+		calc:      calc,
+		market:    market,
+		primaryTF: primaryTF,
+	}
+}
+
+func (p *pipelineLiveSnapshot) Snapshot(ctx context.Context) (entity.IndicatorSet, float64) {
+	if p == nil || p.symbol == nil || p.calc == nil || p.market == nil {
+		return entity.IndicatorSet{}, 0
+	}
+	symbolID := p.symbol.SymbolID()
+	if symbolID <= 0 {
+		return entity.IndicatorSet{}, 0
+	}
+
+	ind, err := p.calc.Calculate(ctx, symbolID, p.primaryTF)
+	if err != nil || ind == nil {
+		slog.Debug("strategy snapshot: calculate indicators failed, falling back",
+			"symbolID", symbolID, "interval", p.primaryTF, "err", err)
+		return entity.IndicatorSet{}, 0
+	}
+
+	ticker, err := p.market.GetLatestTicker(ctx, symbolID)
+	if err != nil || ticker == nil {
+		slog.Debug("strategy snapshot: latest ticker unavailable",
+			"symbolID", symbolID, "err", err)
+		return *ind, 0
+	}
+	return *ind, ticker.Last
+}

--- a/backend/internal/interfaces/api/handler/strategy.go
+++ b/backend/internal/interfaces/api/handler/strategy.go
@@ -1,6 +1,8 @@
 package handler
 
 import (
+	"context"
+	"log/slog"
 	"net/http"
 	"time"
 
@@ -9,17 +11,52 @@ import (
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase"
 )
 
+// LiveMarketSnapshot is the narrow port StrategyHandler uses to compute the
+// stance from the *current* market state. A nil snapshot preserves the legacy
+// behaviour of resolving with an empty IndicatorSet (rule-based → HOLD with
+// "insufficient indicator data"), which is what unit tests for the resolver
+// assume.
+type LiveMarketSnapshot interface {
+	// Snapshot returns the latest indicator set and last traded price for the
+	// currently active trading symbol. Returning an empty IndicatorSet or
+	// price 0 is allowed and is treated the same as "warmup" — the resolver
+	// will fall back to HOLD.
+	Snapshot(ctx context.Context) (entity.IndicatorSet, float64)
+}
+
 type StrategyHandler struct {
 	stanceResolver *usecase.RuleBasedStanceResolver
+	// snapshot is optional; when nil GetStrategy falls back to the legacy
+	// empty-IndicatorSet path. Wired by the router at startup from the live
+	// IndicatorCalculator + MarketDataService + Pipeline.
+	snapshot LiveMarketSnapshot
 }
 
 func NewStrategyHandler(stanceResolver *usecase.RuleBasedStanceResolver) *StrategyHandler {
 	return &StrategyHandler{stanceResolver: stanceResolver}
 }
 
+// WithLiveSnapshot returns a StrategyHandler that computes the stance from the
+// live market snapshot on every GET /strategy call. Kept as a functional
+// option so existing tests (which construct the handler with only a resolver)
+// keep compiling.
+func (h *StrategyHandler) WithLiveSnapshot(snap LiveMarketSnapshot) *StrategyHandler {
+	h.snapshot = snap
+	return h
+}
+
 func (h *StrategyHandler) GetStrategy(c *gin.Context) {
 	indicators := entity.IndicatorSet{}
-	result := h.stanceResolver.Resolve(c.Request.Context(), indicators, 0)
+	var lastPrice float64
+	if h.snapshot != nil {
+		ind, price := h.snapshot.Snapshot(c.Request.Context())
+		indicators = ind
+		lastPrice = price
+		if price == 0 {
+			slog.Debug("strategy: live snapshot has zero price; resolver will fall back to HOLD")
+		}
+	}
+	result := h.stanceResolver.Resolve(c.Request.Context(), indicators, lastPrice)
 	c.JSON(http.StatusOK, result)
 }
 

--- a/backend/internal/interfaces/api/handler/strategy_live_test.go
+++ b/backend/internal/interfaces/api/handler/strategy_live_test.go
@@ -1,0 +1,80 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase"
+)
+
+// stubSnapshot lets tests inject a canned IndicatorSet + price into the
+// StrategyHandler without wiring up a real pipeline/market service. Keeps
+// the test independent of the live snapshot implementation.
+type stubSnapshot struct {
+	indicators entity.IndicatorSet
+	price      float64
+}
+
+func (s *stubSnapshot) Snapshot(_ context.Context) (entity.IndicatorSet, float64) {
+	return s.indicators, s.price
+}
+
+func ptrFloat(v float64) *float64 { return &v }
+func ptrBool(v bool) *bool        { return &v }
+
+// TestStrategyHandler_GetStrategy_WithLiveSnapshot_TrendFollow feeds a
+// well-formed trending indicator snapshot through the handler and checks
+// that GET /strategy no longer returns the legacy "insufficient indicator
+// data" HOLD. Without WithLiveSnapshot the handler uses an empty
+// IndicatorSet and therefore always emits HOLD — this test is the
+// regression guard for the dashboard bug that kicked off the fix.
+func TestStrategyHandler_GetStrategy_WithLiveSnapshot_TrendFollow(t *testing.T) {
+	resolver := usecase.NewRuleBasedStanceResolver(nil)
+
+	// An uptrending snapshot: SMA20 > SMA50 by more than the convergence
+	// threshold (0.002) so the rule-based resolver commits to TREND_FOLLOW
+	// instead of HOLD.
+	indicators := entity.IndicatorSet{
+		SMA20:         ptrFloat(120),
+		SMA50:         ptrFloat(100),
+		RSI14:         ptrFloat(55),
+		BBBandwidth:   ptrFloat(0.05),
+		VolumeRatio:   ptrFloat(1.0),
+		RecentSqueeze: ptrBool(false),
+	}
+	snap := &stubSnapshot{indicators: indicators, price: 12000}
+
+	h := NewStrategyHandler(resolver).WithLiveSnapshot(snap)
+	w := doRequest(h.GetStrategy, http.MethodGet, "/strategy", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	body := decodeBody(t, w)
+	if body["stance"] == "HOLD" {
+		t.Fatalf("live snapshot should unblock HOLD; got stance=%v reasoning=%v", body["stance"], body["reasoning"])
+	}
+	if body["source"] != "rule-based" {
+		t.Fatalf("expected source 'rule-based', got %v", body["source"])
+	}
+}
+
+// TestStrategyHandler_GetStrategy_WithLiveSnapshot_ZeroPriceFallsBackToHold
+// documents that an empty snapshot (warmup / pipeline idle) preserves the
+// legacy behaviour so dashboards in that state aren't noisy.
+func TestStrategyHandler_GetStrategy_WithLiveSnapshot_ZeroPriceFallsBackToHold(t *testing.T) {
+	resolver := usecase.NewRuleBasedStanceResolver(nil)
+	snap := &stubSnapshot{} // empty indicators, price 0
+
+	h := NewStrategyHandler(resolver).WithLiveSnapshot(snap)
+	w := doRequest(h.GetStrategy, http.MethodGet, "/strategy", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	body := decodeBody(t, w)
+	if body["stance"] != "HOLD" {
+		t.Fatalf("empty snapshot should fall back to HOLD, got %v", body["stance"])
+	}
+}

--- a/backend/internal/interfaces/api/router.go
+++ b/backend/internal/interfaces/api/router.go
@@ -69,6 +69,14 @@ func NewRouter(deps Dependencies) *gin.Engine {
 	v1.GET("/pnl", riskHandler.GetPnL)
 
 	strategyHandler := handler.NewStrategyHandler(deps.StanceResolver)
+	// Wire the live snapshot so GET /strategy reflects the pipeline's
+	// current-bar stance instead of "insufficient indicator data". Nil-guard
+	// each dependency so tests / limited-feature deployments still work.
+	if deps.Pipeline != nil && deps.IndicatorCalculator != nil && deps.MarketDataService != nil {
+		strategyHandler.WithLiveSnapshot(handler.NewPipelineLiveSnapshot(
+			deps.Pipeline, deps.IndicatorCalculator, deps.MarketDataService, "PT15M",
+		))
+	}
 	v1.GET("/strategy", strategyHandler.GetStrategy)
 	v1.PUT("/strategy", strategyHandler.SetStrategy)
 	v1.DELETE("/strategy/override", strategyHandler.DeleteOverride)


### PR DESCRIPTION
## Summary
ダッシュボードで戦略方針が常に「HOLD (insufficient indicator data)」と表示される silent failure を修正。pipeline は裏側でちゃんと指標を計算して判定しているのに、API 側は**空の IndicatorSet を渡していた**ため常に warmup fallback の HOLD を返していた。

## Root cause
```go
func (h *StrategyHandler) GetStrategy(c *gin.Context) {
    indicators := entity.IndicatorSet{}  // ← 空
    result := h.stanceResolver.Resolve(c.Request.Context(), indicators, 0)
}
```

## Fix
- `LiveMarketSnapshot` インターフェースを新設、`StrategyHandler` に optional で注入
- `PipelineLiveSnapshot` 実装 → Pipeline から symbolID を取得、IndicatorCalculator で指標計算、MarketDataService で tick を取得
- router.go で実依存を `WithLiveSnapshot` で配線 (nil-guard あり)
- 既存 unit tests (snapshot 無しで構築するもの) は全て後方互換で動作

## 検証
修正前:
```json
{"stance":"HOLD","reasoning":"insufficient indicator data","source":"rule-based"}
```
修正後:
```json
{"stance":"HOLD","reasoning":"BB squeeze without breakout","source":"rule-based"}
```
→ 実指標に基づく判定が返るようになった。

## Test plan
- [x] `go test ./internal/interfaces/api/handler/... -run Strategy` 全11件緑 (新規2件含む)
- [x] `go build ./...` 緑
- [x] Docker 経由で `/api/v1/strategy` が実指標ベースの reasoning を返すことを確認
- [ ] merge 後に UI で戦略方針が動的に切り替わることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)