### PR TITLE
feat(backend): tick / orderbook L2 / trades の永続化基盤を追加

### DIFF
--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -6,6 +6,8 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
+	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -51,7 +53,7 @@ func main() {
 	tradingConfigRepo := database.NewTradingConfigRepo(db)
 
 	// --- Usecase ---
-	marketDataSvc := usecase.NewMarketDataService(marketDataRepo)
+	marketDataSvc := usecase.NewMarketDataServiceWithConfig(marketDataRepo, loadPersistenceConfig())
 	realtimeHub := usecase.NewRealtimeHub()
 	marketDataSvc.SetRealtimeHub(realtimeHub)
 	indicatorCalc := usecase.NewIndicatorCalculator(marketDataRepo)
@@ -220,6 +222,7 @@ func main() {
 		"capital", cfg.Risk.InitialCapital,
 	)
 
+	marketDataSvc.StartPersistenceWorker(ctx)
 	go startMarketRelay(ctx, wsClient, marketDataSvc, realtimeHub, symbolID, symbolSwitchCh)
 	go startDailyLossReset(ctx, riskMgr)
 	go startBacktestRetentionCleanup(ctx, backtestResultRepo, cfg.Backtest.RetentionDays)
@@ -251,6 +254,44 @@ const (
 	wsInitialBackoff     = 1 * time.Second
 	wsMaxBackoff         = 60 * time.Second
 )
+
+// loadPersistenceConfig builds a PersistenceConfig from environment variables,
+// falling back to DefaultPersistenceConfig() for anything unset or unparseable.
+// Env vars (all optional):
+//   - PERSIST_TICK_DATA            "true"/"false"   (default true)
+//   - TICKER_PERSIST_INTERVAL_MS   integer ms       (default 1000)
+//   - ORDERBOOK_PERSIST_INTERVAL_MS integer ms       (default 5000)
+//   - ORDERBOOK_PERSIST_DEPTH      integer levels   (default 20)
+//   - TICK_RETENTION_DAYS          integer days     (default 90)
+//   - TICK_PERSIST_QUEUE_SIZE      integer          (default 1024)
+func loadPersistenceConfig() usecase.PersistenceConfig {
+	cfg := usecase.DefaultPersistenceConfig()
+
+	if v := strings.TrimSpace(os.Getenv("PERSIST_TICK_DATA")); v != "" {
+		switch strings.ToLower(v) {
+		case "1", "true", "yes", "on":
+			cfg.Enable = true
+		case "0", "false", "no", "off":
+			cfg.Enable = false
+		}
+	}
+	if v, err := strconv.Atoi(os.Getenv("TICKER_PERSIST_INTERVAL_MS")); err == nil && v >= 0 {
+		cfg.TickerInterval = time.Duration(v) * time.Millisecond
+	}
+	if v, err := strconv.Atoi(os.Getenv("ORDERBOOK_PERSIST_INTERVAL_MS")); err == nil && v >= 0 {
+		cfg.OrderbookInterval = time.Duration(v) * time.Millisecond
+	}
+	if v, err := strconv.Atoi(os.Getenv("ORDERBOOK_PERSIST_DEPTH")); err == nil && v >= 0 {
+		cfg.OrderbookDepth = v
+	}
+	if v, err := strconv.Atoi(os.Getenv("TICK_RETENTION_DAYS")); err == nil && v >= 0 {
+		cfg.RetentionDays = v
+	}
+	if v, err := strconv.Atoi(os.Getenv("TICK_PERSIST_QUEUE_SIZE")); err == nil && v > 0 {
+		cfg.QueueSize = v
+	}
+	return cfg
+}
 
 func startMarketRelay(
 	ctx context.Context,
@@ -417,7 +458,10 @@ func detectMessageType(raw []byte) string {
 	return "ticker"
 }
 
-func handleMarketMessage(ctx context.Context, raw []byte, marketDataSvc *usecase.MarketDataService, realtimeHub *usecase.RealtimeHub) {
+// handleMarketMessage routes a raw venue WS payload into MarketDataService.
+// The realtime hub is owned by the service itself (set via SetRealtimeHub) so
+// callers no longer need to pass it through here.
+func handleMarketMessage(ctx context.Context, raw []byte, marketDataSvc *usecase.MarketDataService, _ *usecase.RealtimeHub) {
 	if len(raw) == 0 {
 		return
 	}
@@ -453,9 +497,7 @@ func handleMarketMessage(ctx context.Context, raw []byte, marketDataSvc *usecase
 			Spread:    r.Spread.Float64(),
 			Timestamp: r.Timestamp,
 		}
-		if realtimeHub != nil {
-			_ = realtimeHub.PublishData("orderbook", orderbook.SymbolID, orderbook)
-		}
+		marketDataSvc.HandleOrderbook(ctx, orderbook)
 	case "trades":
 		var r rawMarketTradesResponse
 		if err := json.Unmarshal(raw, &r); err != nil {
@@ -477,9 +519,7 @@ func handleMarketMessage(ctx context.Context, raw []byte, marketDataSvc *usecase
 				TradedAt:    t.TradedAt,
 			}
 		}
-		if realtimeHub != nil {
-			_ = realtimeHub.PublishData("market_trades", trades.SymbolID, trades)
-		}
+		marketDataSvc.HandleTrades(ctx, trades)
 	case "ticker":
 		var r rawTicker
 		if err := json.Unmarshal(raw, &r); err != nil {

--- a/backend/internal/domain/repository/market_data.go
+++ b/backend/internal/domain/repository/market_data.go
@@ -23,4 +23,20 @@ type MarketDataRepository interface {
 
 	// GetLatestTicker returns the most recent ticker for a symbol.
 	GetLatestTicker(ctx context.Context, symbolID int64) (*entity.Ticker, error)
+
+	// SaveTrades batch-saves market trade ticks. Duplicates (by trade ID) are ignored.
+	SaveTrades(ctx context.Context, symbolID int64, trades []entity.MarketTrade) error
+
+	// SaveOrderbook persists a single orderbook snapshot. depthLimit caps how many
+	// ask/bid levels are serialized into the JSON column (0 = all available levels).
+	SaveOrderbook(ctx context.Context, ob entity.Orderbook, depthLimit int) error
+
+	// GetOrderbookHistory returns orderbook snapshots for a symbol within [from, to],
+	// oldest first, up to limit rows. from/to are unix milliseconds; 0 means unbounded.
+	GetOrderbookHistory(ctx context.Context, symbolID int64, from, to int64, limit int) ([]entity.Orderbook, error)
+
+	// PurgeOldMarketData removes rows older than cutoffMillis from the high-volume
+	// market data tables (tickers, trades, orderbook_snapshots). Returns total
+	// rows deleted across all three.
+	PurgeOldMarketData(ctx context.Context, cutoffMillis int64) (int64, error)
 }

--- a/backend/internal/infrastructure/database/market_data_repo.go
+++ b/backend/internal/infrastructure/database/market_data_repo.go
@@ -3,6 +3,7 @@ package database
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
@@ -114,4 +115,174 @@ func (r *MarketDataRepo) GetLatestTicker(ctx context.Context, symbolID int64) (*
 		return nil, fmt.Errorf("get latest ticker: %w", err)
 	}
 	return &t, nil
+}
+
+// SaveTrades batch-inserts market trade ticks. Duplicate trade_ids per symbol are
+// silently ignored via INSERT OR IGNORE — the WS feed retransmits the most recent
+// trades on every "trades" frame, so dedup at write-time keeps the table clean.
+func (r *MarketDataRepo) SaveTrades(ctx context.Context, symbolID int64, trades []entity.MarketTrade) error {
+	if len(trades) == 0 {
+		return nil
+	}
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	stmt, err := tx.PrepareContext(ctx,
+		`INSERT OR IGNORE INTO trades (symbol_id, trade_id, order_side, price, amount, asset_amount, traded_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+	)
+	if err != nil {
+		return fmt.Errorf("prepare stmt: %w", err)
+	}
+	defer stmt.Close()
+
+	for _, t := range trades {
+		if _, err := stmt.ExecContext(ctx,
+			symbolID, t.ID, t.OrderSide, t.Price, t.Amount, t.AssetAmount, t.TradedAt,
+		); err != nil {
+			return fmt.Errorf("exec stmt: %w", err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit tx: %w", err)
+	}
+	return nil
+}
+
+// orderbookDepthEntry is the on-disk shape inside depth_json. Short keys keep
+// the JSON small (1 row × thousands per day per symbol); the struct is local
+// to this file because no other layer reads the raw JSON directly.
+type orderbookDepthEntry struct {
+	P float64 `json:"p"`
+	A float64 `json:"a"`
+}
+
+type orderbookDepth struct {
+	Asks []orderbookDepthEntry `json:"asks"`
+	Bids []orderbookDepthEntry `json:"bids"`
+}
+
+func truncateLevels(levels []entity.OrderbookEntry, depthLimit int) []orderbookDepthEntry {
+	n := len(levels)
+	if depthLimit > 0 && n > depthLimit {
+		n = depthLimit
+	}
+	out := make([]orderbookDepthEntry, n)
+	for i := 0; i < n; i++ {
+		out[i] = orderbookDepthEntry{P: levels[i].Price, A: levels[i].Amount}
+	}
+	return out
+}
+
+// SaveOrderbook persists one snapshot. depthLimit caps how many ask/bid levels
+// are serialized — the venue ships 100+ levels per side and we typically only
+// need the top ~20 for SOR / impact estimation.
+func (r *MarketDataRepo) SaveOrderbook(ctx context.Context, ob entity.Orderbook, depthLimit int) error {
+	depth := orderbookDepth{
+		Asks: truncateLevels(ob.Asks, depthLimit),
+		Bids: truncateLevels(ob.Bids, depthLimit),
+	}
+	depthJSON, err := json.Marshal(depth)
+	if err != nil {
+		return fmt.Errorf("marshal depth: %w", err)
+	}
+	_, err = r.db.ExecContext(ctx,
+		`INSERT INTO orderbook_snapshots (symbol_id, best_ask, best_bid, mid_price, spread, depth_json, timestamp)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		ob.SymbolID, ob.BestAsk, ob.BestBid, ob.MidPrice, ob.Spread, string(depthJSON), ob.Timestamp,
+	)
+	if err != nil {
+		return fmt.Errorf("save orderbook: %w", err)
+	}
+	return nil
+}
+
+func (r *MarketDataRepo) GetOrderbookHistory(ctx context.Context, symbolID int64, from, to int64, limit int) ([]entity.Orderbook, error) {
+	if limit <= 0 {
+		limit = 1000
+	}
+	args := []any{symbolID}
+	q := `SELECT symbol_id, best_ask, best_bid, mid_price, spread, depth_json, timestamp
+	      FROM orderbook_snapshots WHERE symbol_id = ?`
+	if from > 0 {
+		q += ` AND timestamp >= ?`
+		args = append(args, from)
+	}
+	if to > 0 {
+		q += ` AND timestamp <= ?`
+		args = append(args, to)
+	}
+	q += ` ORDER BY timestamp ASC LIMIT ?`
+	args = append(args, limit)
+
+	rows, err := r.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query orderbook history: %w", err)
+	}
+	defer rows.Close()
+
+	var out []entity.Orderbook
+	for rows.Next() {
+		var (
+			ob       entity.Orderbook
+			depthRaw string
+		)
+		if err := rows.Scan(&ob.SymbolID, &ob.BestAsk, &ob.BestBid, &ob.MidPrice, &ob.Spread, &depthRaw, &ob.Timestamp); err != nil {
+			return nil, fmt.Errorf("scan orderbook: %w", err)
+		}
+		var depth orderbookDepth
+		if err := json.Unmarshal([]byte(depthRaw), &depth); err != nil {
+			return nil, fmt.Errorf("unmarshal depth: %w", err)
+		}
+		ob.Asks = make([]entity.OrderbookEntry, len(depth.Asks))
+		for i, a := range depth.Asks {
+			ob.Asks[i] = entity.OrderbookEntry{Price: a.P, Amount: a.A}
+		}
+		ob.Bids = make([]entity.OrderbookEntry, len(depth.Bids))
+		for i, b := range depth.Bids {
+			ob.Bids[i] = entity.OrderbookEntry{Price: b.P, Amount: b.A}
+		}
+		out = append(out, ob)
+	}
+	return out, rows.Err()
+}
+
+// PurgeOldMarketData deletes high-volume rows older than cutoffMillis from
+// tickers / trades / orderbook_snapshots. Returns total rows deleted.
+// The three deletes run in independent statements (not a single tx) so that
+// a long retention sweep never blocks the writer goroutine for the whole batch.
+func (r *MarketDataRepo) PurgeOldMarketData(ctx context.Context, cutoffMillis int64) (int64, error) {
+	var total int64
+
+	res, err := r.db.ExecContext(ctx,
+		`DELETE FROM tickers WHERE timestamp < ?`, cutoffMillis)
+	if err != nil {
+		return total, fmt.Errorf("purge tickers: %w", err)
+	}
+	if n, err := res.RowsAffected(); err == nil {
+		total += n
+	}
+
+	res, err = r.db.ExecContext(ctx,
+		`DELETE FROM trades WHERE traded_at < ?`, cutoffMillis)
+	if err != nil {
+		return total, fmt.Errorf("purge trades: %w", err)
+	}
+	if n, err := res.RowsAffected(); err == nil {
+		total += n
+	}
+
+	res, err = r.db.ExecContext(ctx,
+		`DELETE FROM orderbook_snapshots WHERE timestamp < ?`, cutoffMillis)
+	if err != nil {
+		return total, fmt.Errorf("purge orderbook_snapshots: %w", err)
+	}
+	if n, err := res.RowsAffected(); err == nil {
+		total += n
+	}
+
+	return total, nil
 }

--- a/backend/internal/infrastructure/database/market_data_repo_test.go
+++ b/backend/internal/infrastructure/database/market_data_repo_test.go
@@ -243,3 +243,127 @@ func TestGetLatestTicker_NotFound(t *testing.T) {
 		t.Fatal("expected error for non-existent symbol")
 	}
 }
+
+func TestSaveAndGetOrderbook(t *testing.T) {
+	repo := setupTestDB(t)
+	ctx := context.Background()
+
+	ob := entity.Orderbook{
+		SymbolID:  7,
+		BestAsk:   9011.3,
+		BestBid:   8978.8,
+		MidPrice:  8995.0,
+		Spread:    32.5,
+		Timestamp: 1700000000000,
+		Asks: []entity.OrderbookEntry{
+			{Price: 9011.3, Amount: 1.0},
+			{Price: 9012.0, Amount: 2.5},
+		},
+		Bids: []entity.OrderbookEntry{
+			{Price: 8978.8, Amount: 0.1},
+			{Price: 8978.0, Amount: 1.2},
+		},
+	}
+	if err := repo.SaveOrderbook(ctx, ob, 20); err != nil {
+		t.Fatalf("save orderbook: %v", err)
+	}
+
+	rows, err := repo.GetOrderbookHistory(ctx, 7, 0, 0, 10)
+	if err != nil {
+		t.Fatalf("get orderbook history: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 snapshot, got %d", len(rows))
+	}
+	got := rows[0]
+	if got.BestAsk != 9011.3 || got.BestBid != 8978.8 {
+		t.Fatalf("best ask/bid mismatch: %+v", got)
+	}
+	if len(got.Asks) != 2 || got.Asks[0].Amount != 1.0 {
+		t.Fatalf("asks not round-tripped: %+v", got.Asks)
+	}
+	if len(got.Bids) != 2 || got.Bids[1].Price != 8978.0 {
+		t.Fatalf("bids not round-tripped: %+v", got.Bids)
+	}
+}
+
+func TestSaveOrderbook_DepthLimitTruncates(t *testing.T) {
+	repo := setupTestDB(t)
+	ctx := context.Background()
+
+	asks := make([]entity.OrderbookEntry, 50)
+	for i := range asks {
+		asks[i] = entity.OrderbookEntry{Price: float64(9000 + i), Amount: 1}
+	}
+	ob := entity.Orderbook{SymbolID: 7, Asks: asks, Bids: nil, Timestamp: 1700000000000}
+
+	if err := repo.SaveOrderbook(ctx, ob, 10); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	rows, err := repo.GetOrderbookHistory(ctx, 7, 0, 0, 10)
+	if err != nil || len(rows) != 1 {
+		t.Fatalf("get: err=%v rows=%d", err, len(rows))
+	}
+	if len(rows[0].Asks) != 10 {
+		t.Fatalf("expected 10 ask levels (depthLimit), got %d", len(rows[0].Asks))
+	}
+}
+
+func TestSaveTrades_DedupsByTradeID(t *testing.T) {
+	repo := setupTestDB(t)
+	ctx := context.Background()
+
+	batch1 := []entity.MarketTrade{
+		{ID: 1, OrderSide: "BUY", Price: 9000, Amount: 0.1, AssetAmount: 900, TradedAt: 1000},
+		{ID: 2, OrderSide: "SELL", Price: 9001, Amount: 0.2, AssetAmount: 1800, TradedAt: 1100},
+	}
+	batch2 := []entity.MarketTrade{
+		// ID=2 is a duplicate of batch1; INSERT OR IGNORE drops it.
+		{ID: 2, OrderSide: "SELL", Price: 9001, Amount: 0.2, AssetAmount: 1800, TradedAt: 1100},
+		{ID: 3, OrderSide: "BUY", Price: 9002, Amount: 0.1, AssetAmount: 900, TradedAt: 1200},
+	}
+	if err := repo.SaveTrades(ctx, 7, batch1); err != nil {
+		t.Fatalf("save batch1: %v", err)
+	}
+	if err := repo.SaveTrades(ctx, 7, batch2); err != nil {
+		t.Fatalf("save batch2: %v", err)
+	}
+
+	var count int
+	if err := repo.db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM trades WHERE symbol_id = ?", int64(7)).Scan(&count); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 3 {
+		t.Fatalf("expected 3 unique trades, got %d", count)
+	}
+}
+
+func TestPurgeOldMarketData(t *testing.T) {
+	repo := setupTestDB(t)
+	ctx := context.Background()
+
+	_ = repo.SaveTicker(ctx, entity.Ticker{SymbolID: 7, Last: 100, Timestamp: 1000})
+	_ = repo.SaveTicker(ctx, entity.Ticker{SymbolID: 7, Last: 200, Timestamp: 5000})
+	_ = repo.SaveTrades(ctx, 7, []entity.MarketTrade{
+		{ID: 10, OrderSide: "BUY", Price: 1, Amount: 1, TradedAt: 1000},
+		{ID: 11, OrderSide: "BUY", Price: 1, Amount: 1, TradedAt: 5000},
+	})
+	_ = repo.SaveOrderbook(ctx, entity.Orderbook{SymbolID: 7, Timestamp: 1000}, 10)
+	_ = repo.SaveOrderbook(ctx, entity.Orderbook{SymbolID: 7, Timestamp: 5000}, 10)
+
+	deleted, err := repo.PurgeOldMarketData(ctx, 3000)
+	if err != nil {
+		t.Fatalf("purge: %v", err)
+	}
+	// 1 ticker (ts=1000) + 1 trade (ts=1000) + 1 orderbook (ts=1000) = 3 rows
+	if deleted != 3 {
+		t.Fatalf("expected 3 deleted, got %d", deleted)
+	}
+
+	// Newer rows survive.
+	rows, _ := repo.GetOrderbookHistory(ctx, 7, 0, 0, 10)
+	if len(rows) != 1 || rows[0].Timestamp != 5000 {
+		t.Fatalf("expected only timestamp=5000 to survive, got %+v", rows)
+	}
+}

--- a/backend/internal/infrastructure/database/migrations.go
+++ b/backend/internal/infrastructure/database/migrations.go
@@ -78,14 +78,34 @@ func RunMigrations(db *sql.DB) error {
 		`CREATE TABLE IF NOT EXISTS trades (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
 			symbol_id INTEGER NOT NULL,
+			trade_id INTEGER NOT NULL DEFAULT 0,
 			order_side TEXT NOT NULL,
 			price REAL NOT NULL,
 			amount REAL NOT NULL,
 			asset_amount REAL NOT NULL,
-			traded_at INTEGER NOT NULL
+			traded_at INTEGER NOT NULL,
+			UNIQUE(symbol_id, trade_id)
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_trades_symbol_time
 			ON trades(symbol_id, traded_at DESC)`,
+
+		// orderbook_snapshots: L2 板スナップショットの永続化先。
+		// depth_json には ask/bid を {p,a} ペア配列の JSON で保存し、SQLite の
+		// json_extract で必要に応じて読み出せる。テーブルを正規化すると
+		// 1 スナップショットあたり 20+ 行になり、リプレイ時のスキャンが重くなるので
+		// 1 行 1 スナップショットを採用する。
+		`CREATE TABLE IF NOT EXISTS orderbook_snapshots (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			symbol_id INTEGER NOT NULL,
+			best_ask REAL NOT NULL,
+			best_bid REAL NOT NULL,
+			mid_price REAL NOT NULL,
+			spread REAL NOT NULL,
+			depth_json TEXT NOT NULL,
+			timestamp INTEGER NOT NULL
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_orderbook_snapshots_symbol_time
+			ON orderbook_snapshots(symbol_id, timestamp DESC)`,
 
 		`CREATE TABLE IF NOT EXISTS trade_history (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -192,6 +212,20 @@ func RunMigrations(db *sql.DB) error {
 		if _, err := db.Exec(m); err != nil {
 			return fmt.Errorf("migration failed: %w", err)
 		}
+	}
+
+	// trades は元々 (symbol_id, traded_at) 主体で設計されていたが、
+	// WS から流れてくる MarketTrade.id を保存して重複 INSERT を防ぐため
+	// trade_id カラムと一意インデックスを後付けで足す。
+	// 既存行 (永続化フックが繋がる前のレコードはそもそも空) は trade_id=0
+	// のまま残るため、UNIQUE INDEX は trade_id != 0 の部分インデックスにする。
+	if err := addColumnIfNotExists(db, "trades", "trade_id",
+		"trade_id INTEGER NOT NULL DEFAULT 0"); err != nil {
+		return fmt.Errorf("trades alter trade_id: %w", err)
+	}
+	if _, err := db.Exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_trades_symbol_trade_id
+		ON trades(symbol_id, trade_id) WHERE trade_id <> 0`); err != nil {
+		return fmt.Errorf("create idx_trades_symbol_trade_id: %w", err)
 	}
 
 	// client_orders をライフサイクル監査ログに格上げするための ALTER 群。

--- a/backend/internal/interfaces/api/handler/handler_test.go
+++ b/backend/internal/interfaces/api/handler/handler_test.go
@@ -1109,7 +1109,7 @@ func TestSymbolHandler_GetSymbols_NilClient(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestOrderbookHandler_GetOrderbook_InvalidSymbolId(t *testing.T) {
-	h := NewOrderbookHandler(nil)
+	h := NewOrderbookHandler(nil, nil)
 
 	w := httptest.NewRecorder()
 	_, r := gin.CreateTestContext(w)

--- a/backend/internal/interfaces/api/handler/orderbook.go
+++ b/backend/internal/interfaces/api/handler/orderbook.go
@@ -6,14 +6,16 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/infrastructure/rakuten"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase"
 )
 
 type OrderbookHandler struct {
-	restClient *rakuten.RESTClient
+	restClient    *rakuten.RESTClient
+	marketDataSvc *usecase.MarketDataService
 }
 
-func NewOrderbookHandler(restClient *rakuten.RESTClient) *OrderbookHandler {
-	return &OrderbookHandler{restClient: restClient}
+func NewOrderbookHandler(restClient *rakuten.RESTClient, marketDataSvc *usecase.MarketDataService) *OrderbookHandler {
+	return &OrderbookHandler{restClient: restClient, marketDataSvc: marketDataSvc}
 }
 
 // GetOrderbook handles GET /api/v1/orderbook.
@@ -37,4 +39,37 @@ func (h *OrderbookHandler) GetOrderbook(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, ob)
+}
+
+// GetOrderbookHistory handles GET /api/v1/orderbook/history.
+// Query: symbolId (required), from/to (unix-millis, optional), limit (default 1000).
+// Returns persisted orderbook snapshots in ascending timestamp order.
+func (h *OrderbookHandler) GetOrderbookHistory(c *gin.Context) {
+	if h.marketDataSvc == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "market data service unavailable"})
+		return
+	}
+	symbolStr := c.DefaultQuery("symbolId", "7")
+	symbolID, err := strconv.ParseInt(symbolStr, 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid symbolId"})
+		return
+	}
+	from, _ := strconv.ParseInt(c.DefaultQuery("from", "0"), 10, 64)
+	to, _ := strconv.ParseInt(c.DefaultQuery("to", "0"), 10, 64)
+	limit, _ := strconv.Atoi(c.DefaultQuery("limit", "1000"))
+	if limit <= 0 || limit > 10000 {
+		limit = 1000
+	}
+
+	rows, err := h.marketDataSvc.GetOrderbookHistory(c.Request.Context(), symbolID, from, to, limit)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"symbolId":  symbolID,
+		"count":     len(rows),
+		"snapshots": rows,
+	})
 }

