### PR TITLE
feat(backtest): execution-quality params を multi-period / walk-forward にも配信

### DIFF
--- a/backend/internal/interfaces/api/handler/backtest.go
+++ b/backend/internal/interfaces/api/handler/backtest.go
@@ -309,34 +309,10 @@ func (h *BacktestHandler) Run(c *gin.Context) {
 		positionSizing = resolved.Risk.PositionSizing
 	}
 
-	var fillSource infrabt.FillPriceSource
-	var bookSource booklimit.BookSource
-	switch req.SlippageModel {
-	case "orderbook":
-		replay, err := h.buildOrderbookReplay(c.Request.Context(), cfg)
-		if err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-			return
-		}
-		fillSource = replay
-		bookSource = replay
-	case "post_only_with_taker":
-		replay, err := h.buildOrderbookReplay(c.Request.Context(), cfg)
-		if err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-			return
-		}
-		prob := req.MakerFillProbability
-		if prob <= 0 {
-			prob = 0.5
-		}
-		fillSource = &infrabt.PostOnlyLimitFill{
-			MakerFillProbability: prob,
-			TakerSource:          replay,
-			BookSource:           replay,
-			SymbolID:             cfg.SymbolID,
-		}
-		bookSource = replay
+	fillSource, bookSource, err := h.buildExecutionSourcesForCfg(c.Request.Context(), cfg)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
 	}
 
 	result, err := runner.Run(context.Background(), bt.RunInput{
@@ -387,6 +363,44 @@ func (h *BacktestHandler) Run(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusOK, result)
+}
+
+// buildExecutionSourcesForCfg returns the FillPriceSource and BookSource for
+// a given run config based on cfg.SlippageModel. Centralised so /backtest/run,
+// /backtest/run-multi, and /backtest/walk-forward all use the same builder
+// and stay consistent when new slippage models are added.
+//
+// Returns (nil, nil, nil) for "" / "percent" — the runner falls back to
+// LegacyPercentSlippage in that case. ThinBookError-style errors are
+// surfaced as plain errors so callers can map to HTTP 400.
+func (h *BacktestHandler) buildExecutionSourcesForCfg(ctx context.Context, cfg entity.BacktestConfig) (infrabt.FillPriceSource, booklimit.BookSource, error) {
+	switch cfg.SlippageModel {
+	case "", "percent":
+		return nil, nil, nil
+	case "orderbook":
+		replay, err := h.buildOrderbookReplay(ctx, cfg)
+		if err != nil {
+			return nil, nil, err
+		}
+		return replay, replay, nil
+	case "post_only_with_taker":
+		replay, err := h.buildOrderbookReplay(ctx, cfg)
+		if err != nil {
+			return nil, nil, err
+		}
+		prob := cfg.MakerFillProbability
+		if prob <= 0 {
+			prob = 0.5
+		}
+		return &infrabt.PostOnlyLimitFill{
+			MakerFillProbability: prob,
+			TakerSource:          replay,
+			BookSource:           replay,
+			SymbolID:             cfg.SymbolID,
+		}, replay, nil
+	default:
+		return nil, nil, errors.New("unknown slippageModel: " + cfg.SlippageModel)
+	}
 }
 
 // buildOrderbookReplay validates that enough L2 snapshots exist for the

--- a/backend/internal/interfaces/api/handler/backtest_multi.go
+++ b/backend/internal/interfaces/api/handler/backtest_multi.go
@@ -35,6 +35,16 @@ type runMultiBacktestRequest struct {
 	MaxPositionAmount     float64 `json:"maxPositionAmount"`
 	MaxDailyLoss          float64 `json:"maxDailyLoss"`
 
+	// Execution-quality knobs propagated to every period (PR-Q3 follow-up).
+	// Empty / zero values fall back to legacy behaviour (percent slippage,
+	// no fees, no book gate). Mirrors runBacktestRequest.
+	SlippageModel        string  `json:"slippageModel,omitempty"`
+	MakerFillProbability float64 `json:"makerFillProbability,omitempty"`
+	MakerFeeRate         float64 `json:"makerFeeRate,omitempty"`
+	TakerFeeRate         float64 `json:"takerFeeRate,omitempty"`
+	MaxSlippageBps       float64 `json:"maxSlippageBps,omitempty"`
+	MaxBookSidePct       float64 `json:"maxBookSidePct,omitempty"`
+
 	Periods []entity.PeriodSpec `json:"periods" binding:"required"`
 
 	ProfileName    string  `json:"profileName,omitempty"`
@@ -166,16 +176,20 @@ func (h *BacktestHandler) RunMulti(c *gin.Context) {
 			}
 
 			cfg := entity.BacktestConfig{
-				Symbol:           primary.Symbol,
-				SymbolID:         primary.SymbolID,
-				PrimaryInterval:  primary.Interval,
-				HigherTFInterval: "PT1H",
-				FromTimestamp:    fromTs,
-				ToTimestamp:      toTs,
-				InitialBalance:   shared.InitialBalance,
-				SpreadPercent:    shared.Spread,
-				DailyCarryCost:   shared.CarryingCost,
-				SlippagePercent:  shared.Slippage,
+				Symbol:               primary.Symbol,
+				SymbolID:             primary.SymbolID,
+				PrimaryInterval:      primary.Interval,
+				HigherTFInterval:     "PT1H",
+				FromTimestamp:        fromTs,
+				ToTimestamp:          toTs,
+				InitialBalance:       shared.InitialBalance,
+				SpreadPercent:        shared.Spread,
+				DailyCarryCost:       shared.CarryingCost,
+				SlippagePercent:      shared.Slippage,
+				SlippageModel:        req.SlippageModel,
+				MakerFillProbability: req.MakerFillProbability,
+				MakerFeeRate:         req.MakerFeeRate,
+				TakerFeeRate:         req.TakerFeeRate,
 			}
 			if len(higherCandles) == 0 {
 				cfg.HigherTFInterval = ""
@@ -201,6 +215,10 @@ func (h *BacktestHandler) RunMulti(c *gin.Context) {
 				bbLookback = resolved.StanceRules.BBSqueezeLookback
 				positionSizing = resolved.Risk.PositionSizing
 			}
+			fillSrc, bookSrc, buildErr := h.buildExecutionSourcesForCfg(c.Request.Context(), cfg)
+			if buildErr != nil {
+				return nil, bt.RunInput{}, buildErr
+			}
 			input := bt.RunInput{
 				Config:            cfg,
 				TradeAmount:       shared.TradeAmount,
@@ -208,6 +226,8 @@ func (h *BacktestHandler) RunMulti(c *gin.Context) {
 				HigherCandles:     higherCandles,
 				BBSqueezeLookback: bbLookback,
 				PositionSizing:    positionSizing,
+				FillPriceSource:   fillSrc,
+				BookSource:        bookSrc,
 				RiskConfig: entity.RiskConfig{
 					MaxPositionAmount:     shared.MaxPositionAmount,
 					MaxDailyLoss:          shared.MaxDailyLoss,
@@ -216,6 +236,8 @@ func (h *BacktestHandler) RunMulti(c *gin.Context) {
 					TrailingATRMultiplier: shared.TrailingATRMultiplier,
 					TakeProfitPercent:     shared.TakeProfitPercent,
 					InitialCapital:        shared.InitialBalance,
+					MaxSlippageBps:        req.MaxSlippageBps,
+					MaxBookSidePct:        req.MaxBookSidePct,
 				},
 			}
 			return runner, input, nil

--- a/backend/internal/interfaces/api/handler/backtest_walkforward.go
+++ b/backend/internal/interfaces/api/handler/backtest_walkforward.go
@@ -30,6 +30,15 @@ type runWalkForwardRequest struct {
 	Slippage       float64 `json:"slippage"`
 	TradeAmount    float64 `json:"tradeAmount"`
 
+	// Execution-quality knobs. Applied uniformly to every WFO window. Zero
+	// values fall back to legacy behaviour. Mirrors runBacktestRequest.
+	SlippageModel        string  `json:"slippageModel,omitempty"`
+	MakerFillProbability float64 `json:"makerFillProbability,omitempty"`
+	MakerFeeRate         float64 `json:"makerFeeRate,omitempty"`
+	TakerFeeRate         float64 `json:"takerFeeRate,omitempty"`
+	MaxSlippageBps       float64 `json:"maxSlippageBps,omitempty"`
+	MaxBookSidePct       float64 `json:"maxBookSidePct,omitempty"`
+
 	From              string `json:"from"`              // "YYYY-MM-DD"
 	To                string `json:"to"`                // "YYYY-MM-DD"
 	InSampleMonths    int    `json:"inSampleMonths"`    // default 6
@@ -204,16 +213,20 @@ func (h *BacktestHandler) RunWalkForward(c *gin.Context) {
 				return nil, fmt.Errorf("strategy: %w", err)
 			}
 			cfg := entity.BacktestConfig{
-				Symbol:           primary.Symbol,
-				SymbolID:         primary.SymbolID,
-				PrimaryInterval:  primary.Interval,
-				HigherTFInterval: "PT1H",
-				FromTimestamp:    wFrom.UnixMilli(),
-				ToTimestamp:      wTo.UnixMilli(),
-				InitialBalance:   shared.InitialBalance,
-				SpreadPercent:    shared.Spread,
-				DailyCarryCost:   shared.CarryingCost,
-				SlippagePercent:  shared.Slippage,
+				Symbol:               primary.Symbol,
+				SymbolID:             primary.SymbolID,
+				PrimaryInterval:      primary.Interval,
+				HigherTFInterval:     "PT1H",
+				FromTimestamp:        wFrom.UnixMilli(),
+				ToTimestamp:          wTo.UnixMilli(),
+				InitialBalance:       shared.InitialBalance,
+				SpreadPercent:        shared.Spread,
+				DailyCarryCost:       shared.CarryingCost,
+				SlippagePercent:      shared.Slippage,
+				SlippageModel:        req.SlippageModel,
+				MakerFillProbability: req.MakerFillProbability,
+				MakerFeeRate:         req.MakerFeeRate,
+				TakerFeeRate:         req.TakerFeeRate,
 			}
 			if len(higherCandles) == 0 {
 				cfg.HigherTFInterval = ""
@@ -233,6 +246,12 @@ func (h *BacktestHandler) RunWalkForward(c *gin.Context) {
 				TrailingATRMultiplier: nonZeroFloat(profile.Risk.TrailingATRMultiplier, shared.TrailingATRMultiplier),
 				TakeProfitPercent:     nonZeroFloat(profile.Risk.TakeProfitPercent, shared.TakeProfitPercent),
 				InitialCapital:        shared.InitialBalance,
+				MaxSlippageBps:        req.MaxSlippageBps,
+				MaxBookSidePct:        req.MaxBookSidePct,
+			}
+			fillSrc, bookSrc, buildErr := h.buildExecutionSourcesForCfg(ctx, cfg)
+			if buildErr != nil {
+				return nil, fmt.Errorf("execution sources: %w", buildErr)
 			}
 			windowRunner := bt.NewBacktestRunner(bt.WithStrategy(strat))
 			// cycle44: plumb the per-combination profile's bb_squeeze_lookback
@@ -245,6 +264,8 @@ func (h *BacktestHandler) RunWalkForward(c *gin.Context) {
 				HigherCandles:     higherCandles,
 				BBSqueezeLookback: profile.StanceRules.BBSqueezeLookback,
 				PositionSizing:    profile.Risk.PositionSizing,
+				FillPriceSource:   fillSrc,
+				BookSource:        bookSrc,
 				RiskConfig:        risk,
 			})
 			if err != nil {


### PR DESCRIPTION
## Summary
POST /backtest/run で追加した 6 つの execution-quality 系パラメータを **/backtest/run-multi** と **/backtest/walk-forward** でも受け取れるようにする。WFO で「post-only モデルだと ATR を変えても WR が動くか」のような観察を window ごとに走らせるのが本来の目的。

## Propagated parameters
- `slippageModel` (`percent` / `orderbook` / `post_only_with_taker`)
- `makerFillProbability`
- `makerFeeRate` / `takerFeeRate`
- `maxSlippageBps` / `maxBookSidePct`

## Changes
- **handler/backtest.go**: `buildExecutionSourcesForCfg` ヘルパを抽出 (`cfg.SlippageModel` に応じて percent/orderbook/post_only_with_taker を構築)。`Run` ハンドラもこれを使うよう refactor
- **handler/backtest_multi.go**: `runMultiBacktestRequest` に 6 フィールド追加 → 各 period の cfg + RunInput に流す
- **handler/backtest_walkforward.go**: `runWalkForwardRequest` に 6 フィールド追加 → 各 window の cfg + RunInput に流す。`risk` にも `MaxSlippageBps` / `MaxBookSidePct` を埋める

## Why a shared helper
3 ハンドラそれぞれで switch を持つと、新しい slippageModel を追加したとき抜けが出る。ヘルパに集約することで「どこで `OrderbookReplay` を構築するか」を 1 箇所に。

## Test plan
- [x] `go test ./... -race -count=1` 全 OK
- [x] 既存 handler テストはレガシー経路を保つ（フィールドは optional、zero で legacy）

## 後続 PR
- フロント新パラメータ入力 UI
- profile JSON 内に execution params を埋める

🤖 Generated with [Claude Code](https://claude.com/claude-code)