### PR TITLE
feat(live): SOR Iceberg strategy (split lot into N slices) (C)

### DIFF
--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -320,7 +320,12 @@ func loadSORConfig() sor.Config {
 			cfg.Strategy = sor.StrategyMarket
 		case string(sor.StrategyPostOnlyEscalate):
 			cfg.Strategy = sor.StrategyPostOnlyEscalate
+		case string(sor.StrategyIceberg):
+			cfg.Strategy = sor.StrategyIceberg
 		}
+	}
+	if v, err := strconv.Atoi(os.Getenv("SOR_SLICE_COUNT")); err == nil && v > 0 {
+		cfg.SliceCount = v
 	}
 	if v, err := strconv.Atoi(os.Getenv("SOR_LIMIT_OFFSET_TICKS")); err == nil && v >= 0 {
 		cfg.LimitOffsetTicks = v

--- a/backend/internal/infrastructure/live/real_executor.go
+++ b/backend/internal/infrastructure/live/real_executor.go
@@ -454,6 +454,15 @@ func (r *RealExecutor) runPlan(ctx context.Context, plan sor.Plan, signalPrice f
 		return 0, 0, errors.New("empty plan")
 	}
 
+	// Iceberg flow: only Submit + WaitInterval steps, no WaitOrEscalate.
+	// We send slices in order, sleep between them, and surface the *last*
+	// successful slice's order ID + fillPrice. Errors on intermediate
+	// slices are logged and skipped so a single transient failure doesn't
+	// orphan the rest of the iceberg.
+	if plan.Strategy == sor.StrategyIceberg {
+		return r.runIcebergPlan(ctx, plan, signalPrice)
+	}
+
 	// First step is always Submit by construction (verified in tests).
 	primary := plan.Steps[0]
 	if primary.Kind != sor.StepKindSubmit {
@@ -519,6 +528,69 @@ func (r *RealExecutor) runPlan(ctx context.Context, plan sor.Plan, signalPrice f
 		return 0, signalPrice, fmt.Errorf("escalation MARKET fallback failed: %w", err)
 	}
 	return fb.ID, fillPriceOf(fb, signalPrice), nil
+}
+
+// runIcebergPlan sequentially submits each Submit step in the plan with the
+// configured WaitInterval pauses between them. Returns the first successful
+// slice's order ID and the volume-weighted average fill price across all
+// completed slices. Per-slice failures are logged and skipped so partial
+// fills still produce useful order tracking.
+func (r *RealExecutor) runIcebergPlan(ctx context.Context, plan sor.Plan, signalPrice float64) (int64, float64, error) {
+	var (
+		firstID       int64
+		costAccum     float64
+		amtAccum      float64
+		anySucceeded  bool
+		lastErr       error
+	)
+	for _, step := range plan.Steps {
+		select {
+		case <-ctx.Done():
+			return firstID, fallbackVWAP(costAccum, amtAccum, signalPrice), ctx.Err()
+		default:
+		}
+		switch step.Kind {
+		case sor.StepKindSubmit:
+			ord, err := r.submit(ctx, step.Order)
+			if err != nil {
+				slog.Warn("iceberg slice submit failed", "error", err)
+				lastErr = err
+				continue
+			}
+			anySucceeded = true
+			if firstID == 0 {
+				firstID = ord.ID
+			}
+			price := fillPriceOf(ord, signalPrice)
+			costAccum += price * step.Order.OrderData.Amount
+			amtAccum += step.Order.OrderData.Amount
+		case sor.StepKindWaitInterval:
+			if step.WaitMs <= 0 {
+				continue
+			}
+			select {
+			case <-ctx.Done():
+				return firstID, fallbackVWAP(costAccum, amtAccum, signalPrice), ctx.Err()
+			case <-time.After(time.Duration(step.WaitMs) * time.Millisecond):
+			}
+		default:
+			// Skip unexpected kinds — Plan was constructed by the SOR so
+			// hitting one means a mismatch between Selector and runPlan,
+			// not a venue issue.
+			slog.Warn("iceberg unexpected step kind", "kind", step.Kind)
+		}
+	}
+	if !anySucceeded {
+		return 0, signalPrice, lastErr
+	}
+	return firstID, fallbackVWAP(costAccum, amtAccum, signalPrice), nil
+}
+
+func fallbackVWAP(cost, amount, fallback float64) float64 {
+	if amount <= 0 {
+		return fallback
+	}
+	return cost / amount
 }
 
 // submit posts a single order and returns the venue's first response row.

--- a/backend/internal/infrastructure/live/real_executor_test.go
+++ b/backend/internal/infrastructure/live/real_executor_test.go
@@ -584,3 +584,31 @@ func TestRealExecutor_LastOrderAt_BumpsOnSubmit(t *testing.T) {
 		t.Fatal("expected LastOrderAt to advance after Open")
 	}
 }
