### PR TITLE
fix(fe): show orderbook mid as live price to avoid venue ticker lag

### DIFF
--- a/frontend/src/components/LiveTickerCard.tsx
+++ b/frontend/src/components/LiveTickerCard.tsx
@@ -1,18 +1,22 @@
-import type { LiveTicker } from '../lib/api'
+import type { LiveTicker, RealtimeOrderbook } from '../lib/api'
 
 type LiveTickerCardProps = {
   ticker: LiveTicker | null
+  // 楽天 venue は ticker payload を ~600ms 遅らせて配信するため、表示価格は
+  // ほぼリアルタイム (p50≈10ms) で届く orderbook の midPrice を使う。
+  // 約定が止まる低出来高シンボル (ETH/JPY など) でも板が動けば表示が更新される。
+  orderbook: RealtimeOrderbook | null
   connectionState: 'connecting' | 'connected' | 'disconnected'
   currencyPair?: string
 }
 
 function formatYen(value: number | null | undefined) {
-  if (value === null || value === undefined) return '\u2014'
+  if (value === null || value === undefined) return '—'
   return `¥${value.toLocaleString('ja-JP', { maximumFractionDigits: 0 })}`
 }
 
 function formatTime(timestamp: number | null | undefined) {
-  if (!timestamp) return '\u2014'
+  if (!timestamp) return '—'
   return new Date(timestamp).toLocaleTimeString('ja-JP')
 }
 
@@ -22,17 +26,20 @@ const CONNECTION_LABEL: Record<'connecting' | 'connected' | 'disconnected', stri
   disconnected: '切断',
 }
 