--- a/backend/internal/interfaces/api/router.go
+++ b/backend/internal/interfaces/api/router.go
@@ -110,8 +110,12 @@ func NewRouter(deps Dependencies) *gin.Engine {
 	}
 
 	if deps.RESTClient != nil {
-		orderbookHandler := handler.NewOrderbookHandler(deps.RESTClient)
+		orderbookHandler := handler.NewOrderbookHandler(deps.RESTClient, deps.MarketDataService)
 		v1.GET("/orderbook", orderbookHandler.GetOrderbook)
+		// History endpoint reads persisted snapshots; only useful when the
+		// MarketDataService is wired (composition root attaches it). The
+		// handler itself nil-guards and returns 503 when missing.
+		v1.GET("/orderbook/history", orderbookHandler.GetOrderbookHistory)
 
 		symbolHandler := handler.NewSymbolHandler(deps.RESTClient)
 		v1.GET("/symbols", symbolHandler.GetSymbols)

--- a/backend/internal/usecase/market_data.go
+++ b/backend/internal/usecase/market_data.go
@@ -4,24 +4,210 @@ import (
 	"context"
 	"log/slog"
 	"sync"
+	"sync/atomic"
+	"time"
 
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/repository"
 )
 
+// PersistenceConfig controls how high-frequency market data is written to disk.
+// Tickers come in at ~1 Hz from the venue WS and orderbook snapshots arrive
+// even faster, so we throttle and run all DB writes on a single background
+// goroutine to keep the trading hot path lock-free.
+type PersistenceConfig struct {
+	// Enable toggles persistence of tickers / trades / orderbooks. When false,
+	// HandleTicker still distributes events to subscribers and the realtime
+	// hub but no DB writes occur.
+	Enable bool
+	// TickerInterval is the minimum gap between ticker rows per symbol. 0
+	// disables throttling.
+	TickerInterval time.Duration
+	// OrderbookInterval is the minimum gap between orderbook snapshots per
+	// symbol. 0 disables throttling.
+	OrderbookInterval time.Duration
+	// OrderbookDepth caps how many ask/bid levels are serialized per snapshot.
+	OrderbookDepth int
+	// RetentionDays drops rows older than this many days. 0 disables
+	// retention sweeps.
+	RetentionDays int
+	// QueueSize bounds the writer channel. When full, additional events are
+	// dropped (counted in DropCount) rather than blocking the producer.
+	QueueSize int
+}
+
+// DefaultPersistenceConfig returns the values used when env vars are unset.
+// Sized so that 90 days of LTC/JPY tickers (~1/sec) and 5s orderbook snapshots
+// land near 2 GB on disk — well within the SQLite-on-named-volume budget.
+func DefaultPersistenceConfig() PersistenceConfig {
+	return PersistenceConfig{
+		Enable:            true,
+		TickerInterval:    1 * time.Second,
+		OrderbookInterval: 5 * time.Second,
+		OrderbookDepth:    20,
+		RetentionDays:     90,
+		QueueSize:         1024,
+	}
+}
+
+// persistTask is what the writer goroutine consumes. Exactly one of the
+// pointer fields is non-nil per task.
+type persistTask struct {
+	ticker    *entity.Ticker
+	orderbook *entity.Orderbook
+	trades    *entity.MarketTradesResponse
+}
+
 // MarketDataService manages receiving, distributing, and persisting market data.
 type MarketDataService struct {
 	repo repository.MarketDataRepository
 
-	mu         sync.RWMutex
-	tickerSubs []chan entity.Ticker
+	mu          sync.RWMutex
+	tickerSubs  []chan entity.Ticker
 	realtimeHub *RealtimeHub
+
+	cfg PersistenceConfig
+
+	// throttle bookkeeping (per-symbol last-saved unix-millis).
+	throttleMu        sync.Mutex
+	lastTickerSavedMs map[int64]int64
+	lastOrderbookMs   map[int64]int64
+
+	// writer channel + lifecycle
+	writerCh   chan persistTask
+	writerDone chan struct{}
+	dropCount  atomic.Int64
 }
 
 func NewMarketDataService(repo repository.MarketDataRepository) *MarketDataService {
-	return &MarketDataService{
-		repo: repo,
+	return NewMarketDataServiceWithConfig(repo, DefaultPersistenceConfig())
+}
+
+func NewMarketDataServiceWithConfig(repo repository.MarketDataRepository, cfg PersistenceConfig) *MarketDataService {
+	if cfg.QueueSize <= 0 {
+		cfg.QueueSize = 1024
 	}
+	return &MarketDataService{
+		repo:              repo,
+		cfg:               cfg,
+		lastTickerSavedMs: make(map[int64]int64),
+		lastOrderbookMs:   make(map[int64]int64),
+	}
+}
+
+// StartPersistenceWorker spins up the single writer goroutine + the retention
+// sweeper. Safe to call once at startup; subsequent calls are no-ops. Stops
+// when ctx is cancelled.
+func (s *MarketDataService) StartPersistenceWorker(ctx context.Context) {
+	if !s.cfg.Enable {
+		return
+	}
+	s.mu.Lock()
+	if s.writerCh != nil {
+		s.mu.Unlock()
+		return
+	}
+	s.writerCh = make(chan persistTask, s.cfg.QueueSize)
+	s.writerDone = make(chan struct{})
+	s.mu.Unlock()
+
+	go s.runWriter(ctx)
+	if s.cfg.RetentionDays > 0 {
+		go s.runRetention(ctx)
+	}
+}
+
+func (s *MarketDataService) runWriter(ctx context.Context) {
+	defer close(s.writerDone)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case task, ok := <-s.writerCh:
+			if !ok {
+				return
+			}
+			s.executeTask(ctx, task)
+		}
+	}
+}
+
+func (s *MarketDataService) executeTask(ctx context.Context, task persistTask) {
+	switch {
+	case task.ticker != nil:
+		if err := s.repo.SaveTicker(ctx, *task.ticker); err != nil {
+			slog.Warn("failed to save ticker", "error", err)
+		}
+	case task.orderbook != nil:
+		if err := s.repo.SaveOrderbook(ctx, *task.orderbook, s.cfg.OrderbookDepth); err != nil {
+			slog.Warn("failed to save orderbook", "error", err)
+		}
+	case task.trades != nil:
+		if err := s.repo.SaveTrades(ctx, task.trades.SymbolID, task.trades.Trades); err != nil {
+			slog.Warn("failed to save trades", "error", err)
+		}
+	}
+}
+
+func (s *MarketDataService) runRetention(ctx context.Context) {
+	// 起動直後に 1 度走らせ、その後は 24h 周期。コンテナ再起動が頻繁な
+	// 環境でも古いデータを確実に掃除できる。
+	sweep := func() {
+		cutoff := time.Now().Add(-time.Duration(s.cfg.RetentionDays) * 24 * time.Hour).UnixMilli()
+		deleted, err := s.repo.PurgeOldMarketData(ctx, cutoff)
+		if err != nil {
+			slog.Warn("market data retention sweep failed", "error", err)
+			return
+		}
+		if deleted > 0 {
+			slog.Info("market data retention sweep", "deleted", deleted, "retentionDays", s.cfg.RetentionDays)
+		}
+	}
+	sweep()
+
+	ticker := time.NewTicker(24 * time.Hour)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			sweep()
+		}
+	}
+}
+
+// enqueue tries to push a task onto the writer channel without blocking.
+// Returns true when accepted, false when the queue was full (caller-visible
+// via DropCount).
+//
+// Fallback: if the writer goroutine has not been started (writerCh==nil), we
+// run the task inline. This keeps tests and CLI tools that construct the
+// service without StartPersistenceWorker working as before, at the cost of a
+// short DB hop on the caller's goroutine. Production wires StartPersistenceWorker
+// at boot, so the synchronous path is only hit in the test mocks and one-shot
+// scripts.
+func (s *MarketDataService) enqueue(task persistTask) bool {
+	if !s.cfg.Enable {
+		return false
+	}
+	if s.writerCh == nil {
+		s.executeTask(context.Background(), task)
+		return true
+	}
+	select {
+	case s.writerCh <- task:
+		return true
+	default:
+		s.dropCount.Add(1)
+		return false
+	}
+}
+
+// DropCount returns the cumulative number of persistence tasks dropped because
+// the writer queue was full. Exposed for test assertions and future metrics.
+func (s *MarketDataService) DropCount() int64 {
+	return s.dropCount.Load()
 }
 
 func (s *MarketDataService) SetRealtimeHub(hub *RealtimeHub) {
@@ -53,10 +239,45 @@ func (s *MarketDataService) UnsubscribeTicker(ch <-chan entity.Ticker) {
 	}
 }
 
