### PR TITLE
fix(test): donchian gate テストを CMF gate から独立させる (CI 緑化)

### DIFF
--- a/backend/internal/usecase/strategy/donchian_gate_test.go
+++ b/backend/internal/usecase/strategy/donchian_gate_test.go
@@ -20,6 +20,12 @@ func TestConfigurableStrategy_DonchianGateBlocksBreakoutBuy(t *testing.T) {
 	// Keep other breakout gates permissive so only the Donchian gate can fire.
 	profile.SignalRules.Breakout.ADXMin = 0
 	profile.SignalRules.Breakout.RequireMACDConfirm = false
+	// Isolate the donchian gate from other breakout gates that the production
+	// profile may activate (PR-9 added cmf_buy_min=0.1). makeBreakoutBuyReady
+	// helpers don't populate CMF20, so any active CMF gate would otherwise
+	// block the signal regardless of donchian state.
+	profile.SignalRules.Breakout.CMFBuyMin = 0
+	profile.SignalRules.Breakout.CMFSellMax = 0
 
 	s, err := NewConfigurableStrategy(profile)
 	if err != nil {
@@ -58,6 +64,12 @@ func TestConfigurableStrategy_DonchianGateAllowsBreakoutBuy(t *testing.T) {
 	profile.SignalRules.Breakout.DonchianPeriod = 20
 	profile.SignalRules.Breakout.ADXMin = 0
 	profile.SignalRules.Breakout.RequireMACDConfirm = false
+	// Isolate the donchian gate from other breakout gates that the production
+	// profile may activate (PR-9 added cmf_buy_min=0.1). makeBreakoutBuyReady
+	// helpers don't populate CMF20, so any active CMF gate would otherwise
+	// block the signal regardless of donchian state.
+	profile.SignalRules.Breakout.CMFBuyMin = 0
+	profile.SignalRules.Breakout.CMFSellMax = 0
 
 	s, err := NewConfigurableStrategy(profile)
 	if err != nil {
@@ -90,6 +102,12 @@ func TestConfigurableStrategy_DonchianGateMissingDonchianCountsAsFail(t *testing
 	profile.SignalRules.Breakout.DonchianPeriod = 20
 	profile.SignalRules.Breakout.ADXMin = 0
 	profile.SignalRules.Breakout.RequireMACDConfirm = false
+	// Isolate the donchian gate from other breakout gates that the production
+	// profile may activate (PR-9 added cmf_buy_min=0.1). makeBreakoutBuyReady
+	// helpers don't populate CMF20, so any active CMF gate would otherwise
+	// block the signal regardless of donchian state.
+	profile.SignalRules.Breakout.CMFBuyMin = 0
+	profile.SignalRules.Breakout.CMFSellMax = 0
 
 	s, err := NewConfigurableStrategy(profile)
 	if err != nil {
@@ -121,6 +139,12 @@ func TestConfigurableStrategy_DonchianGateZeroIsDisabled(t *testing.T) {
 	profile.SignalRules.Breakout.DonchianPeriod = 0 // gate disabled
 	profile.SignalRules.Breakout.ADXMin = 0
 	profile.SignalRules.Breakout.RequireMACDConfirm = false
+	// Isolate the donchian gate from other breakout gates that the production
+	// profile may activate (PR-9 added cmf_buy_min=0.1). makeBreakoutBuyReady
+	// helpers don't populate CMF20, so any active CMF gate would otherwise
+	// block the signal regardless of donchian state.
+	profile.SignalRules.Breakout.CMFBuyMin = 0
+	profile.SignalRules.Breakout.CMFSellMax = 0
 
 	s, err := NewConfigurableStrategy(profile)
 	if err != nil {
@@ -151,6 +175,12 @@ func TestConfigurableStrategy_DonchianGateBlocksBreakoutSell(t *testing.T) {
 	profile.SignalRules.Breakout.DonchianPeriod = 20
 	profile.SignalRules.Breakout.ADXMin = 0
 	profile.SignalRules.Breakout.RequireMACDConfirm = false
+	// Isolate the donchian gate from other breakout gates that the production
+	// profile may activate (PR-9 added cmf_buy_min=0.1). makeBreakoutBuyReady
+	// helpers don't populate CMF20, so any active CMF gate would otherwise
+	// block the signal regardless of donchian state.
+	profile.SignalRules.Breakout.CMFBuyMin = 0
+	profile.SignalRules.Breakout.CMFSellMax = 0
 
 	s, err := NewConfigurableStrategy(profile)
 	if err != nil {


### PR DESCRIPTION
## Summary

`main` で `go test ./... -race` が以下 2 件で失敗していた状態を修正:

```
--- FAIL: TestConfigurableStrategy_DonchianGateAllowsBreakoutBuy (0.00s)
    donchian_gate_test.go:80: expected breakout BUY, got HOLD
    (reason="breakout: CMF below buy threshold")
--- FAIL: TestConfigurableStrategy_DonchianGateZeroIsDisabled (0.00s)
    donchian_gate_test.go:141: gate=0 should pass through; expected BUY, got HOLD
    (reason="breakout: CMF below buy threshold")
```

## 原因

PR-9 で `cmf_buy_min=0.1` が production profile に入ったあと、PR-11 で
追加された donchian gate テストが production profile を読み込んでいるため
CMF gate に巻き込まれて失敗するようになっていた。
`makeBreakoutBuyReadyIndicators` / `makeBreakoutSellReadyIndicators` は
CMF20 を populate しないので、production profile の `cmf_buy_min=0.1` が
有効な状態だと CMF gate が常に reject する。

## Fix

donchian_gate_test.go の各テスト setup で
`Breakout.CMFBuyMin = 0` / `Breakout.CMFSellMax = 0` を明示し、
**donchian gate だけを評価対象に絞る**。同じパターンが
`obv_cmf_gate_test.go:184` でも使われている (CMF gate を 0 にして
Donchian/ADX を独立検証する形)。

将来 breakout に新しい gate が追加されても donchian テストが
巻き込まれないよう、isolation コメントも残した。

## Test plan

- [x] `cd backend && go test ./internal/usecase/strategy/ -count=1 -v` (5/5 PASS)
- [x] `cd backend && go test ./... -race -count=1` (CI と同じコマンド) 全 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)