-export function LiveTickerCard({ ticker, connectionState, currencyPair }: LiveTickerCardProps) {
-  const delta = ticker ? ticker.last - ticker.open : null
+export function LiveTickerCard({ ticker, orderbook, connectionState, currencyPair }: LiveTickerCardProps) {
+  const mid = orderbook?.midPrice && orderbook.midPrice > 0 ? orderbook.midPrice : null
+  const referencePrice = mid ?? ticker?.last ?? null
+  const delta = referencePrice !== null && ticker ? referencePrice - ticker.open : null
   const deltaClass = delta !== null && delta < 0 ? 'text-accent-red' : 'text-accent-green'
   const pairLabel = currencyPair ?? 'BTC/JPY'
+  const updatedAt = orderbook?.timestamp ?? ticker?.timestamp
 
   return (
     <section className="rounded-3xl border border-white/8 bg-bg-card/90 p-5 shadow-[0_12px_40px_rgba(0,0,0,0.22)]">
       <div className="flex items-start justify-between gap-4">
         <div>
           <p className="text-xs uppercase tracking-[0.28em] text-text-secondary">リアルタイムティッカー</p>
-          <h2 className="mt-2 text-xl font-semibold text-white">{pairLabel} ライブ価格</h2>
+          <h2 className="mt-2 text-xl font-semibold text-white">{pairLabel} 実勢価格</h2>
         </div>
         <span className={`rounded-full px-3 py-1 text-xs font-medium ${
           connectionState === 'connected'
@@ -47,16 +54,19 @@ export function LiveTickerCard({ ticker, connectionState, currencyPair }: LiveTi
 
       <div className="mt-5 grid gap-4 sm:grid-cols-2">
         <div>
-          <p className="text-3xl font-semibold text-white">{formatYen(ticker?.last)}</p>
+          <p className="text-3xl font-semibold text-white">{formatYen(referencePrice)}</p>
           <p className={`mt-2 text-sm ${deltaClass}`}>
-            {delta === null ? '\u2014' : `${delta >= 0 ? '+' : ''}${formatYen(delta)}`}
+            {delta === null ? '—' : `${delta >= 0 ? '+' : ''}${formatYen(delta)}`}
+          </p>
+          <p className="mt-1 text-[11px] text-text-secondary">
+            Mid (板) / Last {formatYen(ticker?.last)}
           </p>
         </div>
         <div className="grid grid-cols-2 gap-3 text-sm">
           <Metric label="売気配" value={formatYen(ticker?.bestAsk)} />
           <Metric label="買気配" value={formatYen(ticker?.bestBid)} />
-          <Metric label="出来高" value={ticker?.volume?.toLocaleString('ja-JP') ?? '\u2014'} />
-          <Metric label="更新時刻" value={formatTime(ticker?.timestamp)} />
+          <Metric label="出来高" value={ticker?.volume?.toLocaleString('ja-JP') ?? '—'} />
+          <Metric label="更新時刻" value={formatTime(updatedAt)} />
         </div>
       </div>
     </section>

--- a/frontend/src/hooks/useMarketTickerStream.ts
+++ b/frontend/src/hooks/useMarketTickerStream.ts
@@ -79,9 +79,20 @@ export function useMarketTickerStream(symbolId: number) {
           case 'market_trades':
             void queryClient.invalidateQueries({ queryKey: ['trades', symbolId] })
             return
-          case 'orderbook':
+          case 'orderbook': {
             setOrderbook(payload.data)
+            // 楽天 venue は ticker payload を ~600ms 遅らせて配信する一方、
+            // orderbook はほぼリアルタイム (p50≈10ms) で届く。板の bestBid/
+            // bestAsk と timestamp を ticker state にマージし、リアルタイム
+            // ティッカーの気配値が板より遅れて見える現象を解消する。
+            const ob = payload.data
+            setTicker((prev) =>
+              prev
+                ? { ...prev, bestBid: ob.bestBid, bestAsk: ob.bestAsk, timestamp: ob.timestamp }
+                : prev,
+            )
             return
+          }
           case 'position_update':
             // RealExecutor pushes position changes immediately on diff
             // detection (see PR-O). Invalidate the positions query so the

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -92,6 +92,7 @@ function Dashboard() {
         <section className="space-y-4">
           <LiveTickerCard
             ticker={ticker}
+            orderbook={orderbook}
             connectionState={connectionState}
             currencyPair={currentSymbol?.currencyPair?.replace('_', '/')}
           />


### PR DESCRIPTION
## Summary

- 楽天 venue の WS で **ticker payload は p50=632ms / max=2.2s 遅延**、 orderbook は p50=10ms で届く事を実測 → リアルタイムティッカーの気配値が板情報パネルより毎回 ~0.9-1.6 秒遅れていた
- ETH/JPY のような低出来高銘柄では `ticker.last` が約定不在で固定化し、見出し価格が長時間動かない問題も併発
- フロント側で 2 つの対策を実施:
  1. **A**: `useMarketTickerStream` で orderbook 受信時に `bestBid` / `bestAsk` / `timestamp` を ticker state にマージ → 板と気配値が常に同期
  2. **B**: `LiveTickerCard` の見出し価格を `orderbook.midPrice` に変更 (ticker.last はサブ行に併記)、ラベルを "ライブ価格" → "実勢価格" に変更

## 計測結果 (3.7 分間 / ETH/JPY)

```
[venue→backend lag (recvMs - payloadTs)]
  ticker:    p50=632ms   p90=1331ms   max=2235ms
  orderbook: p50=10ms    p90=25ms     max=173ms

[orderbook → ticker propagation]
  p50=864ms  p90=1644ms  p99=2787ms

[ticker.last の変化回数]  0 / 213  (3.7 分間でゼロ更新)
```

## Test plan

- [x] `pnpm tsc --noEmit` で本 PR の差分にエラーが出ないこと (既存の別箇所のエラーは PR 範囲外)
- [x] `docker compose up --build -d` で起動し、ブラウザで実勢価格 / 売気配 / 買気配 / Mid (板情報パネル) が一致することを確認
- [ ] CI (`go test`, `pnpm test`) のパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)