### PR TITLE
feat(strategy): Signal.Urgency hint で Execution をルーティング (S, minimal)

### DIFF
--- a/backend/internal/domain/entity/backtest_event.go
+++ b/backend/internal/domain/entity/backtest_event.go
@@ -76,6 +76,10 @@ type ApprovedSignalEvent struct {
 	// executors use this value verbatim so that backtest and live code
 	// share one sizing decision. 0 means "no-trade" (rejected by sizer).
 	Amount float64
+	// Urgency is mirrored from Signal.Urgency by the risk handler so the
+	// executor can route on a single field without reaching back into the
+	// raw signal. Empty value preserves legacy behaviour.
+	Urgency SignalUrgency
 }
 
 func (e ApprovedSignalEvent) EventType() string     { return EventTypeApproved }

--- a/backend/internal/domain/entity/signal.go
+++ b/backend/internal/domain/entity/signal.go
@@ -9,11 +9,35 @@ const (
 	SignalActionHold SignalAction = "HOLD"
 )
 
+// SignalUrgency conveys the strategy's preference for *how* the order
+// should be executed once it has been approved. The Execution layer reads
+// this to pick a concrete SOR strategy:
+//
+//   - SignalUrgencyUrgent  : "lift the offer now" — favour MARKET, even at cost.
+//   - SignalUrgencyNormal  : no preference; honour the configured default.
+//   - SignalUrgencyPassive : "wait for the price" — favour post-only LIMIT.
+//
+// An empty value means "unspecified" and is treated identically to Normal,
+// preserving bit-identical behaviour for existing strategies that do not
+// populate this field.
+type SignalUrgency string
+
+const (
+	SignalUrgencyUnspecified SignalUrgency = ""
+	SignalUrgencyUrgent      SignalUrgency = "urgent"
+	SignalUrgencyNormal      SignalUrgency = "normal"
+	SignalUrgencyPassive     SignalUrgency = "passive"
+)
+
 // Signal はStrategy Engineが生成する売買シグナル。
 type Signal struct {
-	SymbolID   int64        `json:"symbolId"`
-	Action     SignalAction `json:"action"`
-	Confidence float64      `json:"confidence"` // 0.0–1.0: indicator agreement score
-	Reason     string       `json:"reason"`
-	Timestamp  int64        `json:"timestamp"`
+	SymbolID   int64         `json:"symbolId"`
+	Action     SignalAction  `json:"action"`
+	Confidence float64       `json:"confidence"` // 0.0–1.0: indicator agreement score
+	Reason     string        `json:"reason"`
+	// Urgency is optional. Strategies that don't fill it leave it as
+	// SignalUrgencyUnspecified, which the Execution layer treats as
+	// "honour the configured SOR default" — i.e. fully backwards compatible.
+	Urgency   SignalUrgency `json:"urgency,omitempty"`
+	Timestamp int64         `json:"timestamp"`
 }

--- a/backend/internal/infrastructure/live/real_executor.go
+++ b/backend/internal/infrastructure/live/real_executor.go
@@ -115,6 +115,90 @@ func NewRealExecutor(orderClient repository.OrderClient, symbolID int64, spreadP
 	return r
 }
 