-// HandleTicker persists a received ticker and distributes it to all subscribers.
+// shouldPersistTicker reports whether enough time has elapsed since the last
+// persisted ticker for symbolID. Updates the bookkeeping when accepting.
+func (s *MarketDataService) shouldPersistTicker(symbolID, ts int64) bool {
+	if s.cfg.TickerInterval <= 0 {
+		return true
+	}
+	gap := s.cfg.TickerInterval.Milliseconds()
+	s.throttleMu.Lock()
+	defer s.throttleMu.Unlock()
+	last := s.lastTickerSavedMs[symbolID]
+	if ts-last < gap {
+		return false
+	}
+	s.lastTickerSavedMs[symbolID] = ts
+	return true
+}
+
+func (s *MarketDataService) shouldPersistOrderbook(symbolID, ts int64) bool {
+	if s.cfg.OrderbookInterval <= 0 {
+		return true
+	}
+	gap := s.cfg.OrderbookInterval.Milliseconds()
+	s.throttleMu.Lock()
+	defer s.throttleMu.Unlock()
+	last := s.lastOrderbookMs[symbolID]
+	if ts-last < gap {
+		return false
+	}
+	s.lastOrderbookMs[symbolID] = ts
+	return true
+}
+
+// HandleTicker distributes a ticker to subscribers, publishes a realtime event,
+// and (when persistence is enabled and the per-symbol throttle allows it)
+// enqueues it for the writer goroutine.
 func (s *MarketDataService) HandleTicker(ctx context.Context, ticker entity.Ticker) {
-	if err := s.repo.SaveTicker(ctx, ticker); err != nil {
-		slog.Warn("failed to save ticker", "error", err)
+	if s.cfg.Enable && s.shouldPersistTicker(ticker.SymbolID, ticker.Timestamp) {
+		t := ticker
+		s.enqueue(persistTask{ticker: &t})
 	}
 
 	s.mu.RLock()
@@ -77,6 +298,43 @@ func (s *MarketDataService) HandleTicker(ctx context.Context, ticker entity.Tick
 	}
 }
 
+// HandleOrderbook persists an orderbook snapshot (subject to throttle) and
+// publishes a realtime event so the frontend panel updates immediately.
+func (s *MarketDataService) HandleOrderbook(ctx context.Context, ob entity.Orderbook) {
+	if s.cfg.Enable && s.shouldPersistOrderbook(ob.SymbolID, ob.Timestamp) {
+		o := ob
+		s.enqueue(persistTask{orderbook: &o})
+	}
+
+	s.mu.RLock()
+	hub := s.realtimeHub
+	s.mu.RUnlock()
+	if hub != nil {
+		if err := hub.PublishData("orderbook", ob.SymbolID, ob); err != nil {
+			slog.Warn("failed to publish orderbook event", "error", err)
+		}
+	}
+}
+
+// HandleTrades enqueues a market trade batch for persistence and publishes
+// the realtime event. Unlike tickers/orderbooks there is no throttle —
+// individual trades are uniquely identified and de-duped at write time.
+func (s *MarketDataService) HandleTrades(ctx context.Context, trades entity.MarketTradesResponse) {
+	if s.cfg.Enable && len(trades.Trades) > 0 {
+		t := trades
+		s.enqueue(persistTask{trades: &t})
+	}
+
+	s.mu.RLock()
+	hub := s.realtimeHub
+	s.mu.RUnlock()
+	if hub != nil {
+		if err := hub.PublishData("market_trades", trades.SymbolID, trades); err != nil {
+			slog.Warn("failed to publish market_trades event", "error", err)
+		}
+	}
+}
+
 // GetCandles retrieves candlestick data from the repository.
 // If before > 0, only candles older than that timestamp are returned.
 func (s *MarketDataService) GetCandles(ctx context.Context, symbolID int64, interval string, limit int, before int64) ([]entity.Candle, error) {
@@ -91,4 +349,9 @@ func (s *MarketDataService) GetLatestTicker(ctx context.Context, symbolID int64)
 // SaveCandles persists candlestick data.
 func (s *MarketDataService) SaveCandles(ctx context.Context, symbolID int64, interval string, candles []entity.Candle) error {
 	return s.repo.SaveCandles(ctx, symbolID, interval, candles)
+}
+
+// GetOrderbookHistory exposes the underlying repo query for replay tooling.
+func (s *MarketDataService) GetOrderbookHistory(ctx context.Context, symbolID int64, from, to int64, limit int) ([]entity.Orderbook, error) {
+	return s.repo.GetOrderbookHistory(ctx, symbolID, from, to, limit)
 }

--- a/backend/internal/usecase/market_data_test.go
+++ b/backend/internal/usecase/market_data_test.go
@@ -12,9 +12,11 @@ import (
 
 // mockMarketDataRepo is a test mock for MarketDataRepository
 type mockMarketDataRepo struct {
-	mu      sync.Mutex
-	candles []entity.Candle
-	tickers []entity.Ticker
+	mu         sync.Mutex
+	candles    []entity.Candle
+	tickers    []entity.Ticker
+	trades     []entity.MarketTrade
+	orderbooks []entity.Orderbook
 }
 
 func newMockRepo() *mockMarketDataRepo {
@@ -77,6 +79,80 @@ func (m *mockMarketDataRepo) GetLatestTicker(_ context.Context, symbolID int64) 
 		}
 	}
 	return nil, fmt.Errorf("not found")
+}
+
+func (m *mockMarketDataRepo) SaveTrades(_ context.Context, _ int64, ts []entity.MarketTrade) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.trades = append(m.trades, ts...)
+	return nil
+}
+
+func (m *mockMarketDataRepo) SaveOrderbook(_ context.Context, ob entity.Orderbook, _ int) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.orderbooks = append(m.orderbooks, ob)
+	return nil
+}
+
+func (m *mockMarketDataRepo) GetOrderbookHistory(_ context.Context, symbolID int64, from, to int64, limit int) ([]entity.Orderbook, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var out []entity.Orderbook
+	for _, ob := range m.orderbooks {
+		if ob.SymbolID != symbolID {
+			continue
+		}
+		if from > 0 && ob.Timestamp < from {
+			continue
+		}
+		if to > 0 && ob.Timestamp > to {
+			continue
+		}
+		out = append(out, ob)
+		if limit > 0 && len(out) >= limit {
+			break
+		}
+	}
+	return out, nil
+}
+
+func (m *mockMarketDataRepo) PurgeOldMarketData(_ context.Context, cutoffMillis int64) (int64, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var deleted int64
+
+	keptTickers := m.tickers[:0]
+	for _, t := range m.tickers {
+		if t.Timestamp < cutoffMillis {
+			deleted++
+			continue
+		}
+		keptTickers = append(keptTickers, t)
+	}
+	m.tickers = keptTickers
+
+	keptTrades := m.trades[:0]
+	for _, t := range m.trades {
+		if t.TradedAt < cutoffMillis {
+			deleted++
+			continue
+		}
+		keptTrades = append(keptTrades, t)
+	}
+	m.trades = keptTrades
+
+	keptObs := m.orderbooks[:0]
+	for _, ob := range m.orderbooks {
+		if ob.Timestamp < cutoffMillis {
+			deleted++
+			continue
+		}
+		keptObs = append(keptObs, ob)
+	}
+	m.orderbooks = keptObs
+
+	return deleted, nil
 }
 
 func TestMarketDataService_SubscribeTicker(t *testing.T) {
@@ -189,5 +265,85 @@ func TestMarketDataService_PublishesRealtimeTicker(t *testing.T) {
 		}
 	case <-time.After(500 * time.Millisecond):
 		t.Fatal("timeout waiting for realtime event")
+	}
+}
+
+func TestMarketDataService_TickerThrottle(t *testing.T) {
+	repo := newMockRepo()
+	cfg := DefaultPersistenceConfig()
+	cfg.QueueSize = 16
+	svc := NewMarketDataServiceWithConfig(repo, cfg)
+
+	ctx := context.Background()
+	// 1 秒スロットリング下では 100ms 間隔で 5 件流しても 1 件しか保存されない。
+	base := int64(1_700_000_000_000)
+	for i := 0; i < 5; i++ {
+		svc.HandleTicker(ctx, entity.Ticker{SymbolID: 7, Last: float64(100 + i), Timestamp: base + int64(i)*100})
+	}
+
+	if got := len(repo.tickers); got != 1 {
+		t.Fatalf("expected 1 ticker after throttle, got %d", got)
+	}
+
+	// 1 秒経過した最初の ts は新規保存される。
+	svc.HandleTicker(ctx, entity.Ticker{SymbolID: 7, Last: 999, Timestamp: base + 1000})
+	if got := len(repo.tickers); got != 2 {
+		t.Fatalf("expected 2 tickers after 1s gap, got %d", got)
+	}
+}
+
+func TestMarketDataService_OrderbookThrottle(t *testing.T) {
+	repo := newMockRepo()
+	cfg := DefaultPersistenceConfig()
+	svc := NewMarketDataServiceWithConfig(repo, cfg)
+
+	ctx := context.Background()
+	base := int64(1_700_000_000_000)
+	// 5 秒スロットリングで 1 秒刻みの 5 件 (base+0..base+4000) は最初だけ通る。
+	for i := 0; i < 5; i++ {
+		svc.HandleOrderbook(ctx, entity.Orderbook{SymbolID: 7, Timestamp: base + int64(i)*1000})
+	}
+	if got := len(repo.orderbooks); got != 1 {
+		t.Fatalf("expected 1 orderbook after throttle, got %d", got)
+	}
+
+	// ts - last == 5000 で境界を満たすので通過し 2 件目になる。
+	svc.HandleOrderbook(ctx, entity.Orderbook{SymbolID: 7, Timestamp: base + 5000})
+	if got := len(repo.orderbooks); got != 2 {
+		t.Fatalf("expected 2 orderbooks after 5s gap, got %d", got)
+	}
+}
+
+func TestMarketDataService_TradesAlwaysPersist(t *testing.T) {
+	repo := newMockRepo()
+	cfg := DefaultPersistenceConfig()
+	svc := NewMarketDataServiceWithConfig(repo, cfg)
+
+	ctx := context.Background()
+	for i := 0; i < 3; i++ {
+		svc.HandleTrades(ctx, entity.MarketTradesResponse{
+			SymbolID:  7,
+			Timestamp: int64(1000 + i),
+			Trades: []entity.MarketTrade{
+				{ID: int64(i + 1), OrderSide: "BUY", Price: 100, Amount: 1, TradedAt: int64(1000 + i)},
+			},
+		})
+	}
+	if got := len(repo.trades); got != 3 {
+		t.Fatalf("expected 3 trades persisted, got %d", got)
+	}
+}
+
+func TestMarketDataService_DisabledPersistence(t *testing.T) {
+	repo := newMockRepo()
+	cfg := PersistenceConfig{Enable: false, QueueSize: 16}
+	svc := NewMarketDataServiceWithConfig(repo, cfg)
+
+	svc.HandleTicker(context.Background(), entity.Ticker{SymbolID: 7, Last: 100, Timestamp: 1000})
+	svc.HandleOrderbook(context.Background(), entity.Orderbook{SymbolID: 7, Timestamp: 1000})
+
+	if len(repo.tickers) != 0 || len(repo.orderbooks) != 0 {
+		t.Fatalf("disabled persistence should not write: tickers=%d obs=%d",
+			len(repo.tickers), len(repo.orderbooks))
 	}
 }


