### PR TITLE
feat(fe): dashboard に halt / OFI-Microprice / execution quality を表面化

### DIFF
--- a/frontend/src/components/ExecutionQualityCard.tsx
+++ b/frontend/src/components/ExecutionQualityCard.tsx
@@ -1,0 +1,79 @@
+import { useExecutionQuality } from '../hooks/useExecutionQuality'
+
+// Compact 24h execution-quality summary. Hidden when the API has not yet
+// returned a payload (e.g. endpoint disabled / no trades in window).
+export function ExecutionQualityCard() {
+  const { data, isLoading, isError } = useExecutionQuality(86400)
+
+  return (
+    <div className="rounded-3xl border border-white/8 bg-bg-card/90 p-5 shadow-[0_12px_40px_rgba(0,0,0,0.22)]">
+      <div className="flex items-center justify-between">
+        <div>
+          <p className="text-xs uppercase tracking-[0.28em] text-text-secondary">Execution Quality</p>
+          <h2 className="mt-2 text-xl font-semibold text-white">直近 24 時間</h2>
+        </div>
+        <span className="rounded-full bg-white/8 px-2.5 py-1 font-mono text-[11px] text-slate-300">24h</span>
+      </div>
+
+      {isLoading ? (
+        <p className="mt-4 text-sm text-text-secondary">読み込み中…</p>
+      ) : isError || !data ? (
+        <p className="mt-4 text-sm text-text-secondary">データを取得できませんでした</p>
+      ) : data.trades.count === 0 ? (
+        <p className="mt-4 text-sm text-text-secondary">直近 24 時間の約定はありません</p>
+      ) : (
+        <div className="mt-4 grid grid-cols-2 gap-3 text-sm">
+          <Row label="取引数" value={`${data.trades.count} 件`} />
+          <Row
+            label="Maker 比率"
+            value={`${(data.trades.makerRatio * 100).toFixed(1)} %`}
+            valueClass="text-accent-green"
+          />
+          <Row
+            label="平均スリッページ"
+            value={
+              data.trades.avgSlippageBps != null
+                ? `${data.trades.avgSlippageBps.toFixed(1)} bps`
+                : '—'
+            }
+            valueClass={
+              data.trades.avgSlippageBps != null && data.trades.avgSlippageBps > 0
+                ? 'text-accent-red'
+                : 'text-accent-green'
+            }
+          />
+          <Row
+            label="手数料合計"
+            value={formatJpy(data.trades.totalFeeJpy)}
+            valueClass={data.trades.totalFeeJpy < 0 ? 'text-accent-green' : 'text-slate-200'}
+          />
+        </div>
+      )}
+    </div>
+  )
+}
+
+function Row({
+  label,
+  value,
+  valueClass = 'text-white',
+}: {
+  label: string
+  value: string
+  valueClass?: string
+}) {
+  return (
+    <div className="flex flex-col gap-1 rounded-xl border border-white/8 bg-white/5 px-3 py-2">
+      <span className="text-[10px] uppercase tracking-wider text-text-secondary">{label}</span>
+      <span className={`font-mono text-base ${valueClass}`}>{value}</span>
+    </div>
+  )
+}
+
+function formatJpy(value: number): string {
+  if (!Number.isFinite(value)) return '—'
+  const sign = value < 0 ? '-' : ''
+  const abs = Math.abs(value)
+  if (abs < 1) return `${sign}¥${abs.toFixed(2)}`
+  return `${sign}¥${Math.round(abs).toLocaleString('ja-JP')}`
+}

--- a/frontend/src/components/HaltReasonBadge.tsx
+++ b/frontend/src/components/HaltReasonBadge.tsx
@@ -1,0 +1,42 @@
+type HaltReasonBadgeProps = {
+  haltReason?: string
+  manuallyStopped?: boolean
+  tradingHalted?: boolean
+}
+
+// Renders a critical-red badge when the bot is halted automatically (circuit
+// breaker / reconciliation / daily-loss). Returns null when the bot is
+// running or stopped via a plain manual /stop — in those cases the existing
+// "ステータス" KPI carries the full message.
+export function HaltReasonBadge({ haltReason, manuallyStopped, tradingHalted }: HaltReasonBadgeProps) {
+  // Only show when an automatic halt left a reason — manual stops carry an
+  // empty haltReason and don't deserve the red bar.
+  if (!haltReason) return null
+  // Some backend paths set both manuallyStopped + haltReason (auto halt is
+  // implemented via manual_stop=true under the hood); we still want to show
+  // the red bar then.
+  void manuallyStopped
+  void tradingHalted
+  const [category, ...detail] = haltReason.split(':')
+  const displayCategory = category === 'circuit_breaker'
+    ? 'サーキットブレーカー'
+    : category === 'reconciliation'
+      ? '整合性違反'
+      : category
+  return (
+    <div className="rounded-2xl border border-accent-red/40 bg-accent-red/10 px-4 py-3 text-sm text-accent-red shadow-[0_0_24px_rgba(255,80,80,0.15)]">
+      <div className="flex items-center gap-3">
+        <span className="text-base font-semibold">🚨 自動停止中</span>
+        <span className="rounded-full bg-accent-red/20 px-2 py-0.5 font-mono text-[11px]">
+          {displayCategory}
+        </span>
+      </div>
+      {detail.length > 0 && (
+        <p className="mt-1 font-mono text-xs text-accent-red/90">{detail.join(':')}</p>
+      )}
+      <p className="mt-2 text-[11px] text-accent-red/80">
+        手動で /start を叩くまで自動売買は停止します。原因を確認してから再開してください。
+      </p>
+    </div>
+  )
+}

