### PR TITLE
feat(backtest): signal-to-fill latency モデル (H)

### DIFF
--- a/backend/internal/domain/entity/backtest.go
+++ b/backend/internal/domain/entity/backtest.go
@@ -30,6 +30,12 @@ type BacktestConfig struct {
 	// Zero values disable fee accounting so legacy backtests stay free.
 	MakerFeeRate float64 `json:"makerFeeRate,omitempty"`
 	TakerFeeRate float64 `json:"takerFeeRate,omitempty"`
+
+	// LatencyMs offsets the fill-time orderbook lookup forward by this many
+	// milliseconds. Models the "signal -> network -> venue -> fill" gap so a
+	// backtest cannot benefit from prices unavailable to the live bot.
+	// 0 disables (legacy default).
+	LatencyMs int64 `json:"latencyMs,omitempty"`
 }
 
 // BacktestSummary stores fixed output metrics for a run.

--- a/backend/internal/infrastructure/backtest/fill_price.go
+++ b/backend/internal/infrastructure/backtest/fill_price.go
@@ -320,6 +320,41 @@ func (p *PostOnlyLimitFill) lookupTouch(kind FillKind, side entity.OrderSide, ts
 	return 0, false
 }
 
+// LatencyAdjustedSource wraps another FillPriceSource and shifts the
+// timestamp passed to FillPrice forward by LatencyMs. This models the
+// signal-to-fill gap (network + venue queue + ack) so backtests can't
+// benefit from a price that was only visible after the bot would have
+// already committed to its order. The wrapped source still sees signalPrice
+// unchanged so percent-style models keep their semantics.
+//
+// Maker-flag passthrough: when the wrapped source implements MakerFlagSource,
+// the wrapper exposes the same flag through its own LastFillWasMaker so the
+// SimExecutor can keep classifying fills correctly.
+type LatencyAdjustedSource struct {
+	Inner     FillPriceSource
+	LatencyMs int64
+}
+
+// FillPrice forwards to Inner with ts shifted by LatencyMs.
+func (l *LatencyAdjustedSource) FillPrice(kind FillKind, side entity.OrderSide, signalPrice, amount float64, ts int64) (float64, error) {
+	if l == nil || l.Inner == nil {
+		return 0, fmt.Errorf("LatencyAdjustedSource: inner source is nil")
+	}
+	return l.Inner.FillPrice(kind, side, signalPrice, amount, ts+l.LatencyMs)
+}
+
+// LastFillWasMaker proxies to the wrapped source when it implements the
+// MakerFlagSource hook. Returns false otherwise (taker default).
+func (l *LatencyAdjustedSource) LastFillWasMaker() bool {
+	if l == nil || l.Inner == nil {
+		return false
+	}
+	if mfs, ok := l.Inner.(MakerFlagSource); ok {
+		return mfs.LastFillWasMaker()
+	}
+	return false
+}
+
 // LoadOrderbookReplay is a convenience helper for the runner: load the entire
 // snapshot range for a symbol/window and wrap it in an OrderbookReplay.
 //

--- a/backend/internal/infrastructure/backtest/fill_price_test.go
+++ b/backend/internal/infrastructure/backtest/fill_price_test.go
@@ -281,3 +281,56 @@ func TestPostOnlyLimitFill_DeterministicSampler(t *testing.T) {
 		t.Fatalf("non-deterministic: first=(%f,%v) second=(%f,%v)", first, firstMaker, second, secondMaker)
 	}
 }
