### PR TITLE
feat(indicator): SMA/EMA/RSI/MACD/BB/ATR/VolumeSMA periods are now profile-driven

### DIFF
--- a/backend/cmd/backtest/main.go
+++ b/backend/cmd/backtest/main.go
@@ -723,6 +723,7 @@ func buildRunInput(f runFlags, profile *entity.StrategyProfile) (bt.RunInput, er
 	}
 	if profile != nil {
 		in.BBSqueezeLookback = profile.StanceRules.BBSqueezeLookback
+		in.IndicatorPeriods = profile.Indicators
 		in.PositionSizing = profile.Risk.PositionSizing
 	}
 	return in, nil

--- a/backend/internal/domain/entity/strategy_config.go
+++ b/backend/internal/domain/entity/strategy_config.go
@@ -31,10 +31,14 @@ type StrategyProfile struct {
 }
 
 // IndicatorConfig declares the lookback periods and shape parameters used when
-// computing technical indicators (SMA / RSI / MACD / BB / ATR).
+// computing technical indicators. PR-B covers SMA / EMA / RSI / MACD / BB /
+// ATR / VolumeSMA. PR-C will extend this with ADX / Stochastics / Donchian /
+// CMF / OBVSlope / Ichimoku periods.
 type IndicatorConfig struct {
 	SMAShort     int     `json:"sma_short"`
 	SMALong      int     `json:"sma_long"`
+	EMAFast      int     `json:"ema_fast"`
+	EMASlow      int     `json:"ema_slow"`
 	RSIPeriod    int     `json:"rsi_period"`
 	MACDFast     int     `json:"macd_fast"`
 	MACDSlow     int     `json:"macd_slow"`
@@ -42,6 +46,58 @@ type IndicatorConfig struct {
 	BBPeriod     int     `json:"bb_period"`
 	BBMultiplier float64 `json:"bb_multiplier"`
 	ATRPeriod    int     `json:"atr_period"`
+	// VolumeSMAPeriod drives both VolumeSMA and the VolumeRatio denominator.
+	// 0 falls back to BBPeriod (legacy behaviour computed VolumeSMA20 alongside
+	// BB20; keeping the same default avoids surprising existing profiles).
+	VolumeSMAPeriod int `json:"volume_sma_period"`
+}
+
+// WithDefaults returns the IndicatorConfig with zero-valued fields filled
+// in from the legacy hardcoded defaults (SMA 20/50, EMA 12/26, RSI 14, MACD
+// 12/26/9, BB 20×2.0, ATR 14, VolumeSMA = bb_period). This is what the
+// IndicatorCalculator / IndicatorHandler use when a profile does not specify
+// every field — they get period-aware behaviour where the profile is
+// explicit and the legacy LTC PT15M baseline elsewhere.
+//
+// Method on a copy so callers cannot accidentally mutate the receiver.
+func (c IndicatorConfig) WithDefaults() IndicatorConfig {
+	if c.SMAShort <= 0 {
+		c.SMAShort = 20
+	}
+	if c.SMALong <= 0 {
+		c.SMALong = 50
+	}
+	if c.EMAFast <= 0 {
+		c.EMAFast = 12
+	}
+	if c.EMASlow <= 0 {
+		c.EMASlow = 26
+	}
+	if c.RSIPeriod <= 0 {
+		c.RSIPeriod = 14
+	}
+	if c.MACDFast <= 0 {
+		c.MACDFast = 12
+	}
+	if c.MACDSlow <= 0 {
+		c.MACDSlow = 26
+	}
+	if c.MACDSignal <= 0 {
+		c.MACDSignal = 9
+	}
+	if c.BBPeriod <= 0 {
+		c.BBPeriod = 20
+	}
+	if c.BBMultiplier <= 0 {
+		c.BBMultiplier = 2.0
+	}
+	if c.ATRPeriod <= 0 {
+		c.ATRPeriod = 14
+	}
+	if c.VolumeSMAPeriod <= 0 {
+		c.VolumeSMAPeriod = c.BBPeriod
+	}
+	return c
 }
 
 // StanceRulesConfig declares thresholds for rule-based stance classification
@@ -342,6 +398,20 @@ func (p StrategyProfile) Validate() error {
 	}
 	if ind.SMAShort > 0 && ind.SMALong > 0 && ind.SMAShort >= ind.SMALong {
 		errs = append(errs, fmt.Errorf("indicators.sma_short (%d) must be < sma_long (%d)", ind.SMAShort, ind.SMALong))
+	}
+	// EMAFast/Slow are optional: 0 means "fall back to defaults" via WithDefaults.
+	// Reject only obviously broken ordering (fast >= slow) and negative values.
+	if ind.EMAFast < 0 {
+		errs = append(errs, fmt.Errorf("indicators.ema_fast must be >= 0 (got %d)", ind.EMAFast))
+	}
+	if ind.EMASlow < 0 {
+		errs = append(errs, fmt.Errorf("indicators.ema_slow must be >= 0 (got %d)", ind.EMASlow))
+	}
+	if ind.EMAFast > 0 && ind.EMASlow > 0 && ind.EMAFast >= ind.EMASlow {
+		errs = append(errs, fmt.Errorf("indicators.ema_fast (%d) must be < ema_slow (%d)", ind.EMAFast, ind.EMASlow))
+	}
+	if ind.VolumeSMAPeriod < 0 {
+		errs = append(errs, fmt.Errorf("indicators.volume_sma_period must be >= 0 (got %d)", ind.VolumeSMAPeriod))
 	}
 	if ind.RSIPeriod <= 0 {
 		errs = append(errs, fmt.Errorf("indicators.rsi_period must be > 0 (got %d)", ind.RSIPeriod))

--- a/backend/internal/domain/entity/strategy_config_test.go
+++ b/backend/internal/domain/entity/strategy_config_test.go
@@ -212,13 +212,16 @@ func TestStrategyProfile_JSONRoundTrip(t *testing.T) {
   "indicators": {
     "sma_short": 10,
     "sma_long": 30,
+    "ema_fast": 0,
+    "ema_slow": 0,
     "rsi_period": 14,
     "macd_fast": 12,
     "macd_slow": 26,
     "macd_signal": 9,
     "bb_period": 20,
     "bb_multiplier": 2.0,
-    "atr_period": 14
+    "atr_period": 14,
+    "volume_sma_period": 0
   },
   "stance_rules": {
     "rsi_oversold": 20,

--- a/backend/internal/interfaces/api/handler/backtest.go
+++ b/backend/internal/interfaces/api/handler/backtest.go
@@ -307,10 +307,12 @@ func (h *BacktestHandler) Run(c *gin.Context) {
 	// "only override if > 0" guard.
 	var bbLookback int
 	var positionSizing *entity.PositionSizingConfig
+	var indicatorPeriods entity.IndicatorConfig
 	if profile != nil {
 		resolved := resolveRiskProfile(baseDir, profile)
 		bbLookback = resolved.StanceRules.BBSqueezeLookback
 		positionSizing = resolved.Risk.PositionSizing
+		indicatorPeriods = resolved.Indicators
 	}
 
 	fillSource, bookSource, err := h.buildExecutionSourcesForCfg(c.Request.Context(), cfg)
@@ -325,6 +327,7 @@ func (h *BacktestHandler) Run(c *gin.Context) {
 		PrimaryCandles:    primary.Candles,
 		HigherCandles:     higherCandles,
 		BBSqueezeLookback: bbLookback,
+		IndicatorPeriods:  indicatorPeriods,
 		PositionSizing:    positionSizing,
 		FillPriceSource:   fillSource,
 		BookSource:        bookSource,

--- a/backend/internal/interfaces/api/handler/backtest_multi.go
+++ b/backend/internal/interfaces/api/handler/backtest_multi.go
@@ -212,10 +212,12 @@ func (h *BacktestHandler) RunMulti(c *gin.Context) {
 			// the profile. Zero falls back to the legacy default of 5.
 			var bbLookback int
 			var positionSizing *entity.PositionSizingConfig
+			var indicatorPeriods entity.IndicatorConfig
 			if profile != nil {
 				resolved := resolveRiskProfile(baseDir, profile)
 				bbLookback = resolved.StanceRules.BBSqueezeLookback
 				positionSizing = resolved.Risk.PositionSizing
+				indicatorPeriods = resolved.Indicators
 			}
 			fillSrc, bookSrc, buildErr := h.buildExecutionSourcesForCfg(c.Request.Context(), cfg)
 			if buildErr != nil {
@@ -227,6 +229,7 @@ func (h *BacktestHandler) RunMulti(c *gin.Context) {
 				PrimaryCandles:    primary.Candles,
 				HigherCandles:     higherCandles,
 				BBSqueezeLookback: bbLookback,
+				IndicatorPeriods:  indicatorPeriods,
 				PositionSizing:    positionSizing,
 				FillPriceSource:   fillSrc,
 				BookSource:        bookSrc,

--- a/backend/internal/interfaces/api/handler/backtest_walkforward.go
+++ b/backend/internal/interfaces/api/handler/backtest_walkforward.go
@@ -265,6 +265,7 @@ func (h *BacktestHandler) RunWalkForward(c *gin.Context) {
 				PrimaryCandles:    primary.Candles,
 				HigherCandles:     higherCandles,
 				BBSqueezeLookback: profile.StanceRules.BBSqueezeLookback,
+				IndicatorPeriods:  profile.Indicators,
 				PositionSizing:    profile.Risk.PositionSizing,
 				FillPriceSource:   fillSrc,
 				BookSource:        bookSrc,

--- a/backend/internal/usecase/backtest/handler.go
+++ b/backend/internal/usecase/backtest/handler.go
@@ -130,6 +130,13 @@ type IndicatorHandler struct {
 	// effect (cycle43 discovered this field was a silent no-op).
 	bbSqueezeLookback int
 
+	// periods drives the lookback periods for SMA / EMA / RSI / MACD / BB /
+	// ATR / VolumeSMA. Filled from a StrategyProfile via SetIndicatorPeriods
+	// at composition time; zero-valued fields fall back to legacy defaults
+	// via IndicatorConfig.WithDefaults so callers without a profile keep the
+	// pre-PR-B behaviour.
+	periods entity.IndicatorConfig
+
 	primaryCandles map[int64][]entity.Candle
 	higherCandles  map[int64][]entity.Candle
 
@@ -182,9 +189,23 @@ func NewIndicatorHandler(primaryInterval, higherTFInterval string, bufferSize in
 		HigherTFInterval:  higherTFInterval,
 		BufferSize:        bufferSize,
 		bbSqueezeLookback: 5, // cycle44: legacy default, overridable via SetBBSqueezeLookback
+		periods:           entity.IndicatorConfig{}.WithDefaults(),
 		primaryCandles:    make(map[int64][]entity.Candle),
 		higherCandles:     make(map[int64][]entity.Candle),
 	}
+}
+
+// SetIndicatorPeriods overrides the lookback periods used inside
+// calculateIndicatorSet for SMA / EMA / RSI / MACD / BB / ATR / VolumeSMA.
+// Zero-valued fields fall back to the legacy defaults via
+// IndicatorConfig.WithDefaults. Mirrors usecase.IndicatorCalculator's
+// SetIndicatorPeriods so live and backtest paths share one knob set.
+//
+// PR-C will extend this to ADX / Stochastics / Donchian / CMF / OBVSlope /
+// Ichimoku; until then those continue to use their hardcoded periods inside
+// calculateIndicatorSet.
+func (h *IndicatorHandler) SetIndicatorPeriods(p entity.IndicatorConfig) {
+	h.periods = p.WithDefaults()
 }
 
 // attachBookDerived populates Microprice / OFI on the supplied IndicatorSet
@@ -246,13 +267,13 @@ func (h *IndicatorHandler) Handle(_ context.Context, event entity.Event) ([]enti
 	switch candleEvent.Interval {
 	case h.PrimaryInterval:
 		h.primaryCandles[candleEvent.SymbolID] = appendCapped(h.primaryCandles[candleEvent.SymbolID], candleEvent.Candle, h.BufferSize)
-		primary := calculateIndicatorSet(candleEvent.SymbolID, h.primaryCandles[candleEvent.SymbolID], h.bbSqueezeLookback)
+		primary := calculateIndicatorSet(candleEvent.SymbolID, h.primaryCandles[candleEvent.SymbolID], h.periods, h.bbSqueezeLookback)
 		h.attachBookDerived(&primary, candleEvent.SymbolID, candleEvent.Timestamp)
 
 		var higherTF *entity.IndicatorSet
 		if h.HigherTFInterval != "" {
 			if selected := selectCandlesAtOrBefore(h.higherCandles[candleEvent.SymbolID], candleEvent.Timestamp); len(selected) > 0 {
-				set := calculateIndicatorSet(candleEvent.SymbolID, selected, h.bbSqueezeLookback)
+				set := calculateIndicatorSet(candleEvent.SymbolID, selected, h.periods, h.bbSqueezeLookback)
 				higherTF = &set
 			}
 		}
@@ -817,15 +838,24 @@ func selectCandlesAtOrBefore(candles []entity.Candle, timestamp int64) []entity.
 }
 
 // calculateIndicatorSet builds an IndicatorSet from oldest-first candles.
+// periods drives SMA / EMA / RSI / MACD / BB / ATR / VolumeSMA lookbacks; a
+// zero-valued IndicatorConfig falls back to legacy defaults via WithDefaults
+// so legacy call sites without a profile keep their pre-PR-B behaviour.
+//
 // bbSqueezeLookback is the window (in bars) used to detect a recent BB
 // squeeze; 0 disables the detection (RecentSqueeze stays false), matching
 // the cycle43 "0 = disabled" convention for the other integer stance
 // parameters. Legacy callers can pass 5 to preserve pre-cycle44 behaviour.
-func calculateIndicatorSet(symbolID int64, candles []entity.Candle, bbSqueezeLookback int) entity.IndicatorSet {
+//
+// PR-C will profile-drive ADX / Stochastics / Donchian / CMF / OBVSlope /
+// Ichimoku; until then those use their hardcoded periods below.
+func calculateIndicatorSet(symbolID int64, candles []entity.Candle, periods entity.IndicatorConfig, bbSqueezeLookback int) entity.IndicatorSet {
 	n := len(candles)
 	if n == 0 {
 		return entity.IndicatorSet{SymbolID: symbolID}
 	}
+
+	periods = periods.WithDefaults()
 
 	closes := make([]float64, n)
 	highs := make([]float64, n)
@@ -838,59 +868,60 @@ func calculateIndicatorSet(symbolID int64, candles []entity.Candle, bbSqueezeLoo
 
 	result := entity.IndicatorSet{
 		SymbolID:  symbolID,
-		SMAShort:     floatToPtr(indicator.SMA(closes, 20)),
-		SMALong:     floatToPtr(indicator.SMA(closes, 50)),
-		EMAFast:     floatToPtr(indicator.EMA(closes, 12)),
-		EMASlow:     floatToPtr(indicator.EMA(closes, 26)),
-		RSI:     floatToPtr(indicator.RSI(closes, 14)),
+		SMAShort:  floatToPtr(indicator.SMA(closes, periods.SMAShort)),
+		SMALong:   floatToPtr(indicator.SMA(closes, periods.SMALong)),
+		EMAFast:   floatToPtr(indicator.EMA(closes, periods.EMAFast)),
+		EMASlow:   floatToPtr(indicator.EMA(closes, periods.EMASlow)),
+		RSI:       floatToPtr(indicator.RSI(closes, periods.RSIPeriod)),
 		Timestamp: candles[n-1].Time,
 	}
 
-	macdLine, signalLine, histogram := indicator.MACD(closes, 12, 26, 9)
+	macdLine, signalLine, histogram := indicator.MACD(closes, periods.MACDFast, periods.MACDSlow, periods.MACDSignal)
 	result.MACDLine = floatToPtr(macdLine)
 	result.SignalLine = floatToPtr(signalLine)
 	result.Histogram = floatToPtr(histogram)
 
-	bbUpper, bbMiddle, bbLower, bbBandwidth := indicator.BollingerBands(closes, 20, 2.0)
+	bbUpper, bbMiddle, bbLower, bbBandwidth := indicator.BollingerBands(closes, periods.BBPeriod, periods.BBMultiplier)
 	result.BBUpper = floatToPtr(bbUpper)
 	result.BBMiddle = floatToPtr(bbMiddle)
 	result.BBLower = floatToPtr(bbLower)
 	result.BBBandwidth = floatToPtr(bbBandwidth)
 
-	result.ATR = floatToPtr(indicator.ATR(highs, lows, closes, 14))
+	result.ATR = floatToPtr(indicator.ATR(highs, lows, closes, periods.ATRPeriod))
 
-	// PR-6: ADX family. Mirror the live-pipeline calculator.
+	// PR-6: ADX family. Mirror the live-pipeline calculator. PR-C will profile-drive.
 	adxVal, plusDI, minusDI := indicator.ADX(highs, lows, closes, 14)
 	result.ADX = floatToPtr(adxVal)
 	result.PlusDI = floatToPtr(plusDI)
 	result.MinusDI = floatToPtr(minusDI)
 
 	// PR-7: Stochastics (14, 3, 3) + Stochastic RSI (14, 14). Mirror the
-	// live-pipeline calculator.
+	// live-pipeline calculator. PR-C will profile-drive.
 	stochK, stochD := indicator.Stochastics(highs, lows, closes, 14, 3, 3)
 	result.StochK = floatToPtr(stochK)
 	result.StochD = floatToPtr(stochD)
 	result.StochRSI = floatToPtr(indicator.StochasticRSI(closes, 14, 14))
 
 	// PR-8: Ichimoku. Mirror the live pipeline; nil when all five lines
-	// are still in warmup.
+	// are still in warmup. PR-C will profile-drive.
 	if snap := buildIchimokuSnapshotBT(indicator.Ichimoku(highs, lows, closes, 9, 26, 52)); snap != nil {
 		result.Ichimoku = snap
 	}
 
 	// PR-11: Donchian Channel (20-bar default). Mirror the live pipeline;
-	// nil until 20 bars of history are available.
+	// nil until 20 bars of history are available. PR-C will profile-drive.
 	donU, donL, donM := indicator.Donchian(highs, lows, 20)
 	result.DonchianUpper = floatToPtr(donU)
 	result.DonchianLower = floatToPtr(donL)
 	result.DonchianMiddle = floatToPtr(donM)
 
-	// Volume indicators
+	// Volume indicators. VolumeSMA shares the BB period by default (legacy
+	// behaviour was VolumeSMA20 alongside BB20).
 	volumes := make([]float64, n)
 	for i, c := range candles {
 		volumes[i] = c.Volume
 	}
-	volSMA := indicator.VolumeSMA(volumes, 20)
+	volSMA := indicator.VolumeSMA(volumes, periods.VolumeSMAPeriod)
 	result.VolumeSMA = floatToPtr(volSMA)
 	if !math.IsNaN(volSMA) && volSMA > 0 && n > 0 {
 		vr := indicator.VolumeRatio(volumes[n-1], volSMA)
@@ -898,25 +929,26 @@ func calculateIndicatorSet(symbolID int64, candles []entity.Candle, bbSqueezeLoo
 	}
 
 	// PR-9: OBV + CMF (volume-based). Mirror the live-pipeline calculator.
+	// PR-C will profile-drive.
 	result.OBV = floatToPtr(indicator.OBV(closes, volumes))
 	result.OBVSlope = floatToPtr(indicator.OBVSlope(closes, volumes, 20))
 	result.CMF = floatToPtr(indicator.CMF(highs, lows, closes, volumes, 20))
 
 	// RecentSqueeze: check if any of the last `bbSqueezeLookback` candles
-	// had BBBandwidth < 0.02. cycle44: now honours the profile field via
-	// the handler's bbSqueezeLookback. 0 keeps RecentSqueeze false (gate
-	// disabled). Capped by n-19 so small warmup windows do not read past
-	// the start of BB computation.
-	if n >= 20 && bbSqueezeLookback > 0 {
+	// had BBBandwidth < threshold. cycle44: now honours the profile field
+	// via the handler's bbSqueezeLookback. 0 keeps RecentSqueeze false
+	// (gate disabled). Capped by n-(bbPeriod-1) so small warmup windows
+	// do not read past the start of BB computation.
+	if n >= periods.BBPeriod && bbSqueezeLookback > 0 {
 		recentSqueeze := false
 		lookback := bbSqueezeLookback
-		if lookback > n-19 {
-			lookback = n - 19
+		if lookback > n-(periods.BBPeriod-1) {
+			lookback = n - (periods.BBPeriod - 1)
 		}
 		for i := 0; i < lookback; i++ {
 			offset := n - 1 - i
 			windowCloses := closes[:offset+1]
-			_, _, _, bw := indicator.BollingerBands(windowCloses, 20, 2.0)
+			_, _, _, bw := indicator.BollingerBands(windowCloses, periods.BBPeriod, periods.BBMultiplier)
 			if !math.IsNaN(bw) && bw < 0.02 {
 				recentSqueeze = true
 				break

--- a/backend/internal/usecase/backtest/indicator_periods_test.go
+++ b/backend/internal/usecase/backtest/indicator_periods_test.go
@@ -1,0 +1,161 @@
+package backtest
+
+import (
+	"math"
+	"testing"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+)
+
+// TestCalculateIndicatorSet_PeriodsDriveValues is the PR-B wiring guard:
+// it proves that calculateIndicatorSet actually consumes the IndicatorConfig
+// argument, rather than ignoring it the way SetBBSqueezeLookback was
+// originally a silent no-op (cycle43). Two runs on the same trending
+// candle series with different SMA / EMA / RSI / BB / ATR / VolumeSMA
+// periods must produce numerically distinguishable values.
+//
+// We use a strong linear uptrend so longer lookbacks lag the price
+// noticeably more than shorter ones — every period axis becomes a visible
+// signal. A passive guard (just checking that the values are non-nil)
+// would have missed cycle43-style "the field is set but the period is
+// hardcoded" regressions.
+func TestCalculateIndicatorSet_PeriodsDriveValues(t *testing.T) {
+	candles := buildTrendingCandles(120)
+
+	defaults := calculateIndicatorSet(42, candles, entity.IndicatorConfig{}, 0)
+	scaled := calculateIndicatorSet(42, candles, entity.IndicatorConfig{
+		SMAShort:        60,
+		SMALong:         100,
+		EMAFast:         36,
+		EMASlow:         78,
+		RSIPeriod:       42,
+		MACDFast:        24,
+		MACDSlow:        52,
+		MACDSignal:      18,
+		BBPeriod:        60,
+		BBMultiplier:    2.0,
+		ATRPeriod:       42,
+		VolumeSMAPeriod: 60,
+	}, 0)
+
+	cases := []struct {
+		name string
+		// short/long extractor — both must be non-nil and differ between
+		// the two runs to count as proof the period is honoured.
+		gotDefault, gotScaled *float64
+	}{
+		{"SMAShort", defaults.SMAShort, scaled.SMAShort},
+		{"SMALong", defaults.SMALong, scaled.SMALong},
+		{"EMAFast", defaults.EMAFast, scaled.EMAFast},
+		{"EMASlow", defaults.EMASlow, scaled.EMASlow},
+		{"RSI", defaults.RSI, scaled.RSI},
+		{"MACDLine", defaults.MACDLine, scaled.MACDLine},
+		{"BBMiddle", defaults.BBMiddle, scaled.BBMiddle},
+		{"ATR", defaults.ATR, scaled.ATR},
+		{"VolumeSMA", defaults.VolumeSMA, scaled.VolumeSMA},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.gotDefault == nil || tc.gotScaled == nil {
+				t.Fatalf("%s: expected non-nil values for both runs (defaults=%v, scaled=%v)", tc.name, tc.gotDefault, tc.gotScaled)
+			}
+			if math.Abs(*tc.gotDefault-*tc.gotScaled) < 1e-6 {
+				t.Errorf("%s: defaults=%.6f, scaled=%.6f — values are too close; the period flag is likely silently ignored", tc.name, *tc.gotDefault, *tc.gotScaled)
+			}
+		})
+	}
+}
+
+// TestCalculateIndicatorSet_DefaultsMatchLegacy proves that an empty
+// IndicatorConfig is bit-identical to the legacy hardcoded periods (SMA
+// 20/50, EMA 12/26, RSI 14, MACD 12/26/9, BB 20×2.0, ATR 14, VolumeSMA 20).
+// This is the pre-PR-B equivalence guarantee — production.json is allowed to
+// omit the indicator block entirely without disturbing existing results.
+func TestCalculateIndicatorSet_DefaultsMatchLegacy(t *testing.T) {
+	candles := buildTrendingCandles(120)
+
+	withZero := calculateIndicatorSet(42, candles, entity.IndicatorConfig{}, 0)
+	withExplicit := calculateIndicatorSet(42, candles, entity.IndicatorConfig{
+		SMAShort:        20,
+		SMALong:         50,
+		EMAFast:         12,
+		EMASlow:         26,
+		RSIPeriod:       14,
+		MACDFast:        12,
+		MACDSlow:        26,
+		MACDSignal:      9,
+		BBPeriod:        20,
+		BBMultiplier:    2.0,
+		ATRPeriod:       14,
+		VolumeSMAPeriod: 20,
+	}, 0)
+
+	if !floatPtrEq(withZero.SMAShort, withExplicit.SMAShort, 1e-9) {
+		t.Errorf("SMAShort: zero=%v explicit=%v", deref(withZero.SMAShort), deref(withExplicit.SMAShort))
+	}
+	if !floatPtrEq(withZero.SMALong, withExplicit.SMALong, 1e-9) {
+		t.Errorf("SMALong: zero=%v explicit=%v", deref(withZero.SMALong), deref(withExplicit.SMALong))
+	}
+	if !floatPtrEq(withZero.EMAFast, withExplicit.EMAFast, 1e-9) {
+		t.Errorf("EMAFast: zero=%v explicit=%v", deref(withZero.EMAFast), deref(withExplicit.EMAFast))
+	}
+	if !floatPtrEq(withZero.EMASlow, withExplicit.EMASlow, 1e-9) {
+		t.Errorf("EMASlow: zero=%v explicit=%v", deref(withZero.EMASlow), deref(withExplicit.EMASlow))
+	}
+	if !floatPtrEq(withZero.RSI, withExplicit.RSI, 1e-9) {
+		t.Errorf("RSI: zero=%v explicit=%v", deref(withZero.RSI), deref(withExplicit.RSI))
+	}
+	if !floatPtrEq(withZero.BBMiddle, withExplicit.BBMiddle, 1e-9) {
+		t.Errorf("BBMiddle: zero=%v explicit=%v", deref(withZero.BBMiddle), deref(withExplicit.BBMiddle))
+	}
+	if !floatPtrEq(withZero.ATR, withExplicit.ATR, 1e-9) {
+		t.Errorf("ATR: zero=%v explicit=%v", deref(withZero.ATR), deref(withExplicit.ATR))
+	}
+	if !floatPtrEq(withZero.VolumeSMA, withExplicit.VolumeSMA, 1e-9) {
+		t.Errorf("VolumeSMA: zero=%v explicit=%v", deref(withZero.VolumeSMA), deref(withExplicit.VolumeSMA))
+	}
+}
+
+// buildTrendingCandles produces a noisy uptrend that exercises every
+// indicator family — different lookbacks see different running averages,
+// RSI gain/loss balance shifts, ATR window includes more / fewer outlier
+// bars, etc. A pure linear trend was rejected because RSI saturates at
+// 100 and ATR collapses to a constant, masking period-flag regressions.
+func buildTrendingCandles(n int) []entity.Candle {
+	out := make([]entity.Candle, n)
+	for i := range out {
+		// Sinusoidal noise on top of a linear drift gives every period
+		// axis a different running mean / variance, so longer lookbacks
+		// produce numerically distinct values from shorter ones.
+		drift := float64(i) * 0.8
+		osc := 5.0 * math.Sin(float64(i)*0.4)
+		base := 100.0 + drift + osc
+		// Variable bar range so ATR depends on which bars the window
+		// includes, not just the slope.
+		span := 1.0 + 0.5*math.Cos(float64(i)*0.3)
+		out[i] = entity.Candle{
+			Time:   int64(i) * 60_000,
+			Open:   base,
+			High:   base + span,
+			Low:    base - span,
+			Close:  base + 0.3*math.Sin(float64(i)*0.7),
+			Volume: 100 + 30*math.Sin(float64(i)*0.2),
+		}
+	}
+	return out
+}
+
+func floatPtrEq(a, b *float64, eps float64) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return math.Abs(*a-*b) < eps
+}
+
+func deref(p *float64) any {
+	if p == nil {
+		return "<nil>"
+	}
+	return *p
+}

--- a/backend/internal/usecase/backtest/recent_squeeze_test.go
+++ b/backend/internal/usecase/backtest/recent_squeeze_test.go
@@ -13,7 +13,7 @@ import (
 func TestCalculateIndicatorSet_BBSqueezeLookbackZeroDisables(t *testing.T) {
 	candles := buildTightRangeCandles(80)
 
-	got := calculateIndicatorSet(42, candles, 0)
+	got := calculateIndicatorSet(42, candles, entity.IndicatorConfig{}, 0)
 	if got.RecentSqueeze != nil {
 		t.Fatalf("bbSqueezeLookback=0 should leave RecentSqueeze nil; got %v", *got.RecentSqueeze)
 	}
@@ -33,8 +33,8 @@ func TestCalculateIndicatorSet_BBSqueezeLookbackZeroDisables(t *testing.T) {
 func TestCalculateIndicatorSet_BBSqueezeLookbackDrivesDetection(t *testing.T) {
 	candles := buildTightRangeCandles(80)
 
-	off := calculateIndicatorSet(42, candles, 0)
-	on := calculateIndicatorSet(42, candles, 5)
+	off := calculateIndicatorSet(42, candles, entity.IndicatorConfig{}, 0)
+	on := calculateIndicatorSet(42, candles, entity.IndicatorConfig{}, 5)
 
 	if off.RecentSqueeze != nil {
 		t.Fatalf("off lookback=0 should leave RecentSqueeze nil; got %v", *off.RecentSqueeze)

--- a/backend/internal/usecase/backtest/runner.go
+++ b/backend/internal/usecase/backtest/runner.go
@@ -46,6 +46,13 @@ type RunInput struct {
 	// callers that don't set a profile (baseline DefaultStrategy runs).
 	BBSqueezeLookback int
 
+	// IndicatorPeriods drives the lookback periods used inside
+	// calculateIndicatorSet for SMA / EMA / RSI / MACD / BB / ATR /
+	// VolumeSMA. Zero-valued fields fall back to the legacy defaults via
+	// IndicatorConfig.WithDefaults so callers without a profile keep the
+	// pre-PR-B behaviour bit-identical.
+	IndicatorPeriods entity.IndicatorConfig
+
 	// PositionSizing declares dynamic lot sizing for the run. nil / zero-value
 	// keeps the legacy fixed-lot behaviour (TradeAmount is used verbatim on
 	// every approved signal).
@@ -188,6 +195,11 @@ func (r *BacktestRunner) Run(ctx context.Context, input RunInput) (*entity.Backt
 	if input.BBSqueezeLookback > 0 {
 		indicatorHandler.SetBBSqueezeLookback(input.BBSqueezeLookback)
 	}
+	// PR-B: profile-driven indicator periods. WithDefaults inside
+	// SetIndicatorPeriods means an empty IndicatorPeriods is bit-identical to
+	// the pre-PR-B hardcoded periods; a profile with non-zero fields lets PT5M
+	// / PT1M strategies tune their own lookbacks.
+	indicatorHandler.SetIndicatorPeriods(input.IndicatorPeriods)
 	// PR-J: enable Microprice / OFI when the caller supplied a BookSource.
 	// Same source the pre-trade gate uses, so backtest runs see the same
 	// L2 history.

--- a/backend/internal/usecase/indicator.go
+++ b/backend/internal/usecase/indicator.go
@@ -17,10 +17,21 @@ type IndicatorCalculator struct {
 	// a profile should call SetBBSqueezeLookback so stance_rules.
 	// bb_squeeze_lookback takes effect. 0 disables RecentSqueeze entirely.
 	bbSqueezeLookback int
+
+	// periods drives all indicator lookbacks computed in Calculate. Filled
+	// from a StrategyProfile via SetIndicatorPeriods at composition time;
+	// zero-valued fields fall back to legacy defaults via
+	// IndicatorConfig.WithDefaults so existing call sites behave the same
+	// without a profile.
+	periods entity.IndicatorConfig
 }
 
 func NewIndicatorCalculator(repo repository.MarketDataRepository) *IndicatorCalculator {
-	return &IndicatorCalculator{repo: repo, bbSqueezeLookback: 5}
+	return &IndicatorCalculator{
+		repo:              repo,
+		bbSqueezeLookback: 5,
+		periods:           entity.IndicatorConfig{}.WithDefaults(),
+	}
 }
 
 // SetBBSqueezeLookback lets the composition root override the window
@@ -31,6 +42,17 @@ func (c *IndicatorCalculator) SetBBSqueezeLookback(n int) {
 		n = 0
 	}
 	c.bbSqueezeLookback = n
+}
+
+// SetIndicatorPeriods overrides the lookback periods used for SMA / EMA /
+// RSI / MACD / BB / ATR / VolumeSMA. Zero-valued fields are filled in from
+// the legacy hardcoded defaults via IndicatorConfig.WithDefaults so a
+// partial profile still produces a working set.
+//
+// PR-C will extend this to ADX / Stochastics / Donchian / CMF / OBVSlope /
+// Ichimoku; until then those continue to use their hardcoded periods.
+func (c *IndicatorCalculator) SetIndicatorPeriods(p entity.IndicatorConfig) {
+	c.periods = p.WithDefaults()
 }
 
 // Calculate computes all technical indicators for the given symbol and interval.
@@ -61,31 +83,34 @@ func (c *IndicatorCalculator) Calculate(ctx context.Context, symbolID int64, int
 		timestamp = candles[0].Time // newest candle's timestamp
 	}
 
+	periods := c.periods.WithDefaults()
+
 	result := &entity.IndicatorSet{
 		SymbolID:  symbolID,
-		SMAShort:     toPtr(indicator.SMA(prices, 20)),
-		SMALong:     toPtr(indicator.SMA(prices, 50)),
-		EMAFast:     toPtr(indicator.EMA(prices, 12)),
-		EMASlow:     toPtr(indicator.EMA(prices, 26)),
-		RSI:     toPtr(indicator.RSI(prices, 14)),
+		SMAShort:  toPtr(indicator.SMA(prices, periods.SMAShort)),
+		SMALong:   toPtr(indicator.SMA(prices, periods.SMALong)),
+		EMAFast:   toPtr(indicator.EMA(prices, periods.EMAFast)),
+		EMASlow:   toPtr(indicator.EMA(prices, periods.EMASlow)),
+		RSI:       toPtr(indicator.RSI(prices, periods.RSIPeriod)),
 		Timestamp: timestamp,
 	}
 
-	macdLine, signalLine, histogram := indicator.MACD(prices, 12, 26, 9)
+	macdLine, signalLine, histogram := indicator.MACD(prices, periods.MACDFast, periods.MACDSlow, periods.MACDSignal)
 	result.MACDLine = toPtr(macdLine)
 	result.SignalLine = toPtr(signalLine)
 	result.Histogram = toPtr(histogram)
 
-	bbUpper, bbMiddle, bbLower, bbBandwidth := indicator.BollingerBands(prices, 20, 2.0)
+	bbUpper, bbMiddle, bbLower, bbBandwidth := indicator.BollingerBands(prices, periods.BBPeriod, periods.BBMultiplier)
 	result.BBUpper = toPtr(bbUpper)
 	result.BBMiddle = toPtr(bbMiddle)
 	result.BBLower = toPtr(bbLower)
 	result.BBBandwidth = toPtr(bbBandwidth)
 
-	result.ATR = toPtr(indicator.ATR(highs, lows, prices, 14))
+	result.ATR = toPtr(indicator.ATR(highs, lows, prices, periods.ATRPeriod))
 
 	// PR-6: ADX family. ADX/PlusDI/MinusDI return NaN until 2*period+1
 	// bars are available; toPtr collapses that to nil for the caller.
+	// PR-C will profile-drive this period.
 	adxVal, plusDI, minusDI := indicator.ADX(highs, lows, prices, 14)
 	result.ADX = toPtr(adxVal)
 	result.PlusDI = toPtr(plusDI)
@@ -93,6 +118,7 @@ func (c *IndicatorCalculator) Calculate(ctx context.Context, symbolID int64, int
 
 	// PR-7: Stochastics (14, 3, 3) + Stochastic RSI (14, 14). Both return
 	// NaN -> nil pointer when the warmup window is not filled yet.
+	// PR-C will profile-drive these periods.
 	stochK, stochD := indicator.Stochastics(highs, lows, prices, 14, 3, 3)
 	result.StochK = toPtr(stochK)
 	result.StochD = toPtr(stochD)
@@ -100,6 +126,7 @@ func (c *IndicatorCalculator) Calculate(ctx context.Context, symbolID int64, int
 
 	// PR-8: Ichimoku. Each of the five lines may be NaN independently during
 	// warmup; buildIchimokuSnapshot returns nil when every line is unknown.
+	// PR-C will profile-drive these periods.
 	if snap := buildIchimokuSnapshot(indicator.Ichimoku(highs, lows, prices, 9, 26, 52)); snap != nil {
 		result.Ichimoku = snap
 	}
@@ -107,6 +134,7 @@ func (c *IndicatorCalculator) Calculate(ctx context.Context, symbolID int64, int
 	// PR-11: Donchian Channel (20-bar default). Mirror the other range-of-N
 	// indicators — NaN until 20 bars of history are available; toPtr
 	// collapses that into nil pointers for downstream gates.
+	// PR-C will profile-drive this period.
 	donU, donL, donM := indicator.Donchian(highs, lows, 20)
 	result.DonchianUpper = toPtr(donU)
 	result.DonchianLower = toPtr(donL)
@@ -117,7 +145,7 @@ func (c *IndicatorCalculator) Calculate(ctx context.Context, symbolID int64, int
 	for i, cd := range candles {
 		volumes[n-1-i] = cd.Volume
 	}
-	volSMA := indicator.VolumeSMA(volumes, 20)
+	volSMA := indicator.VolumeSMA(volumes, periods.VolumeSMAPeriod)
 	result.VolumeSMA = toPtr(volSMA)
 	if !math.IsNaN(volSMA) && volSMA > 0 && n > 0 {
 		vr := indicator.VolumeRatio(volumes[n-1], volSMA)
@@ -127,6 +155,7 @@ func (c *IndicatorCalculator) Calculate(ctx context.Context, symbolID int64, int
 	// PR-9: OBV + CMF (volume-based). OBVSlope carries the gate signal
 	// (cumulative buying volume over 20 bars); raw OBV is exposed for
 	// diagnostics / frontend charting. CMF is bounded in [-1, 1].
+	// PR-C will profile-drive these periods.
 	result.OBV = toPtr(indicator.OBV(prices, volumes))
 	result.OBVSlope = toPtr(indicator.OBVSlope(prices, volumes, 20))
 	result.CMF = toPtr(indicator.CMF(highs, lows, prices, volumes, 20))
@@ -134,17 +163,18 @@ func (c *IndicatorCalculator) Calculate(ctx context.Context, symbolID int64, int
 	// RecentSqueeze: check if any of the last `c.bbSqueezeLookback`
 	// candles had BBBandwidth < 0.02. cycle44: profile's stance_rules
 	// now drives this via SetBBSqueezeLookback; 0 disables the gate
-	// (RecentSqueeze stays nil).
-	if n >= 20 && c.bbSqueezeLookback > 0 {
+	// (RecentSqueeze stays nil). bb period must match the BB calculation
+	// above so the squeeze window is consistent.
+	if n >= periods.BBPeriod && c.bbSqueezeLookback > 0 {
 		recentSqueeze := false
 		lookback := c.bbSqueezeLookback
-		if lookback > n-19 {
-			lookback = n - 19
+		if lookback > n-(periods.BBPeriod-1) {
+			lookback = n - (periods.BBPeriod - 1)
 		}
 		for i := 0; i < lookback; i++ {
 			offset := n - 1 - i
 			windowPrices := prices[:offset+1]
-			_, _, _, bw := indicator.BollingerBands(windowPrices, 20, 2.0)
+			_, _, _, bw := indicator.BollingerBands(windowPrices, periods.BBPeriod, periods.BBMultiplier)
 			if !math.IsNaN(bw) && bw < 0.02 {
 				recentSqueeze = true
 				break

--- a/backend/internal/usecase/indicator_test.go
+++ b/backend/internal/usecase/indicator_test.go
@@ -3,6 +3,7 @@ package usecase
 import (
 	"context"
 	"encoding/json"
+	"math"
 	"testing"
 
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
@@ -74,6 +75,89 @@ func TestIndicatorCalculator_InsufficientData(t *testing.T) {
 	// SMAShort requires 20 data points, so should be nil
 	if result.SMAShort != nil {
 		t.Fatalf("SMAShort should be nil with only 5 data points, got %f", *result.SMAShort)
+	}
+}
+
+// TestIndicatorCalculator_SetIndicatorPeriods is the PR-B wiring guard for
+// the live calculator. SetIndicatorPeriods must actually feed into the SMA /
+// EMA / RSI / BB / ATR / VolumeSMA computations, not just store a value.
+//
+// Two runs on the same noisy candle series with different periods must
+// produce numerically distinguishable values. A passive guard (just
+// checking the call doesn't panic) would have missed cycle43-style "the
+// field is set but the period is hardcoded" regressions.
+func TestIndicatorCalculator_SetIndicatorPeriods(t *testing.T) {
+	repo := newMockRepo()
+	ctx := context.Background()
+
+	// 200 noisy candles so longer-period lookbacks have a visibly different
+	// running mean from shorter ones. Linear-only data would let RSI saturate.
+	candles := make([]entity.Candle, 200)
+	for i := range candles {
+		drift := float64(i) * 0.7
+		osc := 5.0 * math.Sin(float64(i)*0.4)
+		base := 100.0 + drift + osc
+		span := 1.0 + 0.5*math.Cos(float64(i)*0.3)
+		candles[i] = entity.Candle{
+			Time:   int64(1700000000000 + i*60000),
+			Open:   base,
+			High:   base + span,
+			Low:    base - span,
+			Close:  base + 0.3*math.Sin(float64(i)*0.7),
+			Volume: 100 + 30*math.Sin(float64(i)*0.2),
+		}
+	}
+	_ = repo.SaveCandles(ctx, 7, "PT1M", candles)
+
+	defaults := NewIndicatorCalculator(repo)
+	defaultsRes, err := defaults.Calculate(ctx, 7, "PT1M")
+	if err != nil {
+		t.Fatalf("defaults: %v", err)
+	}
+
+	scaled := NewIndicatorCalculator(repo)
+	scaled.SetIndicatorPeriods(entity.IndicatorConfig{
+		SMAShort:        60,
+		SMALong:         100,
+		EMAFast:         36,
+		EMASlow:         78,
+		RSIPeriod:       42,
+		MACDFast:        24,
+		MACDSlow:        52,
+		MACDSignal:      18,
+		BBPeriod:        60,
+		BBMultiplier:    2.0,
+		ATRPeriod:       42,
+		VolumeSMAPeriod: 60,
+	})
+	scaledRes, err := scaled.Calculate(ctx, 7, "PT1M")
+	if err != nil {
+		t.Fatalf("scaled: %v", err)
+	}
+
+	cases := []struct {
+		name             string
+		def, scl         *float64
+	}{
+		{"SMAShort", defaultsRes.SMAShort, scaledRes.SMAShort},
+		{"SMALong", defaultsRes.SMALong, scaledRes.SMALong},
+		{"EMAFast", defaultsRes.EMAFast, scaledRes.EMAFast},
+		{"EMASlow", defaultsRes.EMASlow, scaledRes.EMASlow},
+		{"RSI", defaultsRes.RSI, scaledRes.RSI},
+		{"MACDLine", defaultsRes.MACDLine, scaledRes.MACDLine},
+		{"BBMiddle", defaultsRes.BBMiddle, scaledRes.BBMiddle},
+		{"ATR", defaultsRes.ATR, scaledRes.ATR},
+		{"VolumeSMA", defaultsRes.VolumeSMA, scaledRes.VolumeSMA},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.def == nil || tc.scl == nil {
+				t.Fatalf("%s: expected both non-nil (def=%v scl=%v)", tc.name, tc.def, tc.scl)
+			}
+			if math.Abs(*tc.def-*tc.scl) < 1e-6 {
+				t.Errorf("%s: defaults=%.6f scaled=%.6f — values too close; period flag likely silently ignored", tc.name, *tc.def, *tc.scl)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- Core 指標 (SMA/EMA/RSI/MACD/BB/ATR/VolumeSMA) の lookback period を `StrategyProfile.Indicators` から読むようにした
- PT5M / PT1M 戦略でタイムフレームに合わせた期間調整が可能に
- 既存 LTC PT15M production.json は profile 値が現ハードコードと同じなので bit-identical (等価性は test で確認)

## なぜ

PR-A で IndicatorSet フィールド名を期間中立にしたのに続き、本 PR で計算側を profile 駆動にする。これで PT5M で SMA60/EMA36/RSI42/BB60 等を指定して \"PT15M 等価のスケール\" を作れるようになる。

## 変更点

### entity.IndicatorConfig 拡張
- 新規フィールド: \`ema_fast\` / \`ema_slow\` / \`volume_sma_period\` (従来ハードコード 12/26/20)
- \`WithDefaults()\` メソッド: 0 値を legacy 値で埋める単一の source of truth
- \`Validate()\`: ema_fast >= 0, ema_slow >= 0, ema_fast < ema_slow, volume_sma_period >= 0

### usecase.IndicatorCalculator (live)
- \`SetIndicatorPeriods(IndicatorConfig)\` を追加
- \`Calculate\` 内で SMA/EMA/RSI/MACD/BB/ATR/VolumeSMA を profile 期間で計算

### usecase/backtest.IndicatorHandler (backtest)
- 同じく \`SetIndicatorPeriods(IndicatorConfig)\` を追加
- \`calculateIndicatorSet(symbolID, candles, periods, bbSqueezeLookback)\` にシグネチャ変更

### 配線
- \`backtest.RunInput.IndicatorPeriods\` 追加 → runner で \`SetIndicatorPeriods\` 呼び出し
- API: \`backtest.go\` / \`backtest_multi.go\` / \`backtest_walkforward.go\` で \`profile.Indicators\` を渡す
- CLI: \`cmd/backtest/main.go\` の \`buildRunInput\` で同様

## scope outside this PR

下記 indicator は本 PR ではまだハードコード。PR-C で profile 駆動化:
- ADX (period=14)
- Stochastics (k=14, smoothK=3, smoothD=3)
- Stochastic RSI (rsi=14, stoch=14)
- Donchian Channel (period=20)
- OBV slope (period=20)
- CMF (period=20)
- Ichimoku (tenkan=9, kijun=26, senkouB=52)

各箇所に \`PR-C will profile-drive this period\` の TODO コメントを残してある。

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./... -count=1\` 全パッケージ pass (production.json 等価性維持)
- [x] **配線確認テスト** 追加:
  - \`usecase/backtest/indicator_periods_test.go\` — \`PeriodsDriveValues\` (異なる期間で値が変わる) + \`DefaultsMatchLegacy\` (空 config = legacy 値と bit-identical)
  - \`usecase/indicator_test.go\` — \`TestIndicatorCalculator_SetIndicatorPeriods\` (live 側でも同じ guard)
- [x] 既存 \`TestStrategyProfile_JSONRoundTrip\` を新フィールド込みで更新

## Next

- PR-C: 残り指標 (Ichimoku/ADX/Stoch/Donchian/CMF/OBVSlope) の期間を profile 化
- PR-D: live 側 (\`cmd/main.go\` / \`event_pipeline.go\`) の配線。今はまだ \`SetIndicatorPeriods\` を呼んでいないので live は legacy 値のまま — backtest だけ profile 駆動になっている状態
- PR-E: ETH PT5M baseline profile + smoke

🤖 Generated with [Claude Code](https://claude.com/claude-code)