### PR TITLE
feat(risk): venue 状態との定期 reconciliation (N)

### DIFF
--- a/backend/cmd/event_pipeline.go
+++ b/backend/cmd/event_pipeline.go
@@ -16,6 +16,7 @@ import (
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/booklimit"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/circuitbreaker"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/eventengine"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/reconcile"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/sor"
 )
 
@@ -53,6 +54,8 @@ type EventDrivenPipeline struct {
 	sorConfig            sor.Config
 	circuitBreakerConfig circuitbreaker.Config
 	staleCheckIntervalMs int64
+	reconcileConfig      reconcile.Config
+	clientOrderRepo      repository.ClientOrderRepository
 
 	// sleepFn is used by syncState for retry backoff (test-injectable).
 	sleepFn func(time.Duration)
@@ -69,6 +72,7 @@ type EventDrivenPipelineConfig struct {
 	SOR                  sor.Config
 	CircuitBreaker       circuitbreaker.Config
 	StaleCheckIntervalMs int64
+	Reconcile            reconcile.Config
 }
 
 func NewEventDrivenPipeline(
@@ -80,6 +84,7 @@ func NewEventDrivenPipeline(
 	riskMgr *usecase.RiskManager,
 	tradeHistoryRepo repository.TradeHistoryRepository,
 	riskStateRepo repository.RiskStateRepository,
+	clientOrderRepo repository.ClientOrderRepository,
 ) *EventDrivenPipeline {
 	return &EventDrivenPipeline{
 		symbolID:          cfg.SymbolID,
@@ -91,6 +96,7 @@ func NewEventDrivenPipeline(
 		sorConfig:            cfg.SOR,
 		circuitBreakerConfig: cfg.CircuitBreaker,
 		staleCheckIntervalMs: cfg.StaleCheckIntervalMs,
+		reconcileConfig:      cfg.Reconcile,
 		orderClient:          orderClient,
 		symbolFetcher:     symbolFetcher,
 		marketDataSvc:     marketDataSvc,
@@ -98,6 +104,7 @@ func NewEventDrivenPipeline(
 		riskMgr:           riskMgr,
 		tradeHistoryRepo:  tradeHistoryRepo,
 		riskStateRepo:     riskStateRepo,
+		clientOrderRepo:   clientOrderRepo,
 	}
 }
 
@@ -359,6 +366,9 @@ func (p *EventDrivenPipeline) runEventLoop(ctx context.Context, snap eventSnapsh
 		defer cbWatcher.Reset() // re-arm on next pipeline lifecycle
 	}
 
+	// Reconciler: opt-in. Runs on its own goroutine bound to ctx.
+	p.startReconciler(ctx, snap)
+
 	slog.Info("event-pipeline: event loop running", "symbolID", snap.symbolID)
 
 	for {
@@ -574,4 +584,79 @@ func (p *EventDrivenPipeline) realtimeHubFromMarketData() *usecase.RealtimeHub {
 		return nil
 	}
 	return p.marketDataSvc.RealtimeHub()
+}
+
+// reconcilePublisher adapts realtime hub PublishData to reconcile.Publisher.
+type reconcilePublisher struct{ hub *usecase.RealtimeHub }
+
+func (p *reconcilePublisher) PublishDrift(kind, severity, message string, ts int64) {
+	if p == nil || p.hub == nil {
+		return
+	}
+	sev := usecase.RiskSeverityWarning
+	switch severity {
+	case "critical":
+		sev = usecase.RiskSeverityCritical
+	case "info":
+		sev = usecase.RiskSeverityInfo
+	}
+	payload := usecase.RiskEventPayload{
+		Kind:      usecase.RiskEventKind("reconciliation_drift"),
+		Severity:  sev,
+		Message:   "reconcile " + kind + ": " + message,
+		Timestamp: ts,
+	}
+	if err := p.hub.PublishData("risk_event", 0, payload); err != nil {
+		slog.Warn("event-pipeline: reconcile publish failed", "error", err)
+	}
+}
+
+// startReconciler runs the reconciler on its own goroutine. Lifecycle is
+// tied to ctx; the loop exits cleanly when the pipeline is stopped.
+//
+// Symbol switches update the reconciler's symbol via SetSymbolID through
+// the live snapshot — we do not need a separate notification channel
+// because the reconciler is read-only.
+func (p *EventDrivenPipeline) startReconciler(ctx context.Context, snap eventSnapshot) *reconcile.Reconciler {
+	if !p.reconcileConfig.Enable {
+		return nil
+	}
+	pub := &reconcilePublisher{hub: nil}
+	if p.marketDataSvc != nil {
+		pub.hub = p.marketDataSvc.RealtimeHub()
+	}
+	r := reconcile.New(p.reconcileConfig, p.orderClient, p.riskMgr, p.riskMgr, p.clientOrderRepo, pub, snap.symbolID)
+	interval := time.Duration(p.reconcileConfig.IntervalSec) * time.Second
+	if interval <= 0 {
+		interval = 60 * time.Second
+	}
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		// First pass after a short warmup so syncState has populated the
+		// in-memory state at least once.
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(15 * time.Second):
+		}
+		r.Run(ctx)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				// Always reconcile against the live symbol — SwitchSymbol
+				// updates p.symbolID but the reconciler is built once.
+				r.SetSymbolID(p.SymbolID())
+				r.Run(ctx)
+			}
+		}
+	}()
+	slog.Info("event-pipeline: reconciler armed",
+		"intervalSec", p.reconcileConfig.IntervalSec,
+		"posHaltPct", p.reconcileConfig.PositionHaltPct,
+		"balHaltPct", p.reconcileConfig.BalanceHaltPct,
+	)
+	return r
 }

