### PR TITLE
feat(indicator): Microprice + OFI 板由来シグナル (J)

### DIFF
--- a/backend/cmd/event_pipeline.go
+++ b/backend/cmd/event_pipeline.go
@@ -297,6 +297,10 @@ func (p *EventDrivenPipeline) runEventLoop(ctx context.Context, snap eventSnapsh
 
 	// IndicatorHandler: calculates technical indicators on candle close (priority 10).
 	indicatorHandler := backtest.NewIndicatorHandler("PT15M", "PT1H", 500)
+	if p.marketDataSvc != nil {
+		// PR-J: feed Microprice / OFI from the live in-memory book cache.
+		indicatorHandler.SetBookSource(p.marketDataSvc, 10_000, 60_000, 5)
+	}
 	bus.Register(entity.EventTypeCandle, 10, indicatorHandler)
 
 	// StrategyHandler: signal generation from indicators (priority 20).

--- a/backend/internal/domain/entity/indicator.go
+++ b/backend/internal/domain/entity/indicator.go
@@ -59,6 +59,20 @@ type IndicatorSet struct {
 	OBVSlope20 *float64 `json:"obvSlope20"`
 	CMF20      *float64 `json:"cmf20"`
 
+	// Orderbook-derived signals (PR-J). All nil unless a BookSource is wired
+	// into the IndicatorHandler and a recent enough snapshot exists.
+	//
+	// Microprice = (BestBid * askVol + BestAsk * bidVol) / (askVol + bidVol)
+	// — leans toward the heavier side of the book; richer than plain mid.
+	Microprice *float64 `json:"microprice,omitempty"`
+
+	// OFIShort / OFILong = sum over the rolling window (10s / 60s by default)
+	// of (Δbid_topN_depth − Δask_topN_depth), normalised by topN_depth so the
+	// number is dimensionless ([-1, +1]ish). Positive = bid pressure
+	// (taker-buy intent), negative = ask pressure.
+	OFIShort *float64 `json:"ofiShort,omitempty"`
+	OFILong  *float64 `json:"ofiLong,omitempty"`
+
 	Timestamp int64 `json:"timestamp"`
 }
 

--- a/backend/internal/infrastructure/indicator/microprice.go
+++ b/backend/internal/infrastructure/indicator/microprice.go
@@ -1,0 +1,60 @@
+package indicator
+
+import "github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+
+// Microprice returns the volume-weighted touch:
+//
+//	microprice = (BestBid * askDepth + BestAsk * bidDepth) / (bidDepth + askDepth)
+//
+// Intuition: when askDepth >> bidDepth (sellers dominate the touch), the
+// microprice tilts down toward BestBid — that's where transactions are most
+// likely to happen next. Mirror image for bidDepth >> askDepth.
+//
+// Returns (0, false) when the book has no usable touch (zero volumes on both
+// sides, or unset BestBid/BestAsk). Callers must check ok before using.
+//
+// We sum the *whole* visible side rather than just top-1 depth so a thin top
+// followed by a thick second-level still produces a sensible weight. This
+// matches the way OFI normalises against top-N depth, keeping the two
+// signals comparable in scale.
+func Microprice(ob entity.Orderbook) (float64, bool) {
+	if ob.BestBid <= 0 || ob.BestAsk <= 0 {
+		return 0, false
+	}
+	bidDepth := sumDepth(ob.Bids)
+	askDepth := sumDepth(ob.Asks)
+	total := bidDepth + askDepth
+	if total <= 0 {
+		return 0, false
+	}
+	return (ob.BestBid*askDepth + ob.BestAsk*bidDepth) / total, true
+}
+
+func sumDepth(levels []entity.OrderbookEntry) float64 {
+	s := 0.0
+	for _, lvl := range levels {
+		if lvl.Amount > 0 {
+			s += lvl.Amount
+		}
+	}
+	return s
+}
+
+// TopNDepth returns the cumulative amount across the first n levels of one
+// side of the book. Used both by Microprice consumers (to inspect the
+// "weight" used) and by OFI for normalisation.
+func TopNDepth(levels []entity.OrderbookEntry, n int) float64 {
+	if n <= 0 {
+		return 0
+	}
+	if n > len(levels) {
+		n = len(levels)
+	}
+	s := 0.0
+	for i := 0; i < n; i++ {
+		if levels[i].Amount > 0 {
+			s += levels[i].Amount
+		}
+	}
+	return s
+}

--- a/backend/internal/infrastructure/indicator/microprice_test.go
+++ b/backend/internal/infrastructure/indicator/microprice_test.go
@@ -1,0 +1,85 @@
+package indicator
+
+import (
+	"math"
+	"testing"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+)
+
+func TestMicroprice_BalancedBookReturnsMid(t *testing.T) {
+	ob := entity.Orderbook{
+		BestBid: 100, BestAsk: 102,
+		Bids: []entity.OrderbookEntry{{Price: 100, Amount: 5}},
+		Asks: []entity.OrderbookEntry{{Price: 102, Amount: 5}},
+	}
+	got, ok := Microprice(ob)
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	// (100*5 + 102*5) / 10 = 101 — same as plain mid.
+	if math.Abs(got-101) > 1e-9 {
+		t.Fatalf("expected 101, got %f", got)
+	}
+}
+
+func TestMicroprice_BidHeavyTiltsUp(t *testing.T) {
+	ob := entity.Orderbook{
+		BestBid: 100, BestAsk: 102,
+		Bids: []entity.OrderbookEntry{{Price: 100, Amount: 9}},
+		Asks: []entity.OrderbookEntry{{Price: 102, Amount: 1}},
+	}
+	got, ok := Microprice(ob)
+	if !ok {
+		t.Fatal("ok")
+	}
+	// (100*1 + 102*9) / 10 = 101.8 — closer to the ask side because buyers
+	// are stacked and sellers will likely move first.
+	if math.Abs(got-101.8) > 1e-9 {
+		t.Fatalf("expected 101.8, got %f", got)
+	}
+}
+
+func TestMicroprice_AskHeavyTiltsDown(t *testing.T) {
+	ob := entity.Orderbook{
+		BestBid: 100, BestAsk: 102,
+		Bids: []entity.OrderbookEntry{{Price: 100, Amount: 1}},
+		Asks: []entity.OrderbookEntry{{Price: 102, Amount: 9}},
+	}
+	got, ok := Microprice(ob)
+	if !ok {
+		t.Fatal("ok")
+	}
+	if math.Abs(got-100.2) > 1e-9 {
+		t.Fatalf("expected 100.2, got %f", got)
+	}
+}
+
+func TestMicroprice_RejectsEmptyOrZeroSides(t *testing.T) {
+	cases := []entity.Orderbook{
+		{}, // zero touch
+		{BestBid: 100, BestAsk: 0, Bids: []entity.OrderbookEntry{{Price: 100, Amount: 1}}},
+		{BestBid: 100, BestAsk: 102, Bids: nil, Asks: nil},
+	}
+	for i, ob := range cases {
+		if _, ok := Microprice(ob); ok {
+			t.Fatalf("case %d: expected ok=false", i)
+		}
+	}
+}
+
+func TestTopNDepth(t *testing.T) {
+	levels := []entity.OrderbookEntry{
+		{Price: 100, Amount: 1}, {Price: 101, Amount: 2}, {Price: 102, Amount: 3},
+	}
+	if got := TopNDepth(levels, 2); math.Abs(got-3) > 1e-9 {
+		t.Fatalf("top2 = %f, want 3", got)
+	}
+	// n > len returns full sum
+	if got := TopNDepth(levels, 100); math.Abs(got-6) > 1e-9 {
+		t.Fatalf("top100 = %f, want 6", got)
+	}
+	if got := TopNDepth(levels, 0); got != 0 {
+		t.Fatalf("top0 = %f, want 0", got)
+	}
+}

--- a/backend/internal/infrastructure/indicator/ofi.go
+++ b/backend/internal/infrastructure/indicator/ofi.go
@@ -1,0 +1,106 @@
+package indicator
+
+import (
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+)
+
+// OFICalculator computes Order Flow Imbalance (OFI) over a rolling time
+// window from a sequence of orderbook snapshots.
+//
+// Definition used here:
+//
+//	bidDepth(t) = TopNDepth(Bids, TopN)
+//	askDepth(t) = TopNDepth(Asks, TopN)
+//	delta(t)    = (bidDepth(t) - bidDepth(t-1)) - (askDepth(t) - askDepth(t-1))
+//	OFI(window) = sum_{t in window} delta(t) / depth_at_window_start
+//
+// We normalise by the bid+ask top-N depth observed at the *start* of the
+// window so the metric is dimensionless and comparable across symbols.
+// Positive values mean bid pressure has grown faster than ask pressure
+// over the window (taker-buy intent); negative the opposite.
+//
+// The calculator only stores observation snapshots — there is no caller-
+// driven state outside the time window. Old observations are evicted when
+// they fall outside windowMs from the latest Add.
+type OFICalculator struct {
+	topN     int
+	windowMs int64
+
+	obs []ofiObservation
+}
+
+type ofiObservation struct {
+	timestamp int64
+	bidDepth  float64
+	askDepth  float64
+}
+
+// NewOFICalculator constructs an OFI calculator. windowMs is the rolling
+// window in unix-millis (e.g. 10_000 for 10 s, 60_000 for 1 min). topN is
+// the depth limit (passed through to TopNDepth).
+//
+// topN <= 0 falls back to 5; windowMs <= 0 falls back to 10_000 — the
+// short-window default.
+func NewOFICalculator(topN int, windowMs int64) *OFICalculator {
+	if topN <= 0 {
+		topN = 5
+	}
+	if windowMs <= 0 {
+		windowMs = 10_000
+	}
+	return &OFICalculator{topN: topN, windowMs: windowMs}
+}
+
+// Add records a snapshot. Snapshots out of order (timestamp <= last) are
+// silently ignored — OFI by definition needs monotonically advancing time.
+func (o *OFICalculator) Add(ob entity.Orderbook) {
+	if len(o.obs) > 0 && ob.Timestamp <= o.obs[len(o.obs)-1].timestamp {
+		return
+	}
+	o.obs = append(o.obs, ofiObservation{
+		timestamp: ob.Timestamp,
+		bidDepth:  TopNDepth(ob.Bids, o.topN),
+		askDepth:  TopNDepth(ob.Asks, o.topN),
+	})
+	o.evictBefore(ob.Timestamp - o.windowMs)
+}
+
+// Compute returns the normalised OFI for the current window. Returns
+// (0, false) until at least 2 observations are present and the window-
+// start depth is non-zero.
+func (o *OFICalculator) Compute() (float64, bool) {
+	if len(o.obs) < 2 {
+		return 0, false
+	}
+	first := o.obs[0]
+	denom := first.bidDepth + first.askDepth
+	if denom <= 0 {
+		return 0, false
+	}
+	bidDelta := o.obs[len(o.obs)-1].bidDepth - first.bidDepth
+	askDelta := o.obs[len(o.obs)-1].askDepth - first.askDepth
+	return (bidDelta - askDelta) / denom, true
+}
+
+// Reset drops all observations. Used by the IndicatorHandler when symbol or
+// pipeline state changes invalidate the historical context.
+func (o *OFICalculator) Reset() { o.obs = o.obs[:0] }
+
+// Len reports how many snapshots are currently in the window. Exposed for
+// tests and metrics.
+func (o *OFICalculator) Len() int { return len(o.obs) }
+
+// evictBefore drops observations strictly older than cutoff. Linear scan is
+// fine: at typical 5 s persist throttle and 60 s window, the buffer holds
+// ~12 entries.
+func (o *OFICalculator) evictBefore(cutoff int64) {
+	idx := 0
+	for ; idx < len(o.obs); idx++ {
+		if o.obs[idx].timestamp >= cutoff {
+			break
+		}
+	}
+	if idx > 0 {
+		o.obs = append(o.obs[:0], o.obs[idx:]...)
+	}
+}

--- a/backend/internal/infrastructure/indicator/ofi_test.go
+++ b/backend/internal/infrastructure/indicator/ofi_test.go
@@ -1,0 +1,81 @@
+package indicator
+
+import (
+	"math"
+	"testing"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+)
+
+func ob(ts int64, bidAmt, askAmt float64) entity.Orderbook {
+	return entity.Orderbook{
+		Timestamp: ts,
+		Bids:      []entity.OrderbookEntry{{Price: 100, Amount: bidAmt}},
+		Asks:      []entity.OrderbookEntry{{Price: 102, Amount: askAmt}},
+	}
+}
+
+func TestOFI_NotReadyWithSingleSnapshot(t *testing.T) {
+	c := NewOFICalculator(5, 10_000)
+	c.Add(ob(0, 1, 1))
+	if _, ok := c.Compute(); ok {
+		t.Fatal("OFI must be unavailable until 2 snapshots accumulate")
+	}
+}
+
+func TestOFI_PositiveOnBidGrowth(t *testing.T) {
+	c := NewOFICalculator(5, 10_000)
+	c.Add(ob(0, 1, 1))      // bid=1, ask=1, total=2
+	c.Add(ob(1000, 3, 1))   // bidΔ=+2, askΔ=0 → (2-0)/2 = +1.0
+	got, ok := c.Compute()
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	if math.Abs(got-1.0) > 1e-9 {
+		t.Fatalf("expected +1.0, got %f", got)
+	}
+}
+
+func TestOFI_NegativeOnAskGrowth(t *testing.T) {
+	c := NewOFICalculator(5, 10_000)
+	c.Add(ob(0, 1, 1))
+	c.Add(ob(1000, 1, 3)) // (0 - 2) / 2 = -1.0
+	got, _ := c.Compute()
+	if math.Abs(got-(-1.0)) > 1e-9 {
+		t.Fatalf("expected -1.0, got %f", got)
+	}
+}
+
+func TestOFI_EvictsObservationsOlderThanWindow(t *testing.T) {
+	c := NewOFICalculator(5, 10_000)
+	c.Add(ob(0, 10, 10))      // depth=20 baseline
+	c.Add(ob(5_000, 12, 8))   // still inside window
+	c.Add(ob(15_000, 14, 6))  // 15s after first → first should be evicted
+	if c.Len() != 2 {
+		t.Fatalf("expected 2 obs after eviction, got %d", c.Len())
+	}
+	// New baseline is the (12,8) snapshot at t=5000.
+	// Δbid = 14-12 = 2, Δask = 6-8 = -2 → (2 - (-2)) / (12+8) = 0.2
+	got, _ := c.Compute()
+	if math.Abs(got-0.2) > 1e-9 {
+		t.Fatalf("expected +0.2 after eviction, got %f", got)
+	}
+}
+
+func TestOFI_IgnoresOutOfOrderSnapshots(t *testing.T) {
+	c := NewOFICalculator(5, 10_000)
+	c.Add(ob(1000, 1, 1))
+	c.Add(ob(500, 100, 0)) // older — must be dropped
+	if c.Len() != 1 {
+		t.Fatalf("expected 1 obs, got %d", c.Len())
+	}
+}
+
+func TestOFI_ZeroDenominatorReturnsNotOK(t *testing.T) {
+	c := NewOFICalculator(5, 10_000)
+	c.Add(ob(0, 0, 0))      // both sides empty at window start
+	c.Add(ob(1000, 1, 1))
+	if _, ok := c.Compute(); ok {
+		t.Fatal("expected unavailable when window-start depth is 0")
+	}
+}

--- a/backend/internal/usecase/backtest/handler.go
+++ b/backend/internal/usecase/backtest/handler.go
@@ -132,6 +132,45 @@ type IndicatorHandler struct {
 
 	primaryCandles map[int64][]entity.Candle
 	higherCandles  map[int64][]entity.Candle
+
+	// bookSource and OFI calculators are optional (PR-J). When wired,
+	// every primary-interval Candle event also computes Microprice and
+	// short/long-window OFI from the most recent orderbook snapshot at or
+	// before the candle close timestamp. nil keeps the legacy behaviour
+	// (Microprice / OFI fields stay nil on the IndicatorSet).
+	bookSource    indicatorBookSource
+	ofiShort      map[int64]*indicator.OFICalculator
+	ofiLong       map[int64]*indicator.OFICalculator
+	ofiShortMs    int64
+	ofiLongMs     int64
+	ofiTopN       int
+}
+
+// indicatorBookSource is the narrow port the handler needs to look up the
+// book at signal time. It mirrors booklimit.BookSource so callers can pass
+// the same MarketDataService / OrderbookReplay used elsewhere.
+type indicatorBookSource interface {
+	LatestBefore(ctx context.Context, symbolID, ts int64) (entity.Orderbook, bool, error)
+}
+
+// SetBookSource enables the orderbook-derived signals. windowShortMs and
+// windowLongMs default to 10s / 60s when zero. topN defaults to 5.
+func (h *IndicatorHandler) SetBookSource(src indicatorBookSource, windowShortMs, windowLongMs int64, topN int) {
+	if topN <= 0 {
+		topN = 5
+	}
+	if windowShortMs <= 0 {
+		windowShortMs = 10_000
+	}
+	if windowLongMs <= 0 {
+		windowLongMs = 60_000
+	}
+	h.bookSource = src
+	h.ofiShortMs = windowShortMs
+	h.ofiLongMs = windowLongMs
+	h.ofiTopN = topN
+	h.ofiShort = make(map[int64]*indicator.OFICalculator)
+	h.ofiLong = make(map[int64]*indicator.OFICalculator)
 }
 
 func NewIndicatorHandler(primaryInterval, higherTFInterval string, bufferSize int) *IndicatorHandler {
@@ -145,6 +184,43 @@ func NewIndicatorHandler(primaryInterval, higherTFInterval string, bufferSize in
 		bbSqueezeLookback: 5, // cycle44: legacy default, overridable via SetBBSqueezeLookback
 		primaryCandles:    make(map[int64][]entity.Candle),
 		higherCandles:     make(map[int64][]entity.Candle),
+	}
+}
+
+// attachBookDerived populates Microprice / OFI on the supplied IndicatorSet
+// when a BookSource is wired and a usable snapshot exists. No-ops when the
+// gate is disabled (legacy path).
+func (h *IndicatorHandler) attachBookDerived(set *entity.IndicatorSet, symbolID, ts int64) {
+	if h == nil || h.bookSource == nil {
+		return
+	}
+	ob, found, err := h.bookSource.LatestBefore(context.Background(), symbolID, ts)
+	if err != nil || !found {
+		return
+	}
+	if mp, ok := indicator.Microprice(ob); ok {
+		v := mp
+		set.Microprice = &v
+	}
+	short := h.ofiShort[symbolID]
+	if short == nil {
+		short = indicator.NewOFICalculator(h.ofiTopN, h.ofiShortMs)
+		h.ofiShort[symbolID] = short
+	}
+	short.Add(ob)
+	if v, ok := short.Compute(); ok {
+		x := v
+		set.OFIShort = &x
+	}
+	long := h.ofiLong[symbolID]
+	if long == nil {
+		long = indicator.NewOFICalculator(h.ofiTopN, h.ofiLongMs)
+		h.ofiLong[symbolID] = long
+	}
+	long.Add(ob)
+	if v, ok := long.Compute(); ok {
+		x := v
+		set.OFILong = &x
 	}
 }
 
@@ -171,6 +247,7 @@ func (h *IndicatorHandler) Handle(_ context.Context, event entity.Event) ([]enti
 	case h.PrimaryInterval:
 		h.primaryCandles[candleEvent.SymbolID] = appendCapped(h.primaryCandles[candleEvent.SymbolID], candleEvent.Candle, h.BufferSize)
 		primary := calculateIndicatorSet(candleEvent.SymbolID, h.primaryCandles[candleEvent.SymbolID], h.bbSqueezeLookback)
+		h.attachBookDerived(&primary, candleEvent.SymbolID, candleEvent.Timestamp)
 
 		var higherTF *entity.IndicatorSet
 		if h.HigherTFInterval != "" {

--- a/backend/internal/usecase/backtest/handler_test.go
+++ b/backend/internal/usecase/backtest/handler_test.go
@@ -333,3 +333,105 @@ func TestTickRiskHandler_WorstCaseStopLossOnBothHit(t *testing.T) {
 		t.Fatalf("expected stop_loss by worst-case, got %s", order.Reason)
 	}
 }
+
+// indicatorBookFake feeds IndicatorHandler with a fixed sequence of
+// orderbooks keyed by timestamp. It returns the most recent ob whose
+// timestamp <= ts, mirroring OrderbookReplay's contract.
+type indicatorBookFake struct {
+	books []entity.Orderbook // ascending by timestamp
+}
+
+func (f *indicatorBookFake) LatestBefore(_ context.Context, _ int64, ts int64) (entity.Orderbook, bool, error) {
+	var pick entity.Orderbook
+	found := false
+	for _, ob := range f.books {
+		if ob.Timestamp > ts {
+			break
+		}
+		pick = ob
+		found = true
+	}
+	return pick, found, nil
+}
+
+func TestIndicatorHandler_AttachesMicropriceAndOFIWhenBookSourceWired(t *testing.T) {
+	books := []entity.Orderbook{
+		{
+			Timestamp: 1_000, BestBid: 100, BestAsk: 102,
+			Bids: []entity.OrderbookEntry{{Price: 100, Amount: 5}},
+			Asks: []entity.OrderbookEntry{{Price: 102, Amount: 5}},
+		},
+		{
+			Timestamp: 2_000, BestBid: 100, BestAsk: 102,
+			Bids: []entity.OrderbookEntry{{Price: 100, Amount: 8}},
+			Asks: []entity.OrderbookEntry{{Price: 102, Amount: 2}},
+		},
+	}
+	src := &indicatorBookFake{books: books}
+
+	h := NewIndicatorHandler("PT15M", "", 500)
+	h.SetBookSource(src, 10_000, 60_000, 5)
+
+	// Two primary candles to drive the indicator path. Build the minimum
+	// IndicatorSet that the handler needs (it does not require warmed-up
+	// SMA/RSI to attach Microprice/OFI).
+	candle := entity.Candle{Open: 100, High: 102, Low: 99, Close: 101, Time: 1_000, Volume: 1}
+	_, err := h.Handle(context.Background(), entity.CandleEvent{
+		SymbolID:  7,
+		Interval:  "PT15M",
+		Candle:    candle,
+		Timestamp: 1_000,
+	})
+	if err != nil {
+		t.Fatalf("first handle: %v", err)
+	}
+
+	candle2 := entity.Candle{Open: 101, High: 103, Low: 100, Close: 102, Time: 2_000, Volume: 1}
+	out, err := h.Handle(context.Background(), entity.CandleEvent{
+		SymbolID:  7,
+		Interval:  "PT15M",
+		Candle:    candle2,
+		Timestamp: 2_000,
+	})
+	if err != nil {
+		t.Fatalf("second handle: %v", err)
+	}
+	if len(out) != 1 {
+		t.Fatalf("expected 1 indicator event, got %d", len(out))
+	}
+	indEv := out[0].(entity.IndicatorEvent)
+
+	// Microprice for the second snapshot: bid-heavy (8 vs 2). Expected
+	// (100*2 + 102*8) / 10 = 101.6
+	if indEv.Primary.Microprice == nil {
+		t.Fatal("expected Microprice to be populated")
+	}
+	if got := *indEv.Primary.Microprice; got < 101.59 || got > 101.61 {
+		t.Fatalf("microprice = %f, want ~101.6", got)
+	}
+
+	// OFI short window: bid +3, ask -3 over 1s window with denom 10 →
+	// (3 - (-3)) / 10 = 0.6
+	if indEv.Primary.OFIShort == nil {
+		t.Fatal("expected OFIShort to be populated")
+	}
+	if got := *indEv.Primary.OFIShort; got < 0.59 || got > 0.61 {
+		t.Fatalf("OFIShort = %f, want ~0.6", got)
+	}
+}
+
+func TestIndicatorHandler_NilBookSourceLeavesFieldsUnset(t *testing.T) {
+	h := NewIndicatorHandler("PT15M", "", 500)
+	candle := entity.Candle{Open: 100, High: 102, Low: 99, Close: 101, Time: 1_000, Volume: 1}
+	out, err := h.Handle(context.Background(), entity.CandleEvent{
+		SymbolID: 7, Interval: "PT15M", Candle: candle, Timestamp: 1_000,
+	})
+	if err != nil {
+		t.Fatalf("handle: %v", err)
+	}
+	indEv := out[0].(entity.IndicatorEvent)
+	if indEv.Primary.Microprice != nil || indEv.Primary.OFIShort != nil || indEv.Primary.OFILong != nil {
+		t.Fatalf("orderbook-derived fields must stay nil: mp=%v short=%v long=%v",
+			indEv.Primary.Microprice, indEv.Primary.OFIShort, indEv.Primary.OFILong)
+	}
+}

--- a/backend/internal/usecase/backtest/runner.go
+++ b/backend/internal/usecase/backtest/runner.go
@@ -181,6 +181,12 @@ func (r *BacktestRunner) Run(ctx context.Context, input RunInput) (*entity.Backt
 	if input.BBSqueezeLookback > 0 {
 		indicatorHandler.SetBBSqueezeLookback(input.BBSqueezeLookback)
 	}
+	// PR-J: enable Microprice / OFI when the caller supplied a BookSource.
+	// Same source the pre-trade gate uses, so backtest runs see the same
+	// L2 history.
+	if input.BookSource != nil {
+		indicatorHandler.SetBookSource(input.BookSource, 10_000, 60_000, 5)
+	}
 	strategyHandler := NewStrategyHandler(strategy)
 	riskHandler := &RiskHandler{
 		RiskManager:     riskMgr,


### PR DESCRIPTION
## Summary
板の傾きを 2 つの新指標として `IndicatorSet` に追加し、価格データだけでは見えない短期方向性の手がかりを戦略レイヤーに渡せるようにする。バックテストとライブで同じ計算が走り、BookSource が wire されていなければ legacy 完全互換（新フィールドは nil のまま）。

## Indicators added

### Microprice
`(BestBid × askDepth + BestAsk × bidDepth) / (bidDepth + askDepth)`
- 単純な mid `(BB+BA)/2` より板の **重い側** に寄る
- bid 厚 → microprice ↑、ask 厚 → ↓
- 短期 (数秒〜数十秒) のフェアバリューとして使える

### OFI (Order Flow Imbalance)
直近 N 秒の `Δbid_topN_depth − Δask_topN_depth` を window 開始時の総深さで **正規化** した無次元値（[-1, +1] 程度）。
- 正値 = bid 圧 (taker-buy intent)
- 負値 = ask 圧
- 2 種類の窓: **OFIShort = 10 s**、**OFILong = 60 s**
- 銘柄横断で比較可能 (LTC/JPY と BTC/JPY を同じ閾値で扱える)

## Changes
- `entity.IndicatorSet` に `Microprice` / `OFIShort` / `OFILong` を追加（すべて `*float64`）
- 新 `internal/infrastructure/indicator/microprice.go` + `ofi.go`（純粋計算 + 単体テスト）
- `usecase/backtest/handler.go`: `IndicatorHandler.SetBookSource(src, shortMs, longMs, topN)` を追加。primary candle 確定ごとに直前 snapshot から計算
- `usecase/backtest/runner.go`: `RunInput.BookSource` を IndicatorHandler にも自動配信
- `cmd/event_pipeline.go`: 起動時に `MarketDataService` を BookSource として wire（前 PR で `LatestBefore` を実装済み）

## Defaults
- OFI Short window = 10_000 ms
- OFI Long window = 60_000 ms
- topN = 5
- snapshot 不足時は **nil** を返す（戦略側で安全に扱える）

## Test plan
- [x] `go test ./... -race -count=1` 全 OK
- [x] Microprice: バランス板 = mid、bid 偏重で上振れ、ask 偏重で下振れ、touch なしで非該当
- [x] OFI: 1 件では返さない、bid 増で +、ask 増で -、window 経過で eviction、out-of-order 棄却、零分母で非該当
- [x] IndicatorHandler 統合: BookSource ありで Microprice/OFI が attach、無しで全て nil

## 後続 PR
- OFI 閾値で signal 生成（戦略ルール拡張）
- フロント表示（板パネルの下に Microprice / OFI を表示）

🤖 Generated with [Claude Code](https://claude.com/claude-code)