### PR DESCRIPTION
## Summary
ライブ取引・バックテスト双方で execution layer の改善（SOR / 板厚みベースのリスク制限 / OFI / Microprice シグナル等）を組む前段として、WS から受信する ticker / orderbook / trades を SQLite に永続化する基盤を整備。**この PR を起点に G (Orderbook-replay backtest) や D (板厚みリスク制限) を実装可能にする**。

## Changes
- **Schema**：
  - `orderbook_snapshots` テーブル新設（best_ask/bid/mid/spread + depth_json）
  - `trades` に `trade_id` 列を追加し UNIQUE 部分インデックスで dedup
- **Repository (domain + infrastructure)**:
  - `SaveTrades` / `SaveOrderbook(depthLimit)` / `GetOrderbookHistory` / `PurgeOldMarketData`
- **MarketDataService (usecase)**:
  - 非同期 single-writer goroutine + バウンド付きキュー (default 1024)
  - per-symbol throttle: ticker=1s / orderbook=5s
  - 90 日 retention sweep（24h 周期）
  - `HandleOrderbook` / `HandleTrades` を新設して `cmd/main` の WS ハンドラから呼ぶ
  - 既存 `HandleTicker` のセマンティクスは維持（subscriber 配信 + realtime publish）
- **API**: `GET /api/v1/orderbook/history?symbolId&from&to&limit` を追加
- **Env vars**:
  - `PERSIST_TICK_DATA` (true) / `TICKER_PERSIST_INTERVAL_MS` (1000) / `ORDERBOOK_PERSIST_INTERVAL_MS` (5000) / `ORDERBOOK_PERSIST_DEPTH` (20) / `TICK_RETENTION_DAYS` (90) / `TICK_PERSIST_QUEUE_SIZE` (1024)