+
+func TestRealExecutor_Iceberg_SubmitsAllSlices(t *testing.T) {
+	calls := 0
+	mock := &mockOrderClient{
+		createOrderFn: func(_ context.Context, req entity.OrderRequest) ([]entity.Order, error) {
+			calls++
+			return []entity.Order{{ID: int64(900 + calls), Price: 100}}, nil
+		},
+	}
+	router := sor.New(sor.Config{Strategy: sor.StrategyIceberg, SliceCount: 3, MinIntervalMs: 1})
+	exec := NewRealExecutor(mock, 7, 0, WithSOR(router))
+
+	if _, err := exec.Open(7, entity.OrderSideBuy, 100, 0.6, "iceberg", 1000); err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if calls != 3 {
+		t.Fatalf("expected 3 venue submissions, got %d", calls)
+	}
+	// All three submits must be MARKET orders with positive amount.
+	for i, c := range mock.calls {
+		if c.OrderData.OrderType != entity.OrderTypeMarket {
+			t.Fatalf("call %d not MARKET: %s", i, c.OrderData.OrderType)
+		}
+		if c.OrderData.Amount <= 0 {
+			t.Fatalf("call %d amount must be positive: %f", i, c.OrderData.Amount)
+		}
+	}
+}

--- a/backend/internal/usecase/sor/sor.go
+++ b/backend/internal/usecase/sor/sor.go
@@ -27,6 +27,12 @@ const (
 	// then cancel + replace with MARKET if not fully filled within the
 	// configured escalation window.
 	StrategyPostOnlyEscalate Strategy = "post_only_escalate"
+	// StrategyIceberg: split the lot into SliceCount even pieces and submit
+	// them one at a time with MinIntervalMs between submissions. Each piece
+	// is a plain MARKET order — no maker probing. Useful when a single
+	// MARKET would soak too much of the visible book and trip the pre-trade
+	// gate, or simply to obscure the trader's full size.
+	StrategyIceberg Strategy = "iceberg"
 )
 
 // Config controls the router's choice. Zero value selects the legacy
@@ -50,7 +56,19 @@ type Config struct {
 	// MinIntervalMs bounds back-to-back venue requests so we don't trip
 	// the documented 200 ms / user rate limit. Default DefaultMinIntervalMs.
 	MinIntervalMs int64
+	// SliceCount is how many pieces to split the lot into when using
+	// StrategyIceberg. 0 falls back to DefaultSliceCount (5). Capped at
+	// DefaultSliceCountMax internally to keep the venue rate-limit budget
+	// reasonable.
+	SliceCount int
 }
+
+// DefaultSliceCount is the iceberg fallback when Config.SliceCount is zero.
+const DefaultSliceCount = 5
+
+// DefaultSliceCountMax caps the iceberg slice count so a misconfigured
+// SliceCount cannot DoS the venue.
+const DefaultSliceCountMax = 20
 
 // DefaultEscalateAfterMs is the fallback timeout when Config.EscalateAfterMs
 // is zero. 30 s matches the design discussion: a typical 15 m bar's signal
