### PR TITLE
feat(risk): 板厚みベースの pre-trade gate (D)

### DIFF
--- a/backend/cmd/event_pipeline.go
+++ b/backend/cmd/event_pipeline.go
@@ -13,6 +13,7 @@ import (
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/infrastructure/live"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/backtest"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/booklimit"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/eventengine"
 )
 
@@ -293,6 +294,18 @@ func (p *EventDrivenPipeline) runEventLoop(ctx context.Context, snap eventSnapsh
 	riskHandler := &backtest.RiskHandler{
 		RiskManager: p.riskMgr,
 		TradeAmount: snap.tradeAmount,
+	}
+	// Pre-trade orderbook depth gate. Live mode keeps the gate forgiving on
+	// missing/stale snapshots (AllowOnMissingBook=true) so a transient WS
+	// gap does not block trading; the simulator path uses the strict mode.
+	if cfg := p.riskMgr.GetStatus().Config; cfg.MaxSlippageBps > 0 || cfg.MaxBookSidePct > 0 {
+		riskHandler.BookGate = booklimit.New(p.marketDataSvc, booklimit.Config{
+			MaxSlippageBps:     cfg.MaxSlippageBps,
+			MaxBookSidePct:     cfg.MaxBookSidePct,
+			TopN:               booklimit.DefaultTopN,
+			StaleAfterMillis:   60_000,
+			AllowOnMissingBook: true,
+		})
 	}
 	bus.Register(entity.EventTypeSignal, 30, riskHandler)
 

--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -80,6 +80,8 @@ func main() {
 		InitialCapital:        cfg.Risk.InitialCapital,
 		MaxConsecutiveLosses:  cfg.Risk.MaxConsecutiveLosses,
 		CooldownMinutes:       cfg.Risk.CooldownMinutes,
+		MaxSlippageBps:        cfg.Risk.MaxSlippageBps,
+		MaxBookSidePct:        cfg.Risk.MaxBookSidePct,
 	})
 	orderExecutor := usecase.NewOrderExecutor(restClient, riskMgr)
 	// Browser notifications subscribe to "trade_event" on the realtime hub —

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -51,6 +51,10 @@ type RiskConfig struct {
 	InitialCapital        float64
 	MaxConsecutiveLosses  int
 	CooldownMinutes       int
+	// Pre-trade orderbook depth gate. Both default to 0 (disabled) so the
+	// gate stays opt-in until the user has confidence in the live cache.
+	MaxSlippageBps float64
+	MaxBookSidePct float64
 }
 
 type RakutenConfig struct {
@@ -77,6 +81,8 @@ func Load() *Config {
 			InitialCapital:        getEnvFloat("RISK_INITIAL_CAPITAL", 10000),
 			MaxConsecutiveLosses:  getEnvInt("RISK_MAX_CONSECUTIVE_LOSSES", 3),
 			CooldownMinutes:       getEnvInt("RISK_COOLDOWN_MINUTES", 30),
+			MaxSlippageBps:        getEnvFloat("RISK_MAX_SLIPPAGE_BPS", 0),
+			MaxBookSidePct:        getEnvFloat("RISK_MAX_BOOK_SIDE_PCT", 0),
 		},
 		Rakuten: RakutenConfig{
 			BaseURL:   getEnv("RAKUTEN_API_BASE_URL", "https://exchange.rakuten-wallet.co.jp"),

--- a/backend/internal/domain/entity/risk.go
+++ b/backend/internal/domain/entity/risk.go
@@ -15,6 +15,13 @@ type RiskConfig struct {
 	InitialCapital        float64 `json:"initialCapital"`       // 軍資金（円）
 	MaxConsecutiveLosses  int     `json:"maxConsecutiveLosses"` // 連敗上限（0=無効）
 	CooldownMinutes       int     `json:"cooldownMinutes"`      // 冷却期間（分）
+
+	// MaxSlippageBps: 板リプレイ／実板の VWAP が mid からこの bps を超える
+	// と注文をブロックする (0=無効)。50 で 0.5%。
+	MaxSlippageBps float64 `json:"maxSlippageBps,omitempty"`
+	// MaxBookSidePct: 自ロットが板上位 5 段累積数量のこの % を超えると
+	// 注文をブロックする (0=無効)。30 = 30%。
+	MaxBookSidePct float64 `json:"maxBookSidePct,omitempty"`
 }
 
 // OrderProposal はRisk Managerに承認を求める注文提案。

--- a/backend/internal/infrastructure/backtest/fill_price.go
+++ b/backend/internal/infrastructure/backtest/fill_price.go
@@ -112,6 +112,15 @@ func NewOrderbookReplay(snapshots []entity.Orderbook, staleAfterMillis int64) *O
 // for the pre-flight coverage check.
 func (o *OrderbookReplay) SnapshotCount() int { return len(o.snapshots) }
 
+// LatestBefore implements booklimit.BookSource: it returns the snapshot whose
+// timestamp is the most recent at or before ts and within the stale window.
+// Same lookup primitive used by FillPrice — exposed so the pre-trade gate can
+// share one OrderbookReplay instance with the simulator.
+func (o *OrderbookReplay) LatestBefore(_ context.Context, _ int64, ts int64) (entity.Orderbook, bool, error) {
+	snap, ok := o.lookup(ts)
+	return snap, ok, nil
+}
+
 // FillPrice picks the most recent snapshot at or before ts and walks the
 // appropriate side until the requested amount is filled. ThinBookError is
 // returned when (a) no snapshot is in range, or (b) the side is too thin.

--- a/backend/internal/interfaces/api/handler/backtest.go
+++ b/backend/internal/interfaces/api/handler/backtest.go
@@ -17,6 +17,7 @@ import (
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/infrastructure/strategyprofile"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase"
 	bt "github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/backtest"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/booklimit"
 	strategyuc "github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/strategy"
 )
 
@@ -138,6 +139,12 @@ type runBacktestRequest struct {
 	MaxDailyLoss          float64 `json:"maxDailyLoss"`
 	MaxConsecutiveLosses  int     `json:"maxConsecutiveLosses"`
 	CooldownMinutes       int     `json:"cooldownMinutes"`
+	// Pre-trade orderbook depth gate (D). Both default to 0 (disabled) so
+	// existing requests run unchanged. Only meaningful with
+	// slippageModel="orderbook" because the percent path has no book to
+	// inspect — the runner silently drops the gate when BookSource is nil.
+	MaxSlippageBps float64 `json:"maxSlippageBps,omitempty"`
+	MaxBookSidePct float64 `json:"maxBookSidePct,omitempty"`
 
 	// PDCA extensions (spec §8.2). All optional; when ProfileName is set,
 	// the profile's values become the base and non-zero individual fields
@@ -292,13 +299,15 @@ func (h *BacktestHandler) Run(c *gin.Context) {
 	}
 
 	var fillSource infrabt.FillPriceSource
+	var bookSource booklimit.BookSource
 	if req.SlippageModel == "orderbook" {
-		var err error
-		fillSource, err = h.buildOrderbookFillSource(c.Request.Context(), cfg)
+		replay, err := h.buildOrderbookReplay(c.Request.Context(), cfg)
 		if err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
 		}
+		fillSource = replay
+		bookSource = replay
 	}
 
 	result, err := runner.Run(context.Background(), bt.RunInput{
@@ -309,6 +318,7 @@ func (h *BacktestHandler) Run(c *gin.Context) {
 		BBSqueezeLookback: bbLookback,
 		PositionSizing:    positionSizing,
 		FillPriceSource:   fillSource,
+		BookSource:        bookSource,
 		RiskConfig: entity.RiskConfig{
 			MaxPositionAmount:     req.MaxPositionAmount,
 			MaxDailyLoss:          req.MaxDailyLoss,
@@ -319,6 +329,8 @@ func (h *BacktestHandler) Run(c *gin.Context) {
 			InitialCapital:        req.InitialBalance,
 			MaxConsecutiveLosses:  req.MaxConsecutiveLosses,
 			CooldownMinutes:       req.CooldownMinutes,
+			MaxSlippageBps:        req.MaxSlippageBps,
+			MaxBookSidePct:        req.MaxBookSidePct,
 		},
 	})
 	if err != nil {
@@ -348,14 +360,16 @@ func (h *BacktestHandler) Run(c *gin.Context) {
 	c.JSON(http.StatusOK, result)
 }
 
-// buildOrderbookFillSource validates that enough L2 snapshots exist for the
-// requested run window and returns an OrderbookReplay-backed FillPriceSource.
+// buildOrderbookReplay validates that enough L2 snapshots exist for the
+// requested run window and returns the OrderbookReplay used both as the
+// simulator's FillPriceSource and as the pre-trade gate's BookSource.
+//
 // Returns a user-facing error (caller maps to HTTP 400) when:
 //   - the handler was constructed without a MarketDataService
 //   - the run window is open-ended (we need both endpoints to bound the load)
 //   - fewer than orderbookReplayMinCoverageRatio of the 5 s buckets in the
 //     window have a snapshot
-func (h *BacktestHandler) buildOrderbookFillSource(ctx context.Context, cfg entity.BacktestConfig) (infrabt.FillPriceSource, error) {
+func (h *BacktestHandler) buildOrderbookReplay(ctx context.Context, cfg entity.BacktestConfig) (*infrabt.OrderbookReplay, error) {
 	if h.marketDataSvc == nil {
 		return nil, errors.New("orderbook replay unavailable: backend was started without market data persistence")
 	}

--- a/backend/internal/usecase/backtest/handler.go
+++ b/backend/internal/usecase/backtest/handler.go
@@ -14,6 +14,7 @@ import (
 	infra "github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/infrastructure/backtest"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/infrastructure/indicator"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/booklimit"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/eventengine"
 )
 
@@ -326,6 +327,12 @@ type RiskHandler struct {
 	// MinConfidence mirrors pipeline.minConfidence so the sizer's confidence
 	// scaling matches the live path's cut-off semantics.
 	MinConfidence float64
+	// BookGate is an optional pre-trade gate that inspects the current
+	// orderbook depth before approving a signal. nil disables the gate.
+	BookGate *booklimit.Gate
+	// BookGateRejects counts how many signals the gate vetoed across
+	// the run, broken down by reason. Used for backtest reports.
+	BookGateRejects map[string]int
 }
 
 func (h *RiskHandler) Handle(ctx context.Context, event entity.Event) ([]entity.Event, error) {
@@ -381,6 +388,20 @@ func (h *RiskHandler) Handle(ctx context.Context, event entity.Event) ([]entity.
 	check := h.RiskManager.CheckOrderAt(ctx, time.UnixMilli(signalEvent.Timestamp), proposal)
 	if !check.Approved {
 		return nil, nil
+	}
+
+	// Pre-trade orderbook depth gate. Runs after RiskManager so the gate
+	// only sees signals that have already cleared position / daily-loss /
+	// cooldown checks. A nil BookGate short-circuits to allow.
+	if h.BookGate != nil {
+		decision := h.BookGate.Check(ctx, signalEvent.Signal.SymbolID, side, amount, signalEvent.Timestamp)
+		if !decision.Allow {
+			if h.BookGateRejects == nil {
+				h.BookGateRejects = make(map[string]int)
+			}
+			h.BookGateRejects[decision.Reason]++
+			return nil, nil
+		}
 	}
 
 	return []entity.Event{

--- a/backend/internal/usecase/backtest/runner.go
+++ b/backend/internal/usecase/backtest/runner.go
@@ -11,6 +11,7 @@ import (
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/port"
 	infra "github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/infrastructure/backtest"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/booklimit"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/eventengine"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/positionsize"
 	strategyuc "github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/strategy"
@@ -30,6 +31,13 @@ type RunInput struct {
 	//                      runner does not own a repo handle).
 	// Mutually exclusive with Config.SlippageModel; pass exactly one.
 	FillPriceSource infra.FillPriceSource
+
+	// BookSource feeds the pre-trade orderbook depth gate. nil disables the
+	// gate entirely; the runner then ignores RiskConfig.MaxSlippageBps and
+	// RiskConfig.MaxBookSidePct because they would have nothing to consult.
+	// In practice the same OrderbookReplay used as FillPriceSource is also
+	// passed here so backtests share one data source for fills and gating.
+	BookSource booklimit.BookSource
 
 	// BBSqueezeLookback is the window (bars) the IndicatorHandler uses to
 	// detect a recent BB squeeze. cycle44: plumbed through from the
@@ -185,6 +193,21 @@ func (r *BacktestRunner) Run(ctx context.Context, input RunInput) (*entity.Backt
 		riskHandler.Sizer = positionsize.New(ps, defaults)
 		riskHandler.Equity = EquityFunc(func() float64 { return sim.Balance() })
 		riskHandler.Peak = NewPeakTracker(input.Config.InitialBalance)
+	}
+	// Pre-trade book depth gate. The runner only attaches it when both a
+	// BookSource and at least one configured threshold are present —
+	// otherwise the legacy backtest path stays bit-identical.
+	if input.BookSource != nil && (riskCfg.MaxSlippageBps > 0 || riskCfg.MaxBookSidePct > 0) {
+		riskHandler.BookGate = booklimit.New(input.BookSource, booklimit.Config{
+			MaxSlippageBps: riskCfg.MaxSlippageBps,
+			MaxBookSidePct: riskCfg.MaxBookSidePct,
+			TopN:           booklimit.DefaultTopN,
+			// Backtest enforces the staleness check (60 s window matches the
+			// orderbook-replay simulator) and rejects missing snapshots so
+			// gaps in the persisted history do not silently waive the gate.
+			StaleAfterMillis:   60_000,
+			AllowOnMissingBook: false,
+		})
 	}
 	executionHandler := &ExecutionHandler{
 		Executor:    simAdapter,

--- a/backend/internal/usecase/backtest/runner_test.go
+++ b/backend/internal/usecase/backtest/runner_test.go
@@ -436,3 +436,68 @@ func TestBacktestRunner_OrderbookReplayMissingSourceErrors(t *testing.T) {
 		t.Fatal("expected error when slippageModel=orderbook but no FillPriceSource")
 	}
 }
+
+// TestBacktestRunner_BookGateBlocksThinTradesEntirely confirms the runner
+// wires the pre-trade gate into RiskHandler. With a snapshot whose ask side
+// is far thinner than the requested lot, every signal must be rejected and
+// the run produces zero trades.
+func TestBacktestRunner_BookGateBlocksThinTradesEntirely(t *testing.T) {
+	primary := make([]entity.Candle, 0, 60)
+	baseTime := int64(1_770_000_000_000)
+	price := 100.0
+	for i := 0; i < 60; i++ {
+		price += math.Sin(float64(i)/5.0) * 1.5
+		ts := baseTime + int64(i)*15*60*1000
+		primary = append(primary, entity.Candle{
+			Open: price - 0.5, High: price + 1.0, Low: price - 1.0, Close: price, Time: ts,
+		})
+	}
+	// Each bar gets a 1-tick-deep snapshot — way below the 0.01 trade size.
+	snaps := make([]entity.Orderbook, 0, len(primary))
+	for _, c := range primary {
+		snaps = append(snaps, entity.Orderbook{
+			SymbolID:  7,
+			Timestamp: c.Time,
+			Asks:      []entity.OrderbookEntry{{Price: c.Close * 1.001, Amount: 0.0001}},
+			Bids:      []entity.OrderbookEntry{{Price: c.Close * 0.999, Amount: 0.0001}},
+			BestAsk:   c.Close * 1.001,
+			BestBid:   c.Close * 0.999,
+			MidPrice:  c.Close,
+		})
+	}
+	replay := newOrderbookReplayForTest(snaps)
+
+	cfg := entity.BacktestConfig{
+		Symbol:          "BTC_JPY",
+		SymbolID:        7,
+		PrimaryInterval: "PT15M",
+		FromTimestamp:   primary[0].Time,
+		ToTimestamp:     primary[len(primary)-1].Time,
+		InitialBalance:  100000,
+		SlippageModel:   "orderbook",
+	}
+	risk := entity.RiskConfig{
+		MaxPositionAmount: 1_000_000_000,
+		MaxDailyLoss:      1_000_000_000,
+		StopLossPercent:   5,
+		TakeProfitPercent: 10,
+		InitialCapital:    100000,
+		MaxSlippageBps:    50,
+		MaxBookSidePct:    30,
+	}
+	runner := NewBacktestRunner()
+	result, err := runner.Run(context.Background(), RunInput{
+		Config:          cfg,
+		RiskConfig:      risk,
+		TradeAmount:     0.01,
+		PrimaryCandles:  primary,
+		FillPriceSource: replay,
+		BookSource:      replay,
+	})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if result.Summary.TotalTrades != 0 {
+		t.Fatalf("expected book gate to block all trades, got %d", result.Summary.TotalTrades)
+	}
+}

--- a/backend/internal/usecase/booklimit/book_limit.go
+++ b/backend/internal/usecase/booklimit/book_limit.go
@@ -1,0 +1,268 @@
+// Package booklimit provides a pre-trade orderbook depth gate shared by the
+// backtest runner and the live pipeline.
+//
+// The gate runs after a signal has been risk-approved and before the executor
+// fills it: it inspects the most recent orderbook snapshot for the symbol,
+// computes the implied VWAP for the proposed lot, and rejects the trade when
+// either of two thresholds is breached:
+//
+//   - Expected slippage > MaxSlippageBps (relative to mid price)
+//   - Lot exceeds MaxBookSidePct of the cumulative top-N levels on the
+//     side being hit
+//
+// Backtest and live pipelines share the same Gate instance via the BookSource
+// abstraction so the same rejection logic governs both worlds.
+package booklimit
+
+import (
+	"context"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+)
+
+// Decision captures the outcome of one pre-trade check.
+type Decision struct {
+	Allow  bool
+	Reason string // empty when Allow is true
+	// SlippageBps and BookFillRatio are populated for observability even when
+	// the trade is allowed. SlippageBps is signed: positive when the fill is
+	// worse than mid (the typical case for taker fills).
+	SlippageBps   float64
+	BookFillRatio float64 // requestedAmount / topNCumulativeAmount on the side being hit
+}
+
+// Config controls the thresholds. Zero values disable the corresponding
+// check, which is what the runner uses when the caller has not opted in.
+type Config struct {
+	// MaxSlippageBps rejects trades whose VWAP would deviate from mid by
+	// more than this many basis points. 0 disables the check. 50 = 0.5%.
+	MaxSlippageBps float64
+	// MaxBookSidePct rejects trades whose lot is more than this percentage
+	// of the cumulative top-N levels on the side being hit. 0 disables.
+	// 30 = lot must be <= 30% of top-N depth.
+	MaxBookSidePct float64
+	// TopN is how many levels feed the cumulative-depth ratio. 0 falls back
+	// to DefaultTopN (5) so callers don't have to remember a magic number.
+	TopN int
+	// StaleAfterMillis bounds how old a snapshot may be relative to the
+	// trade timestamp. 0 disables the staleness check (live mode treats a
+	// missing-but-recent book as "no opinion" — see GateBehaviour below).
+	StaleAfterMillis int64
+	// AllowOnMissingBook controls what happens when the BookSource has no
+	// snapshot in range:
+	//   - true  (live default): treat as "no opinion" → trade is allowed.
+	//   - false (backtest):     reject with reason "no_book".
+	AllowOnMissingBook bool
+}
+
+// DefaultTopN is the fallback level count for the cumulative-depth ratio.
+const DefaultTopN = 5
+
+// DefaultConfig returns the values the live pipeline uses when no override
+// is supplied.
+func DefaultConfig() Config {
+	return Config{
+		MaxSlippageBps:     50, // 0.5%
+		MaxBookSidePct:     30, // lot <= 30% of top-5 cumulative depth
+		TopN:               DefaultTopN,
+		StaleAfterMillis:   60_000,
+		AllowOnMissingBook: true,
+	}
+}
+
+// BookSource is the minimal port the gate needs to look up the latest snapshot
+// at or before a given timestamp. Live wires a per-symbol cache here;
+// backtest wires the same eager-loaded slice used by the orderbook-replay
+// FillPriceSource.
+type BookSource interface {
+	LatestBefore(ctx context.Context, symbolID, ts int64) (entity.Orderbook, bool, error)
+}
+
+// Gate is the runtime object: a Config + BookSource pair.
+type Gate struct {
+	Source BookSource
+	Cfg    Config
+}
+
+// New constructs a Gate. Either argument may be nil — a nil Source short-
+// circuits Check to "allow" so callers can wire the gate unconditionally
+// and disable it by leaving Source nil during early dev.
+func New(source BookSource, cfg Config) *Gate {
+	if cfg.TopN <= 0 {
+		cfg.TopN = DefaultTopN
+	}
+	return &Gate{Source: source, Cfg: cfg}
+}
+
+// Check evaluates a proposed trade. The gate is intentionally side-aware:
+//   - BUY hits asks (the trader is the taker, lifting offers)
+//   - SELL hits bids
+func (g *Gate) Check(ctx context.Context, symbolID int64, side entity.OrderSide, amount float64, tsMillis int64) Decision {
+	// No source wired → skip the gate entirely (used by tests and the
+	// initial CLI-only path before live cache is available).
+	if g == nil || g.Source == nil {
+		return Decision{Allow: true}
+	}
+	if amount <= 0 {
+		return Decision{Allow: true}
+	}
+
+	snap, found, err := g.Source.LatestBefore(ctx, symbolID, tsMillis)
+	if err != nil || !found {
+		if g.Cfg.AllowOnMissingBook {
+			return Decision{Allow: true, Reason: "no_book_pass"}
+		}
+		return Decision{Allow: false, Reason: "no_book"}
+	}
+	if g.Cfg.StaleAfterMillis > 0 && tsMillis-snap.Timestamp > g.Cfg.StaleAfterMillis {
+		if g.Cfg.AllowOnMissingBook {
+			return Decision{Allow: true, Reason: "stale_book_pass"}
+		}
+		return Decision{Allow: false, Reason: "stale_book"}
+	}
+
+	// Pick the side being hit.
+	var levels []entity.OrderbookEntry
+	if side == entity.OrderSideBuy {
+		levels = snap.Asks
+	} else {
+		levels = snap.Bids
+	}
+	if len(levels) == 0 {
+		return Decision{Allow: false, Reason: "empty_book_side"}
+	}
+
+	mid := snap.MidPrice
+	if mid <= 0 {
+		// Fall back to (bestAsk+bestBid)/2 when the venue did not supply mid.
+		if snap.BestAsk > 0 && snap.BestBid > 0 {
+			mid = (snap.BestAsk + snap.BestBid) / 2
+		}
+	}
+
+	vwap, depth := walkLevels(levels, amount, side)
+
+	// Book-fill ratio uses cumulative top-N depth, NOT the depth actually
+	// consumed by the lot — we want to reject "lot would soak too much of
+	// the visible book" even if the lot itself fits in the very top level.
+	topN := topNCumAmount(levels, g.Cfg.TopN)
+	var fillRatio float64
+	if topN > 0 {
+		fillRatio = amount / topN
+	}
+
+	if depth < amount {
+		// Lot did not fully fit in the visible book at all; this is more
+		// severe than the soft "ratio" check above and we always reject it
+		// regardless of MaxBookSidePct. The orderbook-replay simulator
+		// surfaces the same condition as ThinBookError; here we catch it
+		// before the order is even placed.
+		return Decision{
+			Allow:         false,
+			Reason:        "thin_book_pre_trade",
+			BookFillRatio: fillRatio,
+		}
+	}
+
+	slipBps := 0.0
+	if mid > 0 {
+		// Sign the slippage so taker fills come out positive.
+		if side == entity.OrderSideBuy {
+			slipBps = (vwap - mid) / mid * 10000
+		} else {
+			slipBps = (mid - vwap) / mid * 10000
+		}
+	}
+
+	if g.Cfg.MaxBookSidePct > 0 && fillRatio*100 > g.Cfg.MaxBookSidePct {
+		return Decision{
+			Allow:         false,
+			Reason:        "lot_exceeds_book_side_ratio",
+			SlippageBps:   slipBps,
+			BookFillRatio: fillRatio,
+		}
+	}
+	if g.Cfg.MaxSlippageBps > 0 && slipBps > g.Cfg.MaxSlippageBps {
+		return Decision{
+			Allow:         false,
+			Reason:        "slippage_exceeds_threshold",
+			SlippageBps:   slipBps,
+			BookFillRatio: fillRatio,
+		}
+	}
+	return Decision{
+		Allow:         true,
+		SlippageBps:   slipBps,
+		BookFillRatio: fillRatio,
+	}
+}
+
+// walkLevels computes the VWAP for filling `amount` against the given side.
+// Returns (vwap, totalDepth). When totalDepth < amount, vwap is the average
+// over what was filled (caller should reject via the depth comparison rather
+// than relying on vwap).
+func walkLevels(levels []entity.OrderbookEntry, amount float64, side entity.OrderSide) (vwap float64, totalDepth float64) {
+	sortLevels(levels, side)
+	remaining := amount
+	cost := 0.0
+	filled := 0.0
+	depth := 0.0
+	for _, lvl := range levels {
+		if lvl.Amount <= 0 {
+			continue
+		}
+		depth += lvl.Amount
+		take := lvl.Amount
+		if take > remaining {
+			take = remaining
+		}
+		cost += lvl.Price * take
+		filled += take
+		remaining -= take
+	}
+	if filled <= 0 {
+		return 0, depth
+	}
+	return cost / filled, depth
+}
+
+// sortLevels orders by best-price-first. The snapshot persisted by the venue
+// is already in this order, but we sort defensively so callers can pass
+// reshuffled slices (e.g. tests).
+func sortLevels(levels []entity.OrderbookEntry, side entity.OrderSide) {
+	if len(levels) <= 1 {
+		return
+	}
+	if side == entity.OrderSideBuy {
+		// Asks: ascending price.
+		for i := 1; i < len(levels); i++ {
+			for j := i; j > 0 && levels[j-1].Price > levels[j].Price; j-- {
+				levels[j-1], levels[j] = levels[j], levels[j-1]
+			}
+		}
+	} else {
+		// Bids: descending price.
+		for i := 1; i < len(levels); i++ {
+			for j := i; j > 0 && levels[j-1].Price < levels[j].Price; j-- {
+				levels[j-1], levels[j] = levels[j], levels[j-1]
+			}
+		}
+	}
+}
+
+func topNCumAmount(levels []entity.OrderbookEntry, n int) float64 {
+	if n <= 0 || len(levels) == 0 {
+		return 0
+	}
+	if n > len(levels) {
+		n = len(levels)
+	}
+	sum := 0.0
+	for i := 0; i < n; i++ {
+		if levels[i].Amount > 0 {
+			sum += levels[i].Amount
+		}
+	}
+	return sum
+}
+

--- a/backend/internal/usecase/booklimit/book_limit_test.go
+++ b/backend/internal/usecase/booklimit/book_limit_test.go
@@ -1,0 +1,202 @@
+package booklimit
+
+import (
+	"context"
+	"testing"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+)
+
+type fakeSource struct {
+	snap   entity.Orderbook
+	found  bool
+	err    error
+}
+
+func (f *fakeSource) LatestBefore(_ context.Context, _ int64, _ int64) (entity.Orderbook, bool, error) {
+	return f.snap, f.found, f.err
+}
+
+func ob(ts int64, asks, bids []entity.OrderbookEntry, bestAsk, bestBid, mid float64) entity.Orderbook {
+	return entity.Orderbook{
+		Timestamp: ts,
+		Asks:      asks,
+		Bids:      bids,
+		BestAsk:   bestAsk,
+		BestBid:   bestBid,
+		MidPrice:  mid,
+	}
+}
+
+func TestGate_AllowsTradeBelowAllThresholds(t *testing.T) {
+	src := &fakeSource{
+		snap: ob(1000,
+			[]entity.OrderbookEntry{{Price: 1001, Amount: 10}, {Price: 1002, Amount: 10}, {Price: 1003, Amount: 10}, {Price: 1004, Amount: 10}, {Price: 1005, Amount: 10}},
+			[]entity.OrderbookEntry{{Price: 999, Amount: 10}},
+			1001, 999, 1000,
+		),
+		found: true,
+	}
+	g := New(src, Config{
+		MaxSlippageBps:     50,
+		MaxBookSidePct:     30,
+		TopN:               5,
+		StaleAfterMillis:   60_000,
+		AllowOnMissingBook: true,
+	})
+
+	// 1.0 LTC vs 50 LTC top-5 → 2% ratio, fills entirely at 1001 → ~10 bps
+	d := g.Check(context.Background(), 7, entity.OrderSideBuy, 1.0, 1500)
+	if !d.Allow {
+		t.Fatalf("expected allow, got %+v", d)
+	}
+	// VWAP = 1001 → slip = (1001-1000)/1000 × 10000 = 10 bps
+	if d.SlippageBps < 9.9 || d.SlippageBps > 10.1 {
+		t.Fatalf("unexpected slippage bps: %f", d.SlippageBps)
+	}
+	if d.BookFillRatio < 0.019 || d.BookFillRatio > 0.021 {
+		t.Fatalf("unexpected book fill ratio: %f", d.BookFillRatio)
+	}
+}
+
+func TestGate_RejectsExcessiveSlippage(t *testing.T) {
+	// VWAP からのスリッページが 100 bps 想定: 半々で 1010 と 1020 を消化
+	src := &fakeSource{
+		snap: ob(1000,
+			[]entity.OrderbookEntry{{Price: 1010, Amount: 0.5}, {Price: 1020, Amount: 100}},
+			[]entity.OrderbookEntry{{Price: 999, Amount: 10}},
+			1010, 999, 1000,
+		),
+		found: true,
+	}
+	g := New(src, Config{MaxSlippageBps: 50, MaxBookSidePct: 0, TopN: 5, AllowOnMissingBook: true})
+
+	// 1.0 LTC: 0.5@1010 + 0.5@1020 → VWAP 1015 → 150 bps
+	d := g.Check(context.Background(), 7, entity.OrderSideBuy, 1.0, 1500)
+	if d.Allow {
+		t.Fatalf("expected reject for slippage, got %+v", d)
+	}
+	if d.Reason != "slippage_exceeds_threshold" {
+		t.Fatalf("unexpected reason: %s", d.Reason)
+	}
+}
+
+func TestGate_RejectsExcessiveBookRatio(t *testing.T) {
+	// 全く深くない板。3 LTC を打つと 5 段累計 (5 LTC) の 60% を食う。
+	src := &fakeSource{
+		snap: ob(1000,
+			[]entity.OrderbookEntry{
+				{Price: 1001, Amount: 1}, {Price: 1002, Amount: 1},
+				{Price: 1003, Amount: 1}, {Price: 1004, Amount: 1},
+				{Price: 1005, Amount: 1}, {Price: 1006, Amount: 100},
+			},
+			[]entity.OrderbookEntry{{Price: 999, Amount: 10}},
+			1001, 999, 1000,
+		),
+		found: true,
+	}
+	g := New(src, Config{MaxSlippageBps: 9999, MaxBookSidePct: 30, TopN: 5})
+
+	d := g.Check(context.Background(), 7, entity.OrderSideBuy, 3.0, 1500)
+	if d.Allow {
+		t.Fatalf("expected reject for book ratio, got %+v", d)
+	}
+	if d.Reason != "lot_exceeds_book_side_ratio" {
+		t.Fatalf("unexpected reason: %s", d.Reason)
+	}
+	if d.BookFillRatio < 0.59 || d.BookFillRatio > 0.61 {
+		t.Fatalf("expected ~0.6 ratio, got %f", d.BookFillRatio)
+	}
+}
+
+func TestGate_RejectsThinBookPreTrade(t *testing.T) {
+	src := &fakeSource{
+		snap: ob(1000,
+			[]entity.OrderbookEntry{{Price: 1001, Amount: 0.5}}, // total depth 0.5
+			nil, 1001, 999, 1000,
+		),
+		found: true,
+	}
+	g := New(src, Config{MaxSlippageBps: 50, MaxBookSidePct: 30, TopN: 5})
+
+	d := g.Check(context.Background(), 7, entity.OrderSideBuy, 1.0, 1500)
+	if d.Allow {
+		t.Fatalf("expected reject thin book, got %+v", d)
+	}
+	if d.Reason != "thin_book_pre_trade" {
+		t.Fatalf("unexpected reason: %s", d.Reason)
+	}
+}
+
+func TestGate_NoBookAllowedInLiveMode(t *testing.T) {
+	src := &fakeSource{found: false}
+	g := New(src, Config{MaxSlippageBps: 50, AllowOnMissingBook: true})
+	d := g.Check(context.Background(), 7, entity.OrderSideBuy, 1.0, 1500)
+	if !d.Allow {
+		t.Fatalf("expected allow on missing book in live mode, got %+v", d)
+	}
+}
+
+func TestGate_NoBookRejectedInBacktestMode(t *testing.T) {
+	src := &fakeSource{found: false}
+	g := New(src, Config{MaxSlippageBps: 50, AllowOnMissingBook: false})
+	d := g.Check(context.Background(), 7, entity.OrderSideBuy, 1.0, 1500)
+	if d.Allow {
+		t.Fatalf("expected reject on missing book in backtest mode, got %+v", d)
+	}
+	if d.Reason != "no_book" {
+		t.Fatalf("unexpected reason: %s", d.Reason)
+	}
+}
+
+func TestGate_StaleSnapshotHandledByMode(t *testing.T) {
+	old := ob(1000,
+		[]entity.OrderbookEntry{{Price: 1001, Amount: 10}},
+		[]entity.OrderbookEntry{{Price: 999, Amount: 10}},
+		1001, 999, 1000,
+	)
+	src := &fakeSource{snap: old, found: true}
+
+	// Live: stale → allow with reason
+	gLive := New(src, Config{MaxSlippageBps: 50, StaleAfterMillis: 60_000, AllowOnMissingBook: true})
+	d := gLive.Check(context.Background(), 7, entity.OrderSideBuy, 1.0, 70_000)
+	if !d.Allow || d.Reason != "stale_book_pass" {
+		t.Fatalf("live stale: %+v", d)
+	}
+
+	// Backtest: stale → reject
+	gBT := New(src, Config{MaxSlippageBps: 50, StaleAfterMillis: 60_000, AllowOnMissingBook: false})
+	d = gBT.Check(context.Background(), 7, entity.OrderSideBuy, 1.0, 70_000)
+	if d.Allow || d.Reason != "stale_book" {
+		t.Fatalf("backtest stale: %+v", d)
+	}
+}
+
+func TestGate_NilSourceShortCircuits(t *testing.T) {
+	g := New(nil, Config{MaxSlippageBps: 50})
+	d := g.Check(context.Background(), 7, entity.OrderSideBuy, 1.0, 1500)
+	if !d.Allow {
+		t.Fatalf("nil source should always allow, got %+v", d)
+	}
+}
+
+func TestGate_SellSideEvaluatesBidsWithSignedSlippage(t *testing.T) {
+	// 売り注文: bid 側を食う。bestBid=999、自ロット 1.0 が 999@10 で完結、
+	// VWAP=999、slip=(1000-999)/1000 × 10000 = 10 bps。
+	src := &fakeSource{
+		snap: ob(1000,
+			[]entity.OrderbookEntry{{Price: 1001, Amount: 10}},
+			[]entity.OrderbookEntry{{Price: 999, Amount: 10}, {Price: 998, Amount: 10}, {Price: 997, Amount: 10}, {Price: 996, Amount: 10}, {Price: 995, Amount: 10}},
+			1001, 999, 1000,
+		),
+		found: true,
+	}
+	g := New(src, Config{MaxSlippageBps: 50, MaxBookSidePct: 30, TopN: 5, AllowOnMissingBook: true})
+	d := g.Check(context.Background(), 7, entity.OrderSideSell, 1.0, 1500)
+	if !d.Allow {
+		t.Fatalf("expected allow, got %+v", d)
+	}
+	if d.SlippageBps < 9.9 || d.SlippageBps > 10.1 {
+		t.Fatalf("expected ~10 bps, got %f", d.SlippageBps)
+	}
+}

--- a/backend/internal/usecase/market_data.go
+++ b/backend/internal/usecase/market_data.go
@@ -73,6 +73,12 @@ type MarketDataService struct {
 	lastTickerSavedMs map[int64]int64
 	lastOrderbookMs   map[int64]int64
 
+	// latestOrderbookBySymbol caches the last orderbook seen on the WS feed
+	// per symbol so the live pre-trade gate can read it without hitting the
+	// DB. Populated unconditionally (independent of persistence throttling).
+	bookCacheMu       sync.RWMutex
+	latestOrderbooks  map[int64]entity.Orderbook
+
 	// writer channel + lifecycle
 	writerCh   chan persistTask
 	writerDone chan struct{}
@@ -92,6 +98,7 @@ func NewMarketDataServiceWithConfig(repo repository.MarketDataRepository, cfg Pe
 		cfg:               cfg,
 		lastTickerSavedMs: make(map[int64]int64),
 		lastOrderbookMs:   make(map[int64]int64),
+		latestOrderbooks:  make(map[int64]entity.Orderbook),
 	}
 }
 
@@ -301,6 +308,12 @@ func (s *MarketDataService) HandleTicker(ctx context.Context, ticker entity.Tick
 // HandleOrderbook persists an orderbook snapshot (subject to throttle) and
 // publishes a realtime event so the frontend panel updates immediately.
 func (s *MarketDataService) HandleOrderbook(ctx context.Context, ob entity.Orderbook) {
+	// Always update the in-memory cache so the pre-trade gate sees fresh
+	// data even when persistence is throttled or disabled.
+	s.bookCacheMu.Lock()
+	s.latestOrderbooks[ob.SymbolID] = ob
+	s.bookCacheMu.Unlock()
+
 	if s.cfg.Enable && s.shouldPersistOrderbook(ob.SymbolID, ob.Timestamp) {
 		o := ob
 		s.enqueue(persistTask{orderbook: &o})
@@ -354,4 +367,22 @@ func (s *MarketDataService) SaveCandles(ctx context.Context, symbolID int64, int
 // GetOrderbookHistory exposes the underlying repo query for replay tooling.
 func (s *MarketDataService) GetOrderbookHistory(ctx context.Context, symbolID int64, from, to int64, limit int) ([]entity.Orderbook, error) {
 	return s.repo.GetOrderbookHistory(ctx, symbolID, from, to, limit)
+}
+
+// LatestBefore implements booklimit.BookSource for the live pipeline. The
+// cache is populated by HandleOrderbook on every WS frame; we return the
+// snapshot only when its timestamp is at or before ts (the gate's clock is
+// monotonic, but this guards against test fixtures injecting future ts).
+// Returns (zero, false, nil) when no cache entry exists yet.
+func (s *MarketDataService) LatestBefore(_ context.Context, symbolID, ts int64) (entity.Orderbook, bool, error) {
+	s.bookCacheMu.RLock()
+	defer s.bookCacheMu.RUnlock()
+	ob, ok := s.latestOrderbooks[symbolID]
+	if !ok {
+		return entity.Orderbook{}, false, nil
+	}
+	if ob.Timestamp > ts {
+		return entity.Orderbook{}, false, nil
+	}
+	return ob, true, nil
 }


### PR DESCRIPTION
## Summary
ライブとバックテスト双方で、approve 済みのシグナルを **板の現状に照らして再度評価** する pre-trade gate を導入。スリッページ過大／自ロットが板上位 N 段の薄さに対して大きすぎ／板片側枯れ／板情報なし、のいずれかで注文を棄却する。前 PR (#171) の orderbook-replay と同じ snapshots を 1 インスタンスでシミュレータと gate の両方が参照する。

## Why
- 楽天 LTC/JPY は実測スプレッド 0.4% 前後・上位段のロットが小さい瞬間がある
- バックテストでは TP/SL ヒット → 約定したことになる前提だが、現実は板が薄ければ食えない
- SOR (A) や Maker優先 (B) を積む前に、まず「無理筋トレードを打たない」ガードが必要

## Changes

### 新パッケージ `internal/usecase/booklimit`
- `Gate` / `Config` / `Decision` / `BookSource` interface
- VWAP 計算 (top-N walk) + side-aware sort + signed slippage bps
- `AllowOnMissingBook` で live (forgiving) vs backtest (strict) を切替

### バックテスト統合
- `domain/entity/risk.go`: `RiskConfig` に `MaxSlippageBps` / `MaxBookSidePct`
- `usecase/backtest/handler.go`: `RiskHandler.BookGate` を追加。承認後に gate を通し、reject は `BookGateRejects` カウンタへ
- `usecase/backtest/runner.go`: `RunInput.BookSource` 追加、閾値が立っていれば自動で gate 構築 (60s stale, missing=reject)
- `infrastructure/backtest/fill_price.go`: `OrderbookReplay.LatestBefore` を実装 → fill source と book source を 1 インスタンスで共有
- `interfaces/api/handler/backtest.go`: req に `maxSlippageBps` / `maxBookSidePct`、orderbook モード時は OrderbookReplay を両用

### ライブ統合
- `usecase/market_data.go`: `HandleOrderbook` で per-symbol in-memory cache を更新、`LatestBefore` で `booklimit.BookSource` を実装
- `cmd/event_pipeline.go`: 起動時に `RiskManager.GetStatus().Config` を見て gate を構築 (60s stale, missing=allow)
- `config/config.go` + `cmd/main.go`: `RISK_MAX_SLIPPAGE_BPS` / `RISK_MAX_BOOK_SIDE_PCT` env (default 0=無効、opt-in)

## 既定値
- `MaxSlippageBps = 0` (無効、設定で 50=0.5% を推奨)
- `MaxBookSidePct = 0` (無効、設定で 30=30% を推奨)
- `TopN = 5` 段
- `StaleAfterMillis = 60_000`
- live: missing/stale → allow ("no_book_pass" / "stale_book_pass")
- backtest: missing/stale → reject ("no_book" / "stale_book")

## Test plan
- [x] `go test ./... -race -count=1` 全 OK
- [x] booklimit 単体: 4 種 reject 理由、side 別 VWAP、live/backtest 振る舞い差、nil source short-circuit
- [x] runner 統合: 浅板でゲートが全 trade を block (TotalTrades==0)
- [x] handler 配線確認

## 続く PR との関係
- 今回は **棄却のみ**。次の PR で「閾値を超えそうなら **ロット縮小** で出す」を追加可
- カウンタを report に出す UI は別 PR（`BookGateRejects` を summary に含めるかは要検討）

🤖 Generated with [Claude Code](https://claude.com/claude-code)