### PR TITLE
feat(notify): PR-5/5 service worker による background 通知

### DIFF
--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,0 +1,68 @@
+/* eslint-disable no-restricted-globals */
+// Service worker for background notifications. Receives notification
+// descriptors from the main thread via postMessage and calls
+// self.registration.showNotification(). Lives outside the bundler so it
+// can be registered at /sw.js without import-graph rewrites.
+//
+// Why postMessage instead of opening a WebSocket inside the SW? Browsers
+// aggressively reclaim SW execution time; long-lived connections inside the
+// SW thrash and eventually drop. The main thread (or page) is responsible
+// for keeping the WS open while it can — the SW only handles the actual
+// notification surface so notifications keep firing even after the page is
+// hidden but before the OS reclaims the SW.
+
+const NOTIFICATION_TAG_PREFIX = 'rakuten-bot-notify-'
+
+self.addEventListener('install', (event) => {
+  // Activate immediately so the first page load (with a freshly registered
+  // SW) doesn't have to wait for the next reload to start receiving messages.
+  event.waitUntil(self.skipWaiting())
+})
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(self.clients.claim())
+})
+
+self.addEventListener('message', (event) => {
+  const data = event.data
+  if (!data || typeof data !== 'object') return
+  if (data.type !== 'show-notification') return
+  const desc = data.payload
+  if (!desc || typeof desc !== 'object') return
+  if (typeof desc.title !== 'string') return
+
+  event.waitUntil(
+    self.registration.showNotification(desc.title, {
+      body: desc.body ?? '',
+      tag: NOTIFICATION_TAG_PREFIX + (desc.tag ?? ''),
+      icon: desc.icon ?? '/logo192.png',
+      badge: '/logo192.png',
+      silent: true, // we play our own beep on the main thread when audible
+      requireInteraction: desc.requireInteraction === true,
+      data: { url: desc.url ?? '/' },
+    }),
+  )
+})
+
+// Click on a notification → focus an existing tab if any, else open a new one.
+// This is the "user clicks the OS notification" path; without it the
+// notification body just disappears.
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close()
+  const targetUrl = (event.notification.data && event.notification.data.url) || '/'
+  event.waitUntil(
+    self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then((clientList) => {
+      for (const client of clientList) {
+        if ('focus' in client) {
+          if (client.url.endsWith(targetUrl) || targetUrl === '/') {
+            return client.focus()
+          }
+        }
+      }
+      if (self.clients.openWindow) {
+        return self.clients.openWindow(targetUrl)
+      }
+      return null
+    }),
+  )
+})

--- a/frontend/src/hooks/useNotificationSettings.ts
+++ b/frontend/src/hooks/useNotificationSettings.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from 'react'
+import { ensureServiceWorker } from '../lib/sw-register'
 
 // Notification settings live in localStorage so the user's preference survives
 // page reloads and isn't tied to React state alone. The hook is intentionally
@@ -90,11 +91,23 @@ export function useNotificationSettings() {
         if (current === 'default') {
           await requestPermission()
         }
+        // Register the service worker the moment the user opts in so the
+        // hidden-tab path is ready before the first event fires. Failure is
+        // not fatal — the foreground path still works.
+        void ensureServiceWorker()
       }
       setSettings((prev) => ({ ...prev, enabled: next }))
     },
     [requestPermission],
   )