@@ -89,6 +107,8 @@ type Step struct {
 	// previous Submit step has not fully filled. Populated for
 	// StepKindWaitOrEscalate.
 	FallbackOrder entity.OrderRequest
+	// WaitMs is the fixed pause for StepKindWaitInterval.
+	WaitMs int64
 }
 
 // StepKind describes what the executor must do for a Step.
@@ -102,6 +122,10 @@ const (
 	// when the deadline is reached without a complete fill, the executor
 	// cancels the resting order and submits FallbackOrder.
 	StepKindWaitOrEscalate StepKind = "wait_or_escalate"
+	// StepKindWaitInterval is a fixed pause between two Submit steps. Used
+	// by the iceberg strategy to space out slice submissions and avoid the
+	// venue rate limit.
+	StepKindWaitInterval StepKind = "wait_interval"
 )
 
 // Plan is the full execution plan for one approved signal.
@@ -167,9 +191,48 @@ func (s *Selector) Plan(in SelectInput) Plan {
 	switch s.cfg.Strategy {
 	case StrategyPostOnlyEscalate:
 		return s.planPostOnlyEscalate(in)
+	case StrategyIceberg:
+		return s.planIceberg(in)
 	default:
 		return s.planMarket(in)
 	}
+}
+
+// planIceberg splits the input lot into SliceCount equal MARKET orders with
+// MinIntervalMs spacing. When the resulting per-slice amount would round
+// to 0 (very small lot), falls back to a single MARKET so the signal isn't
+// silently dropped.
+func (s *Selector) planIceberg(in SelectInput) Plan {
+	count := s.cfg.SliceCount
+	if count <= 0 {
+		count = DefaultSliceCount
+	}
+	if count > DefaultSliceCountMax {
+		count = DefaultSliceCountMax
+	}
+	if count <= 1 {
+		return s.planMarket(in)
+	}
+	per := in.Amount / float64(count)
+	if per <= 0 {
+		return s.planMarket(in)
+	}
+	steps := make([]Step, 0, count*2-1)
+	for i := 0; i < count; i++ {
+		// Last slice absorbs any rounding so the total amount matches the
+		// caller's request exactly.
+		amt := per
+		if i == count-1 {
+			amt = in.Amount - per*float64(count-1)
+		}
+		sliceIn := in
+		sliceIn.Amount = amt
+		steps = append(steps, Step{Kind: StepKindSubmit, Order: marketOrder(sliceIn)})
+		if i < count-1 {
+			steps = append(steps, Step{Kind: StepKindWaitInterval, WaitMs: s.cfg.MinIntervalMs})
+		}
+	}
+	return Plan{Strategy: StrategyIceberg, Steps: steps}
 }
 
 func (s *Selector) planMarket(in SelectInput) Plan {

--- a/backend/internal/usecase/sor/sor_test.go
+++ b/backend/internal/usecase/sor/sor_test.go
@@ -143,3 +143,56 @@ func TestSelector_PostOnlyEscalate_TickSizeFallback(t *testing.T) {
 		t.Fatalf("expected fallback tick to yield 8999.9, got %f", got)
 	}
 }
