### PR TITLE
fix(trading): symbol選択を再起動を跨いで永続化 + UI mismatch自動同期 (A+D)

### DIFF
--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -48,6 +48,7 @@ func main() {
 	marketDataRepo := database.NewMarketDataRepo(db)
 	tradeHistoryRepo := database.NewTradeHistoryRepo(db)
 	riskStateRepo := database.NewRiskStateRepo(db)
+	tradingConfigRepo := database.NewTradingConfigRepo(db)
 
 	// --- Usecase ---
 	marketDataSvc := usecase.NewMarketDataService(marketDataRepo)
@@ -80,7 +81,23 @@ func main() {
 	})
 	orderExecutor := usecase.NewOrderExecutor(restClient, riskMgr)
 
+	// Default to the config-file values, then let the persisted state (if any)
+	// override them. This is what fixes the "WS resubscribes to BTC after every
+	// docker restart even though I picked LTC last time" silent failure: the
+	// pipeline now boots with the user's last selection.
 	symbolID := cfg.Trading.SymbolID
+	tradeAmount := cfg.Trading.TradeAmount
+	if persisted, err := tradingConfigRepo.Load(context.Background()); err != nil {
+		slog.Warn("trading config restore failed; falling back to config defaults", "error", err)
+	} else if persisted != nil {
+		if persisted.SymbolID > 0 {
+			symbolID = persisted.SymbolID
+		}
+		if persisted.TradeAmount > 0 {
+			tradeAmount = persisted.TradeAmount
+		}
+		slog.Info("trading config restored from db", "symbolID", symbolID, "tradeAmount", tradeAmount)
+	}
 
 	if err := bootstrapCandles(context.Background(), restClient, marketDataSvc, symbolID, "PT15M", 500); err != nil {
 		slog.Warn("initial candle bootstrap failed", "error", err)
@@ -95,7 +112,7 @@ func main() {
 		EventDrivenPipelineConfig{
 			SymbolID:          symbolID,
 			StateSyncInterval: time.Duration(cfg.Trading.StateSyncIntervalSec) * time.Second,
-			TradeAmount:       cfg.Trading.TradeAmount,
+			TradeAmount:       tradeAmount,
 			MinConfidence:     cfg.Trading.MinConfidence,
 			StopLossPercent:   cfg.Risk.StopLossPercent,
 			TakeProfitPercent: cfg.Risk.TakeProfitPercent,
@@ -132,6 +149,16 @@ func main() {
 		// 新シンボルのローソク足を bootstrap（main の ctx を使う）
 		if err := bootstrapCandles(ctx, restClient, marketDataSvc, newID, "PT15M", 500); err != nil {
 			slog.Warn("candle bootstrap for new symbol failed", "symbolID", newID, "error", err)
+		}
+
+		// Persist so the next restart boots with the user's choice instead of
+		// the config default. Save errors are logged but don't fail the switch
+		// — losing persistence is less bad than refusing the switch.
+		if err := tradingConfigRepo.Save(ctx, repository.TradingConfigState{
+			SymbolID:    newID,
+			TradeAmount: pipeline.TradeAmount(),
+		}); err != nil {
+			slog.Warn("persist trading config failed", "symbolID", newID, "error", err)
 		}
 
 		// 上書き方式: 古い値を drain してから送信。

--- a/backend/internal/domain/repository/trading_config.go
+++ b/backend/internal/domain/repository/trading_config.go
@@ -1,0 +1,18 @@
+package repository
+
+import "context"
+
+// TradingConfigState は永続化された取引設定。pipeline の起動時に
+// 復元されるため、再起動を跨いで「最後に選んでいた銘柄/サイズ」が
+// 失われない。
+type TradingConfigState struct {
+	SymbolID    int64   `json:"symbolId"`
+	TradeAmount float64 `json:"tradeAmount"`
+	UpdatedAt   int64   `json:"updatedAt"`
+}
+
+// TradingConfigRepository は取引設定の永続化インターフェース。
+type TradingConfigRepository interface {
+	Save(ctx context.Context, state TradingConfigState) error
+	Load(ctx context.Context) (*TradingConfigState, error)
+}

--- a/backend/internal/infrastructure/database/migrations.go
+++ b/backend/internal/infrastructure/database/migrations.go
@@ -117,6 +117,18 @@ func RunMigrations(db *sql.DB) error {
 			ttl_sec INTEGER NOT NULL
 		)`,
 
+		// trading_config persists the user's last-selected symbol and trade
+		// amount across restarts. Without this, every container rebuild
+		// silently resets the pipeline to the config-default symbol while
+		// the frontend keeps showing whatever the user picked before, and
+		// the WS subscription never re-attaches to the right asset.
+		`CREATE TABLE IF NOT EXISTS trading_config (
+			id INTEGER PRIMARY KEY CHECK (id = 1),
+			symbol_id INTEGER NOT NULL,
+			trade_amount REAL NOT NULL,
+			updated_at INTEGER NOT NULL DEFAULT 0
+		)`,
+
 		`CREATE TABLE IF NOT EXISTS client_orders (
 			client_order_id TEXT PRIMARY KEY,
 			executed INTEGER NOT NULL,

--- a/backend/internal/infrastructure/database/trading_config_repo.go
+++ b/backend/internal/infrastructure/database/trading_config_repo.go
@@ -1,0 +1,45 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/repository"
+)
+
+// TradingConfigRepo persists pipeline.symbolID + tradeAmount across restarts.
+type TradingConfigRepo struct {
+	db *sql.DB
+}
+
+func NewTradingConfigRepo(db *sql.DB) *TradingConfigRepo {
+	return &TradingConfigRepo{db: db}
+}
+
+func (r *TradingConfigRepo) Save(ctx context.Context, state repository.TradingConfigState) error {
+	_, err := r.db.ExecContext(ctx,
+		`INSERT INTO trading_config (id, symbol_id, trade_amount, updated_at) VALUES (1, ?, ?, ?)
+		 ON CONFLICT(id) DO UPDATE SET symbol_id = excluded.symbol_id, trade_amount = excluded.trade_amount, updated_at = excluded.updated_at`,
+		state.SymbolID, state.TradeAmount, time.Now().Unix(),
+	)
+	if err != nil {
+		return fmt.Errorf("save trading config: %w", err)
+	}
+	return nil
+}
+
+func (r *TradingConfigRepo) Load(ctx context.Context) (*repository.TradingConfigState, error) {
+	var state repository.TradingConfigState
+	err := r.db.QueryRowContext(ctx,
+		`SELECT symbol_id, trade_amount, updated_at FROM trading_config WHERE id = 1`,
+	).Scan(&state.SymbolID, &state.TradeAmount, &state.UpdatedAt)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("load trading config: %w", err)
+	}
+	return &state, nil
+}

--- a/backend/internal/infrastructure/database/trading_config_repo_test.go
+++ b/backend/internal/infrastructure/database/trading_config_repo_test.go
@@ -1,0 +1,72 @@
+package database
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/repository"
+)
+
+func newRepoFixture(t *testing.T) *TradingConfigRepo {
+	t.Helper()
+	dir := t.TempDir()
+	db, err := NewDB(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := RunMigrations(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	return NewTradingConfigRepo(db)
+}
+
+func TestTradingConfigRepo_LoadEmpty(t *testing.T) {
+	repo := newRepoFixture(t)
+	got, err := repo.Load(context.Background())
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil on empty table, got %+v", got)
+	}
+}
+
+func TestTradingConfigRepo_SaveLoadRoundTrip(t *testing.T) {
+	repo := newRepoFixture(t)
+	want := repository.TradingConfigState{SymbolID: 10, TradeAmount: 1500}
+	if err := repo.Save(context.Background(), want); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got, err := repo.Load(context.Background())
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected loaded state, got nil")
+	}
+	if got.SymbolID != want.SymbolID || got.TradeAmount != want.TradeAmount {
+		t.Fatalf("round-trip mismatch: got %+v want %+v", got, want)
+	}
+	if got.UpdatedAt == 0 {
+		t.Fatalf("UpdatedAt should be set, got 0")
+	}
+}
+
+func TestTradingConfigRepo_SaveOverwrites(t *testing.T) {
+	repo := newRepoFixture(t)
+	if err := repo.Save(context.Background(), repository.TradingConfigState{SymbolID: 7, TradeAmount: 500}); err != nil {
+		t.Fatalf("first Save: %v", err)
+	}
+	if err := repo.Save(context.Background(), repository.TradingConfigState{SymbolID: 10, TradeAmount: 1500}); err != nil {
+		t.Fatalf("second Save: %v", err)
+	}
+	got, err := repo.Load(context.Background())
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got.SymbolID != 10 || got.TradeAmount != 1500 {
+		t.Fatalf("upsert did not overwrite: got %+v", got)
+	}
+}

--- a/frontend/src/contexts/SymbolContext.tsx
+++ b/frontend/src/contexts/SymbolContext.tsx
@@ -90,6 +90,34 @@ export function SymbolProvider({ children }: { children: ReactNode }) {
   // 未ロード時に fallback tradeAmount で PUT して誤上書きするのを防ぐ。
   const isSwitchAllowed = tradingConfig !== undefined
 
+  // Defense-in-depth (D): if URL says LTC but the backend's pipeline still
+  // points at BTC (e.g. fresh container, persistence not yet caught up), the
+  // WS subscription would silently stay on the wrong asset and the dashboard
+  // would freeze on stale ticks. Auto-PUT once on mount to close the gap.
+  // We only fire when:
+  //   - both URL and backend config are settled (no race during boot)
+  //   - the symbols differ
+  //   - no PUT is already in-flight (avoid loops on transient errors)
+  useEffect(() => {
+    if (!tradingConfig) return
+    if (!resolvedFromUrl) return
+    if (updateConfig.isPending) return
+    if (resolvedFromUrl.id === tradingConfig.symbolId) return
+    console.warn(
+      '[SymbolContext] mismatch between URL symbol and backend trading_config; auto-syncing',
+      { urlSymbolId: resolvedFromUrl.id, backendSymbolId: tradingConfig.symbolId },
+    )
+    updateConfig.mutate(
+      { symbolId: resolvedFromUrl.id, tradeAmount: tradingConfig.tradeAmount },
+      {
+        onSuccess: () => {
+          void queryClient.invalidateQueries({ queryKey: ['candles'] })
+          void queryClient.invalidateQueries({ queryKey: ['indicators'] })
+        },
+      },
+    )
+  }, [resolvedFromUrl, tradingConfig, updateConfig, queryClient])
+
   const switchSymbol = useCallback(
     (newSymbolId: number) => {
       if (!tradingConfig) return


### PR DESCRIPTION
## Summary

「docker rebuild すると更新時刻が止まる」silent failure の根本解決。原因は pipeline.symbolID が in-memory のみで永続化されていなかったこと。

- **A (永続化)**: trading_config テーブル + repo を追加し、起動時に復元・PUT 時に保存
- **D (UI 自動同期)**: SymbolProvider が URL とバックエンドの mismatch を検知して自動 PUT。万一 A が機能しなくても WS が正しい銘柄に張り直る防御線

## 変更点

### Backend
- `trading_config` テーブル migration 追加
- `repository.TradingConfigRepository` インターフェース新設
- `database.TradingConfigRepo` SQLite 実装 + 3 ケースのユニットテスト
- `main.go`: 起動時に Load (規定値より優先)、`onSymbolSwitch` で Save

### Frontend
- `SymbolContext.tsx`: URL シンボルと `tradingConfig.symbolId` がズレたら自動で `useUpdateTradingConfig.mutate()` 発火し、candles/indicators の cache を invalidate

## 検証 (Docker 経由)

```
$ curl -X PUT /trading-config -d '{"symbolId":10,"tradeAmount":1500}'
{"symbolId":10,"tradeAmount":1500}

$ docker compose restart backend
...
backend-1 | INFO trading config restored from db symbolID=10 tradeAmount=1500
backend-1 | INFO market websocket subscribed symbolID=10

$ curl /trading-config
{"symbolId":10,"tradeAmount":1500}  # 再起動後も維持 ✅
```

## Test plan
- [x] `go test ./internal/infrastructure/database/...` 緑（新規 3 件含む）
- [x] `go build ./...` 緑
- [x] `pnpm test` 緑（既存 37 件）/ `pnpm build` 緑
- [x] Docker で再起動後も WS が正しい銘柄を購読する
- [ ] merge 後にダッシュボードを開いて更新時刻がライブで動くこと、symbol 切替後に再起動しても銘柄が維持されることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)