### PR TITLE
feat: バックテスト用 CSV の自動更新 + チャート JST 表示 + DB マウント構成見直し

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,17 @@
 - Frontend: `localhost:33000` (コンテナ内 3000)
 - API ベース URL: `http://localhost:38080/api/v1`
 
+### サービス構成
+
+| サービス | 役割 | マウント |
+|---|---|---|
+| `backend` | Go API サーバ + EventDrivenPipeline | CSV: `./backend/data` (bind), DB: `backend-db` (named volume), `backend/profiles` (ro) |
+| `frontend` | Vite 開発サーバ | `./frontend` (bind) |
+| `csv-updater` | バックテスト用 CSV を毎時 1 回自動更新する cron コンテナ (alpine + crond) | `./backend/data` (bind) |
+
+- DB (`trading.db`) は **named volume** に隔離。Docker Desktop の VirtioFS で SQLite WAL が壊れる事象を回避するため、bind mount してはいけない。
+- CSV は **bind mount** なのでホスト側で直接読み書き可能。`csv-updater` がここに書き込む。
+
 ## Development
 
 - コード変更後は `docker compose up --build -d` で再ビルドして動作確認。

--- a/backend/Dockerfile.csv-updater
+++ b/backend/Dockerfile.csv-updater
@@ -1,0 +1,19 @@
+FROM alpine:3.20
+
+RUN apk add --no-cache bash curl jq tzdata coreutils gawk
+
+ENV TZ=Asia/Tokyo
+ENV CSV_OUT_DIR=/app/backend/data
+
+WORKDIR /app/backend
+
+COPY scripts/fetch_incremental.sh /app/backend/scripts/fetch_incremental.sh
+COPY scripts/csv-updater-entrypoint.sh /usr/local/bin/csv-updater-entrypoint.sh
+RUN chmod +x /app/backend/scripts/fetch_incremental.sh /usr/local/bin/csv-updater-entrypoint.sh
+
+# crond reads /etc/crontabs/root by default in alpine.
+# Run hourly at minute 5 (avoid edge of API rate windows on the dot).
+RUN printf '5 * * * * /app/backend/scripts/fetch_incremental.sh >> /proc/1/fd/1 2>&1\n' \
+  > /etc/crontabs/root
+
+ENTRYPOINT ["/usr/local/bin/csv-updater-entrypoint.sh"]