+
+  // Re-register on every page load when the user is already opted in, so a
+  // browser update or cache eviction that dropped the SW heals itself.
+  useEffect(() => {
+    if (settings.enabled) {
+      void ensureServiceWorker()
+    }
+  }, [settings.enabled])
 
   const setSoundEnabled = useCallback((next: boolean) => {
     setSettings((prev) => ({ ...prev, soundEnabled: next }))

--- a/frontend/src/lib/notifier.ts
+++ b/frontend/src/lib/notifier.ts
@@ -75,15 +75,45 @@ export function canShowNotification(): boolean {
   )
 }
 
+import { postToServiceWorker } from './sw-register'
+
+// showNotification picks the right surface based on tab visibility:
+//  - Page is visible: use the in-page Notification constructor (synchronous
+//    return so callers can read the Notification handle if needed).
+//  - Page is hidden / minimised: route through the Service Worker so the
+//    notification fires even when the tab isn't running JS. This is what
+//    keeps notifications coming after the user switches to another window.
+// SW path is best-effort — if the SW failed to register (older browsers),
+// we silently fall back to the foreground constructor.
 export function showNotification(opts: ShowNotificationOptions): Notification | null {
   if (!canShowNotification()) return null
+
+  const isHidden = typeof document !== 'undefined' && document.visibilityState === 'hidden'
+  if (isHidden) {
+    void postToServiceWorker({
+      type: 'show-notification',
+      payload: {
+        title: opts.title,
+        body: opts.body,
+        icon: opts.icon,
+        tag: opts.tag,
+      },
+    }).then((delivered) => {
+      // If the SW couldn't take the message, fall back so the user still
+      // sees something while the page is hidden but the SW is asleep.
+      if (!delivered) tryForegroundNotification(opts)
+    })
+    return null
+  }
+  return tryForegroundNotification(opts)
+}
+
+function tryForegroundNotification(opts: ShowNotificationOptions): Notification | null {
   try {
     return new Notification(opts.title, {
       body: opts.body,
       icon: opts.icon,
       tag: opts.tag,
-      // Always silent at the OS level — we play our own beep separately so
-      // the user can mute audio without losing the visual notification.
       silent: true,
     })
   } catch {

--- a/frontend/src/lib/sw-register.ts
+++ b/frontend/src/lib/sw-register.ts
@@ -1,0 +1,51 @@
+// Tiny façade over navigator.serviceWorker so the rest of the app doesn't
+// repeat the feature-detect dance. The SW lives at /sw.js — the public/
+// folder copy is served as-is by Vite + the production server.
+//
+// Registration is fire-and-forget; failures only matter when the user has
+// notifications turned on, in which case useNotificationSettings will fall
+// back to the foreground path.
+
+let registration: ServiceWorkerRegistration | null = null
+let registering: Promise<ServiceWorkerRegistration | null> | null = null
+
+export function isServiceWorkerSupported(): boolean {
+  return typeof navigator !== 'undefined' && 'serviceWorker' in navigator
+}
+
+export async function ensureServiceWorker(): Promise<ServiceWorkerRegistration | null> {
+  if (!isServiceWorkerSupported()) return null
+  if (registration) return registration
+  if (registering) return registering
+  registering = navigator.serviceWorker
+    .register('/sw.js')
+    .then((reg) => {
+      registration = reg
+      return reg
+    })
+    .catch((err) => {
+      console.warn('[sw-register] registration failed', err)
+      return null
+    })
+    .finally(() => {
+      registering = null
+    })
+  return registering
+}
+
+export async function postToServiceWorker(message: unknown): Promise<boolean> {
+  const reg = await ensureServiceWorker()
+  if (!reg) return false
+  // active is the controlling worker. waiting/installing are not yet ready
+  // to accept messages, so we fall back to navigator.serviceWorker.controller
+  // for the very first registration before activate fires.
+  const target = reg.active || navigator.serviceWorker.controller
+  if (!target) return false
+  try {
+    target.postMessage(message)
+    return true
+  } catch (err) {
+    console.warn('[sw-register] postMessage failed', err)
+    return false
+  }
+}


### PR DESCRIPTION
## Summary
ブラウザ通知シリーズの 5/5 (最終)。タブが非可視 (バックグラウンド・最小化・別アプリ前面) でも通知を発火できるよう、Service Worker フォールバックを追加。

## 設計 (方式 Y: SW + main thread WS)
メイン thread が WS を維持し、タブが非可視になった瞬間から通知発火だけを SW にバトンタッチ。

| 状態 | 通知 |
|---|---|
| タブ可視 | foreground Notification ctor で発火 |
| **タブ非可視・ブラウザ起動中** | **SW 経由で発火** ✅ |
| ブラウザ完全終了 | 発火しない (Y 方式の制約) |
| SW 未登録/古いブラウザ | foreground fallback |

ブラウザ完全終了後の配信は Web Push (VAPID) が必要 — 必要なら別シリーズで実装。

## 追加
- \`frontend/public/sw.js\`: skipWaiting + clients.claim, 'show-notification' postMessage リスナー, notificationclick で既存タブ focus
- \`frontend/src/lib/sw-register.ts\`: ensureServiceWorker() / postToServiceWorker() の薄いラッパ
- \`frontend/src/lib/notifier.ts\`: \`document.visibilityState === 'hidden'\` のとき SW 経由で投げる分岐を追加
- \`frontend/src/hooks/useNotificationSettings.ts\`: \`setEnabled(true)\` で ensureServiceWorker(), enabled な状態の再ロードでも自動再登録

## Test plan
- [x] vitest 全 47 件緑
- [x] \`pnpm build\` 緑
- [ ] merge 後にブラウザを最小化 → トレード発生で通知が来ることを確認
- [ ] ブラウザ完全終了 → 通知が来ないことを確認 (Y 方式の前提を再確認)

## シリーズ全体
| PR | 内容 | 状態 |
|---|---|---|
| #160 | PR-1: backend trade_event | ✅ merged |
| #161 | PR-2: backend risk_event | ✅ merged |
| #162 | PR-3: frontend 通知設定 UI | ✅ merged |
| #163 | PR-4: frontend foreground 通知 | ✅ merged |
| **本PR** | **PR-5: SW background 通知** | **review待ち** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)