### PR TITLE
feat(backtest): book-gate / thin-book カウンタを Summary に表面化 (Q-1)

### DIFF
--- a/backend/internal/domain/entity/backtest.go
+++ b/backend/internal/domain/entity/backtest.go
@@ -78,6 +78,18 @@ type BacktestSummary struct {
 	ExpectancyPerTrade float64 `json:"expectancyPerTrade,omitempty"`
 	AvgWinJPY          float64 `json:"avgWinJpy,omitempty"`
 	AvgLossJPY         float64 `json:"avgLossJpy,omitempty"` // absolute value
+
+	// ---- PR-Q1: execution-quality counters surfaced from the runtime ----
+
+	// BookGateRejects buckets pre-trade book-depth gate rejections by reason
+	// ("slippage_exceeds_threshold", "lot_exceeds_book_side_ratio",
+	// "thin_book_pre_trade", "no_book", "stale_book", "empty_book_side").
+	// Empty when the run did not configure the gate.
+	BookGateRejects map[string]int `json:"bookGateRejects,omitempty"`
+	// ThinBookSkips counts orders the simulator could not fill because the
+	// orderbook side did not have enough depth at fill time. Aggregates
+	// open + SL/TP + trailing close skips.
+	ThinBookSkips int `json:"thinBookSkips,omitempty"`
 }
 
 // DrawdownPeriod captures one peak-to-recovery drawdown episode. For an

--- a/backend/internal/usecase/backtest/runner.go
+++ b/backend/internal/usecase/backtest/runner.go
@@ -278,6 +278,23 @@ func (r *BacktestRunner) Run(ctx context.Context, input RunInput) (*entity.Backt
 	trades := sim.ClosedTrades()
 
 	summary := r.reporter.BuildSummary(input.Config, sim.Balance(), trades, equityPoints)
+
+	// PR-Q1: surface execution-quality counters collected by the handlers.
+	// The runner is the only place that has visibility into both, so the
+	// summary is the natural place to merge them. Both stay nil/0 when the
+	// caller did not configure the gate / orderbook-replay path so legacy
+	// runs round-trip identically.
+	if len(riskHandler.BookGateRejects) > 0 {
+		// Defensive copy so later mutations on the handler don't leak
+		// into the persisted summary.
+		copied := make(map[string]int, len(riskHandler.BookGateRejects))
+		for k, v := range riskHandler.BookGateRejects {
+			copied[k] = v
+		}
+		summary.BookGateRejects = copied
+	}
+	summary.ThinBookSkips = executionHandler.ThinBookSkips + tickRiskHandler.ThinBookSkips
+
 	id, err := NewULID()
 	if err != nil {
 		return nil, err

--- a/backend/internal/usecase/backtest/runner_test.go
+++ b/backend/internal/usecase/backtest/runner_test.go
@@ -501,3 +501,57 @@ func TestBacktestRunner_BookGateBlocksThinTradesEntirely(t *testing.T) {
 		t.Fatalf("expected book gate to block all trades, got %d", result.Summary.TotalTrades)
 	}
 }
+
+// TestBacktestRunner_QualityCountersSurfaceInSummary makes sure that when
+// the orderbook-replay path triggers thin-book skips and the pre-trade gate
+// rejects signals, the counters land on BacktestSummary so reports / API
+// callers can see them.
+func TestBacktestRunner_QualityCountersSurfaceInSummary(t *testing.T) {
+	primary := make([]entity.Candle, 0, 60)
+	baseTime := int64(1_770_000_000_000)
+	price := 100.0
+	for i := 0; i < 60; i++ {
+		price += math.Sin(float64(i)/5.0) * 1.5
+		ts := baseTime + int64(i)*15*60*1000
+		primary = append(primary, entity.Candle{
+			Open: price - 0.5, High: price + 1.0, Low: price - 1.0, Close: price, Time: ts,
+		})
+	}
+	// Snapshots with 0.0001 LTC depth — every signal is gate-rejected.
+	snaps := make([]entity.Orderbook, 0, len(primary))
+	for _, c := range primary {
+		snaps = append(snaps, entity.Orderbook{
+			SymbolID: 7, Timestamp: c.Time,
+			Asks: []entity.OrderbookEntry{{Price: c.Close * 1.001, Amount: 0.0001}},
+			Bids: []entity.OrderbookEntry{{Price: c.Close * 0.999, Amount: 0.0001}},
+			BestAsk: c.Close * 1.001, BestBid: c.Close * 0.999, MidPrice: c.Close,
+		})
+	}
+	replay := newOrderbookReplayForTest(snaps)
+
+	cfg := entity.BacktestConfig{
+		Symbol: "BTC_JPY", SymbolID: 7, PrimaryInterval: "PT15M",
+		FromTimestamp: primary[0].Time, ToTimestamp: primary[len(primary)-1].Time,
+		InitialBalance: 100000, SlippageModel: "orderbook",
+	}
+	risk := entity.RiskConfig{
+		MaxPositionAmount: 1_000_000_000, MaxDailyLoss: 1_000_000_000,
+		StopLossPercent: 5, TakeProfitPercent: 10, InitialCapital: 100000,
+		MaxSlippageBps: 50, MaxBookSidePct: 30,
+	}
+	runner := NewBacktestRunner()
+	result, err := runner.Run(context.Background(), RunInput{
+		Config: cfg, RiskConfig: risk, TradeAmount: 0.01,
+		PrimaryCandles: primary, FillPriceSource: replay, BookSource: replay,
+	})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	// Gate rejects every approved signal, so the counters must reflect the
+	// activity even though TotalTrades stays 0.
+	if len(result.Summary.BookGateRejects) == 0 {
+		t.Fatal("expected BookGateRejects to be populated when gate fires")
+	}
+	// ThinBookSkips can be 0 here (no signal even reaches the executor)
+	// — that's a valid outcome of the gate working.
+}


### PR DESCRIPTION
## Summary
バックテスト結果に **execution-quality カウンタ** を追加。これまで pre-trade book gate (#172) と orderbook-replay simulator (#171) の thin-book skip が runtime には記録されていたが、`BacktestSummary` には現れず、結果としてエンドユーザーが「ゲートが何回 fire したか」を確認できなかった。それを直す。

## Q シリーズの位置づけ
- **Q-1 (この PR)**: バックテスト報告での可視化
- **Q-2 (次 PR)**: ライブ 24 h の集計 endpoint + maker/taker 比率
  - 楽天 `GET /api/v1/cfd/trade` の `tradeAction` フィールドが `MAKER` / `TAKER` を持つことを別調査で確認済み

## Changes
- `entity.BacktestSummary` に追加:
  - `BookGateRejects map[string]int`: reason 別 reject 件数 (slippage/lot/thin/no/stale/empty_side)
  - `ThinBookSkips int`: open + SL/TP + trailing close で発生した板薄 skip の合計
- `usecase/backtest/runner.go`: run 終了時にハンドラから集計し、defensive copy で summary に転記
- `runner_test.go`: 浅板環境で gate が全 signal を弾いても summary にカウンタが現れることを assert

## Test plan
- [x] `go test ./... -race -count=1` 全 OK
- [x] 既存 backtest テストはレガシー経路を保ち、新カウンタは nil/0
- [x] 新規テスト: BookGateRejects が populated になる

🤖 Generated with [Claude Code](https://claude.com/claude-code)