### PR TITLE
feat(backtest): maker/taker 手数料モデル + post-only fill simulator (B)

### DIFF
--- a/backend/internal/domain/entity/backtest.go
+++ b/backend/internal/domain/entity/backtest.go
@@ -13,10 +13,23 @@ type BacktestConfig struct {
 	DailyCarryCost   float64 `json:"dailyCarryCost"`
 	SlippagePercent  float64 `json:"slippagePercent"`
 	// SlippageModel selects how fill prices are computed.
-	//   - "" / "percent"  : legacy spread% / slippage% adjustment (default).
-	//   - "orderbook"     : VWAP from persisted L2 snapshots (Phase G).
+	//   - "" / "percent"        : legacy spread% / slippage% adjustment (default).
+	//   - "orderbook"           : VWAP from persisted L2 snapshots (Phase G).
+	//   - "post_only_with_taker": probabilistic maker fill at touch with
+	//                             percent/orderbook taker fallback (Phase B).
 	// Unknown values fall back to "percent".
 	SlippageModel string `json:"slippageModel,omitempty"`
+
+	// MakerFillProbability is consulted when SlippageModel is
+	// "post_only_with_taker" to decide whether each fill rests as a maker.
+	// 0.5 = coin flip (default). 0 disables the maker path entirely.
+	MakerFillProbability float64 `json:"makerFillProbability,omitempty"`
+
+	// MakerFeeRate / TakerFeeRate are notional-rate fees per fill. Negative
+	// values are rebates (Rakuten Wallet pays -0.0001 to makers, taker is 0).
+	// Zero values disable fee accounting so legacy backtests stay free.
+	MakerFeeRate float64 `json:"makerFeeRate,omitempty"`
+	TakerFeeRate float64 `json:"takerFeeRate,omitempty"`
 }
 
 // BacktestSummary stores fixed output metrics for a run.
@@ -90,6 +103,13 @@ type BacktestSummary struct {
 	// orderbook side did not have enough depth at fill time. Aggregates
 	// open + SL/TP + trailing close skips.
 	ThinBookSkips int `json:"thinBookSkips,omitempty"`
+
+	// TotalFeeJPY is the sum of per-trade fees across the run (negative
+	// values mean net rebate). MakerFillCount + TakerFillCount partitions
+	// the fills (open + close legs) into maker vs taker.
+	TotalFeeJPY     float64 `json:"totalFeeJpy,omitempty"`
+	MakerFillCount  int     `json:"makerFillCount,omitempty"`
+	TakerFillCount  int     `json:"takerFillCount,omitempty"`
 }
 
 // DrawdownPeriod captures one peak-to-recovery drawdown episode. For an
@@ -133,6 +153,14 @@ type BacktestTradeRecord struct {
 	PnLPercent   float64 `json:"pnlPercent"`
 	CarryingCost float64 `json:"carryingCost"`
 	SpreadCost   float64 `json:"spreadCost"`
+	// Fee is the venue-charged fee total for this trade (open + close).
+	// Negative when the trader earned a maker rebate. 0 for legacy backtests
+	// that did not configure MakerFeeRate / TakerFeeRate.
+	Fee          float64 `json:"fee,omitempty"`
+	// OpenIsMaker / CloseIsMaker label which legs were filled as maker. Both
+	// false for taker-only / legacy runs.
+	OpenIsMaker  bool    `json:"openIsMaker,omitempty"`
+	CloseIsMaker bool    `json:"closeIsMaker,omitempty"`
 	ReasonEntry  string  `json:"reasonEntry"`
 	ReasonExit   string  `json:"reasonExit"`
 }

--- a/backend/internal/infrastructure/backtest/fill_price.go
+++ b/backend/internal/infrastructure/backtest/fill_price.go
@@ -46,6 +46,15 @@ type FillPriceSource interface {
 	FillPrice(kind FillKind, side entity.OrderSide, signalPrice, amount float64, timestamp int64) (float64, error)
 }
 
