### PR TITLE
feat(api): execution-quality を DB スナップショット経由で配信 (Q-3)

### DIFF
--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -219,6 +219,17 @@ func main() {
 			return s.ManuallyStopped || s.TradingHalted, s.HaltReason
 		}),
 	)
+	executionQualityRepo := database.NewExecutionQualityRepo(db)
+
+	// Snapshot worker. Polls the reporter every 60 s and stores the result
+	// so /execution-quality can serve cached values without hitting the
+	// venue. Retention sweep removes rows older than 7 days.
+	go startExecutionQualitySnapshotWorker(
+		context.Background(),
+		executionQualityReporter,
+		executionQualityRepo,
+		pipeline,
+	)
 
 	router := api.NewRouter(api.Dependencies{
 		RiskManager:         riskMgr,
@@ -238,6 +249,7 @@ func main() {
 		OnSymbolSwitch:        onSymbolSwitch,
 		DailyPnLCalculator:    dailyPnLCalc,
 		ExecutionQualityReporter: executionQualityReporter,
+		ExecutionQualityRepo:     executionQualityRepo,
 	})
 
 	sigCh := make(chan os.Signal, 1)
@@ -699,5 +711,77 @@ func runBacktestRetentionCleanup(ctx context.Context, repo repository.BacktestRe
 	}
 	if deleted > 0 {
 		slog.Info("backtest retention cleanup completed", "deleted", deleted, "retentionDays", retentionDays)
+	}
+}
+
+// startExecutionQualitySnapshotWorker periodically captures the live
+// execution-quality report and persists it so the API can serve cached
+// values. Also sweeps rows older than 7 days once a day.
+//
+// Runs forever; the process lifecycle (signal handling in main) bounds it.
+func startExecutionQualitySnapshotWorker(
+	ctx context.Context,
+	reporter *quality.Reporter,
+	repo *database.ExecutionQualityRepo,
+	pipeline *EventDrivenPipeline,
+) {
+	if reporter == nil || repo == nil || pipeline == nil {
+		return
+	}
+	const (
+		captureInterval = 60 * time.Second
+		retentionDays   = 7
+	)
+
+	captureTicker := time.NewTicker(captureInterval)
+	defer captureTicker.Stop()
+	retentionTicker := time.NewTicker(24 * time.Hour)
+	defer retentionTicker.Stop()
+
+	capture := func() {
+		symbolID := pipeline.SymbolID()
+		if symbolID <= 0 {
+			return
+		}
+		report, err := reporter.Build(ctx, symbolID, 86400)
+		if err != nil {
+			slog.Warn("execution-quality snapshot failed", "error", err)
+			return
+		}
+		if err := repo.Save(ctx, symbolID, time.Now().UnixMilli(), report); err != nil {
+			slog.Warn("execution-quality snapshot save failed", "error", err)
+		}
+	}
+	sweep := func() {
+		cutoff := time.Now().Add(-time.Duration(retentionDays) * 24 * time.Hour).UnixMilli()
+		deleted, err := repo.PurgeOlderThan(ctx, cutoff)
+		if err != nil {
+			slog.Warn("execution-quality retention sweep failed", "error", err)
+			return
+		}
+		if deleted > 0 {
+			slog.Info("execution-quality retention sweep", "deleted", deleted, "retentionDays", retentionDays)
+		}
+	}
+
+	// Warm up: short delay then capture once so the cache is populated
+	// before the first user request.
+	select {
+	case <-ctx.Done():
+		return
+	case <-time.After(15 * time.Second):
+	}
+	capture()
+	sweep()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-captureTicker.C:
+			capture()
+		case <-retentionTicker.C:
+			sweep()
+		}
 	}
 }

--- a/backend/internal/domain/repository/execution_quality.go
+++ b/backend/internal/domain/repository/execution_quality.go
@@ -1,0 +1,20 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+)
+
+// ExecutionQualityRepository persists periodic execution-quality snapshots
+// so the API can serve cached values instead of recomputing on every request.
+type ExecutionQualityRepository interface {
+	// Save inserts one snapshot for symbolID at capturedAt (unix-millis).
+	Save(ctx context.Context, symbolID int64, capturedAt int64, report entity.ExecutionQualityReport) error
+	// Latest returns the most recent snapshot for symbolID, or (nil, nil)
+	// when none exists yet.
+	Latest(ctx context.Context, symbolID int64) (*entity.ExecutionQualityReport, error)
+	// PurgeOlderThan deletes rows captured before cutoffMillis. Used by the
+	// retention sweeper to bound disk usage.
+	PurgeOlderThan(ctx context.Context, cutoffMillis int64) (int64, error)
+}