--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase"
 	backtestuc "github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/backtest"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/circuitbreaker"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/reconcile"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/sor"
 	strategyuc "github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/strategy"
 )
@@ -138,6 +139,15 @@ func main() {
 				EmptyBookHoldMs:      cfg.CircuitBreaker.EmptyBookHoldMs,
 			},
 			StaleCheckIntervalMs: cfg.CircuitBreaker.StaleCheckIntervalMs,
+			Reconcile: reconcile.Config{
+				Enable:          cfg.Reconcile.Enable,
+				IntervalSec:     cfg.Reconcile.IntervalSec,
+				PositionWarnPct: cfg.Reconcile.PositionWarnPct,
+				PositionHaltPct: cfg.Reconcile.PositionHaltPct,
+				BalanceWarnPct:  cfg.Reconcile.BalanceWarnPct,
+				BalanceHaltPct:  cfg.Reconcile.BalanceHaltPct,
+				OrderTTL:        time.Duration(cfg.Reconcile.OrderTTLSec) * time.Second,
+			},
 		},
 		restClient,
 		restClient, // SymbolFetcher
@@ -146,6 +156,7 @@ func main() {
 		riskMgr,
 		tradeHistoryRepo,
 		riskStateRepo,
+		clientOrderRepo,
 	)
 
 	// 初期シンボルの baseStepAmount / minOrderAmount をロード

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -14,6 +14,7 @@ type Config struct {
 	Trading        TradingConfig
 	Backtest       BacktestConfig
 	CircuitBreaker CircuitBreakerConfig
+	Reconcile      ReconcileConfig
 }
 
 type TradingConfig struct {
@@ -73,6 +74,17 @@ type CircuitBreakerConfig struct {
 	StaleCheckIntervalMs int64
 }
 
+// ReconcileConfig mirrors usecase/reconcile/Config. opt-in.
+type ReconcileConfig struct {
+	Enable          bool
+	IntervalSec     int
+	PositionWarnPct float64
+	PositionHaltPct float64
+	BalanceWarnPct  float64
+	BalanceHaltPct  float64
+	OrderTTLSec     int
+}
+
 type RakutenConfig struct {
 	BaseURL   string
 	WSURL     string
@@ -122,6 +134,15 @@ func Load() *Config {
 		Backtest: BacktestConfig{
 			RetentionDays: getEnvInt("BACKTEST_RETENTION_DAYS", 180),
 		},
+		Reconcile: ReconcileConfig{
+			Enable:          getEnvBool("RECONCILE_ENABLED", false),
+			IntervalSec:     getEnvInt("RECONCILE_INTERVAL_SEC", 60),
+			PositionWarnPct: getEnvFloat("RECONCILE_POSITION_WARN_PCT", 0.05),
+			PositionHaltPct: getEnvFloat("RECONCILE_POSITION_HALT_PCT", 0.5),
+			BalanceWarnPct:  getEnvFloat("RECONCILE_BALANCE_WARN_PCT", 0.01),
+			BalanceHaltPct:  getEnvFloat("RECONCILE_BALANCE_HALT_PCT", 0.05),
+			OrderTTLSec:     getEnvInt("RECONCILE_ORDER_TTL_SEC", 300),
+		},
 		CircuitBreaker: CircuitBreakerConfig{
 			// Default = OFF. Operators flip the env vars on once they're
 			// happy with the live book cache so a misconfigured threshold
@@ -157,6 +178,18 @@ func getEnvInt(key string, defaultValue int) int {
 	if value := os.Getenv(key); value != "" {
 		if i, err := strconv.Atoi(value); err == nil {
 			return i
+		}
+	}
+	return defaultValue
+}
+
+func getEnvBool(key string, defaultValue bool) bool {
+	if value := os.Getenv(key); value != "" {
+		switch value {
+		case "1", "true", "True", "TRUE", "yes", "on":
+			return true
+		case "0", "false", "False", "FALSE", "no", "off":
+			return false
 		}
 	}
 	return defaultValue

--- a/backend/internal/usecase/reconcile/reconciler.go
+++ b/backend/internal/usecase/reconcile/reconciler.go
@@ -1,0 +1,380 @@
+// Package reconcile compares the bot's local view of the world (open
+// client_orders, in-memory positions, last-known balance) against the venue's
+// authoritative state every minute. Discrepancies escalate through three
+// tiers:
+//
+//  1. Auto-repair (orders): when the bot is missing a venue-side acknowledgement
+//     for an order, the reconciler patches client_orders to "reconciled-*".
+//  2. Warn (positions / balance drift below halt threshold): publish a
+//     "risk_event" so operators see the drift on the dashboard.
+//  3. Halt (severe drift): call RiskManager.HaltAutomatic so the bot stops
+//     trading until a human inspects.
+//
+// The reconciler is read-only against the venue. It only writes to the bot's
+// own state (client_orders status updates, RiskManager halt) — never sends
+// orders or modifies venue positions.
+package reconcile
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"math"
+	"time"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/repository"
+)
+
+// VenueClient is the narrow surface the reconciler needs. It is intentionally
+// smaller than repository.OrderClient so test fakes are easy to write.
+type VenueClient interface {
+	GetOrders(ctx context.Context, symbolID int64) ([]entity.Order, error)
+	GetPositions(ctx context.Context, symbolID int64) ([]entity.Position, error)
+	GetMyTrades(ctx context.Context, symbolID int64) ([]entity.MyTrade, error)
+	GetAssets(ctx context.Context) ([]entity.Asset, error)
+}
+
+// LocalState is the bot-side view the reconciler compares against the venue.
+// RiskManager satisfies it through tiny adapter methods.
+type LocalState interface {
+	// Positions returns a defensive copy of the in-memory position list.
+	LocalPositions() []entity.Position
+	// Balance returns the JPY balance the bot currently believes it has.
+	LocalBalance() float64
+}
+
+// Halter narrows RiskManager.HaltAutomatic so the test layer doesn't pull in
+// the full risk manager.
+type Halter interface {
+	HaltAutomatic(reason string) bool
+}
+
+// Publisher surfaces drift / halt events to the realtime hub. Nil disables
+// publishing.
+type Publisher interface {
+	PublishDrift(kind string, severity string, message string, ts int64)
+}
+
+// Config bundles the thresholds. All values are in plain ratios (0.05 = 5%).
+type Config struct {
+	// Enable toggles the reconciler.
+	Enable bool
+	// IntervalSec is the reconcile cadence in seconds. 0 falls back to 60.
+	IntervalSec int
+
+	// PositionHaltPct halts trading when the absolute difference between
+	// venue and local total notional, divided by the larger of the two,
+	// exceeds this. 0 disables the halt branch (warn only). 0.5 = 50%.
+	PositionHaltPct float64
+	// PositionWarnPct emits a warning for any drift above this ratio.
+	// Defaults to 0.05 (5%) when 0.
+	PositionWarnPct float64
+
+	// BalanceWarnPct emits a warning for any drift above this ratio.
+	// Defaults to 0.01 (1%) when 0.
+	BalanceWarnPct float64
+	// BalanceHaltPct halts trading when balance drift exceeds this ratio.
+	// 0 disables. 0.05 = 5%.
+	BalanceHaltPct float64
+
+	// OrderTTL is how long a pending/submitted order may stay un-confirmed
+	// before the reconciler marks it reconciled-timeout. 0 falls back to 5m.
+	OrderTTL time.Duration
+}
+
+// DefaultConfig returns conservative thresholds. Everything is opt-in
+// (Enable=false) — the composition root flips it on after env wiring.
+func DefaultConfig() Config {
+	return Config{
+		Enable:          false,
+		IntervalSec:     60,
+		PositionHaltPct: 0.5,
+		PositionWarnPct: 0.05,
+		BalanceWarnPct:  0.01,
+		BalanceHaltPct:  0.05,
+		OrderTTL:        5 * time.Minute,
+	}
+}
+
+// Reconciler runs the three checks. It owns no goroutines on its own; the
+// caller drives Start/Run.
+type Reconciler struct {
+	cfg       Config
+	venue     VenueClient
+	local     LocalState
+	halter    Halter
+	publisher Publisher
+	orders    repository.ClientOrderRepository
+	now       func() time.Time
+	symbolID  int64
+}
+
+// New constructs a reconciler. halter is required (panics on nil).
+func New(
+	cfg Config,
+	venue VenueClient,
+	local LocalState,
+	halter Halter,
+	orders repository.ClientOrderRepository,
+	publisher Publisher,
+	symbolID int64,
+) *Reconciler {
+	if halter == nil {
+		panic("reconcile.New: halter must not be nil")
+	}
+	if cfg.IntervalSec <= 0 {
+		cfg.IntervalSec = 60
+	}
+	if cfg.PositionWarnPct <= 0 {
+		cfg.PositionWarnPct = 0.05
+	}
+	if cfg.BalanceWarnPct <= 0 {
+		cfg.BalanceWarnPct = 0.01
+	}
+	if cfg.OrderTTL <= 0 {
+		cfg.OrderTTL = 5 * time.Minute
+	}
+	return &Reconciler{
+		cfg:       cfg,
+		venue:     venue,
+		local:     local,
+		halter:    halter,
+		publisher: publisher,
+		orders:    orders,
+		now:       time.Now,
+		symbolID:  symbolID,
+	}
+}
+
+// SetClock overrides the now() source. Tests inject a fixed clock.
+func (r *Reconciler) SetClock(now func() time.Time) {
+	if now != nil {
+		r.now = now
+	}
+}
+
+// SetSymbolID updates the symbol the next Run will reconcile against. Called
+// from the live pipeline whenever SwitchSymbol fires.
+func (r *Reconciler) SetSymbolID(id int64) {
+	r.symbolID = id
+}
+
+// Run executes one reconciliation pass: orders → positions → balance.
+// Errors from individual checks log a warning but do not abort subsequent
+// checks; a misbehaving orders endpoint should not blind the operator to
+// position drift.
+func (r *Reconciler) Run(ctx context.Context) {
+	if !r.cfg.Enable {
+		return
+	}
+	if err := r.reconcileOrders(ctx); err != nil {
+		slog.Warn("reconcile: orders pass failed", "error", err)
+	}
+	if err := r.reconcilePositions(ctx); err != nil {
+		slog.Warn("reconcile: positions pass failed", "error", err)
+	}
+	if err := r.reconcileBalance(ctx); err != nil {
+		slog.Warn("reconcile: balance pass failed", "error", err)
+	}
+}
+
+// reconcileOrders walks the pending/submitted client_orders and consults the
+// venue's open-orders + my-trades endpoints to confirm or close them out.
+func (r *Reconciler) reconcileOrders(ctx context.Context) error {
+	if r.orders == nil {
+		return nil
+	}
+	pending, err := r.orders.ListByStatus(ctx, []entity.ClientOrderStatus{
+		entity.ClientOrderStatusPending,
+		entity.ClientOrderStatusSubmitted,
+	}, 200)
+	if err != nil {
+		return fmt.Errorf("list pending orders: %w", err)
+	}
+	if len(pending) == 0 {
+		return nil
+	}
+
+	openOrders, err := r.venue.GetOrders(ctx, r.symbolID)
+	if err != nil {
+		return fmt.Errorf("venue GetOrders: %w", err)
+	}
+	openIDs := make(map[int64]struct{}, len(openOrders))
+	for _, o := range openOrders {
+		openIDs[o.ID] = struct{}{}
+	}
+
+	trades, err := r.venue.GetMyTrades(ctx, r.symbolID)
+	if err != nil {
+		// trade history failures should not block the rest of reconciliation —
+		// fall back to "no fills observed" so timeout logic still fires.
+		slog.Warn("reconcile: GetMyTrades failed", "error", err)
+		trades = nil
+	}
+	filledIDs := make(map[int64]struct{}, len(trades))
+	for _, t := range trades {
+		filledIDs[t.OrderID] = struct{}{}
+	}
+
+	now := r.now().UnixMilli()
+	ttlMs := r.cfg.OrderTTL.Milliseconds()
+	for _, rec := range pending {
+		// We can only reconcile records that have an OrderID; pre-submission
+		// pending rows (OrderID==0) need to wait for the orderclient layer
+		// to fill that in.
+		if rec.OrderID == 0 {
+			if now-rec.CreatedAt > ttlMs {
+				_ = r.orders.UpdateStatus(ctx, rec.ClientOrderID,
+					entity.ClientOrderStatusReconciledTimeout, now,
+					repository.ClientOrderUpdate{})
+			}
+			continue
+		}
+
+		switch {
+		case fmtFilled(filledIDs, rec.OrderID):
+			_ = r.orders.UpdateStatus(ctx, rec.ClientOrderID,
+				entity.ClientOrderStatusReconciledConfirmed, now,
+				repository.ClientOrderUpdate{})
+		case fmtOpen(openIDs, rec.OrderID):
+			// Still resting on the venue — leave as-is, the order is healthy.
+		case now-rec.CreatedAt > ttlMs:
+			// TTL elapsed and the order is neither resting nor filled.
+			// Most likely cancelled outside our control or a stale row.
+			_ = r.orders.UpdateStatus(ctx, rec.ClientOrderID,
+				entity.ClientOrderStatusReconciledNotFound, now,
+				repository.ClientOrderUpdate{})
+		}
+	}
+	return nil
+}
+
+func fmtFilled(filled map[int64]struct{}, id int64) bool {
+	_, ok := filled[id]
+	return ok
+}
+
+func fmtOpen(open map[int64]struct{}, id int64) bool {
+	_, ok := open[id]
+	return ok
+}
+
+// reconcilePositions compares the bot's in-memory positions to the venue's
+// authoritative position list and emits drift events / halts when needed.
+//
+// The metric is signed-net-amount: sum(BUY) − sum(SELL). A 100% drift means
+// the bot believes it is long while the venue says flat (or vice versa) —
+// the most dangerous case.
+func (r *Reconciler) reconcilePositions(ctx context.Context) error {
+	venuePositions, err := r.venue.GetPositions(ctx, r.symbolID)
+	if err != nil {
+		return fmt.Errorf("venue GetPositions: %w", err)
+	}
+	venueNet := signedNetAmount(venuePositions)
+	localNet := signedNetAmount(r.local.LocalPositions())
+
+	delta := math.Abs(venueNet - localNet)
+	denom := math.Max(math.Abs(venueNet), math.Abs(localNet))
+	if denom <= 0 {
+		// Both sides report flat — perfectly aligned, nothing to do.
+		return nil
+	}
+	driftRatio := delta / denom
+
+	now := r.now().UnixMilli()
+	if r.cfg.PositionHaltPct > 0 && driftRatio >= r.cfg.PositionHaltPct {
+		r.haltAndPublish("reconciliation:position_mismatch",
+			fmt.Sprintf("position drift %.1f%% (venue=%.4f local=%.4f)",
+				driftRatio*100, venueNet, localNet),
+			now)
+		return nil
+	}
+	if driftRatio >= r.cfg.PositionWarnPct {
+		r.publish("position_drift", "warning",
+			fmt.Sprintf("position drift %.1f%% (venue=%.4f local=%.4f)",
+				driftRatio*100, venueNet, localNet),
+			now)
+	}
+	return nil
+}
+
+// signedNetAmount collapses a position list into one number: BUY adds,
+// SELL subtracts. Symbol mismatches are not handled here — the caller is
+// expected to scope the reconciler to one symbol.
+func signedNetAmount(pos []entity.Position) float64 {
+	net := 0.0
+	for _, p := range pos {
+		amt := p.RemainingAmount
+		if amt <= 0 {
+			amt = 0
+		}
+		if p.OrderSide == entity.OrderSideSell {
+			net -= amt
+		} else {
+			net += amt
+		}
+	}
+	return net
+}
+
+// reconcileBalance compares the bot's last-known JPY balance to the venue's
+// asset list. Drift can come from manual deposits, withdrawals, or fees the
+// bot did not anticipate.
+func (r *Reconciler) reconcileBalance(ctx context.Context) error {
+	assets, err := r.venue.GetAssets(ctx)
+	if err != nil {
+		return fmt.Errorf("venue GetAssets: %w", err)
+	}
+	venueBalance := 0.0
+	for _, a := range assets {
+		if a.Currency == "JPY" {
+			venueBalance = parseFloatSafe(a.OnhandAmount)
+			break
+		}
+	}
+	localBalance := r.local.LocalBalance()
+	if venueBalance <= 0 || localBalance <= 0 {
+		return nil
+	}
+	delta := math.Abs(venueBalance - localBalance)
+	denom := math.Max(venueBalance, localBalance)
+	driftRatio := delta / denom
+
+	now := r.now().UnixMilli()
+	if r.cfg.BalanceHaltPct > 0 && driftRatio >= r.cfg.BalanceHaltPct {
+		r.haltAndPublish("reconciliation:balance_drift",
+			fmt.Sprintf("balance drift %.1f%% (venue=%.0f local=%.0f)",
+				driftRatio*100, venueBalance, localBalance),
+			now)
+		return nil
+	}
+	if driftRatio >= r.cfg.BalanceWarnPct {
+		r.publish("balance_drift", "warning",
+			fmt.Sprintf("balance drift %.1f%% (venue=%.0f local=%.0f)",
+				driftRatio*100, venueBalance, localBalance),
+			now)
+	}
+	return nil
+}
+
+func (r *Reconciler) haltAndPublish(reason, detail string, ts int64) {
+	r.halter.HaltAutomatic(reason)
+	r.publish("halt", "critical", reason+": "+detail, ts)
+}
+
+func (r *Reconciler) publish(kind, severity, message string, ts int64) {
+	if r.publisher == nil {
+		return
+	}
+	r.publisher.PublishDrift(kind, severity, message, ts)
+}
+
+func parseFloatSafe(s string) float64 {
+	var f float64
+	_, err := fmt.Sscanf(s, "%f", &f)
+	if err != nil {
+		return 0
+	}
+	return f
+}

--- a/backend/internal/usecase/reconcile/reconciler_test.go
+++ b/backend/internal/usecase/reconcile/reconciler_test.go
@@ -1,0 +1,292 @@
+package reconcile
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/repository"
+)
+
+// --- fakes -------------------------------------------------------------
+
+type fakeVenue struct {
+	orders    []entity.Order
+	positions []entity.Position
+	trades    []entity.MyTrade
+	jpy       float64
+	getOrdersErr    error
+	getPositionsErr error
+	getTradesErr    error
+	getAssetsErr    error
+}
+
+func (f *fakeVenue) GetOrders(_ context.Context, _ int64) ([]entity.Order, error) {
+	if f.getOrdersErr != nil {
+		return nil, f.getOrdersErr
+	}
+	return f.orders, nil
+}
+func (f *fakeVenue) GetPositions(_ context.Context, _ int64) ([]entity.Position, error) {
+	if f.getPositionsErr != nil {
+		return nil, f.getPositionsErr
+	}
+	return f.positions, nil
+}
+func (f *fakeVenue) GetMyTrades(_ context.Context, _ int64) ([]entity.MyTrade, error) {
+	if f.getTradesErr != nil {
+		return nil, f.getTradesErr
+	}
+	return f.trades, nil
+}
+func (f *fakeVenue) GetAssets(_ context.Context) ([]entity.Asset, error) {
+	if f.getAssetsErr != nil {
+		return nil, f.getAssetsErr
+	}
+	return []entity.Asset{{Currency: "JPY", OnhandAmount: strconv.FormatFloat(f.jpy, 'f', 2, 64)}}, nil
+}
+
+type fakeLocal struct {
+	pos     []entity.Position
+	balance float64
+}
+
+func (f *fakeLocal) LocalPositions() []entity.Position { return f.pos }
+func (f *fakeLocal) LocalBalance() float64             { return f.balance }
+
+type fakeHalter struct{ reasons []string }
+
+func (h *fakeHalter) HaltAutomatic(reason string) bool {
+	h.reasons = append(h.reasons, reason)
+	return true
+}
+
+type fakePublisher struct {
+	mu     sync.Mutex
+	events []struct {
+		kind, severity, message string
+	}
+}
+
+func (p *fakePublisher) PublishDrift(kind, severity, message string, _ int64) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.events = append(p.events, struct{ kind, severity, message string }{kind, severity, message})
+}
+
+// fakeOrderRepo implements just the methods the reconciler exercises.
+type fakeOrderRepo struct {
+	listing []repository.ClientOrderRecord
+	updates []struct {
+		id     string
+		status entity.ClientOrderStatus
+	}
+}
+
+func (r *fakeOrderRepo) Find(_ context.Context, _ string) (*repository.ClientOrderRecord, error) {
+	return nil, nil
+}
+func (r *fakeOrderRepo) Save(_ context.Context, _ repository.ClientOrderRecord) error { return nil }
+func (r *fakeOrderRepo) InsertOrGet(_ context.Context, _ repository.ClientOrderRecord) (*repository.ClientOrderRecord, bool, error) {
+	return nil, false, nil
+}
+func (r *fakeOrderRepo) UpdateStatus(_ context.Context, id string, status entity.ClientOrderStatus, _ int64, _ repository.ClientOrderUpdate) error {
+	r.updates = append(r.updates, struct {
+		id     string
+		status entity.ClientOrderStatus
+	}{id, status})
+	return nil
+}
+func (r *fakeOrderRepo) ListByStatus(_ context.Context, _ []entity.ClientOrderStatus, _ int) ([]repository.ClientOrderRecord, error) {
+	return r.listing, nil
+}
+func (r *fakeOrderRepo) DeleteExpired(_ context.Context, _ int64) error { return nil }
+
+// --- helpers -----------------------------------------------------------
+
+func newReconciler(t *testing.T, cfg Config, v *fakeVenue, l *fakeLocal, h *fakeHalter, repo repository.ClientOrderRepository, pub Publisher) *Reconciler {
+	t.Helper()
+	cfg.Enable = true
+	r := New(cfg, v, l, h, repo, pub, 7)
+	r.SetClock(func() time.Time { return time.UnixMilli(10_000_000) })
+	return r
+}
+
+// --- tests -------------------------------------------------------------
+
+func TestReconciler_DisabledIsNoop(t *testing.T) {
+	v := &fakeVenue{positions: []entity.Position{{OrderSide: entity.OrderSideBuy, RemainingAmount: 5}}}
+	l := &fakeLocal{}
+	h := &fakeHalter{}
+	r := New(Config{Enable: false}, v, l, h, nil, nil, 7)
+	r.Run(context.Background())
+	if len(h.reasons) > 0 {
+		t.Fatalf("expected no halts, got %v", h.reasons)
+	}
+}
+
+func TestReconciler_PositionHaltOnLargeMismatch(t *testing.T) {
+	v := &fakeVenue{
+		positions: []entity.Position{}, // venue says flat
+	}
+	l := &fakeLocal{
+		pos: []entity.Position{{OrderSide: entity.OrderSideBuy, RemainingAmount: 1.0}},
+	}
+	h := &fakeHalter{}
+	pub := &fakePublisher{}
+	r := newReconciler(t, Config{PositionHaltPct: 0.5, PositionWarnPct: 0.05}, v, l, h, nil, pub)
+	r.Run(context.Background())
+	if len(h.reasons) != 1 || h.reasons[0] != "reconciliation:position_mismatch" {
+		t.Fatalf("expected position_mismatch halt, got %v", h.reasons)
+	}
+}
+
+func TestReconciler_PositionWarnOnly(t *testing.T) {
+	// venue=1.0 BUY, local=1.05 BUY → 5% drift below 50% halt threshold
+	v := &fakeVenue{positions: []entity.Position{{OrderSide: entity.OrderSideBuy, RemainingAmount: 1.0}}}
+	l := &fakeLocal{pos: []entity.Position{{OrderSide: entity.OrderSideBuy, RemainingAmount: 1.05}}}
+	h := &fakeHalter{}
+	pub := &fakePublisher{}
+	r := newReconciler(t, Config{PositionHaltPct: 0.5, PositionWarnPct: 0.04}, v, l, h, nil, pub)
+	r.Run(context.Background())
+	if len(h.reasons) > 0 {
+		t.Fatalf("expected no halt, got %v", h.reasons)
+	}
+	if len(pub.events) != 1 || pub.events[0].kind != "position_drift" {
+		t.Fatalf("expected one position_drift event, got %v", pub.events)
+	}
+}
+
+func TestReconciler_PositionFlatOnBothSidesIsAligned(t *testing.T) {
+	v := &fakeVenue{}
+	l := &fakeLocal{}
+	h := &fakeHalter{}
+	pub := &fakePublisher{}
+	r := newReconciler(t, Config{PositionHaltPct: 0.5}, v, l, h, nil, pub)
+	r.Run(context.Background())
+	if len(h.reasons) > 0 || len(pub.events) > 0 {
+		t.Fatalf("flat-flat is aligned: halts=%v events=%v", h.reasons, pub.events)
+	}
+}
+
+func TestReconciler_BalanceHalt(t *testing.T) {
+	v := &fakeVenue{jpy: 50_000}
+	l := &fakeLocal{balance: 100_000} // 50% drift
+	h := &fakeHalter{}
+	pub := &fakePublisher{}
+	r := newReconciler(t, Config{BalanceHaltPct: 0.05, BalanceWarnPct: 0.01}, v, l, h, nil, pub)
+	r.Run(context.Background())
+	if len(h.reasons) != 1 || h.reasons[0] != "reconciliation:balance_drift" {
+		t.Fatalf("expected balance halt, got %v", h.reasons)
+	}
+}
+
+func TestReconciler_BalanceWarnOnly(t *testing.T) {
+	v := &fakeVenue{jpy: 99_000}
+	l := &fakeLocal{balance: 100_000} // ~1% drift
+	h := &fakeHalter{}
+	pub := &fakePublisher{}
+	r := newReconciler(t, Config{BalanceHaltPct: 0.05, BalanceWarnPct: 0.005}, v, l, h, nil, pub)
+	r.Run(context.Background())
+	if len(h.reasons) > 0 {
+		t.Fatalf("expected no halt, got %v", h.reasons)
+	}
+	if len(pub.events) != 1 || pub.events[0].kind != "balance_drift" {
+		t.Fatalf("expected balance_drift event, got %v", pub.events)
+	}
+}
+
+func TestReconciler_OrderConfirmsFromMyTrades(t *testing.T) {
+	now := time.UnixMilli(10_000_000)
+	v := &fakeVenue{
+		orders: []entity.Order{},
+		trades: []entity.MyTrade{{OrderID: 555}},
+	}
+	repo := &fakeOrderRepo{
+		listing: []repository.ClientOrderRecord{
+			{ClientOrderID: "co-A", Status: entity.ClientOrderStatusSubmitted, OrderID: 555, CreatedAt: now.Add(-1 * time.Minute).UnixMilli()},
+		},
+	}
+	r := newReconciler(t, Config{OrderTTL: 5 * time.Minute}, v, &fakeLocal{}, &fakeHalter{}, repo, nil)
+	r.Run(context.Background())
+	if len(repo.updates) != 1 || repo.updates[0].status != entity.ClientOrderStatusReconciledConfirmed {
+		t.Fatalf("expected reconciled-confirmed, got %v", repo.updates)
+	}
+}
+
+func TestReconciler_OrderTimesOutAfterTTL(t *testing.T) {
+	now := time.UnixMilli(10_000_000)
+	v := &fakeVenue{} // no open orders, no trades
+	repo := &fakeOrderRepo{
+		listing: []repository.ClientOrderRecord{
+			{ClientOrderID: "co-stale", Status: entity.ClientOrderStatusPending, OrderID: 0, CreatedAt: now.Add(-10 * time.Minute).UnixMilli()},
+			{ClientOrderID: "co-stale-with-id", Status: entity.ClientOrderStatusSubmitted, OrderID: 999, CreatedAt: now.Add(-10 * time.Minute).UnixMilli()},
+			{ClientOrderID: "co-fresh", Status: entity.ClientOrderStatusPending, OrderID: 0, CreatedAt: now.Add(-1 * time.Minute).UnixMilli()},
+		},
+	}
+	r := newReconciler(t, Config{OrderTTL: 5 * time.Minute}, v, &fakeLocal{}, &fakeHalter{}, repo, nil)
+	r.Run(context.Background())
+	want := map[string]entity.ClientOrderStatus{
+		"co-stale":         entity.ClientOrderStatusReconciledTimeout,
+		"co-stale-with-id": entity.ClientOrderStatusReconciledNotFound,
+	}
+	if len(repo.updates) != len(want) {
+		t.Fatalf("expected %d updates, got %v", len(want), repo.updates)
+	}
+	for _, u := range repo.updates {
+		if want[u.id] != u.status {
+			t.Fatalf("unexpected update for %s: got %s, want %s", u.id, u.status, want[u.id])
+		}
+	}
+}
+
+func TestReconciler_OrderStillOpenStaysUnchanged(t *testing.T) {
+	now := time.UnixMilli(10_000_000)
+	v := &fakeVenue{
+		orders: []entity.Order{{ID: 555}}, // venue still has it resting
+	}
+	repo := &fakeOrderRepo{
+		listing: []repository.ClientOrderRecord{
+			{ClientOrderID: "co-resting", Status: entity.ClientOrderStatusSubmitted, OrderID: 555, CreatedAt: now.Add(-2 * time.Minute).UnixMilli()},
+		},
+	}
+	r := newReconciler(t, Config{OrderTTL: 5 * time.Minute}, v, &fakeLocal{}, &fakeHalter{}, repo, nil)
+	r.Run(context.Background())
+	if len(repo.updates) != 0 {
+		t.Fatalf("resting orders must not be touched, got %v", repo.updates)
+	}
+}
+
+func TestReconciler_VenueErrorsDoNotAbortLaterChecks(t *testing.T) {
+	v := &fakeVenue{
+		getOrdersErr:    fmt.Errorf("HTTP 500"),
+		getPositionsErr: nil,
+		positions:       []entity.Position{}, // flat
+		jpy:             100_000,
+	}
+	l := &fakeLocal{balance: 100_000}
+	h := &fakeHalter{}
+	pub := &fakePublisher{}
+	repo := &fakeOrderRepo{listing: []repository.ClientOrderRecord{
+		{ClientOrderID: "co-x", Status: entity.ClientOrderStatusSubmitted, OrderID: 1, CreatedAt: time.Now().UnixMilli()},
+	}}
+	r := newReconciler(t, Config{PositionHaltPct: 0.5, BalanceHaltPct: 0.5}, v, l, h, repo, pub)
+	r.Run(context.Background())
+	// Orders pass failed (no updates), but positions/balance still ran cleanly.
+	if len(h.reasons) > 0 {
+		t.Fatalf("balanced state must not halt, got %v", h.reasons)
+	}
+}
+
+func TestReconciler_PanicsOnNilHalter(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic on nil halter")
+		}
+	}()
+	_ = New(Config{}, &fakeVenue{}, &fakeLocal{}, nil, nil, nil, 7)
+}