+// MakerFlagSource is an optional add-on a FillPriceSource may implement to
+// tell the simulator whether the just-computed fill should be classified as
+// maker or taker. When a source does not implement it, the simulator treats
+// every fill as taker (the conservative default for the percent-slippage and
+// orderbook-replay models, both of which model market-style executions).
+type MakerFlagSource interface {
+	LastFillWasMaker() bool
+}
+
 // LegacyPercentSlippage reproduces the historical "spread% / 2 + slippage%"
 // adjustment so existing backtest invocations stay bit-identical.
 type LegacyPercentSlippage struct {
@@ -205,6 +214,110 @@ func (o *OrderbookReplay) lookup(ts int64) (entity.Orderbook, bool) {
 // stays a leaf with no usecase-side imports.
 type OrderbookHistoryLoader interface {
 	GetOrderbookHistory(ctx context.Context, symbolID int64, from, to int64, limit int) ([]entity.Orderbook, error)
+}
+
+// PostOnlyLimitFill simulates a SOR-style "post-only LIMIT then escalate to
+// MARKET" execution. With probability MakerFillProbability the order rests
+// at BestBid (BUY) / BestAsk (SELL) and fills as a maker; otherwise the
+// order escalates and the underlying TakerSource (typically OrderbookReplay)
+// returns the taker fill.
+//
+// The probability is sampled from a deterministic per-call hash of the trade
+// timestamp + side so a single backtest run is reproducible without an
+// external rand source. Tests can override SamplerOverride to force a maker
+// or taker outcome.
+type PostOnlyLimitFill struct {
+	// MakerFillProbability is the chance (0..1) that a post-only LIMIT
+	// rests long enough to fill at the touch. 0 disables the maker path
+	// (every fill becomes taker, equivalent to TakerSource alone).
+	MakerFillProbability float64
+	// TakerSource handles the fallback. Required.
+	TakerSource FillPriceSource
+	// BookSource feeds BestBid/BestAsk for the maker fill price. When nil,
+	// the maker path falls through to taker.
+	BookSource interface {
+		LatestBefore(ctx context.Context, symbolID, ts int64) (entity.Orderbook, bool, error)
+	}
+	// SymbolID is passed through to BookSource. Set once at construction.
+	SymbolID int64
+	// SamplerOverride lets tests pin the outcome ("maker" / "taker"). Empty
+	// string falls back to the deterministic hash.
+	SamplerOverride string
+
+	// lastWasMaker tracks the most recent FillPrice call's classification so
+	// SimExecutor can read it via the MakerFlagSource interface. Mutated on
+	// every FillPrice call; the simulator must read it before the next one.
+	lastWasMaker bool
+}
+
+// FillPrice implements FillPriceSource.
+func (p *PostOnlyLimitFill) FillPrice(kind FillKind, side entity.OrderSide, signalPrice, amount float64, ts int64) (float64, error) {
+	p.lastWasMaker = false
+	if p.tryMaker(kind, side, ts) {
+		if mid, ok := p.lookupTouch(kind, side, ts); ok && mid > 0 {
+			p.lastWasMaker = true
+			return mid, nil
+		}
+	}
+	if p.TakerSource == nil {
+		return 0, fmt.Errorf("PostOnlyLimitFill: TakerSource is nil")
+	}
+	return p.TakerSource.FillPrice(kind, side, signalPrice, amount, ts)
+}
+
+// LastFillWasMaker reports whether the latest FillPrice call was filled at
+// the touch as a maker (true) or via the taker fallback (false).
+func (p *PostOnlyLimitFill) LastFillWasMaker() bool { return p.lastWasMaker }
+
+// tryMaker returns whether the post-only LIMIT should be treated as having
+// filled this round.
+func (p *PostOnlyLimitFill) tryMaker(_ FillKind, _ entity.OrderSide, ts int64) bool {
+	switch p.SamplerOverride {
+	case "maker":
+		return true
+	case "taker":
+		return false
+	}
+	if p.MakerFillProbability <= 0 {
+		return false
+	}
+	if p.MakerFillProbability >= 1 {
+		return true
+	}
+	// Deterministic hash. We avoid math/rand so two runs with the same
+	// inputs produce identical outcomes — important for backtest reproducibility.
+	h := uint64(ts)
+	h ^= h >> 33
+	h *= 0xff51afd7ed558ccd
+	h ^= h >> 33
+	h *= 0xc4ceb9fe1a85ec53
+	h ^= h >> 33
+	r := float64(h%10_000) / 10_000.0
+	return r < p.MakerFillProbability
+}
+
+// lookupTouch returns the price the maker fill would receive: BestBid for an
+// effective buy, BestAsk for an effective sell. Returns ok=false when the
+// book is missing or the touch is zero, so the caller can fall back to taker.
+func (p *PostOnlyLimitFill) lookupTouch(kind FillKind, side entity.OrderSide, ts int64) (float64, bool) {
+	if p.BookSource == nil {
+		return 0, false
+	}
+	ob, ok, err := p.BookSource.LatestBefore(context.Background(), p.SymbolID, ts)
+	if err != nil || !ok {
+		return 0, false
+	}
+	// Maker BUY rests at BestBid; maker SELL rests at BestAsk.
+	if isSellLike(kind, side) {
+		if ob.BestAsk > 0 {
+			return ob.BestAsk, true
+		}
+	} else {
+		if ob.BestBid > 0 {
+			return ob.BestBid, true
+		}
+	}
+	return 0, false
 }
 
 // LoadOrderbookReplay is a convenience helper for the runner: load the entire

--- a/backend/internal/infrastructure/backtest/fill_price_test.go
+++ b/backend/internal/infrastructure/backtest/fill_price_test.go
@@ -206,3 +206,78 @@ func TestSimExecutor_OrderbookReplayThinBookErrorPropagates(t *testing.T) {
 		t.Fatalf("expected ThinBookError to propagate from SimExecutor, got %v", err)
 	}
 }
+
+func TestPostOnlyLimitFill_OverrideMaker_FillsAtBestBidForBuy(t *testing.T) {
+	snap := entity.Orderbook{
+		Timestamp: 1000, BestBid: 99, BestAsk: 101,
+		Asks: []entity.OrderbookEntry{{Price: 101, Amount: 10}},
+		Bids: []entity.OrderbookEntry{{Price: 99, Amount: 10}},
+	}
+	replay := NewOrderbookReplay([]entity.Orderbook{snap}, 60_000)
+	p := &PostOnlyLimitFill{
+		MakerFillProbability: 1.0,
+		TakerSource:          replay,
+		BookSource:           replay,
+		SymbolID:             7,
+		SamplerOverride:      "maker",
+	}
+	got, err := p.FillPrice(FillKindEntry, entity.OrderSideBuy, 0, 1.0, 1500)
+	if err != nil {
+		t.Fatalf("fill: %v", err)
+	}
+	if got != 99 {
+		t.Fatalf("expected fill at BestBid 99, got %f", got)
+	}
+	if !p.LastFillWasMaker() {
+		t.Fatal("expected LastFillWasMaker=true")
+	}
+}
+
+func TestPostOnlyLimitFill_OverrideTaker_FallsBackToTakerSource(t *testing.T) {
+	snap := entity.Orderbook{
+		Timestamp: 1000, BestBid: 99, BestAsk: 101,
+		Asks: []entity.OrderbookEntry{{Price: 101, Amount: 10}},
+		Bids: []entity.OrderbookEntry{{Price: 99, Amount: 10}},
+	}
+	replay := NewOrderbookReplay([]entity.Orderbook{snap}, 60_000)
+	p := &PostOnlyLimitFill{
+		MakerFillProbability: 0.0,
+		TakerSource:          replay,
+		BookSource:           replay,
+		SymbolID:             7,
+		SamplerOverride:      "taker",
+	}
+	got, err := p.FillPrice(FillKindEntry, entity.OrderSideBuy, 0, 1.0, 1500)
+	if err != nil {
+		t.Fatalf("fill: %v", err)
+	}
+	if got != 101 {
+		t.Fatalf("expected taker fill at BestAsk 101, got %f", got)
+	}
+	if p.LastFillWasMaker() {
+		t.Fatal("expected LastFillWasMaker=false on taker fallback")
+	}
+}
+
+func TestPostOnlyLimitFill_DeterministicSampler(t *testing.T) {
+	// Same timestamp must produce the same maker decision across runs.
+	snap := entity.Orderbook{
+		Timestamp: 1000, BestBid: 99, BestAsk: 101,
+		Bids: []entity.OrderbookEntry{{Price: 99, Amount: 10}},
+		Asks: []entity.OrderbookEntry{{Price: 101, Amount: 10}},
+	}
+	replay := NewOrderbookReplay([]entity.Orderbook{snap}, 60_000)
+	p := &PostOnlyLimitFill{
+		MakerFillProbability: 0.5,
+		TakerSource:          replay,
+		BookSource:           replay,
+		SymbolID:             7,
+	}
+	first, _ := p.FillPrice(FillKindEntry, entity.OrderSideBuy, 0, 1.0, 1500)
+	firstMaker := p.LastFillWasMaker()
+	second, _ := p.FillPrice(FillKindEntry, entity.OrderSideBuy, 0, 1.0, 1500)
+	secondMaker := p.LastFillWasMaker()
+	if first != second || firstMaker != secondMaker {
+		t.Fatalf("non-deterministic: first=(%f,%v) second=(%f,%v)", first, firstMaker, second, secondMaker)
+	}
+}

--- a/backend/internal/infrastructure/backtest/simulator.go
+++ b/backend/internal/infrastructure/backtest/simulator.go
@@ -17,6 +17,11 @@ type SimConfig struct {
 	// When nil, the simulator uses LegacyPercentSlippage{SpreadPercent,
 	// SlippagePercent} so existing call sites stay bit-identical.
 	FillPriceSource FillPriceSource
+	// MakerFeeRate / TakerFeeRate are notional-rate fees applied per fill.
+	// Negative values represent rebates (Rakuten Wallet pays -0.01% to
+	// makers). Defaults are 0 for both — legacy backtests stay fee-free.
+	MakerFeeRate float64
+	TakerFeeRate float64
 }
 
 type SimPosition struct {
@@ -27,6 +32,8 @@ type SimPosition struct {
 	Amount         float64
 	EntryTimestamp int64
 	SpreadCostOpen float64
+	OpenFeeJPY     float64 // signed: negative = rebate received on entry
+	OpenWasMaker   bool
 	ReasonEntry    string
 }
 
@@ -79,6 +86,10 @@ func (s *SimExecutor) Open(symbolID int64, side entity.OrderSide, signalPrice, a
 	if err != nil {
 		return entity.OrderEvent{}, err
 	}
+	openMaker := s.lastFillWasMaker()
+	openFee := s.feeFor(fill, amount, openMaker)
+	// Fee is applied immediately to balance: rebates credit, costs debit.
+	s.balance -= openFee
 	position := SimPosition{
 		PositionID:     s.nextPosID,
 		SymbolID:       symbolID,
@@ -87,6 +98,8 @@ func (s *SimExecutor) Open(symbolID int64, side entity.OrderSide, signalPrice, a
 		Amount:         amount,
 		EntryTimestamp: timestamp,
 		SpreadCostOpen: signalPrice * amount * (s.config.SpreadPercent / 100.0) / 2.0,
+		OpenFeeJPY:     openFee,
+		OpenWasMaker:   openMaker,
 		ReasonEntry:    reason,
 	}
 	s.positions = append(s.positions, position)
@@ -126,10 +139,13 @@ func (s *SimExecutor) Close(positionID int64, signalPrice float64, reason string
 	if err != nil {
 		return entity.OrderEvent{}, nil, err
 	}
+	closeMaker := s.lastFillWasMaker()
+	closeFee := s.feeFor(exitFill, pos.Amount, closeMaker)
+	totalFee := pos.OpenFeeJPY + closeFee
 	spreadCostClose := signalPrice * pos.Amount * (s.config.SpreadPercent / 100.0) / 2.0
 	spreadCostTotal := pos.SpreadCostOpen + spreadCostClose
 	carrying := s.carryingCost(pos, timestamp)
-	pnl := s.calcPnL(pos, exitFill) - carrying
+	pnl := s.calcPnL(pos, exitFill) - carrying - closeFee
 	pnlPct := 0.0
 	if pos.EntryPrice != 0 {
 		if pos.Side == entity.OrderSideBuy {
@@ -168,6 +184,9 @@ func (s *SimExecutor) Close(positionID int64, signalPrice float64, reason string
 		PnLPercent:   pnlPct,
 		CarryingCost: carrying,
 		SpreadCost:   spreadCostTotal,
+		Fee:          totalFee,
+		OpenIsMaker:  pos.OpenWasMaker,
+		CloseIsMaker: closeMaker,
 		ReasonEntry:  pos.ReasonEntry,
 		ReasonExit:   reason,
 	}
@@ -246,6 +265,30 @@ func (s *SimExecutor) Equity(markPriceBySymbol map[int64]float64) float64 {
 
 // entryFillPrice / exitFillPrice were folded into FillPriceSource.
 // LegacyPercentSlippage in fill_price.go preserves the original arithmetic.
+
+// feeFor returns the JPY fee paid for one fill at the supplied price/amount.
+// Sign convention: positive = cost, negative = rebate (Rakuten pays makers
+// -0.01% by default).
+func (s *SimExecutor) feeFor(price, amount float64, isMaker bool) float64 {
+	rate := s.config.TakerFeeRate
+	if isMaker {
+		rate = s.config.MakerFeeRate
+	}
+	if rate == 0 {
+		return 0
+	}
+	notional := price * amount
+	return notional * rate
+}
+
+// lastFillWasMaker queries the FillPriceSource for the most recent fill
+// classification. Sources that don't expose this are treated as taker.
+func (s *SimExecutor) lastFillWasMaker() bool {
+	if mfs, ok := s.fillPriceSource.(MakerFlagSource); ok {
+		return mfs.LastFillWasMaker()
+	}
+	return false
+}
 
 func (s *SimExecutor) carryingCost(pos SimPosition, exitTimestamp int64) float64 {
 	if s.config.DailyCarryingCost <= 0 {

--- a/backend/internal/infrastructure/backtest/simulator_test.go
+++ b/backend/internal/infrastructure/backtest/simulator_test.go
@@ -97,3 +97,71 @@ func TestSimExecutor_EquityIncludesUnrealizedPnL(t *testing.T) {
 		t.Fatalf("expected equity above initial with unrealized gain, got %f", eq)
 	}
 }
+
+func TestSimExecutor_AppliesMakerRebateOnEntry(t *testing.T) {
+	// Rebate of -0.01% on a 100 price × 1.0 amount = -0.01 JPY credit.
+	snap := entity.Orderbook{
+		Timestamp: 1000, BestBid: 100, BestAsk: 102,
+		Bids: []entity.OrderbookEntry{{Price: 100, Amount: 10}},
+		Asks: []entity.OrderbookEntry{{Price: 102, Amount: 10}},
+	}
+	replay := NewOrderbookReplay([]entity.Orderbook{snap}, 60_000)
+	src := &PostOnlyLimitFill{
+		MakerFillProbability: 1.0,
+		TakerSource:          replay,
+		BookSource:           replay,
+		SymbolID:             7,
+		SamplerOverride:      "maker",
+	}
+	sim := NewSimExecutor(SimConfig{
+		InitialBalance:  100_000,
+		FillPriceSource: src,
+		MakerFeeRate:    -0.0001,
+		TakerFeeRate:    0,
+	})
+	if _, err := sim.Open(7, entity.OrderSideBuy, 100, 1.0, "test", 1500); err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	// Maker rebate credits balance by 0.01 (notional 100 * 0.0001).
+	if got := sim.Balance(); got < 100_000.0099 || got > 100_000.0101 {
+		t.Fatalf("expected balance ~100000.01, got %f", got)
+	}
+}
+
+func TestSimExecutor_FeeRecordedOnTradeRecord(t *testing.T) {
+	snap := entity.Orderbook{
+		Timestamp: 1000, BestBid: 100, BestAsk: 102,
+		Bids: []entity.OrderbookEntry{{Price: 100, Amount: 10}},
+		Asks: []entity.OrderbookEntry{{Price: 102, Amount: 10}},
+	}
+	replay := NewOrderbookReplay([]entity.Orderbook{snap}, 60_000)
+	src := &PostOnlyLimitFill{
+		MakerFillProbability: 1.0,
+		TakerSource:          replay,
+		BookSource:           replay,
+		SymbolID:             7,
+		SamplerOverride:      "maker",
+	}
+	sim := NewSimExecutor(SimConfig{
+		InitialBalance:  100_000,
+		FillPriceSource: src,
+		MakerFeeRate:    -0.0001,
+		TakerFeeRate:    0,
+	})
+	if _, err := sim.Open(7, entity.OrderSideBuy, 100, 1.0, "test", 1500); err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	_, trade, err := sim.Close(1, 102, "exit", 2000)
+	if err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if trade == nil || !trade.OpenIsMaker || !trade.CloseIsMaker {
+		t.Fatalf("expected both legs maker, got %+v", trade)
+	}
+	// open: -0.0001 * 100 * 1 = -0.01
+	// close: -0.0001 * 100 * 1 = -0.01 (BestBid for SELL close)
+	// Total fee = -0.02 (rebate)
+	if trade.Fee >= 0 {
+		t.Fatalf("expected negative fee (rebate), got %f", trade.Fee)
+	}
+}

--- a/backend/internal/interfaces/api/handler/backtest.go
+++ b/backend/internal/interfaces/api/handler/backtest.go
@@ -126,10 +126,18 @@ type runBacktestRequest struct {
 	CarryingCost          float64 `json:"carryingCost"`
 	Slippage              float64 `json:"slippage"`
 	// SlippageModel: "" / "percent" → legacy %-based adjustment.
-	// "orderbook" → load persisted L2 snapshots for the run window and
-	// compute VWAP fills against them. The handler returns 400 when the
-	// snapshot coverage is insufficient.
+	// "orderbook"            → load persisted L2 snapshots for the run window
+	//                          and compute VWAP fills against them.
+	// "post_only_with_taker" → probabilistic maker fill at touch with
+	//                          orderbook taker fallback (Phase B).
 	SlippageModel string `json:"slippageModel,omitempty"`
+	// MakerFillProbability seeds the post-only-with-taker model. 0 falls
+	// back to 0.5. Ignored for other slippage models.
+	MakerFillProbability float64 `json:"makerFillProbability,omitempty"`
+	// MakerFeeRate / TakerFeeRate let the caller override the venue defaults
+	// (-0.0001 / 0 for Rakuten Wallet leverage). 0 disables fee accounting.
+	MakerFeeRate float64 `json:"makerFeeRate,omitempty"`
+	TakerFeeRate float64 `json:"takerFeeRate,omitempty"`
 	TradeAmount           float64 `json:"tradeAmount"`
 	StopLossPercent       float64 `json:"stopLossPercent"`
 	StopLossATRMultiplier float64 `json:"stopLossAtrMultiplier"` // PR-12
@@ -259,10 +267,13 @@ func (h *BacktestHandler) Run(c *gin.Context) {
 		FromTimestamp:    fromTs,
 		ToTimestamp:      toTs,
 		InitialBalance:   req.InitialBalance,
-		SpreadPercent:    req.Spread,
-		DailyCarryCost:   req.CarryingCost,
-		SlippagePercent:  req.Slippage,
-		SlippageModel:    req.SlippageModel,
+		SpreadPercent:        req.Spread,
+		DailyCarryCost:       req.CarryingCost,
+		SlippagePercent:      req.Slippage,
+		SlippageModel:        req.SlippageModel,
+		MakerFillProbability: req.MakerFillProbability,
+		MakerFeeRate:         req.MakerFeeRate,
+		TakerFeeRate:         req.TakerFeeRate,
 	}
 	if len(higherCandles) == 0 {
 		cfg.HigherTFInterval = ""
@@ -300,13 +311,31 @@ func (h *BacktestHandler) Run(c *gin.Context) {
 
 	var fillSource infrabt.FillPriceSource
 	var bookSource booklimit.BookSource
-	if req.SlippageModel == "orderbook" {
+	switch req.SlippageModel {
+	case "orderbook":
 		replay, err := h.buildOrderbookReplay(c.Request.Context(), cfg)
 		if err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
 		}
 		fillSource = replay
+		bookSource = replay
+	case "post_only_with_taker":
+		replay, err := h.buildOrderbookReplay(c.Request.Context(), cfg)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		prob := req.MakerFillProbability
+		if prob <= 0 {
+			prob = 0.5
+		}
+		fillSource = &infrabt.PostOnlyLimitFill{
+			MakerFillProbability: prob,
+			TakerSource:          replay,
+			BookSource:           replay,
+			SymbolID:             cfg.SymbolID,
+		}
 		bookSource = replay
 	}
 

--- a/backend/internal/usecase/backtest/runner.go
+++ b/backend/internal/usecase/backtest/runner.go
@@ -149,6 +149,8 @@ func (r *BacktestRunner) Run(ctx context.Context, input RunInput) (*entity.Backt
 			// the snapshots from the repo because the runner has no repo
 			// dependency by design.
 			return nil, fmt.Errorf("slippage model %q requires FillPriceSource on RunInput", input.Config.SlippageModel)
+		case "post_only_with_taker":
+			return nil, fmt.Errorf("slippage model %q requires FillPriceSource on RunInput (handler must wrap orderbook+post-only)", input.Config.SlippageModel)
 		default:
 			return nil, fmt.Errorf("unknown slippage model: %q", input.Config.SlippageModel)
 		}
@@ -159,6 +161,8 @@ func (r *BacktestRunner) Run(ctx context.Context, input RunInput) (*entity.Backt
 		DailyCarryingCost: input.Config.DailyCarryCost,
 		SlippagePercent:   input.Config.SlippagePercent,
 		FillPriceSource:   fillSource,
+		MakerFeeRate:      input.Config.MakerFeeRate,
+		TakerFeeRate:      input.Config.TakerFeeRate,
 	})
 	simAdapter := &simExecutorAdapter{sim: sim}
 
@@ -284,6 +288,19 @@ func (r *BacktestRunner) Run(ctx context.Context, input RunInput) (*entity.Backt
 	// summary is the natural place to merge them. Both stay nil/0 when the
 	// caller did not configure the gate / orderbook-replay path so legacy
 	// runs round-trip identically.
+	for _, tr := range trades {
+		summary.TotalFeeJPY += tr.Fee
+		if tr.OpenIsMaker {
+			summary.MakerFillCount++
+		} else {
+			summary.TakerFillCount++
+		}
+		if tr.CloseIsMaker {
+			summary.MakerFillCount++
+		} else {
+			summary.TakerFillCount++
+		}
+	}
 	if len(riskHandler.BookGateRejects) > 0 {
 		// Defensive copy so later mutations on the handler don't leak
 		// into the persisted summary.


### PR DESCRIPTION
## Summary
楽天 Wallet レバレッジ取引の手数料体系 (**Maker -0.01% リベート / Taker 0%**) をバックテストに反映し、Maker 優先戦略の効果を P&L で評価できるようにする。

新しい `slippageModel="post_only_with_taker"` を追加：確率 `makerFillProbability` (default 0.5) で post-only LIMIT が touch (BestBid/BestAsk) に約定し maker rebate を受け取り、それ以外は orderbook taker fallback。

## 楽天公式手数料表（調査結果）
[https://www.rakuten-wallet.co.jp/service/overview.html](https://www.rakuten-wallet.co.jp/service/overview.html) より：

| 項目 | 値 |
|---|---|
| Maker | **-0.01% (リベート)** |
| Taker | **0% (無料)** |
| 建玉管理料 | 0.04% / 日（既存実装あり） |

つまり Maker 優先 = 「手数料節約」ではなく「**リベート稼ぎ**」になる。

## Changes
- **domain/entity/backtest.go**:
  - `BacktestConfig.MakerFillProbability` / `MakerFeeRate` / `TakerFeeRate` / `SlippageModel="post_only_with_taker"`
  - `BacktestSummary.TotalFeeJPY` / `MakerFillCount` / `TakerFillCount`
  - `BacktestTradeRecord.Fee` / `OpenIsMaker` / `CloseIsMaker`
- **infrastructure/backtest/fill_price.go**:
  - `MakerFlagSource` interface (optional add-on)
  - `PostOnlyLimitFill` 実装：確定論的 hash sampler で再現性確保、`SamplerOverride` でテスト時に強制可
- **infrastructure/backtest/simulator.go**:
  - `SimConfig.MakerFeeRate` / `TakerFeeRate`
  - Open/Close で `feeFor()` を計算 → balance / `TradeRecord` に反映
- **usecase/backtest/runner.go**: SimConfig へ rate を流し、Summary に集計
- **interfaces/api/handler/backtest.go**: req に `slippageModel="post_only_with_taker"` / `makerFillProbability` / `makerFeeRate` / `takerFeeRate` を追加。orderbook history を引いて `PostOnlyLimitFill` を構築

## Test plan
- [x] `go test ./... -race -count=1` 全 OK
- [x] `PostOnlyLimitFill`: maker override / taker override / 確定論的 sampler
- [x] `SimExecutor`: maker rebate が balance を増やす / fee が TradeRecord に乗る
- [x] 既存テストはレガシー経路を保つ（FeeRate=0 で fee=0、fill source も legacy）

## 後続 PR
- ライブ側の手数料記録（楽天 my-trades の `fee` で取れるので別途）
- queue position 推定 (H, 別 PR)
- フロント表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)