--- a/frontend/src/components/OrderbookPanel.tsx
+++ b/frontend/src/components/OrderbookPanel.tsx
@@ -4,11 +4,17 @@ import type { RealtimeOrderbook } from '../lib/api'
 type OrderbookPanelProps = {
   orderbook: RealtimeOrderbook | null
   currencyPair?: string
+  // Optional orderbook-derived signals from the latest IndicatorSet.
+  // null / undefined hides the row, mirroring the backend's "not yet
+  // available" convention.
+  microprice?: number | null
+  ofiShort?: number | null
+  ofiLong?: number | null
 }
 
 const ROWS = 12
 
-export function OrderbookPanel({ orderbook, currencyPair }: OrderbookPanelProps) {
+export function OrderbookPanel({ orderbook, currencyPair, microprice, ofiShort, ofiLong }: OrderbookPanelProps) {
   const ask = useMemo(() => buildSide(orderbook?.asks, 'asc', ROWS), [orderbook?.asks])
   const bid = useMemo(() => buildSide(orderbook?.bids, 'desc', ROWS), [orderbook?.bids])
 
@@ -55,8 +61,70 @@ export function OrderbookPanel({ orderbook, currencyPair }: OrderbookPanelProps)
       {!orderbook && (
         <p className="mt-3 text-[11px] text-text-secondary">板を待機中…</p>
       )}
+
+      <BookSignals microprice={microprice} ofiShort={ofiShort} ofiLong={ofiLong} />
     </div>
   )
+}
+
+function BookSignals({
+  microprice,
+  ofiShort,
+  ofiLong,
+}: {
+  microprice?: number | null
+  ofiShort?: number | null
+  ofiLong?: number | null
+}) {
+  const hasAny =
+    (microprice != null && microprice !== 0) ||
+    (ofiShort != null && ofiShort !== 0) ||
+    (ofiLong != null && ofiLong !== 0)
+  if (!hasAny) return null
+  return (
+    <div className="mt-3 grid grid-cols-3 gap-2 rounded-xl border border-white/8 bg-white/5 px-3 py-2 font-mono text-[11px] tabular-nums">
+      <SignalCell label="Micro" value={microprice} formatter={formatPriceCell} />
+      <SignalCell label="OFI 10s" value={ofiShort} formatter={formatRatioCell} />
+      <SignalCell label="OFI 60s" value={ofiLong} formatter={formatRatioCell} />
+    </div>
+  )
+}
+
+function SignalCell({
+  label,
+  value,
+  formatter,
+}: {
+  label: string
+  value: number | null | undefined
+  formatter: (v: number) => { text: string; tone: string }
+}) {
+  if (value == null) {
+    return (
+      <div className="flex flex-col">
+        <span className="text-[10px] uppercase tracking-wider text-text-secondary">{label}</span>
+        <span className="text-text-secondary">—</span>
+      </div>
+    )
+  }
+  const { text, tone } = formatter(value)
+  return (
+    <div className="flex flex-col">
+      <span className="text-[10px] uppercase tracking-wider text-text-secondary">{label}</span>
+      <span className={tone}>{text}</span>
+    </div>
+  )
+}
+
+function formatPriceCell(value: number): { text: string; tone: string } {
+  return { text: value.toLocaleString('ja-JP', { maximumFractionDigits: 1 }), tone: 'text-white' }
+}
+
+function formatRatioCell(value: number): { text: string; tone: string } {
+  const text = value.toFixed(3)
+  if (value > 0.05) return { text: `+${text}`, tone: 'text-accent-green' }
+  if (value < -0.05) return { text: text, tone: 'text-accent-red' }
+  return { text, tone: 'text-slate-200' }
 }
 
 type SideRow = {

--- a/frontend/src/hooks/useExecutionQuality.ts
+++ b/frontend/src/hooks/useExecutionQuality.ts
@@ -1,0 +1,15 @@
+import { useQuery } from '@tanstack/react-query'
+import { fetchExecutionQuality, type ExecutionQualityReport } from '../lib/api'
+
+// 24h KPI fetched from GET /api/v1/execution-quality. Refreshes every 60 s
+// because the underlying my-trades fetch is 1 venue call + a SQLite scan and
+// we don't want to hammer either when the dashboard is just sitting open.
+export function useExecutionQuality(windowSec = 86400) {
+  return useQuery<ExecutionQualityReport>({
+    queryKey: ['execution-quality', windowSec],
+    queryFn: () => fetchExecutionQuality(windowSec),
+    refetchInterval: 60_000,
+    refetchOnWindowFocus: false,
+    staleTime: 30_000,
+  })
+}

--- a/frontend/src/hooks/useMarketTickerStream.ts
+++ b/frontend/src/hooks/useMarketTickerStream.ts
@@ -82,6 +82,13 @@ export function useMarketTickerStream(symbolId: number) {
           case 'orderbook':
             setOrderbook(payload.data)
             return
+          case 'position_update':
+            // RealExecutor pushes position changes immediately on diff
+            // detection (see PR-O). Invalidate the positions query so the
+            // dashboard panel refreshes without waiting for the periodic
+            // sync interval.
+            void queryClient.invalidateQueries({ queryKey: ['positions'] })
+            return
           case 'trade_event': {
             // Open/close 約定: trades / positions / pnl の表示も最新化する。
             void queryClient.invalidateQueries({ queryKey: ['trades', symbolId] })

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -10,6 +10,10 @@ export type StatusResponse = {
   status: 'running' | 'stopped'
   tradingHalted: boolean
   manuallyStopped: boolean
+  // haltReason carries the latest automatic-halt cause when present
+  // (e.g. "circuit_breaker:price_jump", "reconciliation:position_mismatch").
+  // Empty / undefined when running or halted by a plain manual /stop.
+  haltReason?: string
   balance: number
   dailyLoss: number
   totalPosition: number
@@ -46,6 +50,12 @@ export type IndicatorSet = {
   macdLine: number | null
   signalLine: number | null
   histogram: number | null
+  // Orderbook-derived signals (PR-J). Optional on the wire because legacy
+  // backtest runs / live without a BookSource still produce snapshots
+  // without these fields.
+  microprice?: number | null
+  ofiShort?: number | null
+  ofiLong?: number | null
   timestamp: number
 }
 
@@ -190,6 +200,8 @@ export type RiskEventKind =
   | 'consecutive_losses'
   | 'cooldown_started'
   | 'daily_loss_warning'
+  | 'circuit_breaker'
+  | 'reconciliation_drift'
 
 export type RiskEventSeverity = 'info' | 'warning' | 'critical'
 
@@ -207,6 +219,17 @@ export type RiskEventPayload = {
   timestamp: number
 }
 
+// PositionUpdatePayload mirrors the eventengine.Position shape pushed by
+// RealExecutor.SyncPositions when the venue snapshot changes.
+export type PositionUpdatePayload = {
+  positionId: number
+  symbolId: number
+  side: 'BUY' | 'SELL'
+  entryPrice: number
+  amount: number
+  entryTimestamp: number
+}
+
 export type RealtimeEventMessage =
   | { type: 'ticker'; symbolId: number; data: LiveTicker }
   | { type: 'status'; symbolId?: number; data: StatusResponse }
@@ -215,6 +238,46 @@ export type RealtimeEventMessage =
   | { type: 'market_trades'; symbolId: number; data: RealtimeMarketTrades }
   | { type: 'trade_event'; symbolId: number; data: TradeEventPayload }
   | { type: 'risk_event'; symbolId?: number; data: RiskEventPayload }
+  | { type: 'position_update'; symbolId: number; data: PositionUpdatePayload[] }
+
+// ---------------------------------------------------------------------------
+// Execution Quality (PR-Q2) — GET /api/v1/execution-quality
+// ---------------------------------------------------------------------------
+
+export type ExecutionQualityBehaviorBucket = {
+  count: number
+  makerCount: number
+  makerRatio: number
+  feeJpy: number
+}
+
+export type ExecutionQualityReport = {
+  windowSec: number
+  fromTimestamp: number
+  toTimestamp: number
+  trades: {
+    count: number
+    makerCount: number
+    takerCount: number
+    unknownCount: number
+    makerRatio: number
+    totalFeeJpy: number
+    avgSlippageBps?: number
+    byOrderBehavior?: Record<string, ExecutionQualityBehaviorBucket>
+  }
+  circuitBreaker: {
+    halted: boolean
+    haltReason?: string
+  }
+}
+
+export async function fetchExecutionQuality(windowSec = 86400): Promise<ExecutionQualityReport> {
+  const res = await fetch(`${API_BASE}/execution-quality?windowSec=${windowSec}`)
+  if (!res.ok) {
+    throw new Error(`execution-quality fetch failed: ${res.status}`)
+  }
+  return (await res.json()) as ExecutionQualityReport
+}
 
 // --- Backtest types ---
 

--- a/frontend/src/lib/notify-format.ts
+++ b/frontend/src/lib/notify-format.ts
@@ -47,6 +47,10 @@ function riskTitle(kind: RiskEventPayload['kind']): string {
       return '⏸ クールダウン開始'
     case 'daily_loss_warning':
       return '⚠️ 日次損失警告'
+    case 'circuit_breaker':
+      return '🚨 サーキットブレーカー作動'
+    case 'reconciliation_drift':
+      return '⚠️ 整合性ずれ検出'
     default:
       return 'リスクイベント'
   }

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -8,6 +8,8 @@ import { BotControlCard } from '../components/BotControlCard'
 import { LiveTickerCard } from '../components/LiveTickerCard'
 import { ManualTradeCard } from '../components/ManualTradeCard'
 import { OrderbookPanel } from '../components/OrderbookPanel'
+import { ExecutionQualityCard } from '../components/ExecutionQualityCard'
+import { HaltReasonBadge } from '../components/HaltReasonBadge'
 import { useStatus } from '../hooks/useStatus'
 import { usePnl } from '../hooks/usePnl'
 import { useStrategy } from '../hooks/useStrategy'
@@ -57,7 +59,13 @@ function Dashboard() {
       title="トレーディングダッシュボード"
       subtitle="KPI・戦略・ポジション・操作系を集約した監視画面です。"
     >
-      <div className="grid grid-cols-2 gap-3 sm:gap-4 xl:grid-cols-4">
+      <HaltReasonBadge
+        haltReason={status?.haltReason}
+        manuallyStopped={status?.manuallyStopped}
+        tradingHalted={status?.tradingHalted}
+      />
+
+      <div className="mt-3 grid grid-cols-2 gap-3 sm:gap-4 xl:grid-cols-4">
         <KpiCard
           label="残高"
           value={pnl ? `¥${pnl.balance.toLocaleString()}` : '\u2014'}
@@ -118,7 +126,11 @@ function Dashboard() {
           <OrderbookPanel
             orderbook={orderbook}
             currencyPair={currentSymbol?.currencyPair}
+            microprice={indicators?.microprice ?? null}
+            ofiShort={indicators?.ofiShort ?? null}
+            ofiLong={indicators?.ofiLong ?? null}
           />
+          <ExecutionQualityCard />
           <ManualTradeCard
             symbolId={symbolId}
             currencyPair={currentSymbol?.currencyPair}


### PR DESCRIPTION
## Summary
これまでバックエンド側に積んできた observable な情報をダッシュボードに表面化する。Backend は無改修、フロントのみ。

## Changes
- **HaltReasonBadge**: `status.haltReason` が non-empty なら赤バナーで「自動停止中」とカテゴリ (circuit_breaker / reconciliation 等) を出す
- **OrderbookPanel**: 板の下に Microprice / OFI(10s) / OFI(60s) の 3 セルを追加。全 nil なら丸ごと非表示
- **ExecutionQualityCard**: `GET /api/v1/execution-quality` を 60 s polling し、取引数 / Maker 比率 / 平均スリッページ / 手数料合計を表示
- **useMarketTickerStream**: `position_update` メッセージを受信したら positions query を invalidate (PR-O の adaptive polling と組み合わせ)
- **notify-format**: `circuit_breaker` / `reconciliation_drift` の通知タイトルを追加
- **types**:
  - `StatusResponse.haltReason`
  - `IndicatorSet.microprice` / `ofiShort` / `ofiLong`
  - `RealtimeEventMessage` に `position_update`
  - `RiskEventKind` に新 2 種

## Test plan
- [x] `tsc --noEmit`: 新規分エラーなし（既存 `backtest.tsx` / `usePositions.test.tsx` の型エラーは本 PR 範囲外）
- [x] Docker Compose rebuild + Playwright で Dashboard を取得
  - **Execution Quality カード**: 「直近 24 時間 / 取引数 1 件 / Maker 比率 0.0% / 平均スリッページ — / 手数料合計 ¥0.00」が新たに描画
  - HaltReason は status.haltReason 不在のため非表示で正しい
  - OFI/Microprice は indicator data が None のため非表示で正しい

## 後続 PR
- DB 永続化（execution-quality を毎回 my-trades 引き直しでなく定期スナップショット保存）
- WalkForward / multi-period への新パラメータ自動配信
- H. Latency モデル

🤖 Generated with [Claude Code](https://claude.com/claude-code)