### PR TITLE
chore(csv-updater): API 集中を避けるため頻度と起動時挙動を見直す

### DIFF
--- a/backend/Dockerfile.csv-updater
+++ b/backend/Dockerfile.csv-updater
@@ -12,8 +12,11 @@ COPY scripts/csv-updater-entrypoint.sh /usr/local/bin/csv-updater-entrypoint.sh
 RUN chmod +x /app/backend/scripts/fetch_incremental.sh /usr/local/bin/csv-updater-entrypoint.sh
 
 # crond reads /etc/crontabs/root by default in alpine.
-# Run hourly at minute 5 (avoid edge of API rate windows on the dot).
-RUN printf '5 * * * * /app/backend/scripts/fetch_incremental.sh >> /proc/1/fd/1 2>&1\n' \
+# Run every 3 hours at minute 27. Minute 27 sits between the PT15M close
+# boundaries (00/15/30/45) so it avoids competing with the live trading
+# pipeline's own candle-fetch bursts. 3-hour cadence keeps the CSVs fresh
+# enough for backtests without hammering the Rakuten API.
+RUN printf '27 */3 * * * /app/backend/scripts/fetch_incremental.sh >> /proc/1/fd/1 2>&1\n' \
   > /etc/crontabs/root
 
 ENTRYPOINT ["/usr/local/bin/csv-updater-entrypoint.sh"]

--- a/compose.yaml
+++ b/compose.yaml
@@ -46,7 +46,9 @@ services:
       - ./backend/data:/app/backend/data
     environment:
       TZ: Asia/Tokyo
-      RUN_ON_START: "1"
+      # 起動直後の即時 fetch は無効化 (Rakuten API rate limit を避けるため)。
+      # 必要なら: docker compose exec csv-updater /app/backend/scripts/fetch_incremental.sh
+      RUN_ON_START: "0"
     restart: unless-stopped
 
 volumes:


### PR DESCRIPTION
## Summary

本番 backend で `pipeline: rakuten rate limit (20010)` が定常発生していた問題への対処。
csv-updater が毎時 5 分に 8 symbol × 6 interval = 約 70 リクエストを連続発行し、
PT15M 確定 (毎時 0/15/30/45) ・event-pipeline の syncState と衝突して詰まっていた。

## 変更点

- `Dockerfile.csv-updater` の crontab を **`5 * * * *` → `27 */3 * * *`**
  - 分 27 は PT15M 境界から最も遠く、API 輻輳のピークを避けられる
  - 3 時間に 1 回に頻度を下げ、Rakuten API への圧を 1/3 に
  - バックテストの足 (PT15M〜) には十分な鮮度
- `compose.yaml` の `RUN_ON_START: "1" → "0"`
  - `docker compose up --build` のたびに即 70 リクエスト発火 → backend の起動時 syncState と衝突するパターンを解消
  - 必要なら `docker compose exec csv-updater /app/backend/scripts/fetch_incremental.sh` で手動実行できる旨をコメントとして残した

## Test plan

- [x] `docker compose up -d --build csv-updater` で再起動、新 crontab を確認
- [x] `docker compose exec csv-updater cat /etc/crontabs/root` → `27 */3 * * *` 反映
- [x] `docker compose exec csv-updater env | grep RUN_ON_START` → `RUN_ON_START=0` 反映
- [x] 起動直後に fetch ログが流れないことを確認 (ログは `starting crond (foreground)` のみ)
- [x] 既存 CSV データは無傷

## 影響

- バックテスト用 CSV の鮮度が「最大 1 時間遅れ」→「最大 3 時間遅れ」になる。PT15M 単位以上のバックテストにとっては問題なし
- 起動直後にキャッチアップしたい場合は手動実行コマンドで対応 (README 化はしない)

🤖 Generated with [Claude Code](https://claude.com/claude-code)