+
+func TestLatencyAdjustedSource_ShiftsTimestamp(t *testing.T) {
+	// Two snapshots: snap0 at ts=1000 with BestAsk=100, snap1 at ts=5000
+	// with BestAsk=200. Without latency, a fill at ts=2000 picks snap0
+	// (cost 100). With LatencyMs=4000 shifting to ts=6000, it picks snap1.
+	snap0 := entity.Orderbook{
+		Timestamp: 1000, BestAsk: 100, BestBid: 99,
+		Asks: []entity.OrderbookEntry{{Price: 100, Amount: 10}},
+	}
+	snap1 := entity.Orderbook{
+		Timestamp: 5000, BestAsk: 200, BestBid: 199,
+		Asks: []entity.OrderbookEntry{{Price: 200, Amount: 10}},
+	}
+	replay := NewOrderbookReplay([]entity.Orderbook{snap0, snap1}, 60_000)
+
+	// Baseline (no latency).
+	baseline, err := replay.FillPrice(FillKindEntry, entity.OrderSideBuy, 0, 1.0, 2000)
+	if err != nil {
+		t.Fatalf("baseline: %v", err)
+	}
+	if baseline != 100 {
+		t.Fatalf("expected baseline 100, got %f", baseline)
+	}
+
+	wrapped := &LatencyAdjustedSource{Inner: replay, LatencyMs: 4000}
+	shifted, err := wrapped.FillPrice(FillKindEntry, entity.OrderSideBuy, 0, 1.0, 2000)
+	if err != nil {
+		t.Fatalf("shifted: %v", err)
+	}
+	if shifted != 200 {
+		t.Fatalf("expected latency-shifted 200, got %f", shifted)
+	}
+}
+
+func TestLatencyAdjustedSource_PassesThroughMakerFlag(t *testing.T) {
+	snap := entity.Orderbook{
+		Timestamp: 1000, BestBid: 99, BestAsk: 101,
+		Bids: []entity.OrderbookEntry{{Price: 99, Amount: 10}},
+		Asks: []entity.OrderbookEntry{{Price: 101, Amount: 10}},
+	}
+	replay := NewOrderbookReplay([]entity.Orderbook{snap}, 60_000)
+	post := &PostOnlyLimitFill{
+		MakerFillProbability: 1.0, TakerSource: replay, BookSource: replay,
+		SymbolID: 7, SamplerOverride: "maker",
+	}
+	wrapped := &LatencyAdjustedSource{Inner: post, LatencyMs: 0}
+	if _, err := wrapped.FillPrice(FillKindEntry, entity.OrderSideBuy, 0, 1.0, 1500); err != nil {
+		t.Fatalf("fill: %v", err)
+	}
+	if !wrapped.LastFillWasMaker() {
+		t.Fatal("expected wrapper to expose maker=true from inner PostOnlyLimitFill")
+	}
+}