--- a/backend/internal/interfaces/api/handler/candle.go
+++ b/backend/internal/interfaces/api/handler/candle.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/infrastructure/rakuten"
@@ -17,6 +18,16 @@ var allowedIntervals = map[string]struct{}{
 	"PT1H":  {},
 	"P1D":   {},
 	"P1W":   {},
+}
+
+// intervalDurations は各 interval の 1 本ぶんの長さ。最新足までの遅延判定に使う。
+var intervalDurations = map[string]time.Duration{
+	"PT1M":  time.Minute,
+	"PT5M":  5 * time.Minute,
+	"PT15M": 15 * time.Minute,
+	"PT1H":  time.Hour,
+	"P1D":   24 * time.Hour,
+	"P1W":   7 * 24 * time.Hour,
 }
 
 type CandleHandler struct {
@@ -63,10 +74,20 @@ func (h *CandleHandler) GetCandles(c *gin.Context) {
 	}
 
 	// DB のデータが不足していれば楽天APIからオンデマンド取得して補充する。
-	// - before なし: DB が空なら最新データを取得
+	// - before なし: DB が空、または最新足が古い (interval × 2 以上前) ならフェッチ
 	// - before あり: DB が limit 未満なら dateTo=before で過去データを取得
+	staleThreshold := 2 * intervalDurations[interval]
+	stale := false
+	if before == 0 && len(candles) > 0 && staleThreshold > 0 {
+		// candles は GetCandles の段階では DESC（先頭が最新）で返る。
+		latestMs := candles[0].Time
+		nowMs := time.Now().UnixMilli()
+		if nowMs-latestMs > staleThreshold.Milliseconds() {
+			stale = true
+		}
+	}
 	needFetch := h.restClient != nil &&
-		(len(candles) == 0 || (before > 0 && len(candles) < limit))
+		(len(candles) == 0 || stale || (before > 0 && len(candles) < limit))
 	if needFetch {
 		var dateFrom, dateTo *int64
 		if before > 0 {

--- a/backend/scripts/csv-updater-entrypoint.sh
+++ b/backend/scripts/csv-updater-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Entry point for the csv-updater container.
+#  - Optionally runs the fetch script once on startup (RUN_ON_START=1, default)
+#    so a freshly started container catches up before waiting for the next cron
+#    tick.
+#  - Then hands off to crond running in the foreground.
+
+set -euo pipefail
+
+if [[ "${RUN_ON_START:-1}" == "1" ]]; then
+  echo "[csv-updater] running initial fetch on startup..."
+  /app/backend/scripts/fetch_incremental.sh || echo "[csv-updater] initial fetch failed (continuing)"
+fi
+
+echo "[csv-updater] starting crond (foreground)"
+exec crond -f -l 8

--- a/backend/scripts/fetch_incremental.sh
+++ b/backend/scripts/fetch_incremental.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# Incrementally append latest candlestick data to the CSV files used by the
+# backtest engine. Designed to run inside the csv-updater container, which
+# bind-mounts ./backend/data so the host filesystem stays the source of truth.
+#
+# For each (symbol, interval) we read max(time) from the existing CSV, page
+# forward via Rakuten's candlestick API (500 bars per call), then append +
+# dedupe + sort by numeric time. The leading-quote-aware sort key avoids the
+# `sort -u` collapse bug that earlier truncated files to one row.
+
+set -euo pipefail
+
+BASE_URL="${RAKUTEN_API_BASE:-https://exchange.rakuten-wallet.co.jp/api/v1/candlestick}"
+OUT_DIR="${CSV_OUT_DIR:-/app/backend/data}"
+
+SYMBOL_PAIRS=(
+  "BTC_JPY:7"
+  "ETH_JPY:8"
+  "BCH_JPY:9"
+  "LTC_JPY:10"
+  "XRP_JPY:11"
+  "ADA_JPY:14"
+  "DOT_JPY:15"
+  "XLM_JPY:16"
+)
+
+INTERVALS="PT1M PT5M PT15M PT1H P1D P1W"
+
+log() { printf '[csv-updater %s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"; }
+
+now_ms() { echo "$(($(date +%s) * 1000))"; }
+
+csv_max_time() {
+  local file="$1"
+  if [[ ! -s "$file" ]]; then
+    echo 0
+    return
+  fi
+  awk -F, 'NR==1{next}{gsub(/"/,"",$4); t=$4+0; if(t>m) m=t} END{print m+0}' "$file"
+}
+
+fetch_one() {
+  local symbol="$1" sid="$2" interval="$3"
+  local out="$OUT_DIR/candles_${symbol}_${interval}.csv"
+
+  if [[ ! -f "$out" ]]; then
+    log "skip $symbol $interval: file not found ($out)"
+    return
+  fi
+
+  local from_ms
+  from_ms="$(csv_max_time "$out")"
+  if [[ "$from_ms" -le 0 ]]; then
+    log "skip $symbol $interval: cannot determine start"
+    return
+  fi
+  from_ms=$((from_ms + 1))
+
+  local target_ms cur_to pages fetched
+  target_ms="$(now_ms)"
+  cur_to="$target_ms"
+  pages=0
+  fetched=0
+
+  if (( from_ms >= target_ms )); then
+    log "ok   $symbol $interval: already up to date"
+    return
+  fi
+
+  local tmp_new
+  tmp_new="$(mktemp)"
+
+  while true; do
+    local url="${BASE_URL}?symbolId=${sid}&candlestickType=${interval}&dateFrom=${from_ms}&dateTo=${cur_to}"
+    local json
+    json="$(curl -sS "$url")" || { log "err  $symbol $interval: curl failed"; break; }
+
+    local len
+    len="$(jq '.candlesticks | length' <<<"$json" 2>/dev/null || echo 0)"
+    if [[ -z "$len" || "$len" == "null" || "$len" == "0" ]]; then
+      break
+    fi
+
+    jq -r --arg symbol "$symbol" --arg sid "$sid" --arg interval "$interval" '
+      .candlesticks[]
+      | [$symbol, $sid, $interval, (.time|tostring), (.open|tostring), (.high|tostring), (.low|tostring), (.close|tostring), (.volume|tostring)]
+      | @csv
+    ' <<<"$json" >>"$tmp_new"
+
+    fetched=$((fetched + len))
+    pages=$((pages + 1))
+
+    local min_ts
+    min_ts="$(jq '[.candlesticks[].time] | min' <<<"$json")"
+
+    if (( len < 500 )); then break; fi
+    if (( min_ts <= from_ms )); then break; fi
+    cur_to=$((min_ts - 1))
+    sleep 0.15
+  done
+
+  if [[ ! -s "$tmp_new" ]]; then
+    log "ok   $symbol $interval: no new bars"
+    rm -f "$tmp_new"
+    return
+  fi
+
+  # Merge: existing data minus header + new rows, dedupe by numeric time, sort.
+  local tmp_merged
+  tmp_merged="$(mktemp)"
+  {
+    tail -n +2 "$out"
+    cat "$tmp_new"
+  } | awk -F, '{ key=$4; gsub(/"/,"",key); printf "%s\t%s\n", key+0, $0 }' \
+    | sort -t$'\t' -k1,1n -u \
+    | cut -f2- >"$tmp_merged"
+
+  {
+    echo "symbol,symbol_id,interval,time,open,high,low,close,volume"
+    cat "$tmp_merged"
+  } >"$out"
+
+  rm -f "$tmp_new" "$tmp_merged"
+
+  local new_max_iso new_max_ms
+  new_max_ms="$(csv_max_time "$out")"
+  new_max_iso="$(date -u -d "@$((new_max_ms / 1000))" '+%Y-%m-%d %H:%M:%S UTC' 2>/dev/null || echo "$new_max_ms")"
+  log "ok   $symbol $interval: +${fetched} rows (pages=${pages}) latest=${new_max_iso}"
+}
+
+log "begin csv update OUT_DIR=$OUT_DIR"
+
+for pair in "${SYMBOL_PAIRS[@]}"; do
+  symbol="${pair%%:*}"
+  sid="${pair#*:}"
+  for interval in $INTERVALS; do
+    fetch_one "$symbol" "$sid" "$interval"
+  done
+done
+
+log "done"

--- a/compose.yaml
+++ b/compose.yaml
@@ -7,11 +7,12 @@ services:
       - ./backend/.env
     environment:
       SERVER_PORT: "8080"
-      DATABASE_PATH: /app/backend/data/trading.db
+      DATABASE_PATH: /app/backend/db/trading.db
     ports:
       - "38080:8080"
     volumes:
-      - backend-data:/app/backend/data
+      - ./backend/data:/app/backend/data
+      - backend-db:/app/backend/db
       - ./backend/profiles:/app/backend/profiles:ro
     restart: unless-stopped
     healthcheck:
@@ -38,4 +39,4 @@ services:
     restart: unless-stopped
 
 volumes:
-  backend-data:
+  backend-db:

--- a/compose.yaml
+++ b/compose.yaml
@@ -38,5 +38,17 @@ services:
       - /app/frontend/node_modules
     restart: unless-stopped
 
+  csv-updater:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile.csv-updater
+    volumes:
+      - ./backend/data:/app/backend/data
+    environment:
+      TZ: Asia/Tokyo
+      RUN_ON_START: "1"
+    restart: unless-stopped
+
 volumes:
   backend-db:
+

--- a/docs/backtest-csv-data-guide.md
+++ b/docs/backtest-csv-data-guide.md
@@ -2,12 +2,34 @@
 
 バックテスト実行 (`POST /api/v1/backtest/run`) で使う CSV の作成手順。
 
+## 0. 自動更新 (推奨)
+
+通常は **`csv-updater` コンテナ**が `backend/data/candles_*.csv` を毎時 5 分に自動で増分更新する。
+ホストの `backend/data/` を bind mount しているので、コンテナ側の更新がそのままバックテストに反映される。
+
+```bash
+# 起動状況
+docker compose ps csv-updater
+
+# ログ
+docker compose logs -f csv-updater
+
+# 手動で即時更新
+docker compose exec csv-updater /app/backend/scripts/fetch_incremental.sh
+```
+
+cron 式は `backend/Dockerfile.csv-updater` 内 (`5 * * * *`)。対象シンボルと足は
+`backend/scripts/fetch_incremental.sh` の `SYMBOL_PAIRS` / `INTERVALS` を編集する。
+
+以降の手順 (1 〜 8) は **新しいシンボル/足を追加する初回**、または **任意の期間を一括取得し直したい**ときの参考手順。
+
 ## 1. 前提
 
 - 作業ディレクトリ: リポジトリルート
 - 出力先（ホスト）: `backend/data/`
 - API 実行時に参照するパス: `data/candles_XXX_YYY.csv`
   - 例: `data/candles_LTC_JPY_PT15M.csv`
+- `csv-updater` は **CSV が既に存在する (symbol, interval) ペアにのみ追記**する。新しい組み合わせを追加するときは下記のページング取得スクリプトで初回ファイルを作ってから cron に任せる。
 
 ## 2. まずシンボル ID を確認する
 
@@ -113,14 +135,9 @@ awk -F, 'NR==1{next} {gsub(/"/,"",$4); t=$4+0; if (NR>2 && t<prev) dec++; prev=t
 
 - `decreases=0` なら時刻列は昇順で問題なし。
 
-## 6. コンテナへ反映（API から参照させる）
+## 6. コンテナへ反映
 
-`compose.yaml` では backend は named volume (`backend-data`) を使うため、必要ならコピーする。
-
-```bash
-docker compose cp backend/data/candles_LTC_JPY_PT15M.csv backend:/app/backend/data/candles_LTC_JPY_PT15M.csv
-docker compose cp backend/data/candles_LTC_JPY_PT1H.csv  backend:/app/backend/data/candles_LTC_JPY_PT1H.csv
-```
+`compose.yaml` の backend は `./backend/data` を bind mount しているので、ホストでファイルを更新するだけで即コンテナに反映される。コピー操作は不要。
 
 確認:
 

--- a/frontend/src/components/CandlestickChart.tsx
+++ b/frontend/src/components/CandlestickChart.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useRef, useState, useCallback, useMemo } from 'react'
-import { createChart, CandlestickSeries, LineSeries, type IChartApi, type ISeriesApi, type CandlestickData, type LineData, type Time, type SeriesType, type ISeriesPrimitive, type SeriesAttachedParameter, type IPrimitivePaneView, type IPrimitivePaneRenderer } from 'lightweight-charts'
+import { createChart, CandlestickSeries, LineSeries, TickMarkType, type IChartApi, type ISeriesApi, type CandlestickData, type LineData, type Time, type SeriesType, type ISeriesPrimitive, type SeriesAttachedParameter, type IPrimitivePaneView, type IPrimitivePaneRenderer } from 'lightweight-charts'
 import type { CanvasRenderingTarget2D } from 'fancy-canvas'
 import { useCandles, type CandleInterval } from '../hooks/useCandles'
+import { formatChartTickJst, formatChartTimeJst } from '../lib/format'
 import { ADXChart } from './ADXChart'
 import { MACDChart } from './MACDChart'
 import { RSIChart } from './RSIChart'
@@ -438,6 +439,18 @@ export function CandlestickChart({ symbolId }: CandlestickChartProps) {
       timeScale: {
         timeVisible: true,
         secondsVisible: false,
+        tickMarkFormatter: (time: Time, tickMarkType: TickMarkType) => {
+          const seconds = time as number
+          const showDate =
+            tickMarkType === TickMarkType.Year ||
+            tickMarkType === TickMarkType.Month ||
+            tickMarkType === TickMarkType.DayOfMonth
+          return formatChartTickJst(seconds, showDate)
+        },
+      },
+      localization: {
+        locale: 'ja-JP',
+        timeFormatter: (time: Time) => formatChartTimeJst(time as number),
       },
     })
 

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -15,3 +15,34 @@ export function formatAmount(value: number): string {
   const fixed = value.toFixed(AMOUNT_MAX_FRACTION_DIGITS)
   return fixed.replace(/\.?0+$/, '')
 }
+
+// lightweight-charts は UTCTimestamp を UTC 基準で描画する。
+// このプロダクトは JST 固定の市場 (楽天ウォレット) を扱うため、
+// 軸ラベル・クロスヘアの時刻を JST 表記に揃える。
+const JST_OFFSET_MS = 9 * 60 * 60 * 1000
+
+function toJstParts(unixSeconds: number) {
+  const d = new Date(unixSeconds * 1000 + JST_OFFSET_MS)
+  return {
+    year: d.getUTCFullYear(),
+    month: d.getUTCMonth() + 1,
+    day: d.getUTCDate(),
+    hour: d.getUTCHours(),
+    minute: d.getUTCMinutes(),
+  }
+}
+
+const pad2 = (n: number) => String(n).padStart(2, '0')
+
+// 軸目盛 (短い表記)。1 日以上の足は日付を、それ未満は時刻を返す。
+export function formatChartTickJst(unixSeconds: number, withDate: boolean): string {
+  const { month, day, hour, minute } = toJstParts(unixSeconds)
+  if (withDate) return `${month}/${day}`
+  return `${pad2(hour)}:${pad2(minute)}`
+}
+
+// クロスヘア・ツールチップ用 (フル表記)。
+export function formatChartTimeJst(unixSeconds: number): string {
+  const { year, month, day, hour, minute } = toJstParts(unixSeconds)
+  return `${year}-${pad2(month)}-${pad2(day)} ${pad2(hour)}:${pad2(minute)} JST`
+}


### PR DESCRIPTION
## Summary

「最新データの取得・表示」まわりを一通り直した。会話で出てきた問題を順番に整理:

1. **DB が壊れる** (`file is not a database (26)`): Docker Desktop の VirtioFS 越しに SQLite WAL が破損。
   → DB だけ named volume に隔離、CSV は bind mount のまま (hybrid 構成)。
2. **画面のローソク足が UTC 表示**: 軸が「26 日」になる、クロスヘアが 9 時間ずれる。
   → lightweight-charts に JST フォーマッタを設定。
3. **PT5M / PT1M / PT1H など UI で開かれない interval が古いまま**: ハンドラが「DB が空のとき」だけ補充していた。
   → 「DB の最新足が 2 × interval より古ければ stale とみなして補充」を追加。
4. **バックテスト CSV を手作業で更新していた**: `backend/data/candles_*.csv` が 4/16 で止まっていた。
   → alpine + crond の `csv-updater` コンテナを追加して毎時 5 分に増分取得。

各論点を独立コミットに分けてレビューしやすくしている (5 commits)。

## コミット粒度

| # | scope | 内容 |
|---|---|---|
| 1 | `feat(infra)` | DB を named volume `backend-db` に隔離、CSV は `./backend/data` を bind mount |
| 2 | `feat(api)`   | `GET /candles` の auto-fill ロジックに stale 検知を追加 |
| 3 | `feat(fe)`    | `CandlestickChart` を JST 表示に固定 |
| 4 | `feat(infra)` | `csv-updater` コンテナ + `fetch_incremental.sh` を追加 |
| 5 | `docs`        | `AGENTS.md` と `backtest-csv-data-guide.md` を更新 |

## Test plan

- [x] `cd backend && go test ./internal/interfaces/api/handler/ -count=1` (PASS)
- [x] `cd frontend && pnpm test` (47 tests PASS)
- [x] `docker compose up -d --build` で 3 サービスとも healthy
- [x] `GET /api/v1/backtest/results` HTTP 200 (DB エラー解消確認)
- [x] `GET /api/v1/candles/8?interval=PT1M` で空テーブル → 500 行自動取得
- [x] CSV updater 初回 fetch で全 48 ファイルが 2026-04-25 18:20 JST まで更新
- [x] crond foreground 起動、次回 19:05 JST 実行待ち
- [x] チャートが JST で `25日 17:45` のように表示される

## 互換性メモ

- 既存の `backend-data` named volume は不要。残っていれば `docker volume rm rakuten-api-leverage-exchange_backend-data` で削除可。
- 既存の `trading.db` を引き継ぐには named volume `backend-db` に流し込む必要あり (会話でやったように `docker run --rm -v ...:/dest -v ./backend/data:/src alpine cp ...`)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)