### PR TITLE
feat(notify): PR-4/5 frontend foreground 通知

### DIFF
--- a/frontend/src/hooks/useMarketTickerStream.ts
+++ b/frontend/src/hooks/useMarketTickerStream.ts
@@ -1,6 +1,9 @@
 import { useEffect, useRef, useState } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { buildRealtimeWebSocketUrl, type LiveTicker, type RealtimeEventMessage } from '../lib/api'
+import { useNotificationSettings } from './useNotificationSettings'
+import { formatRiskEvent, formatTradeEvent } from '../lib/notify-format'
+import { playBeep, showNotification } from '../lib/notifier'
 
 type ConnectionState = 'connecting' | 'connected' | 'disconnected'
 
@@ -9,6 +12,14 @@ export function useMarketTickerStream(symbolId: number) {
   const [ticker, setTicker] = useState<LiveTicker | null>(null)
   const [connectionState, setConnectionState] = useState<ConnectionState>('connecting')
   const lastIndicatorInvalidateRef = useRef(0)
+  const { shouldFire, settings } = useNotificationSettings()
+  // Read the latest values inside socket callbacks via refs so we don't have
+  // to tear down + rebuild the WebSocket whenever the user toggles
+  // notifications. The socket lifetime is tied to symbolId only.
+  const shouldFireRef = useRef(shouldFire)
+  const soundEnabledRef = useRef(settings.soundEnabled)
+  shouldFireRef.current = shouldFire
+  soundEnabledRef.current = settings.soundEnabled
 
   useEffect(() => {
     // symbolId 変更時に旧シンボルの価格が残らないよう、即座にリセット
@@ -63,6 +74,27 @@ export function useMarketTickerStream(symbolId: number) {
             return
           case 'orderbook':
             return
+          case 'trade_event': {
+            // Open/close 約定: trades / positions / pnl の表示も最新化する。
+            void queryClient.invalidateQueries({ queryKey: ['trades', symbolId] })
+            void queryClient.invalidateQueries({ queryKey: ['positions'] })
+            void queryClient.invalidateQueries({ queryKey: ['pnl'] })
+            if (shouldFireRef.current) {
+              const desc = formatTradeEvent(payload.data)
+              showNotification(desc)
+              if (soundEnabledRef.current) playBeep(desc.beep)
+            }
+            return
+          }
+          case 'risk_event': {
+            void queryClient.invalidateQueries({ queryKey: ['status'] })
+            if (shouldFireRef.current) {
+              const desc = formatRiskEvent(payload.data)
+              showNotification(desc)
+              if (soundEnabledRef.current) playBeep(desc.beep)
+            }
+            return
+          }
         }
       })
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -171,12 +171,50 @@ export type RealtimeOrderbook = {
   timestamp: number
 }
 
+export type TradeEventPayload = {
+  kind: 'open' | 'close'
+  symbolId: number
+  side: 'BUY' | 'SELL'
+  amount: number
+  price: number
+  orderId: number
+  clientOrderId?: string
+  reason?: string
+  positionId?: number
+  timestamp: number
+}
+
+export type RiskEventKind =
+  | 'dd_warning'
+  | 'dd_critical'
+  | 'consecutive_losses'
+  | 'cooldown_started'
+  | 'daily_loss_warning'
+
+export type RiskEventSeverity = 'info' | 'warning' | 'critical'
+
+export type RiskEventPayload = {
+  kind: RiskEventKind
+  severity: RiskEventSeverity
+  message: string
+  balance?: number
+  peak?: number
+  ddPct?: number
+  dailyLoss?: number
+  maxDaily?: number
+  streakLen?: number
+  cooldownTo?: number
+  timestamp: number
+}
+
 export type RealtimeEventMessage =
   | { type: 'ticker'; symbolId: number; data: LiveTicker }
   | { type: 'status'; symbolId?: number; data: StatusResponse }
   | { type: 'config'; symbolId?: number; data: RiskConfig }
   | { type: 'orderbook'; symbolId: number; data: RealtimeOrderbook }
   | { type: 'market_trades'; symbolId: number; data: RealtimeMarketTrades }
+  | { type: 'trade_event'; symbolId: number; data: TradeEventPayload }
+  | { type: 'risk_event'; symbolId?: number; data: RiskEventPayload }
 
 // --- Backtest types ---
 

--- a/frontend/src/lib/notifier.ts
+++ b/frontend/src/lib/notifier.ts
@@ -1,0 +1,92 @@
+// Tiny façade over the browser Notification API + WebAudio beep so callers
+// don't have to repeat the feature-detection / lifecycle dance.
+//
+// Why an in-memory beep instead of a static .mp3? Bundling an audio file is
+// an extra build asset and the user-visible behaviour (a short distinct tone
+// per event severity) doesn't justify it. WebAudio can synthesise a pleasant
+// 100-200ms tone on-the-fly with three different pitches for info/warning/
+// critical. If the user hates it later we can swap in a static asset behind
+// the same playBeep() call without touching consumers.
+
+let cachedAudioCtx: AudioContext | null = null
+
+function getAudioContext(): AudioContext | null {
+  if (typeof window === 'undefined') return null
+  // Some browsers (Safari, older Edge) only expose the prefixed constructor.
+  const Ctor =
+    window.AudioContext ?? (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext
+  if (!Ctor) return null
+  if (!cachedAudioCtx || cachedAudioCtx.state === 'closed') {
+    cachedAudioCtx = new Ctor()
+  }
+  return cachedAudioCtx
+}
+
+export type BeepKind = 'info' | 'success' | 'warning' | 'critical'
+
+const beepFreq: Record<BeepKind, number[]> = {
+  info: [660],
+  success: [880, 1320],
+  warning: [880, 660],
+  critical: [660, 440, 660, 440],
+}
+
+export function playBeep(kind: BeepKind = 'info') {
+  const ctx = getAudioContext()
+  if (!ctx) return
+  // Auto-resume if the AudioContext was suspended (Chrome auto-suspends until
+  // first user gesture; calling resume() inside a click handler upstream is
+  // enough for it to work for the rest of the session).
+  if (ctx.state === 'suspended') {
+    void ctx.resume()
+  }
+  const freqs = beepFreq[kind] ?? beepFreq.info
+  const stepMs = 130
+  const now = ctx.currentTime
+  freqs.forEach((freq, i) => {
+    const osc = ctx.createOscillator()
+    const gain = ctx.createGain()
+    osc.type = 'sine'
+    osc.frequency.value = freq
+    const start = now + (i * stepMs) / 1000
+    const end = start + 0.1
+    gain.gain.setValueAtTime(0.0001, start)
+    gain.gain.exponentialRampToValueAtTime(0.18, start + 0.01)
+    gain.gain.exponentialRampToValueAtTime(0.0001, end)
+    osc.connect(gain).connect(ctx.destination)
+    osc.start(start)
+    osc.stop(end + 0.02)
+  })
+}
+
+export type ShowNotificationOptions = {
+  title: string
+  body: string
+  icon?: string
+  tag?: string // dedupe key — same tag replaces the previous notification
+  silent?: boolean
+}
+
+export function canShowNotification(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    'Notification' in window &&
+    window.Notification.permission === 'granted'
+  )
+}
+
+export function showNotification(opts: ShowNotificationOptions): Notification | null {
+  if (!canShowNotification()) return null
+  try {
+    return new Notification(opts.title, {
+      body: opts.body,
+      icon: opts.icon,
+      tag: opts.tag,
+      // Always silent at the OS level — we play our own beep separately so
+      // the user can mute audio without losing the visual notification.
+      silent: true,
+    })
+  } catch {
+    return null
+  }
+}

--- a/frontend/src/lib/notify-format.test.ts
+++ b/frontend/src/lib/notify-format.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+import { formatRiskEvent, formatTradeEvent } from './notify-format'
+
+describe('formatTradeEvent', () => {
+  it('formats an open BUY into the expected JP title', () => {
+    const desc = formatTradeEvent({
+      kind: 'open',
+      symbolId: 10,
+      side: 'BUY',
+      amount: 0.2,
+      price: 9023.8,
+      orderId: 100,
+      reason: 'trend follow',
+      timestamp: 1,
+    })
+    expect(desc.title).toBe('エントリー 買い 0.2')
+    expect(desc.body).toContain('¥9,024')
+    expect(desc.body).toContain('trend follow')
+    expect(desc.tag).toBe('trade-100')
+    expect(desc.beep).toBe('info')
+  })
+
+  it('uses success beep for close events', () => {
+    const desc = formatTradeEvent({
+      kind: 'close',
+      symbolId: 10,
+      side: 'SELL',
+      amount: 0.2,
+      price: 9100,
+      orderId: 200,
+      timestamp: 1,
+    })
+    expect(desc.title).toBe('クローズ 売り 0.2')
+    expect(desc.beep).toBe('success')
+    // body has no reason, so it should just be the price.
+    expect(desc.body).toBe('¥9,100')
+  })
+})
+
+describe('formatRiskEvent', () => {
+  it('maps dd_critical to critical beep + JP title', () => {
+    const desc = formatRiskEvent({
+      kind: 'dd_critical',
+      severity: 'critical',
+      message: 'MaxDD critical: 19.0%',
+      timestamp: 60_000,
+    })
+    expect(desc.title).toContain('🚨')
+    expect(desc.beep).toBe('critical')
+  })
+
+  it('maps cooldown_started to info beep', () => {
+    const desc = formatRiskEvent({
+      kind: 'cooldown_started',
+      severity: 'info',
+      message: 'cooldown started',
+      timestamp: 60_000,
+    })
+    expect(desc.beep).toBe('info')
+  })
+
+  it('quantises tag by minute so duplicate events within a window dedupe', () => {
+    const a = formatRiskEvent({
+      kind: 'dd_warning',
+      severity: 'warning',
+      message: 'm1',
+      timestamp: 60_000 * 5,
+    })
+    const b = formatRiskEvent({
+      kind: 'dd_warning',
+      severity: 'warning',
+      message: 'm1 again',
+      timestamp: 60_000 * 5 + 30_000,
+    })
+    expect(a.tag).toBe(b.tag)
+  })
+})

--- a/frontend/src/lib/notify-format.ts
+++ b/frontend/src/lib/notify-format.ts
@@ -1,0 +1,64 @@
+// Pure formatters that turn backend payloads into Notification + beep
+// parameters. Kept separate from useTradeNotifications so they can be
+// unit-tested without mocking React / WebSocket / Notification.
+
+import { formatAmount } from './format'
+import type { BeepKind } from './notifier'
+import type { RiskEventPayload, TradeEventPayload } from './api'
+
+export type NotifyDescriptor = {
+  title: string
+  body: string
+  tag: string
+  beep: BeepKind
+}
+
+export function formatTradeEvent(p: TradeEventPayload): NotifyDescriptor {
+  const sideJP = p.side === 'BUY' ? '買い' : '売り'
+  const verb = p.kind === 'open' ? 'エントリー' : 'クローズ'
+  const lot = formatAmount(p.amount)
+  const price = `¥${Math.round(p.price).toLocaleString('ja-JP')}`
+  return {
+    title: `${verb} ${sideJP} ${lot}`,
+    body: `${price}${p.reason ? ` — ${p.reason}` : ''}`,
+    tag: `trade-${p.orderId}`,
+    beep: p.kind === 'open' ? 'info' : 'success',
+  }
+}
+
+export function formatRiskEvent(p: RiskEventPayload): NotifyDescriptor {
+  return {
+    title: riskTitle(p.kind),
+    body: p.message,
+    tag: `risk-${p.kind}-${Math.floor(p.timestamp / 60_000)}`,
+    beep: severityToBeep(p.severity),
+  }
+}
+
+function riskTitle(kind: RiskEventPayload['kind']): string {
+  switch (kind) {
+    case 'dd_warning':
+      return '⚠️ ドローダウン警告'
+    case 'dd_critical':
+      return '🚨 ドローダウン重大'
+    case 'consecutive_losses':
+      return '⚠️ 連敗発生'
+    case 'cooldown_started':
+      return '⏸ クールダウン開始'
+    case 'daily_loss_warning':
+      return '⚠️ 日次損失警告'
+    default:
+      return 'リスクイベント'
+  }
+}
+
+function severityToBeep(s: RiskEventPayload['severity']): BeepKind {
+  switch (s) {
+    case 'critical':
+      return 'critical'
+    case 'warning':
+      return 'warning'
+    default:
+      return 'info'
+  }
+}


### PR DESCRIPTION
## Summary
ブラウザ通知シリーズの 4/5。\`trade_event\` / \`risk_event\` を WebSocket 経由で受け取り、Notification API + WebAudio 合成音で OS 通知を発火する。PR-3 の通知設定が「ON かつ permission=granted」のときだけ実発火。

## 追加

### \`lib/notifier.ts\`
- \`showNotification()\`: Notification API ラッパ。silent=true で OS 音抑制、自前 WebAudio で代替（音 OFF 設定を尊重するため）
- \`playBeep(kind)\`: WebAudio で 100-130ms の合成音 (info/success/warning/critical で pitch 違い)
- AudioContext は遅延生成 + auto-resume

### \`lib/notify-format.ts\`
- \`formatTradeEvent\` / \`formatRiskEvent\` を pure function に分離
- title/body/tag/beep の 4 値を返す descriptor
- vitest 5 ケースで網羅

### \`lib/api.ts\`
- \`RealtimeEventMessage\` に \`trade_event\` / \`risk_event\` を追加
- \`TradeEventPayload\` / \`RiskEventPayload\` を export

### \`hooks/useMarketTickerStream.ts\`
- \`useNotificationSettings\` から \`shouldFire\` / \`soundEnabled\` を ref 経由で参照（toggle 変更で WS 再接続しない設計）
- \`trade_event\`: trades/positions/pnl invalidate + 通知発火
- \`risk_event\`: status invalidate + 通知発火

## Test plan
- [x] vitest 全 47 件緑（新規 5 件含む）
- [x] \`pnpm build\` 緑
- [ ] merge 後に通知 ON → 模擬トレード発生時に OS 通知 + 効果音

## 残り
- PR-5: Service Worker で background 通知

🤖 Generated with [Claude Code](https://claude.com/claude-code)