--- a/backend/internal/interfaces/api/handler/backtest.go
+++ b/backend/internal/interfaces/api/handler/backtest.go
@@ -138,6 +138,9 @@ type runBacktestRequest struct {
 	// (-0.0001 / 0 for Rakuten Wallet leverage). 0 disables fee accounting.
 	MakerFeeRate float64 `json:"makerFeeRate,omitempty"`
 	TakerFeeRate float64 `json:"takerFeeRate,omitempty"`
+	// LatencyMs shifts the fill-time orderbook lookup forward (Phase H).
+	// 0 = no latency model. 200 = a 200 ms signal-to-fill gap.
+	LatencyMs int64 `json:"latencyMs,omitempty"`
 	TradeAmount           float64 `json:"tradeAmount"`
 	StopLossPercent       float64 `json:"stopLossPercent"`
 	StopLossATRMultiplier float64 `json:"stopLossAtrMultiplier"` // PR-12
@@ -274,6 +277,7 @@ func (h *BacktestHandler) Run(c *gin.Context) {
 		MakerFillProbability: req.MakerFillProbability,
 		MakerFeeRate:         req.MakerFeeRate,
 		TakerFeeRate:         req.TakerFeeRate,
+		LatencyMs:            req.LatencyMs,
 	}
 	if len(higherCandles) == 0 {
 		cfg.HigherTFInterval = ""

--- a/backend/internal/interfaces/api/handler/backtest_multi.go
+++ b/backend/internal/interfaces/api/handler/backtest_multi.go
@@ -44,6 +44,7 @@ type runMultiBacktestRequest struct {
 	TakerFeeRate         float64 `json:"takerFeeRate,omitempty"`
 	MaxSlippageBps       float64 `json:"maxSlippageBps,omitempty"`
 	MaxBookSidePct       float64 `json:"maxBookSidePct,omitempty"`
+	LatencyMs            int64   `json:"latencyMs,omitempty"`
 
 	Periods []entity.PeriodSpec `json:"periods" binding:"required"`
 
@@ -190,6 +191,7 @@ func (h *BacktestHandler) RunMulti(c *gin.Context) {
 				MakerFillProbability: req.MakerFillProbability,
 				MakerFeeRate:         req.MakerFeeRate,
 				TakerFeeRate:         req.TakerFeeRate,
+				LatencyMs:            req.LatencyMs,
 			}
 			if len(higherCandles) == 0 {
 				cfg.HigherTFInterval = ""

--- a/backend/internal/interfaces/api/handler/backtest_walkforward.go
+++ b/backend/internal/interfaces/api/handler/backtest_walkforward.go
@@ -38,6 +38,7 @@ type runWalkForwardRequest struct {
 	TakerFeeRate         float64 `json:"takerFeeRate,omitempty"`
 	MaxSlippageBps       float64 `json:"maxSlippageBps,omitempty"`
 	MaxBookSidePct       float64 `json:"maxBookSidePct,omitempty"`
+	LatencyMs            int64   `json:"latencyMs,omitempty"`
 
 	From              string `json:"from"`              // "YYYY-MM-DD"
 	To                string `json:"to"`                // "YYYY-MM-DD"
@@ -227,6 +228,7 @@ func (h *BacktestHandler) RunWalkForward(c *gin.Context) {
 				MakerFillProbability: req.MakerFillProbability,
 				MakerFeeRate:         req.MakerFeeRate,
 				TakerFeeRate:         req.TakerFeeRate,
+				LatencyMs:            req.LatencyMs,
 			}
 			if len(higherCandles) == 0 {
 				cfg.HigherTFInterval = ""

--- a/backend/internal/usecase/backtest/runner.go
+++ b/backend/internal/usecase/backtest/runner.go
@@ -155,6 +155,9 @@ func (r *BacktestRunner) Run(ctx context.Context, input RunInput) (*entity.Backt
 			return nil, fmt.Errorf("unknown slippage model: %q", input.Config.SlippageModel)
 		}
 	}
+	if input.Config.LatencyMs > 0 && fillSource != nil {
+		fillSource = &infra.LatencyAdjustedSource{Inner: fillSource, LatencyMs: input.Config.LatencyMs}
+	}
 	sim := infra.NewSimExecutor(infra.SimConfig{
 		InitialBalance:    input.Config.InitialBalance,
 		SpreadPercent:     input.Config.SpreadPercent,


### PR DESCRIPTION
## Summary
バックテストに **「シグナル発生 → 注文送信 → 楽天サーバ到達 → 約定」までの時間遅延** を反映する。`BacktestConfig.LatencyMs > 0` のとき `FillPriceSource` を `LatencyAdjustedSource` で包み、`FillPrice` の `ts` に `LatencyMs` を足して板を lookup する。これにより live で取れない「未来の板」をシミュレータが掴むのを防ぐ。

opt-in (default 0)。`/backtest/run` / `/backtest/run-multi` / `/backtest/walk-forward` の req に `latencyMs` を追加。

## Changes
- `entity.BacktestConfig.LatencyMs` を追加
- new `infra/backtest/fill_price.go` の `LatencyAdjustedSource`
  - `FillPrice` は `ts + LatencyMs` で Inner を呼ぶ
  - Inner が `MakerFlagSource` なら `LastFillWasMaker` を passthrough（`PostOnlyLimitFill` ラップを壊さない）
- `usecase/backtest/runner.go`: `LatencyMs > 0` のとき自動 wrap
- handler 3 経路に `latencyMs` フィールド追加。pre-trade gate (`booklimit.BookSource`) は **wrap しない** — ゲートは signal 時の板で判断するのが正しい挙動だから

## Test plan
- [x] `go test ./... -race -count=1` 全 OK
- [x] `LatencyAdjustedSource`: ts シフトで snap1 を選択（snap0=100, snap1=200, latency=4000ms）
- [x] maker フラグの passthrough（PostOnlyLimitFill を内に置いて maker 判定が伝わる）

## スコープ外
- 動的 latency 推定（実 API レイテンシ計測）
- live 側のレイテンシ補正（live は実時間動作なので意味なし）
- フロント表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)