+// OpenWithUrgency dispatches to the SOR strategy that best matches the
+// caller's urgency hint:
+//   - urgent  → StrategyMarket (forces immediate market lift)
+//   - passive → StrategyPostOnlyEscalate (favours the maker rebate)
+//   - normal / "" → honours the configured default router
+//
+// Strategies the router was not configured for (e.g. urgent on a Market-only
+// deployment) just round-trip back to the configured default.
+func (r *RealExecutor) OpenWithUrgency(symbolID int64, side entity.OrderSide, signalPrice, amount float64, reason string, timestamp int64, urgency entity.SignalUrgency) (entity.OrderEvent, error) {
+	switch urgency {
+	case entity.SignalUrgencyUrgent:
+		return r.openWithStrategy(symbolID, side, signalPrice, amount, reason, timestamp, sor.StrategyMarket)
+	case entity.SignalUrgencyPassive:
+		return r.openWithStrategy(symbolID, side, signalPrice, amount, reason, timestamp, sor.StrategyPostOnlyEscalate)
+	default:
+		return r.Open(symbolID, side, signalPrice, amount, reason, timestamp)
+	}
+}
+
+// openWithStrategy is the core open routine parameterised by SOR strategy.
+// The default router stays untouched so subsequent Open calls keep using
+// the configured defaults.
+func (r *RealExecutor) openWithStrategy(symbolID int64, side entity.OrderSide, signalPrice, amount float64, reason string, timestamp int64, strat sor.Strategy) (entity.OrderEvent, error) {
+	if amount <= 0 {
+		return entity.OrderEvent{}, fmt.Errorf("amount must be positive")
+	}
+	if signalPrice <= 0 {
+		return entity.OrderEvent{}, fmt.Errorf("signal price must be positive")
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for i := len(r.positions) - 1; i >= 0; i-- {
+		pos := r.positions[i]
+		if pos.SymbolID == symbolID && pos.Side != side {
+			_, _, _ = r.closeLocked(pos.PositionID, signalPrice, "reverse_signal", timestamp)
+		}
+	}
+
+	tempRouter := sor.New(sor.Config{Strategy: strat})
+	in := sor.SelectInput{SymbolID: symbolID, Side: side, Amount: amount}
+	if r.touchSrc != nil {
+		ob, ok, err := r.touchSrc.LatestBefore(context.Background(), symbolID, timestamp)
+		if err == nil && ok {
+			in.BestBid = ob.BestBid
+			in.BestAsk = ob.BestAsk
+		}
+	}
+	plan := tempRouter.Plan(in)
+	orderID, fillPrice, err := r.runPlan(context.Background(), plan, signalPrice)
+	if err != nil {
+		return entity.OrderEvent{}, fmt.Errorf("failed to execute open plan (urgency-routed): %w", err)
+	}
+
+	slog.Info("live order opened with urgency",
+		"orderID", orderID, "symbolID", symbolID, "side", side,
+		"amount", amount, "reason", reason, "strategy", plan.Strategy,
+	)
+
+	posID := orderID
+	if posID == 0 {
+		posID = r.nextOrderID
+		r.nextOrderID++
+	}
+	r.positions = append(r.positions, eventengine.Position{
+		PositionID:     posID,
+		SymbolID:       symbolID,
+		Side:           side,
+		EntryPrice:     fillPrice,
+		Amount:         amount,
+		EntryTimestamp: timestamp,
+	})
+	return entity.OrderEvent{
+		OrderID:   orderID,
+		SymbolID:  symbolID,
+		Side:      string(side),
+		Action:    "open",
+		Price:     fillPrice,
+		Amount:    amount,
+		Reason:    reason,
+		Timestamp: timestamp,
+	}, nil
+}
+
 // Open creates a real order via the configured SOR plan.
 func (r *RealExecutor) Open(symbolID int64, side entity.OrderSide, signalPrice, amount float64, reason string, timestamp int64) (entity.OrderEvent, error) {
 	if amount <= 0 {

--- a/backend/internal/infrastructure/live/real_executor_test.go
+++ b/backend/internal/infrastructure/live/real_executor_test.go
@@ -612,3 +612,50 @@ func TestRealExecutor_Iceberg_SubmitsAllSlices(t *testing.T) {
 		}
 	}
 }
+
+func TestRealExecutor_OpenWithUrgency_UrgentForcesMarketEvenWhenDefaultIsPostOnly(t *testing.T) {
+	calls := 0
+	mock := &mockOrderClient{
+		createOrderFn: func(_ context.Context, req entity.OrderRequest) ([]entity.Order, error) {
+			calls++
+			return []entity.Order{{ID: int64(1000 + calls), Price: 100}}, nil
+		},
+	}
+	// Default router would be post-only-escalate; urgency=urgent must override.
+	router := sor.New(sor.Config{Strategy: sor.StrategyPostOnlyEscalate, TickSize: 0.1})
+	exec := NewRealExecutor(mock, 7, 0, WithSOR(router))
+
+	if _, err := exec.OpenWithUrgency(7, entity.OrderSideBuy, 100, 0.01, "urgent_test", 1000, entity.SignalUrgencyUrgent); err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("urgent must produce a single MARKET submission, got %d calls", calls)
+	}
+	if mock.calls[0].OrderData.OrderType != entity.OrderTypeMarket {
+		t.Fatalf("expected MARKET, got %s", mock.calls[0].OrderData.OrderType)
+	}
+	if mock.calls[0].OrderData.PostOnly != nil {
+		t.Fatalf("urgent must not carry postOnly: %+v", mock.calls[0].OrderData.PostOnly)
+	}
+}
+
+func TestRealExecutor_OpenWithUrgency_NormalRespectsDefaultRouter(t *testing.T) {
+	calls := 0
+	mock := &mockOrderClient{
+		createOrderFn: func(_ context.Context, req entity.OrderRequest) ([]entity.Order, error) {
+			calls++
+			return []entity.Order{{ID: int64(2000 + calls), Price: 100}}, nil
+		},
+	}
+	// Default = market. Normal urgency must just round-trip to Open which
+	// produces a single MARKET.
+	router := sor.New(sor.Config{Strategy: sor.StrategyMarket})
+	exec := NewRealExecutor(mock, 7, 0, WithSOR(router))
+
+	if _, err := exec.OpenWithUrgency(7, entity.OrderSideBuy, 100, 0.01, "normal_test", 1000, entity.SignalUrgencyNormal); err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected 1 venue call, got %d", calls)
+	}
+}

--- a/backend/internal/usecase/backtest/handler.go
+++ b/backend/internal/usecase/backtest/handler.go
@@ -487,6 +487,7 @@ func (h *RiskHandler) Handle(ctx context.Context, event entity.Event) ([]entity.
 			Price:     signalEvent.Price,
 			Timestamp: signalEvent.Timestamp,
 			Amount:    amount,
+			Urgency:   signalEvent.Signal.Urgency,
 		},
 	}, nil
 }