## 設計メモ
- writer goroutine が未起動の場合（テスト・CLI 経由）は同期 fallback。本番のみ非同期にして hot path を遮断する。
- depth 20 段保存 + JSON 1 列で 1 スナップショット ≒ 1KB。LTC/JPY 5s 周期 × 90 日で約 1.5GB を見込み、SQLite (named volume) の容量内。
- retention は (tickers / trades / orderbook_snapshots) を独立 DELETE で発行し、長期 sweep が writer を長時間ブロックしない。
- realtime hub への publish は service に集約。`cmd/main.handleMarketMessage` の二重配線が解消され、orderbook イベントもダッシュボード（前 PR の `OrderbookPanel`）にそのまま流れる。

## Test plan
- [x] `go test ./... -race -count=1` 全 OK（usecase / database / handler を含む）
- [x] Unit test: throttle / disabled-config / dedup / depthLimit / purge cutoff
- [x] 実機 (Docker Compose backend rebuild)
  - `GET /api/v1/orderbook/history?symbolId=10` で 5 秒間隔のスナップショットを確認
  - `latest = { bestAsk: 9004.5, bestBid: 8959.5, askLen: 20, bidLen: 20 }` ✓
  - 約 8 秒で +1〜2 行のペース（5s throttle 通り）

## 次に続く PR の前提として
本 PR で蓄積した data がそのまま使えるよう、以下のキーで読み出せます：
- 板リプレイ (G): `repo.GetOrderbookHistory(symbolID, from, to, limit)`
- 板厚み (D): 同上の `Asks/Bids` を直接走査
- OFI 算出 (J): 同上の時系列差分

🤖 Generated with [Claude Code](https://claude.com/claude-code)