--- a/backend/internal/usecase/risk.go
+++ b/backend/internal/usecase/risk.go
@@ -510,6 +510,24 @@ func (rm *RiskManager) HaltReason() string {
 	return rm.haltReason
 }
 
+// LocalPositions returns a defensive copy of the in-memory position list.
+// Used by the reconciler to compare against venue-side state without
+// holding the risk-manager lock for the full check.
+func (rm *RiskManager) LocalPositions() []entity.Position {
+	rm.mu.RLock()
+	defer rm.mu.RUnlock()
+	out := make([]entity.Position, len(rm.positions))
+	copy(out, rm.positions)
+	return out
+}
+
+// LocalBalance returns the bot's last-known JPY balance.
+func (rm *RiskManager) LocalBalance() float64 {
+	rm.mu.RLock()
+	defer rm.mu.RUnlock()
+	return rm.balance
+}
+
 func (rm *RiskManager) GetStatus() RiskStatus {
 	rm.mu.RLock()
 	defer rm.mu.RUnlock()


### PR DESCRIPTION
## Summary
Bot 側のローカル状態（保留中 client_orders / in-memory positions / last-known balance）と楽天側の真実を **1 分ごとに比較** する safety net を追加。ずれを 3 段階で扱う：

1. **Order auto-repair**: `pending` / `submitted` の `client_orders` を venue の `GetOrders` + `GetMyTrades` と突合し、`reconciled-confirmed` / `reconciled-not-found` / `reconciled-timeout` に確定
2. **Soft drift (warn)**: position / balance のずれが warn 閾値を超えたら `risk_event` (kind=`reconciliation_drift`) を publish
3. **Severe drift (halt)**: halt 閾値を超えたら `RiskManager.HaltAutomatic("reconciliation:<reason>")` で取引停止

ベニューに対しては **read-only**。注文や positions を venue 側で書き換えるロジックは一切持たない。

## Why
- ネット切断・楽天側障害・ホットフィックスで in-memory state がドリフトするケースの最後の砦
- circuit breaker (#175) は **市況** の異常を見るが、こちらは **自分とベニューの整合性** を見る別軸の安全網
- `client_orders` の `reconciled-*` ステータスは元々スキーマで定義済みで、それを実際に動かす Reconciler が無かったのを埋める

## Changes
- new `internal/usecase/reconcile`:
  - `Reconciler` / `Config` / `VenueClient` / `LocalState` / `Halter` / `Publisher`
  - `reconcileOrders`: client_orders の status 突合 + TTL (default 5 m) タイムアウト
  - `reconcilePositions`: signed-net amount 比較 (warn 5% / halt 50% default)
  - `reconcileBalance`: JPY 残高 (warn 1% / halt 5% default)
  - 単体テスト: 9 ケース (disabled / halt / warn / aligned / TTL / fill / open / venue error 耐性 / nil halter panic)
- `usecase/risk.go`: `LocalPositions()` / `LocalBalance()` アクセサ追加
- `cmd/event_pipeline.go`:
  - `reconcilePublisher` で `risk_event` を realtime hub に流す
  - `startReconciler` で 1 分周期 goroutine を起動 (15 s warmup あり)
  - SymbolSwitch に `SetSymbolID` で追従
- `config/config.go` + `cmd/main.go`: 7 つの env (`RECONCILE_*`) を追加、default Enable=false で **opt-in**

## Defaults
- `RECONCILE_ENABLED` = false
- `RECONCILE_INTERVAL_SEC` = 60
- `RECONCILE_POSITION_WARN_PCT` = 0.05 / `_HALT_PCT` = 0.5
- `RECONCILE_BALANCE_WARN_PCT` = 0.01 / `_HALT_PCT` = 0.05
- `RECONCILE_ORDER_TTL_SEC` = 300

## Test plan
- [x] `go test ./... -race -count=1` 全 OK
- [x] reconcile 単体: 9 ケース
- [x] 既存 risk / event_pipeline / handler テストに影響なし

## 後続 PR
- フロント表示 (HaltReason / drift event の UI 表示)
- 手動 trigger エンドポイント
- venue 側自動修復 (例: 整合性違反で hung position を強制 close)

🤖 Generated with [Claude Code](https://claude.com/claude-code)