+
+func TestSelector_Iceberg_SplitsLotIntoSlices(t *testing.T) {
+	s := New(Config{Strategy: StrategyIceberg, SliceCount: 5, MinIntervalMs: 250})
+	plan := s.Plan(SelectInput{
+		SymbolID: 7, Side: entity.OrderSideBuy, Amount: 1.0,
+	})
+	if plan.Strategy != StrategyIceberg {
+		t.Fatalf("strategy: %s", plan.Strategy)
+	}
+	// Expected: 5 Submit steps interleaved with 4 WaitInterval steps.
+	if got := len(plan.Steps); got != 9 {
+		t.Fatalf("expected 9 steps (5 submit + 4 wait), got %d", got)
+	}
+	submitTotal := 0.0
+	for i, step := range plan.Steps {
+		if i%2 == 0 {
+			if step.Kind != StepKindSubmit {
+				t.Fatalf("step %d expected submit, got %s", i, step.Kind)
+			}
+			submitTotal += step.Order.OrderData.Amount
+		} else {
+			if step.Kind != StepKindWaitInterval {
+				t.Fatalf("step %d expected wait, got %s", i, step.Kind)
+			}
+			if step.WaitMs != 250 {
+				t.Fatalf("step %d wait = %d, want 250", i, step.WaitMs)
+			}
+		}
+	}
+	if math.Abs(submitTotal-1.0) > 1e-9 {
+		t.Fatalf("slices total = %f, want 1.0", submitTotal)
+	}
+}
+
+func TestSelector_Iceberg_FallsBackToMarketWhenSliceCountIs1(t *testing.T) {
+	s := New(Config{Strategy: StrategyIceberg, SliceCount: 1})
+	plan := s.Plan(SelectInput{SymbolID: 7, Side: entity.OrderSideBuy, Amount: 1.0})
+	if plan.Strategy != StrategyMarket {
+		t.Fatalf("expected fallback to market, got %s", plan.Strategy)
+	}
+	if len(plan.Steps) != 1 {
+		t.Fatalf("expected 1 step, got %d", len(plan.Steps))
+	}
+}
+
+func TestSelector_Iceberg_CapsSliceCount(t *testing.T) {
+	s := New(Config{Strategy: StrategyIceberg, SliceCount: 1000})
+	plan := s.Plan(SelectInput{SymbolID: 7, Side: entity.OrderSideBuy, Amount: 1.0})
+	// 20 submit + 19 wait = 39
+	if got := len(plan.Steps); got != 39 {
+		t.Fatalf("expected slice count to be capped at 20 (=39 steps), got %d", got)
+	}
+}


### PR DESCRIPTION
## Summary
楽天 API はアイスバーグ注文をネイティブにサポートしていないので SOR でエミュレート。大ロットを `SliceCount` 個に等分し、`MinIntervalMs` (default 250ms = venue rate-limit + 余裕) の間隔で順次発注する。

## Why
- 1 ロット成行で板を soak するとスリッページが膨らむ
- pre-trade gate (#172) に弾かれる確率も下がる
- Maker 戦略 (#173) と排他で使うシンプルな代替手段が欲しかった

## Changes
- `usecase/sor`:
  - `StrategyIceberg` / `SliceCount` Config フィールド
  - `StepKindWaitInterval` / `Step.WaitMs` (Submit 間の固定 pause)
  - `planIceberg`: 偶数分割 + 最終スライスで端数吸収。`SliceCount=1` や per-slice <= 0 は MARKET fallback。上限 `DefaultSliceCountMax=20`
- `infra/live/real_executor`:
  - `runIcebergPlan`: 各 Submit を順次走らせ、Wait は `time.After`
  - 部分失敗は warn ログでスキップして残スライスは継続
  - 戻り値: 最初の成功 order ID + VWAP fill price
- `cmd/main.go`: `SOR_SLICE_COUNT` env

## Test plan
- [x] `go test ./... -race -count=1` 全 OK
- [x] sor 単体: SliceCount=5 で 9 ステップ (5 submit + 4 wait)、合計量保存、SliceCount=1 で MARKET fallback、cap=20
- [x] real_executor: 0.6 LTC を SliceCount=3 で打つと 3 回 venue 呼び出し、全て MARKET、各 amount > 0

## スコープ外 (次以降)
- 動的スライス数 (ロット / 板厚みに応じた分割)
- post-only との併用
- バックテスト統合

🤖 Generated with [Claude Code](https://claude.com/claude-code)