--- a/backend/internal/infrastructure/database/execution_quality_repo.go
+++ b/backend/internal/infrastructure/database/execution_quality_repo.go
@@ -1,0 +1,128 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+)
+
+// ExecutionQualityRepo persists execution-quality snapshots so the API can
+// serve cached values instead of hitting the venue on every request.
+type ExecutionQualityRepo struct {
+	db *sql.DB
+}
+
+func NewExecutionQualityRepo(db *sql.DB) *ExecutionQualityRepo {
+	return &ExecutionQualityRepo{db: db}
+}
+
+func (r *ExecutionQualityRepo) Save(ctx context.Context, symbolID int64, capturedAt int64, report entity.ExecutionQualityReport) error {
+	bucketJSON := []byte("{}")
+	if len(report.Trades.ByOrderBehavior) > 0 {
+		raw, err := json.Marshal(report.Trades.ByOrderBehavior)
+		if err != nil {
+			return fmt.Errorf("marshal byOrderBehavior: %w", err)
+		}
+		bucketJSON = raw
+	}
+	var avgSlip sql.NullFloat64
+	if report.Trades.AvgSlippageBps != nil {
+		avgSlip = sql.NullFloat64{Valid: true, Float64: *report.Trades.AvgSlippageBps}
+	}
+	halted := 0
+	if report.CircuitBreaker.Halted {
+		halted = 1
+	}
+	_, err := r.db.ExecContext(ctx,
+		`INSERT INTO execution_quality_snapshots (
+			symbol_id, captured_at, window_sec, from_ts, to_ts,
+			trades_count, maker_count, taker_count, unknown_count,
+			maker_ratio, total_fee_jpy, avg_slippage_bps,
+			by_order_behavior_json, halted, halt_reason
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		symbolID, capturedAt, report.WindowSec, report.From, report.To,
+		report.Trades.Count, report.Trades.MakerCount, report.Trades.TakerCount,
+		report.Trades.UnknownCount, report.Trades.MakerRatio, report.Trades.TotalFeeJPY,
+		avgSlip, string(bucketJSON), halted, report.CircuitBreaker.HaltReason,
+	)
+	if err != nil {
+		return fmt.Errorf("insert execution_quality_snapshot: %w", err)
+	}
+	return nil
+}
+
+func (r *ExecutionQualityRepo) Latest(ctx context.Context, symbolID int64) (*entity.ExecutionQualityReport, error) {
+	var (
+		windowSec, fromTs, toTs                              int64
+		count, makerCount, takerCount, unknownCount, halted  int
+		makerRatio, totalFeeJpy                              float64
+		avgSlip                                              sql.NullFloat64
+		bucketJSON, haltReason                               string
+	)
+	err := r.db.QueryRowContext(ctx,
+		`SELECT window_sec, from_ts, to_ts,
+		        trades_count, maker_count, taker_count, unknown_count,
+		        maker_ratio, total_fee_jpy, avg_slippage_bps,
+		        by_order_behavior_json, halted, halt_reason
+		 FROM execution_quality_snapshots
+		 WHERE symbol_id = ?
+		 ORDER BY captured_at DESC LIMIT 1`,
+		symbolID,
+	).Scan(
+		&windowSec, &fromTs, &toTs,
+		&count, &makerCount, &takerCount, &unknownCount,
+		&makerRatio, &totalFeeJpy, &avgSlip,
+		&bucketJSON, &halted, &haltReason,
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("query latest execution_quality_snapshot: %w", err)
+	}
+
+	rep := entity.ExecutionQualityReport{
+		WindowSec: windowSec,
+		From:      fromTs,
+		To:        toTs,
+		Trades: entity.ExecutionQualityTrades{
+			Count:        count,
+			MakerCount:   makerCount,
+			TakerCount:   takerCount,
+			UnknownCount: unknownCount,
+			MakerRatio:   makerRatio,
+			TotalFeeJPY:  totalFeeJpy,
+		},
+		CircuitBreaker: entity.ExecutionQualityCircuitBreaker{
+			Halted:     halted == 1,
+			HaltReason: haltReason,
+		},
+	}
+	if avgSlip.Valid {
+		v := avgSlip.Float64
+		rep.Trades.AvgSlippageBps = &v
+	}
+	var buckets map[string]entity.ExecutionQualityBehaviorBucket
+	if err := json.Unmarshal([]byte(bucketJSON), &buckets); err == nil && len(buckets) > 0 {
+		rep.Trades.ByOrderBehavior = buckets
+	}
+	return &rep, nil
+}
+
+func (r *ExecutionQualityRepo) PurgeOlderThan(ctx context.Context, cutoffMillis int64) (int64, error) {
+	res, err := r.db.ExecContext(ctx,
+		`DELETE FROM execution_quality_snapshots WHERE captured_at < ?`,
+		cutoffMillis,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("purge execution_quality_snapshots: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, nil
+	}
+	return n, nil
+}

--- a/backend/internal/infrastructure/database/execution_quality_repo_test.go
+++ b/backend/internal/infrastructure/database/execution_quality_repo_test.go
@@ -1,0 +1,111 @@
+package database
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+)
+
+func setupExecutionQualityRepo(t *testing.T) *ExecutionQualityRepo {
+	t.Helper()
+	tmpDir := t.TempDir()
+	db, err := NewDB(filepath.Join(tmpDir, "test.db"))
+	if err != nil {
+		t.Fatalf("create db: %v", err)
+	}
+	if err := RunMigrations(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return NewExecutionQualityRepo(db)
+}
+
+func TestExecutionQualityRepo_SaveAndLatest(t *testing.T) {
+	repo := setupExecutionQualityRepo(t)
+	ctx := context.Background()
+
+	avg := 12.5
+	report := entity.ExecutionQualityReport{
+		WindowSec: 86400,
+		From:      1000,
+		To:        87400,
+		Trades: entity.ExecutionQualityTrades{
+			Count: 5, MakerCount: 3, TakerCount: 2, UnknownCount: 0,
+			MakerRatio: 0.6, TotalFeeJPY: -1.23,
+			AvgSlippageBps: &avg,
+			ByOrderBehavior: map[string]entity.ExecutionQualityBehaviorBucket{
+				"OPEN": {Count: 3, MakerCount: 2, MakerRatio: 0.667, FeeJPY: -0.5},
+			},
+		},
+		CircuitBreaker: entity.ExecutionQualityCircuitBreaker{
+			Halted: true, HaltReason: "circuit_breaker:price_jump",
+		},
+	}
+	if err := repo.Save(ctx, 7, 5_000_000, report); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	got, err := repo.Latest(ctx, 7)
+	if err != nil {
+		t.Fatalf("latest: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected non-nil report")
+	}
+	if got.Trades.Count != 5 || got.Trades.MakerCount != 3 {
+		t.Fatalf("counts mismatch: %+v", got.Trades)
+	}
+	if got.Trades.AvgSlippageBps == nil || *got.Trades.AvgSlippageBps != 12.5 {
+		t.Fatalf("avg slippage mismatch: %v", got.Trades.AvgSlippageBps)
+	}
+	if !got.CircuitBreaker.Halted || got.CircuitBreaker.HaltReason == "" {
+		t.Fatalf("halt info mismatch: %+v", got.CircuitBreaker)
+	}
+	if got.Trades.ByOrderBehavior["OPEN"].MakerCount != 2 {
+		t.Fatalf("bucket round-trip failed: %+v", got.Trades.ByOrderBehavior)
+	}
+}
+
+func TestExecutionQualityRepo_LatestReturnsNilWhenEmpty(t *testing.T) {
+	repo := setupExecutionQualityRepo(t)
+	got, err := repo.Latest(context.Background(), 7)
+	if err != nil {
+		t.Fatalf("latest: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil for empty table, got %+v", got)
+	}
+}
+
+func TestExecutionQualityRepo_LatestPicksMostRecent(t *testing.T) {
+	repo := setupExecutionQualityRepo(t)
+	ctx := context.Background()
+	a := entity.ExecutionQualityReport{WindowSec: 86400, Trades: entity.ExecutionQualityTrades{Count: 1}}
+	b := entity.ExecutionQualityReport{WindowSec: 86400, Trades: entity.ExecutionQualityTrades{Count: 2}}
+	if err := repo.Save(ctx, 7, 1000, a); err != nil {
+		t.Fatalf("save a: %v", err)
+	}
+	if err := repo.Save(ctx, 7, 2000, b); err != nil {
+		t.Fatalf("save b: %v", err)
+	}
+	got, _ := repo.Latest(ctx, 7)
+	if got.Trades.Count != 2 {
+		t.Fatalf("expected newest count=2, got %d", got.Trades.Count)
+	}
+}
+
+func TestExecutionQualityRepo_PurgeOlderThan(t *testing.T) {
+	repo := setupExecutionQualityRepo(t)
+	ctx := context.Background()
+	_ = repo.Save(ctx, 7, 1000, entity.ExecutionQualityReport{WindowSec: 86400})
+	_ = repo.Save(ctx, 7, 5000, entity.ExecutionQualityReport{WindowSec: 86400})
+	deleted, err := repo.PurgeOlderThan(ctx, 3000)
+	if err != nil {
+		t.Fatalf("purge: %v", err)
+	}
+	if deleted != 1 {
+		t.Fatalf("expected 1 deleted, got %d", deleted)
+	}
+}

--- a/backend/internal/infrastructure/database/migrations.go
+++ b/backend/internal/infrastructure/database/migrations.go
@@ -107,6 +107,32 @@ func RunMigrations(db *sql.DB) error {
 		`CREATE INDEX IF NOT EXISTS idx_orderbook_snapshots_symbol_time
 			ON orderbook_snapshots(symbol_id, timestamp DESC)`,
 
+		// execution_quality_snapshots: PR-Q3. /execution-quality endpoint の
+		// レイテンシと楽天 my-trades 呼び出し回数を抑えるため、worker が
+		// 60 秒間隔で計算結果をここに INSERT し、endpoint は最新行を返す。
+		// by_order_behavior_json は map[string]ExecutionQualityBehaviorBucket
+		// の JSON。avg_slippage_bps は NULL (=mid 不明) 区別のため REAL NULL。
+		`CREATE TABLE IF NOT EXISTS execution_quality_snapshots (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			symbol_id INTEGER NOT NULL,
+			captured_at INTEGER NOT NULL,
+			window_sec INTEGER NOT NULL,
+			from_ts INTEGER NOT NULL,
+			to_ts INTEGER NOT NULL,
+			trades_count INTEGER NOT NULL,
+			maker_count INTEGER NOT NULL,
+			taker_count INTEGER NOT NULL,
+			unknown_count INTEGER NOT NULL,
+			maker_ratio REAL NOT NULL,
+			total_fee_jpy REAL NOT NULL,
+			avg_slippage_bps REAL,
+			by_order_behavior_json TEXT NOT NULL DEFAULT '{}',
+			halted INTEGER NOT NULL DEFAULT 0,
+			halt_reason TEXT NOT NULL DEFAULT ''
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_execution_quality_snapshots_symbol_time
+			ON execution_quality_snapshots(symbol_id, captured_at DESC)`,
+
 		`CREATE TABLE IF NOT EXISTS trade_history (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
 			symbol_id INTEGER NOT NULL,

--- a/backend/internal/interfaces/api/handler/execution_quality.go
+++ b/backend/internal/interfaces/api/handler/execution_quality.go
@@ -5,12 +5,17 @@ import (
 	"strconv"
 
 	"github.com/gin-gonic/gin"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/repository"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/quality"
 )
 
 // ExecutionQualityHandler exposes GET /api/v1/execution-quality.
 type ExecutionQualityHandler struct {
 	reporter *quality.Reporter
+	// snapshotRepo, when set, lets the handler serve the most recent worker-
+	// captured snapshot instead of hitting the venue. Falls through to the
+	// reporter when the cache is empty / `?fresh=true` is supplied.
+	snapshotRepo repository.ExecutionQualityRepository
 	// defaultSymbolID is consulted when the caller omits ?symbolId. The
 	// handler does not own the running pipeline so the composition root
 	// passes a getter that always reflects the current symbol.
@@ -21,7 +26,18 @@ func NewExecutionQualityHandler(reporter *quality.Reporter, defaultSymbol func()
 	return &ExecutionQualityHandler{reporter: reporter, defaultSymbol: defaultSymbol}
 }
 
-// Get handles GET /api/v1/execution-quality?windowSec=86400&symbolId=7.
+// WithSnapshotRepo enables the snapshot-cache path on an existing handler.
+func (h *ExecutionQualityHandler) WithSnapshotRepo(repo repository.ExecutionQualityRepository) *ExecutionQualityHandler {
+	h.snapshotRepo = repo
+	return h
+}
+
+// Get handles GET /api/v1/execution-quality?windowSec=86400&symbolId=7&fresh=false.
+//
+// Default behaviour: serve the most recent worker-captured snapshot. The
+// snapshot worker runs every 60 s so the served data is at most that stale.
+// fresh=true bypasses the cache and recomputes synchronously (still bounded
+// by the venue's 200 ms rate limit; intended for one-off diagnostics).
 func (h *ExecutionQualityHandler) Get(c *gin.Context) {
 	if h.reporter == nil {
 		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "execution quality reporter unavailable"})
@@ -46,6 +62,16 @@ func (h *ExecutionQualityHandler) Get(c *gin.Context) {
 	if symbolID <= 0 {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "symbolId required"})
 		return
+	}
+
+	fresh := c.DefaultQuery("fresh", "false") == "true"
+
+	if !fresh && h.snapshotRepo != nil {
+		if cached, err := h.snapshotRepo.Latest(c.Request.Context(), symbolID); err == nil && cached != nil {
+			c.JSON(http.StatusOK, cached)
+			return
+		}
+		// Fall through to live recompute when the cache is empty or read failed.
 	}
 
 	report, err := h.reporter.Build(c.Request.Context(), symbolID, windowSec)

--- a/backend/internal/interfaces/api/router.go
+++ b/backend/internal/interfaces/api/router.go
@@ -48,6 +48,11 @@ type Dependencies struct {
 	// ExecutionQualityReporter (optional). When set, GET /api/v1/execution-quality
 	// is exposed; when nil the endpoint returns 503.
 	ExecutionQualityReporter *quality.Reporter
+
+	// ExecutionQualityRepo (optional). When set, the endpoint serves the
+	// most recent persisted snapshot (cheap) and only falls back to the
+	// reporter on cache miss / `?fresh=true`.
+	ExecutionQualityRepo repository.ExecutionQualityRepository
 }
 
 func NewRouter(deps Dependencies) *gin.Engine {
@@ -121,6 +126,9 @@ func NewRouter(deps Dependencies) *gin.Engine {
 			defaultSymbol = func() int64 { return pipeline.SymbolID() }
 		}
 		eqHandler := handler.NewExecutionQualityHandler(deps.ExecutionQualityReporter, defaultSymbol)
+		if deps.ExecutionQualityRepo != nil {
+			eqHandler = eqHandler.WithSnapshotRepo(deps.ExecutionQualityRepo)
+		}
 		v1.GET("/execution-quality", eqHandler.Get)
 	}
 


### PR DESCRIPTION
## Summary
`/api/v1/execution-quality` は毎リクエストで楽天 my-trades を REST 呼び出し + SQLite tickers の窓内全件スキャンを走らせていた。フロントが 60 s polling かつ複数タブを開くと呼び出しが倍増し、楽天 rate limit (200 ms/user) を圧迫するリスクがあった。

**worker が 60 s 周期で事前計算 → DB 保存 → API は最新行を返す cache-first 構造に変更。** `?fresh=true` で従来の即時計算経路に戻れる。

## Changes
- `migrations`: `execution_quality_snapshots` テーブルを追加（`avg_slippage_bps` は NULL 許容、`by_order_behavior_json` は TEXT）
- new `domain/repository/execution_quality.go`: `ExecutionQualityRepository` インターフェース
- new `infrastructure/database/execution_quality_repo.go`: 実装 (`Save` / `Latest` / `PurgeOlderThan`) + 単体テスト 4 ケース
- `interfaces/api/handler/execution_quality.go`: `snapshotRepo` を保持。`fresh != "true"` かつ cache hit のとき即返却、miss/エラー時はフォールバック
- `interfaces/api/router.go`: `ExecutionQualityRepo` 依存を追加
- `cmd/main.go`:
  - `startExecutionQualitySnapshotWorker` で 60 s capture / 24 h retention sweep
  - 起動 15 秒後に warmup capture を走らせて初回リクエストの cache miss を回避
  - retention default 7 日

## Test plan
- [x] `go test ./... -race -count=1` 全 OK
- [x] repo 単体: save+latest round-trip / 空 latest=nil / 最新優先 / purge 境界

## 後続 PR
- 履歴グラフ（時系列での maker ratio 推移）
- アラート（maker ratio が閾値を割ったら）

🤖 Generated with [Claude Code](https://claude.com/claude-code)