@@ -716,6 +717,14 @@ type SignalExecutor interface {
 	Open(symbolID int64, side entity.OrderSide, signalPrice, amount float64, reason string, timestamp int64) (entity.OrderEvent, error)
 }
 
+// UrgencyAwareExecutor is an optional add-on interface. When the underlying
+// executor implements it, ExecutionHandler routes through OpenWithUrgency
+// so the executor can pick a SOR strategy from the urgency hint. Executors
+// that don't implement this stay on the legacy Open path verbatim.
+type UrgencyAwareExecutor interface {
+	OpenWithUrgency(symbolID int64, side entity.OrderSide, signalPrice, amount float64, reason string, timestamp int64, urgency entity.SignalUrgency) (entity.OrderEvent, error)
+}
+
 // ExecutionHandler converts approved SignalEvents into OrderEvents.
 //
 // The executor trusts ApprovedSignalEvent.Amount when set (the risk handler
@@ -752,14 +761,28 @@ func (h *ExecutionHandler) Handle(_ context.Context, event entity.Event) ([]enti
 		side = entity.OrderSideSell
 	}
 
-	orderEvent, err := h.Executor.Open(
-		signalEvent.Signal.SymbolID,
-		side,
-		signalEvent.Price,
-		amount,
-		signalEvent.Signal.Reason,
-		signalEvent.Timestamp,
-	)
+	var orderEvent entity.OrderEvent
+	var err error
+	if uae, ok := h.Executor.(UrgencyAwareExecutor); ok && signalEvent.Urgency != "" {
+		orderEvent, err = uae.OpenWithUrgency(
+			signalEvent.Signal.SymbolID,
+			side,
+			signalEvent.Price,
+			amount,
+			signalEvent.Signal.Reason,
+			signalEvent.Timestamp,
+			signalEvent.Urgency,
+		)
+	} else {
+		orderEvent, err = h.Executor.Open(
+			signalEvent.Signal.SymbolID,
+			side,
+			signalEvent.Price,
+			amount,
+			signalEvent.Signal.Reason,
+			signalEvent.Timestamp,
+		)
+	}
 	if err != nil {
 		var thin *infraThinBookError
 		if errors.As(err, &thin) {


### PR DESCRIPTION
## Summary
Strategy 層が「シグナルの緊急度」を Execution 層に伝えられるようにする最小スコープの一歩。**Strategy ↔ Execution 完全分離 (S)** の準備。

仕組み：
- `entity.SignalUrgency` enum を追加 (`""` / `"urgent"` / `"normal"` / `"passive"`)
- `Signal` / `ApprovedSignalEvent` に `Urgency` フィールドを追加（省略時は `""`）
- `ExecutionHandler` は Executor が `UrgencyAwareExecutor` (optional add-on interface) を実装している場合のみ `OpenWithUrgency` 経由でルーティング、そうでなければ既存の `Open()` を使う
- `RealExecutor.OpenWithUrgency`:
  - `urgent`  → `StrategyMarket` (即時成行) に強制切替
  - `passive` → `StrategyPostOnlyEscalate` (メイカー優先) に強制切替
  - `normal` / `""` → 既存の `Open()` に委譲 (= env で設定された SOR デフォルト)

既存戦略は `Urgency` を埋めないので、**後方互換は完全に維持**される。Strategy 側の Urgency 計算ロジックは本 PR では未着手（空のままで legacy）。

## Why "minimal" のか
S を完全に進めると `port.Strategy` interface 変更 → 全 Strategy 実装更新 → ConfigurableStrategy / ProfileRouter / DefaultStrategy / バックテスト の 4 経路全て更新 で 3〜5 PR 規模。  
今回は **配管だけ** 通して、Strategy 側で Urgency を埋め始められる土台を用意する。

## Changes
- `entity.SignalUrgency` 定数 + `Signal.Urgency` / `ApprovedSignalEvent.Urgency`
- `usecase/backtest/handler.go`:
  - `RiskHandler` が ApprovedSignalEvent.Urgency を埋める
  - `UrgencyAwareExecutor` interface (optional add-on)
  - `ExecutionHandler` が implementing executor のときのみ `OpenWithUrgency` を呼ぶ
- `infra/live/real_executor.go`:
  - `OpenWithUrgency` を実装 (RealExecutor は UrgencyAwareExecutor を満たす)
  - 内部で一時 router を作り、urgent / passive を強制切替

## Test plan
- [x] `go test ./... -race -count=1` 全 OK
- [x] urgent: post-only 既定 router でも MARKET を強制 (postOnly フラグ無し、1 venue call)
- [x] normal: 既定 router (MARKET) を尊重 (1 venue call)
- [x] 既存テストは無風 (Urgency=="" でレガシー経路)

## 後続 PR (今回スコープ外)
- ConfigurableStrategy / DefaultStrategy で Urgency を計算
  - 例: confidence > 0.8 → urgent、breakout signal → urgent、Ranging stance → passive
- バックテスト simulator の urgency 別 fill model
- フロント表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)