### PR TITLE
feat(notify): PR-3/5 frontend 通知設定 UI

### DIFF
--- a/frontend/src/components/AppFrame.tsx
+++ b/frontend/src/components/AppFrame.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react'
 import { Link, useSearch } from '@tanstack/react-router'
 import { SymbolSelector } from './SymbolSelector'
+import { NotificationToggle } from './NotificationToggle'
 
 type AppFrameProps = {
   title: string
@@ -29,7 +30,10 @@ export function AppFrame({ title, subtitle, children }: AppFrameProps) {
             <p className="mt-2 max-w-2xl text-sm text-slate-300">{subtitle}</p>
           </div>
           <div className="flex flex-col gap-3 lg:items-end">
-            <SymbolSelector />
+            <div className="flex items-center gap-2">
+              <SymbolSelector />
+              <NotificationToggle />
+            </div>
             <nav className="-mx-1 flex gap-2 overflow-x-auto px-1 pb-1 lg:overflow-visible">
               {navItems.map((item) => (
                 <Link

--- a/frontend/src/components/NotificationToggle.tsx
+++ b/frontend/src/components/NotificationToggle.tsx
@@ -1,0 +1,145 @@
+import { useEffect, useRef, useState } from 'react'
+import { useNotificationSettings, type BrowserPermission } from '../hooks/useNotificationSettings'
+
+// Bell-with-popover that lives in the header. Kept lightweight (no external
+// popover lib) — the popover is just an absolutely positioned panel that
+// toggles on click and closes on outside-click.
+
+export function NotificationToggle() {
+  const { settings, permission, setEnabled, setSoundEnabled, requestPermission } =
+    useNotificationSettings()
+  const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    const onClick = (e: MouseEvent) => {
+      if (!ref.current) return
+      if (!ref.current.contains(e.target as Node)) setOpen(false)
+    }
+    document.addEventListener('mousedown', onClick)
+    return () => document.removeEventListener('mousedown', onClick)
+  }, [open])
+
+  const isOn = settings.enabled && permission === 'granted'
+  const ariaLabel = isOn ? '通知設定 (オン)' : '通知設定 (オフ)'
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-label={ariaLabel}
+        className={`flex h-9 w-9 items-center justify-center rounded-full border transition ${
+          isOn
+            ? 'border-accent-green/50 bg-accent-green/15 text-accent-green'
+            : 'border-white/15 bg-white/5 text-slate-300 hover:bg-white/10'
+        }`}
+      >
+        <BellIcon active={isOn} />
+      </button>
+      {open && (
+        <div className="absolute right-0 top-11 z-30 w-72 rounded-2xl border border-white/10 bg-bg-card/95 p-4 shadow-[0_20px_60px_rgba(0,0,0,0.5)] backdrop-blur">
+          <p className="text-xs uppercase tracking-[0.28em] text-text-secondary">通知設定</p>
+          <h3 className="mt-1 text-base font-semibold text-white">取引イベント通知</h3>
+
+          <ToggleRow
+            label="通知を有効化"
+            checked={settings.enabled}
+            onChange={(v) => void setEnabled(v)}
+          />
+          <ToggleRow
+            label="効果音を鳴らす"
+            checked={settings.soundEnabled}
+            onChange={setSoundEnabled}
+            disabled={!settings.enabled}
+          />
+
+          <div className="mt-3 rounded-xl border border-white/8 bg-white/4 px-3 py-2 text-xs text-slate-300">
+            ブラウザ権限: <PermissionBadge value={permission} />
+            {permission === 'default' && settings.enabled && (
+              <button
+                type="button"
+                onClick={() => void requestPermission()}
+                className="ml-2 rounded-full bg-accent-green/20 px-2 py-0.5 text-[10px] font-semibold text-accent-green hover:bg-accent-green/30"
+              >
+                許可をリクエスト
+              </button>
+            )}
+            {permission === 'denied' && settings.enabled && (
+              <p className="mt-1 text-[11px] text-accent-red">
+                ブラウザ設定で通知をブロックしています。サイト設定から許可に変更してください。
+              </p>
+            )}
+            {permission === 'unsupported' && (
+              <p className="mt-1 text-[11px] text-slate-400">このブラウザは通知をサポートしていません</p>
+            )}
+          </div>
+
+          <p className="mt-3 text-[11px] leading-relaxed text-text-secondary">
+            エントリー / クローズ / リスク警告 (DD・連敗・日次損失) を OS 通知で表示します。
+          </p>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function ToggleRow({
+  label,
+  checked,
+  onChange,
+  disabled,
+}: {
+  label: string
+  checked: boolean
+  onChange: (v: boolean) => void
+  disabled?: boolean
+}) {
+  return (
+    <label
+      className={`mt-3 flex items-center justify-between text-sm ${
+        disabled ? 'opacity-50' : 'text-slate-200'
+      }`}
+    >
+      <span>{label}</span>
+      <button
+        type="button"
+        role="switch"
+        aria-checked={checked}
+        onClick={() => !disabled && onChange(!checked)}
+        disabled={disabled}
+        className={`relative inline-flex h-5 w-9 items-center rounded-full transition ${
+          checked ? 'bg-accent-green' : 'bg-white/15'
+        }`}
+      >
+        <span
+          className={`inline-block h-4 w-4 transform rounded-full bg-white transition ${
+            checked ? 'translate-x-4' : 'translate-x-1'
+          }`}
+        />
+      </button>
+    </label>
+  )
+}
+
+function PermissionBadge({ value }: { value: BrowserPermission }) {
+  const map: Record<BrowserPermission, { text: string; cls: string }> = {
+    granted: { text: 'granted', cls: 'text-accent-green' },
+    denied: { text: 'denied', cls: 'text-accent-red' },
+    default: { text: 'pending', cls: 'text-slate-300' },
+    unsupported: { text: 'unsupported', cls: 'text-slate-400' },
+  }
+  const v = map[value]
+  return <span className={`font-mono ${v.cls}`}>{v.text}</span>
+}
+
+function BellIcon({ active }: { active: boolean }) {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9" />
+      <path d="M10.3 21a1.94 1.94 0 0 0 3.4 0" />
+      {active && <circle cx="18" cy="6" r="2.5" fill="currentColor" stroke="none" />}
+    </svg>
+  )
+}

--- a/frontend/src/hooks/__tests__/useNotificationSettings.test.tsx
+++ b/frontend/src/hooks/__tests__/useNotificationSettings.test.tsx
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, renderHook } from '@testing-library/react'
+import { useNotificationSettings } from '../useNotificationSettings'
+
+// We stub Notification on the window before each test because vitest's jsdom
+// environment does not ship with it. Each test customises permission +
+// requestPermission() return values to drive the hook through its branches.
+
+type MockNotification = {
+  permission: 'default' | 'granted' | 'denied'
+  requestPermission: ReturnType<typeof vi.fn>
+}
+
+function installNotification(perm: MockNotification['permission'], next: MockNotification['permission']) {
+  const requestPermission = vi.fn().mockResolvedValue(next)
+  Object.defineProperty(window, 'Notification', {
+    configurable: true,
+    writable: true,
+    value: { permission: perm, requestPermission } as MockNotification,
+  })
+  return requestPermission
+}
+
+beforeEach(() => {
+  window.localStorage.clear()
+})
+
+afterEach(() => {
+  // Wipe so the next test sets it up cleanly.
+  delete (window as unknown as { Notification?: unknown }).Notification
+})
+
+describe('useNotificationSettings', () => {
+  it('starts disabled and persists toggles to localStorage', () => {
+    installNotification('granted', 'granted')
+    const { result } = renderHook(() => useNotificationSettings())
+    expect(result.current.settings.enabled).toBe(false)
+    expect(result.current.settings.soundEnabled).toBe(true)
+
+    act(() => {
+      void result.current.setEnabled(true)
+    })
+    expect(JSON.parse(window.localStorage.getItem('notif-settings:v1') ?? '{}')).toMatchObject({
+      enabled: true,
+    })
+  })
+
+  it('requests browser permission on first enable when state is default', async () => {
+    const req = installNotification('default', 'granted')
+    const { result } = renderHook(() => useNotificationSettings())
+    await act(async () => {
+      await result.current.setEnabled(true)
+    })
+    expect(req).toHaveBeenCalledOnce()
+    expect(result.current.permission).toBe('granted')
+    expect(result.current.shouldFire).toBe(true)
+  })
+
+  it('shouldFire stays false when permission is denied', async () => {
+    installNotification('denied', 'denied')
+    const { result } = renderHook(() => useNotificationSettings())
+    await act(async () => {
+      await result.current.setEnabled(true)
+    })
+    expect(result.current.permission).toBe('denied')
+    expect(result.current.shouldFire).toBe(false)
+  })
+
+  it('reports unsupported when Notification API is missing', () => {
+    // No installNotification() — Notification stays undefined.
+    const { result } = renderHook(() => useNotificationSettings())
+    expect(result.current.permission).toBe('unsupported')
+    expect(result.current.shouldFire).toBe(false)
+  })
+
+  it('soundEnabled toggles independently of enabled', () => {
+    installNotification('granted', 'granted')
+    const { result } = renderHook(() => useNotificationSettings())
+    act(() => {
+      result.current.setSoundEnabled(false)
+    })
+    expect(result.current.settings.soundEnabled).toBe(false)
+    expect(result.current.settings.enabled).toBe(false)
+  })
+})

--- a/frontend/src/hooks/useNotificationSettings.ts
+++ b/frontend/src/hooks/useNotificationSettings.ts
@@ -1,0 +1,115 @@
+import { useCallback, useEffect, useState } from 'react'
+
+// Notification settings live in localStorage so the user's preference survives
+// page reloads and isn't tied to React state alone. The hook is intentionally
+// thin — it owns the storage shape but lets consumers (PR-4 useTradeNotifications,
+// settings UI) decide what to do with the values.
+
+const STORAGE_KEY = 'notif-settings:v1'
+
+export type BrowserPermission = 'default' | 'granted' | 'denied' | 'unsupported'
+
+export type NotificationSettings = {
+  enabled: boolean
+  soundEnabled: boolean
+}
+
+const DEFAULT_SETTINGS: NotificationSettings = {
+  enabled: false, // off until the user explicitly opts in (per browser UX guidelines)
+  soundEnabled: true,
+}
+
+function readStorage(): NotificationSettings {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY)
+    if (!raw) return DEFAULT_SETTINGS
+    const parsed = JSON.parse(raw) as Partial<NotificationSettings>
+    return {
+      enabled: parsed.enabled ?? DEFAULT_SETTINGS.enabled,
+      soundEnabled: parsed.soundEnabled ?? DEFAULT_SETTINGS.soundEnabled,
+    }
+  } catch {
+    return DEFAULT_SETTINGS
+  }
+}
+
+function writeStorage(s: NotificationSettings) {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(s))
+  } catch {
+    // Quota errors are not fatal; the user can still toggle in-session.
+  }
+}
+
+function readPermission(): BrowserPermission {
+  if (typeof window === 'undefined' || !('Notification' in window)) return 'unsupported'
+  return window.Notification.permission as BrowserPermission
+}
+
+export function useNotificationSettings() {
+  const [settings, setSettings] = useState<NotificationSettings>(() => readStorage())
+  const [permission, setPermission] = useState<BrowserPermission>(() => readPermission())
+
+  useEffect(() => {
+    writeStorage(settings)
+  }, [settings])
+
+  // Re-poll permission on mount + when the tab regains focus, since the user
+  // may change it from the browser settings page outside our control.
+  useEffect(() => {
+    const refresh = () => setPermission(readPermission())
+    refresh()
+    window.addEventListener('focus', refresh)
+    return () => window.removeEventListener('focus', refresh)
+  }, [])
+
+  const requestPermission = useCallback(async (): Promise<BrowserPermission> => {
+    if (typeof window === 'undefined' || !('Notification' in window)) {
+      setPermission('unsupported')
+      return 'unsupported'
+    }
+    try {
+      const result = (await window.Notification.requestPermission()) as BrowserPermission
+      setPermission(result)
+      return result
+    } catch {
+      setPermission('denied')
+      return 'denied'
+    }
+  }, [])
+
+  const setEnabled = useCallback(
+    async (next: boolean) => {
+      if (next) {
+        // First-time enable triggers the browser permission prompt. If the
+        // user denies, surface that state but still flip the toggle to "on"
+        // so the disabled-state warning explains why nothing fires.
+        const current = readPermission()
+        if (current === 'default') {
+          await requestPermission()
+        }
+      }
+      setSettings((prev) => ({ ...prev, enabled: next }))
+    },
+    [requestPermission],
+  )
+
+  const setSoundEnabled = useCallback((next: boolean) => {
+    setSettings((prev) => ({ ...prev, soundEnabled: next }))
+  }, [])
+
+  // shouldFire encapsulates "is everything wired up" so consumers don't repeat
+  // the (enabled && permission === 'granted') guard.
+  const shouldFire = settings.enabled && permission === 'granted'
+
+  return {
+    settings,
+    permission,
+    shouldFire,
+    setEnabled,
+    setSoundEnabled,
+    requestPermission,
+  }
+}


### PR DESCRIPTION
## Summary
ブラウザ通知シリーズの 3/5。ヘッダにベルアイコン + popover を追加し、通知 ON/OFF・音 ON/OFF・ブラウザ permission 状態を一元管理。実通知の発火 (Notification API + 音再生) は PR-4 で実装する。

## 追加
- \`useNotificationSettings\` フック: localStorage 永続化 (\`notif-settings:v1\`), \`Notification.permission\` 監視 (focus 復帰で再取得), \`requestPermission()\` 初回 enable 時に発火, \`shouldFire\` を派生
- \`NotificationToggle\` コンポーネント: ベル ボタン + 開閉式 popover, 通知/音トグル, permission バッジ, denied/unsupported の警告
- \`AppFrame\` ヘッダ右上に配置

## Test plan
- [x] vitest 全 42 件緑（新規 5 件含む）
- [x] \`pnpm build\` 緑
- [ ] PR-4 マージ後、UI でトグル ON → 通知音 + OS 通知が出ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)