### PR TITLE
feat(backtest): orderbook L2 リプレイによる VWAP 約定モデルを追加

### DIFF
--- a/backend/cmd/backtest/main.go
+++ b/backend/cmd/backtest/main.go
@@ -89,6 +89,7 @@ type runFlags struct {
 	Spread         float64
 	CarryingCost   float64
 	Slippage       float64
+	SlippageModel  string
 	TradeAmount    float64
 	StopLoss       float64
 	StopLossATR    float64 // PR-12
@@ -113,6 +114,7 @@ func registerRunFlags(fs *flag.FlagSet, f *runFlags) {
 	fs.Float64Var(&f.Spread, "spread", 0.1, "spread percent")
 	fs.Float64Var(&f.CarryingCost, "carrying-cost", 0.04, "daily carrying cost percent")
 	fs.Float64Var(&f.Slippage, "slippage", 0, "slippage percent")
+	fs.StringVar(&f.SlippageModel, "slippage-model", "percent", "slippage model: percent | orderbook (CLI only supports percent for now)")
 	fs.Float64Var(&f.TradeAmount, "trade-amount", 0.01, "trade amount")
 	fs.Float64Var(&f.StopLoss, "stop-loss", 5, "stop loss percent")
 	fs.Float64Var(&f.StopLossATR, "stop-loss-atr", 0, "stop loss ATR multiplier (0=disabled)")
@@ -690,6 +692,13 @@ func buildRunInput(f runFlags, profile *entity.StrategyProfile) (bt.RunInput, er
 		SpreadPercent:    f.Spread,
 		DailyCarryCost:   f.CarryingCost,
 		SlippagePercent:  f.Slippage,
+		SlippageModel:    f.SlippageModel,
+	}
+	// CLI runs from CSV without a SQLite handle, so the orderbook-replay
+	// model has no snapshot source. Surface that as a clear error rather
+	// than silently falling back.
+	if f.SlippageModel == "orderbook" {
+		return bt.RunInput{}, fmt.Errorf("--slippage-model=orderbook is not supported by the CLI; use POST /api/v1/backtest/run from the running server which has access to persisted snapshots")
 	}
 	if len(higherCandles) == 0 {
 		cfg.HigherTFInterval = ""

--- a/backend/internal/domain/entity/backtest.go
+++ b/backend/internal/domain/entity/backtest.go
@@ -12,6 +12,11 @@ type BacktestConfig struct {
 	SpreadPercent    float64 `json:"spreadPercent"`
 	DailyCarryCost   float64 `json:"dailyCarryCost"`
 	SlippagePercent  float64 `json:"slippagePercent"`
+	// SlippageModel selects how fill prices are computed.
+	//   - "" / "percent"  : legacy spread% / slippage% adjustment (default).
+	//   - "orderbook"     : VWAP from persisted L2 snapshots (Phase G).
+	// Unknown values fall back to "percent".
+	SlippageModel string `json:"slippageModel,omitempty"`
 }
 
 // BacktestSummary stores fixed output metrics for a run.

--- a/backend/internal/infrastructure/backtest/fill_price.go
+++ b/backend/internal/infrastructure/backtest/fill_price.go
@@ -1,0 +1,213 @@
+package backtest
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+)
+
+// FillKind distinguishes how a fill price is being computed.
+//   - FillKindEntry  : opening a fresh position; signal-side is the trader's side.
+//   - FillKindExit   : closing an existing position; the actual market side is opposite.
+//
+// The simulator decides which book side to consume based on FillKind + the
+// trader-facing OrderSide:
+//   - entry BUY  / exit SELL  → consume asks (taker buying)
+//   - entry SELL / exit BUY   → consume bids (taker selling)
+type FillKind int
+
+const (
+	FillKindEntry FillKind = iota
+	FillKindExit
+)
+
+// ThinBookError signals that the orderbook side did not have enough depth to
+// fill the requested size. The runner converts this into a "thin_book" trade
+// skip so the strategy is not credited with an impossible fill.
+type ThinBookError struct {
+	Reason string
+}
+
+func (e *ThinBookError) Error() string {
+	if e.Reason == "" {
+		return "thin book"
+	}
+	return "thin book: " + e.Reason
+}
+
+// FillPriceSource computes the realised fill price for a given trade intent.
+// Implementations may inspect side, signalPrice, amount, and timestamp.
+//
+// Returning a *ThinBookError tells the simulator to skip the trade entirely.
+// Any other error aborts the backtest run.
+type FillPriceSource interface {
+	FillPrice(kind FillKind, side entity.OrderSide, signalPrice, amount float64, timestamp int64) (float64, error)
+}
+
+// LegacyPercentSlippage reproduces the historical "spread% / 2 + slippage%"
+// adjustment so existing backtest invocations stay bit-identical.
+type LegacyPercentSlippage struct {
+	SpreadPercent   float64
+	SlippagePercent float64
+}
+
+func (l LegacyPercentSlippage) FillPrice(kind FillKind, side entity.OrderSide, signalPrice, amount float64, _ int64) (float64, error) {
+	_ = kind
+	_ = amount
+	adjust := (l.SpreadPercent/100.0)/2.0 + (l.SlippagePercent / 100.0)
+	if isSellLike(kind, side) {
+		return signalPrice * (1 - adjust), nil
+	}
+	return signalPrice * (1 + adjust), nil
+}
+
+// isSellLike collapses (kind, side) into "are we hitting the bid?" — true when
+// the trader is reducing a long (entry SELL or exit BUY-position).
+func isSellLike(kind FillKind, side entity.OrderSide) bool {
+	switch kind {
+	case FillKindEntry:
+		return side == entity.OrderSideSell
+	case FillKindExit:
+		// Exit closes a long-side position via SELL. The simulator stores the
+		// position's original side in `side`, not the close-order side, so a
+		// long position (Side=BUY) needs a sell to close → hit the bid.
+		return side == entity.OrderSideBuy
+	}
+	return false
+}
+
+// OrderbookReplay computes a VWAP fill price by walking the persisted
+// orderbook snapshot whose timestamp is the most recent entry at or before
+// the trade timestamp.
+//
+// Snapshots older than StaleAfter (millis) are treated as missing — that
+// trade gets skipped via ThinBookError so the strategy is not credited with
+// a stale-book fill.
+//
+// The implementation eagerly loads the full snapshot range at construction
+// time and binary-searches by timestamp. For 1.5 M rows this is cheap (a few
+// hundred MB if the caller asks for it; typical 14-day backtests load far
+// less). Callers needing streaming access can implement FillPriceSource
+// directly.
+type OrderbookReplay struct {
+	snapshots []entity.Orderbook // ascending by Timestamp
+	stale     int64              // millis
+}
+
+// NewOrderbookReplay builds the replayer from a chronologically sorted slice.
+// staleAfterMillis bounds how old a snapshot may be relative to a trade ts.
+// The default in the runner is 60_000 (60 seconds).
+func NewOrderbookReplay(snapshots []entity.Orderbook, staleAfterMillis int64) *OrderbookReplay {
+	// Defensive copy + sort so callers cannot mutate our state and we tolerate
+	// repos that don't promise ordering.
+	cp := make([]entity.Orderbook, len(snapshots))
+	copy(cp, snapshots)
+	sort.Slice(cp, func(i, j int) bool { return cp[i].Timestamp < cp[j].Timestamp })
+	return &OrderbookReplay{snapshots: cp, stale: staleAfterMillis}
+}
+
+// SnapshotCount exposes the number of snapshots loaded; the runner uses this
+// for the pre-flight coverage check.
+func (o *OrderbookReplay) SnapshotCount() int { return len(o.snapshots) }
+
+// FillPrice picks the most recent snapshot at or before ts and walks the
+// appropriate side until the requested amount is filled. ThinBookError is
+// returned when (a) no snapshot is in range, or (b) the side is too thin.
+func (o *OrderbookReplay) FillPrice(kind FillKind, side entity.OrderSide, signalPrice, amount float64, ts int64) (float64, error) {
+	if amount <= 0 {
+		return 0, fmt.Errorf("amount must be positive")
+	}
+	snap, ok := o.lookup(ts)
+	if !ok {
+		return 0, &ThinBookError{Reason: "no snapshot within stale window"}
+	}
+
+	hitAsk := !isSellLike(kind, side) // BUY hits asks
+	var levels []entity.OrderbookEntry
+	if hitAsk {
+		levels = snap.Asks
+	} else {
+		levels = snap.Bids
+	}
+
+	if len(levels) == 0 {
+		return 0, &ThinBookError{Reason: "empty book side"}
+	}
+
+	// Walk levels in price-priority order. Persisted snapshots store top-of-book
+	// first by venue convention but we sort defensively to be deterministic.
+	sorted := make([]entity.OrderbookEntry, len(levels))
+	copy(sorted, levels)
+	if hitAsk {
+		sort.Slice(sorted, func(i, j int) bool { return sorted[i].Price < sorted[j].Price })
+	} else {
+		sort.Slice(sorted, func(i, j int) bool { return sorted[i].Price > sorted[j].Price })
+	}
+
+	remaining := amount
+	cost := 0.0
+	for _, lvl := range sorted {
+		if lvl.Amount <= 0 {
+			continue
+		}
+		take := lvl.Amount
+		if take > remaining {
+			take = remaining
+		}
+		cost += lvl.Price * take
+		remaining -= take
+		if remaining <= 0 {
+			break
+		}
+	}
+	if remaining > 0 {
+		return 0, &ThinBookError{Reason: "insufficient depth"}
+	}
+
+	_ = signalPrice // signalPrice is unused — VWAP from the book is the real fill.
+	return cost / amount, nil
+}
+
+// lookup returns the snapshot with timestamp <= ts and within stale window,
+// or (zero, false) when no snapshot qualifies.
+func (o *OrderbookReplay) lookup(ts int64) (entity.Orderbook, bool) {
+	if len(o.snapshots) == 0 {
+		return entity.Orderbook{}, false
+	}
+	// sort.Search finds the first index whose timestamp > ts; we want the one
+	// just before that.
+	idx := sort.Search(len(o.snapshots), func(i int) bool {
+		return o.snapshots[i].Timestamp > ts
+	})
+	if idx == 0 {
+		return entity.Orderbook{}, false
+	}
+	candidate := o.snapshots[idx-1]
+	if o.stale > 0 && ts-candidate.Timestamp > o.stale {
+		return entity.Orderbook{}, false
+	}
+	return candidate, true
+}
+
+// OrderbookHistoryLoader is the minimal repo surface OrderbookReplay needs.
+// Defined here (rather than imported from domain/repository) so this file
+// stays a leaf with no usecase-side imports.
+type OrderbookHistoryLoader interface {
+	GetOrderbookHistory(ctx context.Context, symbolID int64, from, to int64, limit int) ([]entity.Orderbook, error)
+}
+
+// LoadOrderbookReplay is a convenience helper for the runner: load the entire
+// snapshot range for a symbol/window and wrap it in an OrderbookReplay.
+//
+// The hard cap of 1_000_000 rows is a safety net for very long windows; the
+// runner pre-checks coverage and bails out with a clear error before reaching
+// it.
+func LoadOrderbookReplay(ctx context.Context, repo OrderbookHistoryLoader, symbolID, from, to int64, staleAfterMillis int64) (*OrderbookReplay, error) {
+	snaps, err := repo.GetOrderbookHistory(ctx, symbolID, from, to, 1_000_000)
+	if err != nil {
+		return nil, fmt.Errorf("load orderbook history: %w", err)
+	}
+	return NewOrderbookReplay(snaps, staleAfterMillis), nil
+}

--- a/backend/internal/infrastructure/backtest/fill_price_test.go
+++ b/backend/internal/infrastructure/backtest/fill_price_test.go
@@ -1,0 +1,208 @@
+package backtest
+
+import (
+	"errors"
+	"math"
+	"testing"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+)
+
+func TestLegacyPercentSlippage_AdjustsBothDirections(t *testing.T) {
+	src := LegacyPercentSlippage{SpreadPercent: 0.2, SlippagePercent: 0}
+
+	// Entry BUY hits asks → upward adjust by spread/2.
+	got, err := src.FillPrice(FillKindEntry, entity.OrderSideBuy, 1000, 0.1, 0)
+	if err != nil {
+		t.Fatalf("entry buy: %v", err)
+	}
+	if math.Abs(got-1001) > 1e-9 {
+		t.Fatalf("entry buy fill = %f, want 1001", got)
+	}
+
+	// Entry SELL hits bids → downward adjust.
+	got, err = src.FillPrice(FillKindEntry, entity.OrderSideSell, 1000, 0.1, 0)
+	if err != nil {
+		t.Fatalf("entry sell: %v", err)
+	}
+	if math.Abs(got-999) > 1e-9 {
+		t.Fatalf("entry sell fill = %f, want 999", got)
+	}
+
+	// Exit on a long (Side=BUY stored on the position) → close with sell, hit bids.
+	got, err = src.FillPrice(FillKindExit, entity.OrderSideBuy, 1000, 0.1, 0)
+	if err != nil {
+		t.Fatalf("exit long: %v", err)
+	}
+	if math.Abs(got-999) > 1e-9 {
+		t.Fatalf("exit long fill = %f, want 999", got)
+	}
+}
+
+func TestOrderbookReplay_VWAPSingleLevelExactFit(t *testing.T) {
+	snap := entity.Orderbook{
+		SymbolID:  7,
+		Timestamp: 1000,
+		Asks: []entity.OrderbookEntry{
+			{Price: 9001, Amount: 1.0},
+			{Price: 9002, Amount: 1.0},
+		},
+		Bids: []entity.OrderbookEntry{
+			{Price: 8999, Amount: 1.0},
+		},
+	}
+	r := NewOrderbookReplay([]entity.Orderbook{snap}, 60_000)
+
+	// Entry buy 0.5 LTC → fully filled at 9001.
+	got, err := r.FillPrice(FillKindEntry, entity.OrderSideBuy, 0, 0.5, 1500)
+	if err != nil {
+		t.Fatalf("entry buy: %v", err)
+	}
+	if math.Abs(got-9001) > 1e-9 {
+		t.Fatalf("vwap = %f, want 9001", got)
+	}
+}
+
+func TestOrderbookReplay_VWAPMultiLevelWalk(t *testing.T) {
+	snap := entity.Orderbook{
+		SymbolID:  7,
+		Timestamp: 1000,
+		Asks: []entity.OrderbookEntry{
+			{Price: 100, Amount: 0.4},
+			{Price: 110, Amount: 0.6},
+			{Price: 120, Amount: 1.0},
+		},
+	}
+	r := NewOrderbookReplay([]entity.Orderbook{snap}, 60_000)
+
+	// Buy 0.8 → consumes 0.4@100 + 0.4@110 → cost 40 + 44 = 84 → vwap 105.
+	got, err := r.FillPrice(FillKindEntry, entity.OrderSideBuy, 0, 0.8, 1500)
+	if err != nil {
+		t.Fatalf("vwap walk: %v", err)
+	}
+	if math.Abs(got-105) > 1e-9 {
+		t.Fatalf("vwap = %f, want 105", got)
+	}
+}
+
+func TestOrderbookReplay_ThinBookOnInsufficientDepth(t *testing.T) {
+	snap := entity.Orderbook{
+		SymbolID:  7,
+		Timestamp: 1000,
+		Asks:      []entity.OrderbookEntry{{Price: 100, Amount: 0.5}}, // 0.5 only
+	}
+	r := NewOrderbookReplay([]entity.Orderbook{snap}, 60_000)
+
+	_, err := r.FillPrice(FillKindEntry, entity.OrderSideBuy, 0, 1.0, 1500)
+	var thin *ThinBookError
+	if !errors.As(err, &thin) {
+		t.Fatalf("expected ThinBookError, got %v", err)
+	}
+}
+
+func TestOrderbookReplay_StaleSnapshotRejected(t *testing.T) {
+	// Snapshot at ts=1000, lookup at ts=70_000 with stale=60_000 → rejected.
+	snap := entity.Orderbook{
+		SymbolID:  7,
+		Timestamp: 1000,
+		Asks:      []entity.OrderbookEntry{{Price: 100, Amount: 10}},
+	}
+	r := NewOrderbookReplay([]entity.Orderbook{snap}, 60_000)
+	_, err := r.FillPrice(FillKindEntry, entity.OrderSideBuy, 0, 1.0, 70_000)
+	var thin *ThinBookError
+	if !errors.As(err, &thin) {
+		t.Fatalf("expected ThinBookError for stale snapshot, got %v", err)
+	}
+}
+
+func TestOrderbookReplay_PicksMostRecentBeforeTimestamp(t *testing.T) {
+	snap1 := entity.Orderbook{
+		SymbolID:  7,
+		Timestamp: 1000,
+		Asks:      []entity.OrderbookEntry{{Price: 100, Amount: 10}},
+	}
+	snap2 := entity.Orderbook{
+		SymbolID:  7,
+		Timestamp: 5000,
+		Asks:      []entity.OrderbookEntry{{Price: 200, Amount: 10}},
+	}
+	r := NewOrderbookReplay([]entity.Orderbook{snap1, snap2}, 60_000)
+
+	// Lookup at ts=4000 → must pick snap1 (200 hasn't happened yet).
+	got, err := r.FillPrice(FillKindEntry, entity.OrderSideBuy, 0, 1.0, 4000)
+	if err != nil {
+		t.Fatalf("lookup: %v", err)
+	}
+	if math.Abs(got-100) > 1e-9 {
+		t.Fatalf("expected snap1 (100), got %f", got)
+	}
+
+	// At ts=5000 the new snap is in scope.
+	got, err = r.FillPrice(FillKindEntry, entity.OrderSideBuy, 0, 1.0, 5000)
+	if err != nil {
+		t.Fatalf("lookup2: %v", err)
+	}
+	if math.Abs(got-200) > 1e-9 {
+		t.Fatalf("expected snap2 (200), got %f", got)
+	}
+}
+
+func TestOrderbookReplay_NoSnapshotsBefore(t *testing.T) {
+	snap := entity.Orderbook{Timestamp: 5000, Asks: []entity.OrderbookEntry{{Price: 100, Amount: 10}}}
+	r := NewOrderbookReplay([]entity.Orderbook{snap}, 60_000)
+	_, err := r.FillPrice(FillKindEntry, entity.OrderSideBuy, 0, 1.0, 1000)
+	var thin *ThinBookError
+	if !errors.As(err, &thin) {
+		t.Fatalf("expected ThinBookError when no snapshot precedes ts, got %v", err)
+	}
+}
+
+func TestOrderbookReplay_EmptySideTreatedAsThinBook(t *testing.T) {
+	snap := entity.Orderbook{
+		Timestamp: 1000,
+		Asks:      nil,
+		Bids:      []entity.OrderbookEntry{{Price: 99, Amount: 5}},
+	}
+	r := NewOrderbookReplay([]entity.Orderbook{snap}, 60_000)
+	_, err := r.FillPrice(FillKindEntry, entity.OrderSideBuy, 0, 1.0, 1500)
+	var thin *ThinBookError
+	if !errors.As(err, &thin) {
+		t.Fatalf("expected ThinBookError on empty asks, got %v", err)
+	}
+}
+
+func TestSimExecutor_DefaultsToLegacyPercentSlippage(t *testing.T) {
+	// Sanity check: SimExecutor without an explicit FillPriceSource matches the
+	// pre-refactor arithmetic exactly.
+	sim := NewSimExecutor(SimConfig{
+		InitialBalance:  100_000,
+		SpreadPercent:   0.2,
+		SlippagePercent: 0,
+	})
+	ev, err := sim.Open(7, entity.OrderSideBuy, 1000, 0.1, "test", 1000)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if math.Abs(ev.Price-1001) > 1e-9 {
+		t.Fatalf("default slippage fill = %f, want 1001", ev.Price)
+	}
+}
+
+func TestSimExecutor_OrderbookReplayThinBookErrorPropagates(t *testing.T) {
+	// SimExecutor wired with an OrderbookReplay must surface ThinBookError to
+	// the runner so the trade gets skipped (not silently filled at signal price).
+	snap := entity.Orderbook{
+		Timestamp: 1000,
+		Asks:      []entity.OrderbookEntry{{Price: 100, Amount: 0.01}}, // thin
+	}
+	r := NewOrderbookReplay([]entity.Orderbook{snap}, 60_000)
+	sim := NewSimExecutor(SimConfig{
+		InitialBalance:  100_000,
+		FillPriceSource: r,
+	})
+	_, err := sim.Open(7, entity.OrderSideBuy, 1000, 0.5, "thin-book", 1500)
+	var thin *ThinBookError
+	if !errors.As(err, &thin) {
+		t.Fatalf("expected ThinBookError to propagate from SimExecutor, got %v", err)
+	}
+}

--- a/backend/internal/infrastructure/backtest/simulator.go
+++ b/backend/internal/infrastructure/backtest/simulator.go
@@ -13,6 +13,10 @@ type SimConfig struct {
 	SpreadPercent     float64
 	DailyCarryingCost float64
 	SlippagePercent   float64
+	// FillPriceSource overrides the default percent-based slippage model.
+	// When nil, the simulator uses LegacyPercentSlippage{SpreadPercent,
+	// SlippagePercent} so existing call sites stay bit-identical.
+	FillPriceSource FillPriceSource
 }
 
 type SimPosition struct {
@@ -27,22 +31,31 @@ type SimPosition struct {
 }
 
 type SimExecutor struct {
-	positions    []SimPosition
-	closedTrades []entity.BacktestTradeRecord
-	balance      float64
-	config       SimConfig
-	nextOrderID  int64
-	nextTradeID  int64
-	nextPosID    int64
+	positions       []SimPosition
+	closedTrades    []entity.BacktestTradeRecord
+	balance         float64
+	config          SimConfig
+	fillPriceSource FillPriceSource
+	nextOrderID     int64
+	nextTradeID     int64
+	nextPosID       int64
 }
 
 func NewSimExecutor(config SimConfig) *SimExecutor {
+	src := config.FillPriceSource
+	if src == nil {
+		src = LegacyPercentSlippage{
+			SpreadPercent:   config.SpreadPercent,
+			SlippagePercent: config.SlippagePercent,
+		}
+	}
 	return &SimExecutor{
-		balance:     config.InitialBalance,
-		config:      config,
-		nextOrderID: 1,
-		nextTradeID: 1,
-		nextPosID:   1,
+		balance:         config.InitialBalance,
+		config:          config,
+		fillPriceSource: src,
+		nextOrderID:     1,
+		nextTradeID:     1,
+		nextPosID:       1,
 	}
 }
 
@@ -62,7 +75,10 @@ func (s *SimExecutor) Open(symbolID int64, side entity.OrderSide, signalPrice, a
 		}
 	}
 
-	fill := s.entryFillPrice(side, signalPrice)
+	fill, err := s.fillPriceSource.FillPrice(FillKindEntry, side, signalPrice, amount, timestamp)
+	if err != nil {
+		return entity.OrderEvent{}, err
+	}
 	position := SimPosition{
 		PositionID:     s.nextPosID,
 		SymbolID:       symbolID,
@@ -106,7 +122,10 @@ func (s *SimExecutor) Close(positionID int64, signalPrice float64, reason string
 	}
 
 	pos := s.positions[idx]
-	exitFill := s.exitFillPrice(pos.Side, signalPrice)
+	exitFill, err := s.fillPriceSource.FillPrice(FillKindExit, pos.Side, signalPrice, pos.Amount, timestamp)
+	if err != nil {
+		return entity.OrderEvent{}, nil, err
+	}
 	spreadCostClose := signalPrice * pos.Amount * (s.config.SpreadPercent / 100.0) / 2.0
 	spreadCostTotal := pos.SpreadCostOpen + spreadCostClose
 	carrying := s.carryingCost(pos, timestamp)
@@ -225,27 +244,8 @@ func (s *SimExecutor) Equity(markPriceBySymbol map[int64]float64) float64 {
 	return equity
 }
 
-func (s *SimExecutor) entryFillPrice(side entity.OrderSide, signalPrice float64) float64 {
-	adjust := (s.config.SpreadPercent / 100.0 / 2.0) + (s.config.SlippagePercent / 100.0)
-	switch side {
-	case entity.OrderSideSell:
-		return signalPrice * (1 - adjust)
-	default:
-		return signalPrice * (1 + adjust)
-	}
-}
-
-func (s *SimExecutor) exitFillPrice(side entity.OrderSide, signalPrice float64) float64 {
-	adjust := (s.config.SpreadPercent / 100.0 / 2.0) + (s.config.SlippagePercent / 100.0)
-	switch side {
-	case entity.OrderSideSell:
-		// Close SELL by BUY.
-		return signalPrice * (1 + adjust)
-	default:
-		// Close BUY by SELL.
-		return signalPrice * (1 - adjust)
-	}
-}
+// entryFillPrice / exitFillPrice were folded into FillPriceSource.
+// LegacyPercentSlippage in fill_price.go preserves the original arithmetic.
 
 func (s *SimExecutor) carryingCost(pos SimPosition, exitTimestamp int64) float64 {
 	if s.config.DailyCarryingCost <= 0 {

--- a/backend/internal/interfaces/api/handler/backtest.go
+++ b/backend/internal/interfaces/api/handler/backtest.go
@@ -12,11 +12,25 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/repository"
+	infrabt "github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/infrastructure/backtest"
 	csvinfra "github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/infrastructure/csv"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/infrastructure/strategyprofile"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase"
 	bt "github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/backtest"
 	strategyuc "github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/strategy"
 )
+
+// orderbookReplayStaleAfterMs is how far we let a snapshot drift before
+// declaring it stale. 60 s matches the design discussion: 5 s persist
+// throttle × ~10 missed frames is treated as "venue feed gap" and the
+// trade is skipped rather than filled at a stale price.
+const orderbookReplayStaleAfterMs = 60_000
+
+// orderbookReplayMinCoverageRatio is the minimum (snapshots / 5s buckets in
+// window) ratio required before /backtest/run accepts an "orderbook"
+// slippage model run. 0.8 = at most 20% of the bucketed window may be
+// missing snapshots.
+const orderbookReplayMinCoverageRatio = 0.8
 
 // defaultProfilesBaseDir mirrors the CLI default: strategy profiles live
 // under backend/profiles/ at repository root. See spec §8.3 for why the
@@ -38,6 +52,10 @@ type BacktestHandler struct {
 	// only; wiring this repo re-enables /backtest/walk-forward/:id and
 	// GET listing without touching the happy path.
 	wfRepo repository.WalkForwardResultRepository
+
+	// marketDataSvc supplies persisted L2 snapshots for slippageModel="orderbook".
+	// When nil, that model returns 400 ("orderbook replay unavailable").
+	marketDataSvc *usecase.MarketDataService
 }
 
 // BacktestHandlerOption configures optional aspects of a BacktestHandler at
@@ -74,6 +92,15 @@ func WithWalkForwardRepo(repo repository.WalkForwardResultRepository) BacktestHa
 	}
 }
 
+// WithMarketDataService enables slippageModel="orderbook" by giving the
+// handler a way to load persisted L2 snapshots. nil keeps the legacy
+// percent-only behaviour.
+func WithMarketDataService(svc *usecase.MarketDataService) BacktestHandlerOption {
+	return func(h *BacktestHandler) {
+		h.marketDataSvc = svc
+	}
+}
+
 func NewBacktestHandler(runner *bt.BacktestRunner, repo repository.BacktestResultRepository, opts ...BacktestHandlerOption) *BacktestHandler {
 	h := &BacktestHandler{
 		runner:          runner,
@@ -97,6 +124,11 @@ type runBacktestRequest struct {
 	Spread                float64 `json:"spread"`
 	CarryingCost          float64 `json:"carryingCost"`
 	Slippage              float64 `json:"slippage"`
+	// SlippageModel: "" / "percent" → legacy %-based adjustment.
+	// "orderbook" → load persisted L2 snapshots for the run window and
+	// compute VWAP fills against them. The handler returns 400 when the
+	// snapshot coverage is insufficient.
+	SlippageModel string `json:"slippageModel,omitempty"`
 	TradeAmount           float64 `json:"tradeAmount"`
 	StopLossPercent       float64 `json:"stopLossPercent"`
 	StopLossATRMultiplier float64 `json:"stopLossAtrMultiplier"` // PR-12
@@ -223,6 +255,7 @@ func (h *BacktestHandler) Run(c *gin.Context) {
 		SpreadPercent:    req.Spread,
 		DailyCarryCost:   req.CarryingCost,
 		SlippagePercent:  req.Slippage,
+		SlippageModel:    req.SlippageModel,
 	}
 	if len(higherCandles) == 0 {
 		cfg.HigherTFInterval = ""
@@ -258,6 +291,16 @@ func (h *BacktestHandler) Run(c *gin.Context) {
 		positionSizing = resolved.Risk.PositionSizing
 	}
 
+	var fillSource infrabt.FillPriceSource
+	if req.SlippageModel == "orderbook" {
+		var err error
+		fillSource, err = h.buildOrderbookFillSource(c.Request.Context(), cfg)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+	}
+
 	result, err := runner.Run(context.Background(), bt.RunInput{
 		Config:            cfg,
 		TradeAmount:       req.TradeAmount,
@@ -265,6 +308,7 @@ func (h *BacktestHandler) Run(c *gin.Context) {
 		HigherCandles:     higherCandles,
 		BBSqueezeLookback: bbLookback,
 		PositionSizing:    positionSizing,
+		FillPriceSource:   fillSource,
 		RiskConfig: entity.RiskConfig{
 			MaxPositionAmount:     req.MaxPositionAmount,
 			MaxDailyLoss:          req.MaxDailyLoss,
@@ -302,6 +346,54 @@ func (h *BacktestHandler) Run(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusOK, result)
+}
+
+// buildOrderbookFillSource validates that enough L2 snapshots exist for the
+// requested run window and returns an OrderbookReplay-backed FillPriceSource.
+// Returns a user-facing error (caller maps to HTTP 400) when:
+//   - the handler was constructed without a MarketDataService
+//   - the run window is open-ended (we need both endpoints to bound the load)
+//   - fewer than orderbookReplayMinCoverageRatio of the 5 s buckets in the
+//     window have a snapshot
+func (h *BacktestHandler) buildOrderbookFillSource(ctx context.Context, cfg entity.BacktestConfig) (infrabt.FillPriceSource, error) {
+	if h.marketDataSvc == nil {
+		return nil, errors.New("orderbook replay unavailable: backend was started without market data persistence")
+	}
+	if cfg.FromTimestamp <= 0 || cfg.ToTimestamp <= 0 || cfg.ToTimestamp <= cfg.FromTimestamp {
+		return nil, errors.New("orderbook replay requires bounded from/to timestamps")
+	}
+
+	snaps, err := h.marketDataSvc.GetOrderbookHistory(ctx, cfg.SymbolID, cfg.FromTimestamp, cfg.ToTimestamp, 1_000_000)
+	if err != nil {
+		return nil, errors.New("orderbook replay: failed to load snapshots: " + err.Error())
+	}
+	if len(snaps) == 0 {
+		return nil, errors.New("orderbook replay: no L2 snapshots in requested window — backtest with slippageModel=\"percent\" instead, or wait for the persistence worker to accumulate data")
+	}
+
+	// Coverage = snapshots / expected_buckets, where the expected bucket size
+	// is the persistence throttle (5 s). Falls back to a conservative 1.0
+	// floor when the throttle is 0 (test config).
+	bucketSec := int64(5)
+	expected := (cfg.ToTimestamp - cfg.FromTimestamp) / 1000 / bucketSec
+	if expected <= 0 {
+		expected = 1
+	}
+	coverage := float64(len(snaps)) / float64(expected)
+	if coverage < orderbookReplayMinCoverageRatio {
+		return nil, fmtCoverageError(len(snaps), expected, coverage)
+	}
+	return infrabt.NewOrderbookReplay(snaps, orderbookReplayStaleAfterMs), nil
+}
+
+func fmtCoverageError(got int, expected int64, coverage float64) error {
+	return errors.New(
+		"orderbook replay: snapshot coverage too low (" +
+			strconv.Itoa(got) + " of ~" + strconv.FormatInt(expected, 10) +
+			" expected buckets, " +
+			strconv.FormatFloat(coverage*100, 'f', 1, 64) +
+			"%). Wait for more data or use slippageModel=\"percent\".",
+	)
 }
 
 // loadProfileForRequest resolves and loads a profile by name. Returns

--- a/backend/internal/interfaces/api/router.go
+++ b/backend/internal/interfaces/api/router.go
@@ -152,6 +152,9 @@ func NewRouter(deps Dependencies) *gin.Engine {
 		if deps.WalkForwardResultRepo != nil {
 			opts = append(opts, handler.WithWalkForwardRepo(deps.WalkForwardResultRepo))
 		}
+		if deps.MarketDataService != nil {
+			opts = append(opts, handler.WithMarketDataService(deps.MarketDataService))
+		}
 		backtestHandler := handler.NewBacktestHandler(deps.BacktestRunner, deps.BacktestResultRepo, opts...)
 		// PR-12: profile discovery endpoints used by the FE backtest picker.
 		// The same profilesBaseDir default is used so /profiles and

--- a/backend/internal/usecase/backtest/handler.go
+++ b/backend/internal/usecase/backtest/handler.go
@@ -11,10 +11,16 @@ import (
 
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/port"
+	infra "github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/infrastructure/backtest"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/infrastructure/indicator"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/eventengine"
 )
+
+// infraThinBookError is a re-export alias so handlers can detect the
+// orderbook-replay's "thin book" sentinel without leaking the infra package
+// name everywhere.
+type infraThinBookError = infra.ThinBookError
 
 // ErrBacktestStrategyMissing is returned by StrategyHandler.Handle when the
 // handler was constructed with a nil port.Strategy. Callers should use
@@ -414,6 +420,11 @@ type TickRiskHandler struct {
 	TakeProfitPercent     float64
 	highWaterMarks        map[int64]float64
 	currentATR            float64
+	// ThinBookSkips counts SL/TP/trailing exits the simulator could not fill
+	// because the orderbook side did not have enough depth (orderbook-replay
+	// slippage model only). Surfaced for logging — the position stays open in
+	// that case, so the next tick will re-attempt the close.
+	ThinBookSkips int
 }
 
 func NewTickRiskHandler(primaryInterval string, executor TickRiskExecutor, stopLossPercent, takeProfitPercent float64) *TickRiskHandler {
@@ -529,6 +540,11 @@ func (h *TickRiskHandler) Handle(_ context.Context, event entity.Event) ([]entit
 			if hit {
 				orderEvent, _, err := h.Executor.Close(pos.PositionID, exitPrice, reason, tickEvent.Timestamp)
 				if err != nil {
+					var thin *infraThinBookError
+					if errors.As(err, &thin) {
+						h.ThinBookSkips++
+						continue
+					}
 					return nil, err
 				}
 				emitted = append(emitted, orderEvent)
@@ -561,6 +577,11 @@ func (h *TickRiskHandler) Handle(_ context.Context, event entity.Event) ([]entit
 			if best > pos.EntryPrice && best-tickEvent.Price >= distance {
 				orderEvent, _, err := h.Executor.Close(pos.PositionID, tickEvent.Price, "trailing_stop", tickEvent.Timestamp)
 				if err != nil {
+					var thin *infraThinBookError
+					if errors.As(err, &thin) {
+						h.ThinBookSkips++
+						continue
+					}
 					return nil, err
 				}
 				emitted = append(emitted, orderEvent)
@@ -570,6 +591,11 @@ func (h *TickRiskHandler) Handle(_ context.Context, event entity.Event) ([]entit
 			if best < pos.EntryPrice && tickEvent.Price-best >= distance {
 				orderEvent, _, err := h.Executor.Close(pos.PositionID, tickEvent.Price, "trailing_stop", tickEvent.Timestamp)
 				if err != nil {
+					var thin *infraThinBookError
+					if errors.As(err, &thin) {
+						h.ThinBookSkips++
+						continue
+					}
 					return nil, err
 				}
 				emitted = append(emitted, orderEvent)
@@ -600,6 +626,10 @@ type SignalExecutor interface {
 type ExecutionHandler struct {
 	Executor    SignalExecutor
 	TradeAmount float64
+	// ThinBookSkips counts approved signals that the simulator could not fill
+	// because the orderbook side did not have enough depth (only meaningful
+	// with the orderbook-replay slippage model). Surfaced for logging.
+	ThinBookSkips int
 }
 
 func (h *ExecutionHandler) Handle(_ context.Context, event entity.Event) ([]entity.Event, error) {
@@ -633,6 +663,11 @@ func (h *ExecutionHandler) Handle(_ context.Context, event entity.Event) ([]enti
 		signalEvent.Timestamp,
 	)
 	if err != nil {
+		var thin *infraThinBookError
+		if errors.As(err, &thin) {
+			h.ThinBookSkips++
+			return nil, nil
+		}
 		return nil, err
 	}
 	return []entity.Event{orderEvent}, nil

--- a/backend/internal/usecase/backtest/runner.go
+++ b/backend/internal/usecase/backtest/runner.go
@@ -23,6 +23,14 @@ type RunInput struct {
 	PrimaryCandles []entity.Candle
 	HigherCandles  []entity.Candle
 
+	// FillPriceSource overrides the default percent-based slippage model.
+	// When nil, the runner picks one based on Config.SlippageModel:
+	//   - "" / "percent" → LegacyPercentSlippage from SpreadPercent / SlippagePercent
+	//   - "orderbook"    → constructed by the caller and supplied here (the
+	//                      runner does not own a repo handle).
+	// Mutually exclusive with Config.SlippageModel; pass exactly one.
+	FillPriceSource infra.FillPriceSource
+
 	// BBSqueezeLookback is the window (bars) the IndicatorHandler uses to
 	// detect a recent BB squeeze. cycle44: plumbed through from the
 	// profile's stance_rules.bb_squeeze_lookback so the legacy hardcoded
@@ -119,11 +127,30 @@ func (r *BacktestRunner) Run(ctx context.Context, input RunInput) (*entity.Backt
 	}
 	riskMgr := usecase.NewRiskManager(riskCfg)
 
+	fillSource := input.FillPriceSource
+	if fillSource == nil {
+		switch input.Config.SlippageModel {
+		case "", "percent":
+			fillSource = infra.LegacyPercentSlippage{
+				SpreadPercent:   input.Config.SpreadPercent,
+				SlippagePercent: input.Config.SlippagePercent,
+			}
+		case "orderbook":
+			// Caller asked for orderbook replay but did not supply a
+			// FillPriceSource. The handler layer is responsible for loading
+			// the snapshots from the repo because the runner has no repo
+			// dependency by design.
+			return nil, fmt.Errorf("slippage model %q requires FillPriceSource on RunInput", input.Config.SlippageModel)
+		default:
+			return nil, fmt.Errorf("unknown slippage model: %q", input.Config.SlippageModel)
+		}
+	}
 	sim := infra.NewSimExecutor(infra.SimConfig{
 		InitialBalance:    input.Config.InitialBalance,
 		SpreadPercent:     input.Config.SpreadPercent,
 		DailyCarryingCost: input.Config.DailyCarryCost,
 		SlippagePercent:   input.Config.SlippagePercent,
+		FillPriceSource:   fillSource,
 	})
 	simAdapter := &simExecutorAdapter{sim: sim}
 

--- a/backend/internal/usecase/backtest/runner_test.go
+++ b/backend/internal/usecase/backtest/runner_test.go
@@ -7,8 +7,13 @@ import (
 
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/port"
+	infrabt "github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/infrastructure/backtest"
 	strategyuc "github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/strategy"
 )
+
+func newOrderbookReplayForTest(snaps []entity.Orderbook) *infrabt.OrderbookReplay {
+	return infrabt.NewOrderbookReplay(snaps, 60_000)
+}
 
 func TestMergeCandleEvents_PrefersHigherOnSameTimestamp(t *testing.T) {
 	primary := []entity.Candle{
@@ -323,5 +328,111 @@ func TestBacktestRunner_ATRTrailingChangesResult(t *testing.T) {
 		baseline.Summary.TotalReturn == atrRun.Summary.TotalReturn {
 		t.Fatalf("ATR trailing had no effect on backtest output (trades=%d, return=%v) — wiring regression",
 			baseline.Summary.TotalTrades, baseline.Summary.TotalReturn)
+	}
+}
+
+// TestBacktestRunner_OrderbookReplayDiffersFromPercent verifies that a run
+// driven by a fully-populated OrderbookReplay produces different trade
+// economics than the legacy percent model. We build a synthetic series and
+// hand-craft per-bar orderbooks so the orderbook fills are systematically
+// inferior (wider spread + thin top of book).
+func TestBacktestRunner_OrderbookReplayDiffersFromPercent(t *testing.T) {
+	primary := make([]entity.Candle, 0, 60)
+	baseTime := int64(1_770_000_000_000)
+	price := 100.0
+	for i := 0; i < 60; i++ {
+		price += math.Sin(float64(i)/5.0) * 1.5
+		ts := baseTime + int64(i)*15*60*1000
+		primary = append(primary, entity.Candle{
+			Open:  price - 0.5,
+			High:  price + 1.0,
+			Low:   price - 1.0,
+			Close: price,
+			Time:  ts,
+		})
+	}
+
+	// Build one orderbook snapshot per bar with a 1% spread (much wider than
+	// the percent baseline below, 0.1%).
+	snaps := make([]entity.Orderbook, 0, len(primary))
+	for _, c := range primary {
+		snaps = append(snaps, entity.Orderbook{
+			SymbolID:  7,
+			Timestamp: c.Time,
+			Asks:      []entity.OrderbookEntry{{Price: c.Close * 1.01, Amount: 1.0}},
+			Bids:      []entity.OrderbookEntry{{Price: c.Close * 0.99, Amount: 1.0}},
+		})
+	}
+	replay := newOrderbookReplayForTest(snaps)
+
+	cfg := entity.BacktestConfig{
+		Symbol:          "BTC_JPY",
+		SymbolID:        7,
+		PrimaryInterval: "PT15M",
+		FromTimestamp:   primary[0].Time,
+		ToTimestamp:     primary[len(primary)-1].Time,
+		InitialBalance:  100000,
+		SpreadPercent:   0.1, // legacy model: 0.1% spread
+	}
+	risk := entity.RiskConfig{
+		MaxPositionAmount: 1_000_000_000,
+		MaxDailyLoss:      1_000_000_000,
+		StopLossPercent:   5,
+		TakeProfitPercent: 10,
+		InitialCapital:    100000,
+	}
+
+	runner := NewBacktestRunner()
+	pctResult, err := runner.Run(context.Background(), RunInput{
+		Config: cfg, RiskConfig: risk, TradeAmount: 0.01,
+		PrimaryCandles: primary,
+	})
+	if err != nil {
+		t.Fatalf("percent run: %v", err)
+	}
+
+	cfg.SlippageModel = "orderbook"
+	obResult, err := runner.Run(context.Background(), RunInput{
+		Config: cfg, RiskConfig: risk, TradeAmount: 0.01,
+		PrimaryCandles:  primary,
+		FillPriceSource: replay,
+	})
+	if err != nil {
+		t.Fatalf("orderbook run: %v", err)
+	}
+
+	if pctResult.Summary.TotalTrades == 0 {
+		t.Skip("baseline produced no trades — extend the sine to ensure signal coverage")
+	}
+	if pctResult.Summary.FinalBalance == obResult.Summary.FinalBalance {
+		t.Fatalf("expected different final balances (orderbook spread is 10x wider), got both = %f",
+			pctResult.Summary.FinalBalance)
+	}
+}
+
+// TestBacktestRunner_OrderbookReplayMissingSourceErrors makes sure runner
+// rejects "orderbook" without a FillPriceSource — the handler is responsible
+// for loading snapshots, not the runner.
+func TestBacktestRunner_OrderbookReplayMissingSourceErrors(t *testing.T) {
+	primary := []entity.Candle{
+		{Time: 1, Open: 100, High: 100, Low: 100, Close: 100},
+		{Time: 2, Open: 100, High: 100, Low: 100, Close: 100},
+	}
+	runner := NewBacktestRunner()
+	_, err := runner.Run(context.Background(), RunInput{
+		Config: entity.BacktestConfig{
+			Symbol:          "BTC_JPY",
+			SymbolID:        7,
+			PrimaryInterval: "PT15M",
+			FromTimestamp:   1, ToTimestamp: 2,
+			InitialBalance: 100000,
+			SlippageModel:  "orderbook",
+		},
+		RiskConfig:     entity.RiskConfig{InitialCapital: 100000, StopLossPercent: 5},
+		TradeAmount:    0.01,
+		PrimaryCandles: primary,
+	})
+	if err == nil {
+		t.Fatal("expected error when slippageModel=orderbook but no FillPriceSource")
 	}
 }


### PR DESCRIPTION
## Summary
バックテストに **orderbook L2 リプレイ** を導入し、シグナル発生時刻直前の板スナップショットをもとに **そのロットを実際に成行で食ったときの VWAP** を約定価格として使えるようにする。前 PR (#170) で永続化された板データがそのまま入力になる。  
従来の「signalPrice × (1 ± spread%/2)」モデルは互換維持のためデフォルトとして残し、`slippageModel="orderbook"` を明示した場合のみ新モデルが動く。

## Why
現状のシミュレータはロットサイズによらず一定の adjust% を返すため、

- 板が薄い側に大量注文を打ち込んだときの執行コストが過小評価される
- LTC/JPY のスプレッド（実測 0.4% 前後）と既定 0.1% との乖離をバックテストに反映できない

を解消する。SOR (A) や板厚みベースのリスク制限 (D) は **このモデルで P&L が正しく出ること** が前提になる。

## Changes
- **domain/entity/backtest.go**: `BacktestConfig.SlippageModel` を追加
- **infrastructure/backtest/**:
  - `fill_price.go` (NEW): `FillPriceSource` interface, `LegacyPercentSlippage`, `OrderbookReplay`, `ThinBookError`
  - `simulator.go`: `SimExecutor` を `FillPriceSource` ベースに refactor。未指定時は legacy 互換 (`entryFillPrice`/`exitFillPrice` の旧式と一致するテスト付き)
- **usecase/backtest/**:
  - `runner.go`: `RunInput.FillPriceSource` を追加。`SlippageModel="orderbook"` で source 未供給ならエラー
  - `handler.go`: `ExecutionHandler` / `TickRiskHandler` が `ThinBookError` を握りつぶし `ThinBookSkips` をカウント。SL/TP/Trailing/エントリー全箇所
- **interfaces/api/handler/backtest.go**: req に `slippageModel`、orderbook 時は `MarketDataService.GetOrderbookHistory` で eager load し、カバレッジ <80% / 永続化未配線 / 範囲未指定なら 400
- **CLI**: `--slippage-model` flag 追加。`orderbook` は CLI 経路ではサポート外（DB ハンドル無し）→ 明示エラー

## 板枯れ・欠損の扱い
- 直前 60 秒以内のスナップショットを採用、超えたら `ThinBookError` で trade スキップ
- 板の片側枯れ（自分のロット > 上位段累積）も `ThinBookError`
- 期間カバレッジ < 80% (5 秒 bucket 基準) なら handler が 400 で弾く

## Test plan
- [x] `go test ./... -race -count=1` 全 OK
- [x] `LegacyPercentSlippage` の方向別調整、legacy 経路のビット一致
- [x] `OrderbookReplay`: 単一/複数段 VWAP、片側枯れ、stale 60s、直前選択、空 side
- [x] `SimExecutor`: orderbook source 経由で `ThinBookError` が伝搬
- [x] runner 統合:
  - `percent` と `orderbook` で final balance が異なる
  - `slippageModel="orderbook"` かつ `FillPriceSource` 未供給でエラー

## 後続 PR との関係
- D (板厚みリスク制限): 同じ snapshots を runner / live どちらからも参照できる
- H (Maker/Taker 区別): 本 PR の `FillPriceSource` を passive/aggressive 切替に拡張
- I (Latency): `FillPriceSource.FillPrice(ts+Δ)` の形でレイテンシシミュレーション可

🤖 Generated with [Claude Code](https://claude.com/claude-code)