### PR TITLE
feat(fe): ダッシュボードに手動取引カードを追加

### DIFF
--- a/frontend/src/components/ManualTradeCard.tsx
+++ b/frontend/src/components/ManualTradeCard.tsx
@@ -1,0 +1,209 @@
+import { useState } from 'react'
+import { useManualOrder } from '../hooks/useManualOrder'
+
+type ManualTradeCardProps = {
+  symbolId: number
+  currencyPair?: string
+  // Venue lot step (e.g. 0.1 for LTC). Falls back to 0.1 when unknown so the
+  // input never goes below the venue minimum for crypto symbols.
+  lotStep?: number
+  minLot?: number
+}
+
+const DEFAULT_LOT_STEP = 0.1
+const DEFAULT_MIN_LOT = 0.1
+
+// Minimal manual-order panel. We intentionally keep this simple (no leverage
+// selector, no limit-price input — backend only accepts MARKET right now)
+// so the user has a fast path to "open one position now / close it now"
+// without going through the auto-trader. A confirmation modal guards against
+// fat-fingered double-clicks since these are real money trades.
+export function ManualTradeCard({ symbolId, currencyPair, lotStep, minLot }: ManualTradeCardProps) {
+  const step = lotStep ?? DEFAULT_LOT_STEP
+  const min = minLot ?? DEFAULT_MIN_LOT
+  const [amount, setAmount] = useState<number>(min)
+  const [pending, setPending] = useState<{ side: 'BUY' | 'SELL'; amount: number } | null>(null)
+  const [feedback, setFeedback] = useState<{ kind: 'ok' | 'err'; message: string } | null>(null)
+  const order = useManualOrder()
+
+  const submit = (side: 'BUY' | 'SELL') => {
+    setFeedback(null)
+    setPending({ side, amount })
+  }
+
+  const confirm = () => {
+    if (!pending) return
+    const { side, amount: amt } = pending
+    setPending(null)
+    order.mutate(
+      { symbolId, side, amount: amt },
+      {
+        onSuccess: (res) => {
+          if (res.executed) {
+            setFeedback({ kind: 'ok', message: `${side} ${amt} 約定 (orderId=${res.orderId})` })
+          } else {
+            setFeedback({ kind: 'err', message: res.reason || '約定しませんでした' })
+          }
+        },
+        onError: (err) => {
+          setFeedback({ kind: 'err', message: err.message })
+        },
+      },
+    )
+  }
+
+  return (
+    <div className="rounded-3xl border border-white/8 bg-bg-card/90 p-5 shadow-[0_12px_40px_rgba(0,0,0,0.22)]">
+      <div className="flex items-center justify-between">
+        <div>
+          <p className="text-xs uppercase tracking-[0.28em] text-text-secondary">Manual Trade</p>
+          <h2 className="mt-2 text-xl font-semibold text-white">手動取引</h2>
+        </div>
+        <span className="rounded-full bg-white/8 px-2.5 py-1 font-mono text-[11px] text-slate-300">
+          {currencyPair?.replace('_', '/') ?? '—'}
+        </span>
+      </div>
+
+      <label className="mt-4 block text-xs uppercase tracking-wide text-text-secondary">
+        数量 (LTC)
+        <div className="mt-2 flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => setAmount((a) => Math.max(min, +(a - step).toFixed(2)))}
+            className="h-8 w-8 rounded-full border border-white/15 text-slate-200 hover:bg-white/10"
+          >
+            −
+          </button>
+          <input
+            type="number"
+            min={min}
+            step={step}
+            value={amount}
+            onChange={(e) => {
+              const v = parseFloat(e.target.value)
+              if (Number.isFinite(v)) setAmount(v)
+            }}
+            className="flex-1 rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-center text-base font-semibold text-white focus:border-accent-green/50 focus:outline-none"
+          />
+          <button
+            type="button"
+            onClick={() => setAmount((a) => +(a + step).toFixed(2))}
+            className="h-8 w-8 rounded-full border border-white/15 text-slate-200 hover:bg-white/10"
+          >
+            +
+          </button>
+        </div>
+      </label>
+
+      <div className="mt-4 grid grid-cols-2 gap-3">
+        <button
+          type="button"
+          onClick={() => submit('BUY')}
+          disabled={order.isPending || amount < min}
+          className="rounded-2xl bg-accent-green/90 px-4 py-3 text-base font-semibold text-bg-dark transition hover:bg-accent-green disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          BUY (買い)
+        </button>
+        <button
+          type="button"
+          onClick={() => submit('SELL')}
+          disabled={order.isPending || amount < min}
+          className="rounded-2xl bg-accent-red/90 px-4 py-3 text-base font-semibold text-white transition hover:bg-accent-red disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          SELL (売り)
+        </button>
+      </div>
+
+      {feedback && (
+        <p
+          className={`mt-3 rounded-xl px-3 py-2 text-xs ${
+            feedback.kind === 'ok'
+              ? 'bg-accent-green/10 text-accent-green'
+              : 'bg-accent-red/10 text-accent-red'
+          }`}
+        >
+          {feedback.message}
+        </p>
+      )}
+
+      <p className="mt-3 text-[11px] leading-relaxed text-text-secondary">
+        成行注文のみ。送信後は確認ダイアログを出します。約定するとブラウザ通知 (有効時) と履歴・ポジションが自動で更新されます。
+      </p>
+
+      {pending && (
+        <ConfirmDialog
+          side={pending.side}
+          amount={pending.amount}
+          currencyPair={currencyPair}
+          onCancel={() => setPending(null)}
+          onConfirm={confirm}
+          pending={order.isPending}
+        />
+      )}
+    </div>
+  )
+}
+
+function ConfirmDialog({
+  side,
+  amount,
+  currencyPair,
+  onCancel,
+  onConfirm,
+  pending,
+}: {
+  side: 'BUY' | 'SELL'
+  amount: number
+  currencyPair?: string
+  onCancel: () => void
+  onConfirm: () => void
+  pending: boolean
+}) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 px-4 backdrop-blur-sm">
+      <div className="w-full max-w-sm rounded-3xl border border-white/10 bg-bg-card p-6 shadow-[0_30px_80px_rgba(0,0,0,0.5)]">
+        <h3 className="text-lg font-semibold text-white">注文を送信しますか？</h3>
+        <dl className="mt-4 space-y-2 text-sm">
+          <Row label="銘柄" value={currencyPair?.replace('_', '/') ?? '—'} />
+          <Row label="方向" value={side === 'BUY' ? '買い (BUY)' : '売り (SELL)'} />
+          <Row label="数量" value={`${amount} LTC`} />
+          <Row label="種別" value="成行 (MARKET)" />
+        </dl>
+        <p className="mt-4 text-xs text-text-secondary">
+          実際の楽天ウォレット証拠金取引口座に注文が送信されます。
+        </p>
+        <div className="mt-5 grid grid-cols-2 gap-3">
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={pending}
+            className="rounded-2xl border border-white/15 bg-white/5 px-4 py-2.5 text-sm font-semibold text-slate-200 hover:bg-white/10 disabled:opacity-50"
+          >
+            キャンセル
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={pending}
+            className={`rounded-2xl px-4 py-2.5 text-sm font-semibold transition disabled:opacity-50 ${
+              side === 'BUY'
+                ? 'bg-accent-green text-bg-dark hover:brightness-110'
+                : 'bg-accent-red text-white hover:brightness-110'
+            }`}
+          >
+            {pending ? '送信中...' : '送信する'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function Row({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-center justify-between">
+      <dt className="text-text-secondary">{label}</dt>
+      <dd className="font-mono text-white">{value}</dd>
+    </div>
+  )
+}

--- a/frontend/src/hooks/useManualOrder.ts
+++ b/frontend/src/hooks/useManualOrder.ts
@@ -1,0 +1,33 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { createManualOrder, type ManualOrderRequest, type ManualOrderResponse } from '../lib/api'
+
+// generateClientOrderId returns a per-click idempotency key. Backend uses this
+// to dedupe accidental double-submits (already wired via clientOrderRepo).
+function generateClientOrderId(side: string): string {
+  const t = Date.now()
+  const r = Math.random().toString(36).slice(2, 8)
+  return `manual-${side.toLowerCase()}-${t}-${r}`
+}
+
+type ManualOrderInput = Omit<ManualOrderRequest, 'orderType' | 'clientOrderId'>
+
+export function useManualOrder() {
+  const queryClient = useQueryClient()
+  return useMutation<ManualOrderResponse, Error, ManualOrderInput>({
+    mutationFn: (input) =>
+      createManualOrder({
+        ...input,
+        orderType: 'MARKET',
+        clientOrderId: generateClientOrderId(input.side),
+      }),
+    onSuccess: () => {
+      // The backend already pushes a trade_event over the realtime hub, but
+      // the order state behind /trades and /positions takes a beat to settle
+      // through the rakuten REST round-trip. Force-invalidate so the user
+      // sees the new position/row even if the WS push lost the race.
+      void queryClient.invalidateQueries({ queryKey: ['positions'] })
+      void queryClient.invalidateQueries({ queryKey: ['trades'] })
+      void queryClient.invalidateQueries({ queryKey: ['pnl'] })
+    },
+  })
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -595,6 +595,26 @@ export async function sendApi<TResponse, TBody = undefined>(
   return res.json()
 }
 
+export type ManualOrderRequest = {
+  symbolId: number
+  side: 'BUY' | 'SELL'
+  amount: number
+  orderType: 'MARKET'
+  clientOrderId: string
+}
+
+export type ManualOrderResponse = {
+  clientOrderId: string
+  executed: boolean
+  orderId?: number
+  reason?: string
+  duplicate?: boolean
+}
+
+export async function createManualOrder(req: ManualOrderRequest): Promise<ManualOrderResponse> {
+  return sendApi<ManualOrderResponse, ManualOrderRequest>('/orders', 'POST', req)
+}
+
 export function buildRealtimeWebSocketUrl(symbolId: number): string {
   if (typeof window === 'undefined') {
     return `${WS_BASE}/ws?symbolId=${symbolId}`

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -6,6 +6,7 @@ import { IndicatorPanel } from '../components/IndicatorPanel'
 import { PositionPanel } from '../components/PositionPanel'
 import { BotControlCard } from '../components/BotControlCard'
 import { LiveTickerCard } from '../components/LiveTickerCard'
+import { ManualTradeCard } from '../components/ManualTradeCard'
 import { useStatus } from '../hooks/useStatus'
 import { usePnl } from '../hooks/usePnl'
 import { useStrategy } from '../hooks/useStrategy'
@@ -112,6 +113,12 @@ function Dashboard() {
             onStart={() => startBot.mutate()}
             onStop={() => stopBot.mutate()}
             isPending={startBot.isPending || stopBot.isPending}
+          />
+          <ManualTradeCard
+            symbolId={symbolId}
+            currencyPair={currentSymbol?.currencyPair}
+            lotStep={currentSymbol?.baseStepAmount}
+            minLot={currentSymbol?.minOrderAmount}
           />
           <IndicatorPanel indicators={indicators} />
           <PositionPanel positions={positions} />


### PR DESCRIPTION
## Summary
\`POST /api/v1/orders\` は backend に既に存在したが UI から呼ぶ手段が無かったので、ダッシュボードに「手動取引」カードを新設。

## 機能
- 数量入力 (LTC, venue lot step 0.1 でインクリ／デクリ)
- BUY (緑) / SELL (赤) の 2 ボタン
- 送信前に確認ダイアログ (誤クリック防止)
- 約定すると trades/positions/pnl のキャッシュを invalidate → 即座に更新
- 約定すると backend が trade_event を push → 通知シリーズ (#160-#164) 経由で OS 通知 + 効果音
- 成功/失敗を色分けした feedback メッセージ

## 追加
- \`lib/api.ts\`: \`createManualOrder\` + \`ManualOrderRequest\`/\`ManualOrderResponse\` 型
- \`hooks/useManualOrder.ts\`: TanStack Query mutation, \`clientOrderId\` は \`side+timestamp+random\` で生成 (idempotency)
- \`components/ManualTradeCard.tsx\`: カード + 確認モーダル
- \`routes/index.tsx\`: BotControlCard と IndicatorPanel の間に配置

## 注文仕様
- 種別: 成行 (MARKET) のみ
- clientOrderId: backend の clientOrderRepo で重複検知
- 価格: 0 を渡すと backend 側で現在価格で約定

## Test plan
- [x] \`pnpm test\` 全 47 件緑
- [x] \`pnpm build\` 緑
- [ ] merge 後にダッシュボードで BUY/SELL → 確認ダイアログ → 送信 → 通知 + ポジション反映を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)