### PR TITLE
feat(indicator): profile-drive ADX / Stoch / Donchian / CMF / OBV / Ichimoku

### DIFF
--- a/backend/internal/domain/entity/strategy_config.go
+++ b/backend/internal/domain/entity/strategy_config.go
@@ -31,9 +31,10 @@ type StrategyProfile struct {
 }
 
 // IndicatorConfig declares the lookback periods and shape parameters used when
-// computing technical indicators. PR-B covers SMA / EMA / RSI / MACD / BB /
-// ATR / VolumeSMA. PR-C will extend this with ADX / Stochastics / Donchian /
-// CMF / OBVSlope / Ichimoku periods.
+// computing technical indicators. Every indicator the strategy layer consumes
+// is profile-driven so PT5M / PT1M strategies can scale lookbacks to their
+// timeframe; zero on any field falls back to the legacy LTC PT15M default
+// via WithDefaults.
 type IndicatorConfig struct {
 	SMAShort     int     `json:"sma_short"`
 	SMALong      int     `json:"sma_long"`
@@ -50,6 +51,49 @@ type IndicatorConfig struct {
 	// 0 falls back to BBPeriod (legacy behaviour computed VolumeSMA20 alongside
 	// BB20; keeping the same default avoids surprising existing profiles).
 	VolumeSMAPeriod int `json:"volume_sma_period"`
+
+	// PR-C: ADX (Average Directional Index) family lookback. Used by both
+	// the trend-follow ADX_min gate and the contrarian ADX_max gate; needs
+	// 2*period+1 bars before producing a non-NaN value (Wilder smoothing).
+	// 0 falls back to 14.
+	ADXPeriod int `json:"adx_period"`
+
+	// PR-C: Stochastics (slow %K) parameters. StochKPeriod is the raw
+	// look-back over which the high/low range is taken, StochSmoothK
+	// smooths the raw %K into the slow %K, StochSmoothD smooths the slow
+	// %K into %D. Legacy values 14 / 3 / 3. 0 each falls back.
+	StochKPeriod  int `json:"stoch_k_period"`
+	StochSmoothK  int `json:"stoch_smooth_k"`
+	StochSmoothD  int `json:"stoch_smooth_d"`
+
+	// PR-C: Stochastic RSI parameters. StochRSIRSIPeriod is the inner RSI
+	// window, StochRSIStochPeriod is the outer stochastic window applied
+	// to the RSI series. Legacy 14 / 14. 0 each falls back.
+	StochRSIRSIPeriod   int `json:"stoch_rsi_rsi_period"`
+	StochRSIStochPeriod int `json:"stoch_rsi_stoch_period"`
+
+	// PR-C: Donchian Channel high/low look-back. Default 20 (~5h on 15m
+	// bars). 0 falls back. Used by the breakout gate's Donchian filter.
+	DonchianPeriod int `json:"donchian_period"`
+
+	// PR-C: OBV slope look-back (in bars). Default 20. Drives OBVSlope
+	// which trend-follow uses as a volume-confirmation gate. 0 falls back.
+	OBVSlopePeriod int `json:"obv_slope_period"`
+
+	// PR-C: CMF (Chaikin Money Flow) look-back. Default 20. Drives the
+	// breakout gate's CMF filter (cmf_buy_min / cmf_sell_max). 0 falls back.
+	CMFPeriod int `json:"cmf_period"`
+
+	// PR-C: Ichimoku Kinkō Hyō periods.
+	//   - IchimokuTenkan: conversion line (default 9)
+	//   - IchimokuKijun:  base line; also drives the +N forward shift of
+	//                     SenkouA/B and the −N backward shift of Chikou
+	//                     (default 26)
+	//   - IchimokuSenkouB: leading span B look-back (default 52)
+	// Used by HTFFilter when mode="ichimoku". 0 each falls back.
+	IchimokuTenkan  int `json:"ichimoku_tenkan"`
+	IchimokuKijun   int `json:"ichimoku_kijun"`
+	IchimokuSenkouB int `json:"ichimoku_senkou_b"`
 }
 
 // WithDefaults returns the IndicatorConfig with zero-valued fields filled
@@ -96,6 +140,42 @@ func (c IndicatorConfig) WithDefaults() IndicatorConfig {
 	}
 	if c.VolumeSMAPeriod <= 0 {
 		c.VolumeSMAPeriod = c.BBPeriod
+	}
+	if c.ADXPeriod <= 0 {
+		c.ADXPeriod = 14
+	}
+	if c.StochKPeriod <= 0 {
+		c.StochKPeriod = 14
+	}
+	if c.StochSmoothK <= 0 {
+		c.StochSmoothK = 3
+	}
+	if c.StochSmoothD <= 0 {
+		c.StochSmoothD = 3
+	}
+	if c.StochRSIRSIPeriod <= 0 {
+		c.StochRSIRSIPeriod = 14
+	}
+	if c.StochRSIStochPeriod <= 0 {
+		c.StochRSIStochPeriod = 14
+	}
+	if c.DonchianPeriod <= 0 {
+		c.DonchianPeriod = 20
+	}
+	if c.OBVSlopePeriod <= 0 {
+		c.OBVSlopePeriod = 20
+	}
+	if c.CMFPeriod <= 0 {
+		c.CMFPeriod = 20
+	}
+	if c.IchimokuTenkan <= 0 {
+		c.IchimokuTenkan = 9
+	}
+	if c.IchimokuKijun <= 0 {
+		c.IchimokuKijun = 26
+	}
+	if c.IchimokuSenkouB <= 0 {
+		c.IchimokuSenkouB = 52
 	}
 	return c
 }
@@ -412,6 +492,50 @@ func (p StrategyProfile) Validate() error {
 	}
 	if ind.VolumeSMAPeriod < 0 {
 		errs = append(errs, fmt.Errorf("indicators.volume_sma_period must be >= 0 (got %d)", ind.VolumeSMAPeriod))
+	}
+	// PR-C: optional periods. 0 means "fall back to default" via WithDefaults;
+	// only reject negative values that would otherwise be silently coerced.
+	if ind.ADXPeriod < 0 {
+		errs = append(errs, fmt.Errorf("indicators.adx_period must be >= 0 (got %d)", ind.ADXPeriod))
+	}
+	if ind.StochKPeriod < 0 {
+		errs = append(errs, fmt.Errorf("indicators.stoch_k_period must be >= 0 (got %d)", ind.StochKPeriod))
+	}
+	if ind.StochSmoothK < 0 {
+		errs = append(errs, fmt.Errorf("indicators.stoch_smooth_k must be >= 0 (got %d)", ind.StochSmoothK))
+	}
+	if ind.StochSmoothD < 0 {
+		errs = append(errs, fmt.Errorf("indicators.stoch_smooth_d must be >= 0 (got %d)", ind.StochSmoothD))
+	}
+	if ind.StochRSIRSIPeriod < 0 {
+		errs = append(errs, fmt.Errorf("indicators.stoch_rsi_rsi_period must be >= 0 (got %d)", ind.StochRSIRSIPeriod))
+	}
+	if ind.StochRSIStochPeriod < 0 {
+		errs = append(errs, fmt.Errorf("indicators.stoch_rsi_stoch_period must be >= 0 (got %d)", ind.StochRSIStochPeriod))
+	}
+	if ind.DonchianPeriod < 0 {
+		errs = append(errs, fmt.Errorf("indicators.donchian_period must be >= 0 (got %d)", ind.DonchianPeriod))
+	}
+	if ind.OBVSlopePeriod < 0 {
+		errs = append(errs, fmt.Errorf("indicators.obv_slope_period must be >= 0 (got %d)", ind.OBVSlopePeriod))
+	}
+	if ind.CMFPeriod < 0 {
+		errs = append(errs, fmt.Errorf("indicators.cmf_period must be >= 0 (got %d)", ind.CMFPeriod))
+	}
+	if ind.IchimokuTenkan < 0 {
+		errs = append(errs, fmt.Errorf("indicators.ichimoku_tenkan must be >= 0 (got %d)", ind.IchimokuTenkan))
+	}
+	if ind.IchimokuKijun < 0 {
+		errs = append(errs, fmt.Errorf("indicators.ichimoku_kijun must be >= 0 (got %d)", ind.IchimokuKijun))
+	}
+	if ind.IchimokuSenkouB < 0 {
+		errs = append(errs, fmt.Errorf("indicators.ichimoku_senkou_b must be >= 0 (got %d)", ind.IchimokuSenkouB))
+	}
+	if ind.IchimokuTenkan > 0 && ind.IchimokuKijun > 0 && ind.IchimokuTenkan >= ind.IchimokuKijun {
+		errs = append(errs, fmt.Errorf("indicators.ichimoku_tenkan (%d) must be < ichimoku_kijun (%d)", ind.IchimokuTenkan, ind.IchimokuKijun))
+	}
+	if ind.IchimokuKijun > 0 && ind.IchimokuSenkouB > 0 && ind.IchimokuKijun >= ind.IchimokuSenkouB {
+		errs = append(errs, fmt.Errorf("indicators.ichimoku_kijun (%d) must be < ichimoku_senkou_b (%d)", ind.IchimokuKijun, ind.IchimokuSenkouB))
 	}
 	if ind.RSIPeriod <= 0 {
 		errs = append(errs, fmt.Errorf("indicators.rsi_period must be > 0 (got %d)", ind.RSIPeriod))

--- a/backend/internal/domain/entity/strategy_config_test.go
+++ b/backend/internal/domain/entity/strategy_config_test.go
@@ -221,7 +221,19 @@ func TestStrategyProfile_JSONRoundTrip(t *testing.T) {
     "bb_period": 20,
     "bb_multiplier": 2.0,
     "atr_period": 14,
-    "volume_sma_period": 0
+    "volume_sma_period": 0,
+    "adx_period": 0,
+    "stoch_k_period": 0,
+    "stoch_smooth_k": 0,
+    "stoch_smooth_d": 0,
+    "stoch_rsi_rsi_period": 0,
+    "stoch_rsi_stoch_period": 0,
+    "donchian_period": 0,
+    "obv_slope_period": 0,
+    "cmf_period": 0,
+    "ichimoku_tenkan": 0,
+    "ichimoku_kijun": 0,
+    "ichimoku_senkou_b": 0
   },
   "stance_rules": {
     "rsi_oversold": 20,

--- a/backend/internal/usecase/backtest/handler.go
+++ b/backend/internal/usecase/backtest/handler.go
@@ -195,15 +195,12 @@ func NewIndicatorHandler(primaryInterval, higherTFInterval string, bufferSize in
 	}
 }
 
-// SetIndicatorPeriods overrides the lookback periods used inside
-// calculateIndicatorSet for SMA / EMA / RSI / MACD / BB / ATR / VolumeSMA.
+// SetIndicatorPeriods overrides every indicator lookback used inside
+// calculateIndicatorSet — SMA / EMA / RSI / MACD / BB / ATR / VolumeSMA /
+// ADX / Stochastics / StochRSI / Donchian / OBVSlope / CMF / Ichimoku.
 // Zero-valued fields fall back to the legacy defaults via
 // IndicatorConfig.WithDefaults. Mirrors usecase.IndicatorCalculator's
 // SetIndicatorPeriods so live and backtest paths share one knob set.
-//
-// PR-C will extend this to ADX / Stochastics / Donchian / CMF / OBVSlope /
-// Ichimoku; until then those continue to use their hardcoded periods inside
-// calculateIndicatorSet.
 func (h *IndicatorHandler) SetIndicatorPeriods(p entity.IndicatorConfig) {
 	h.periods = p.WithDefaults()
 }
@@ -889,28 +886,27 @@ func calculateIndicatorSet(symbolID int64, candles []entity.Candle, periods enti
 
 	result.ATR = floatToPtr(indicator.ATR(highs, lows, closes, periods.ATRPeriod))
 
-	// PR-6: ADX family. Mirror the live-pipeline calculator. PR-C will profile-drive.
-	adxVal, plusDI, minusDI := indicator.ADX(highs, lows, closes, 14)
+	// PR-6: ADX family. Mirror the live-pipeline calculator.
+	adxVal, plusDI, minusDI := indicator.ADX(highs, lows, closes, periods.ADXPeriod)
 	result.ADX = floatToPtr(adxVal)
 	result.PlusDI = floatToPtr(plusDI)
 	result.MinusDI = floatToPtr(minusDI)
 
-	// PR-7: Stochastics (14, 3, 3) + Stochastic RSI (14, 14). Mirror the
-	// live-pipeline calculator. PR-C will profile-drive.
-	stochK, stochD := indicator.Stochastics(highs, lows, closes, 14, 3, 3)
+	// PR-7: Stochastics + Stochastic RSI. Mirror the live-pipeline calculator.
+	stochK, stochD := indicator.Stochastics(highs, lows, closes, periods.StochKPeriod, periods.StochSmoothK, periods.StochSmoothD)
 	result.StochK = floatToPtr(stochK)
 	result.StochD = floatToPtr(stochD)
-	result.StochRSI = floatToPtr(indicator.StochasticRSI(closes, 14, 14))
+	result.StochRSI = floatToPtr(indicator.StochasticRSI(closes, periods.StochRSIRSIPeriod, periods.StochRSIStochPeriod))
 
 	// PR-8: Ichimoku. Mirror the live pipeline; nil when all five lines
-	// are still in warmup. PR-C will profile-drive.
-	if snap := buildIchimokuSnapshotBT(indicator.Ichimoku(highs, lows, closes, 9, 26, 52)); snap != nil {
+	// are still in warmup.
+	if snap := buildIchimokuSnapshotBT(indicator.Ichimoku(highs, lows, closes, periods.IchimokuTenkan, periods.IchimokuKijun, periods.IchimokuSenkouB)); snap != nil {
 		result.Ichimoku = snap
 	}
 
-	// PR-11: Donchian Channel (20-bar default). Mirror the live pipeline;
-	// nil until 20 bars of history are available. PR-C will profile-drive.
-	donU, donL, donM := indicator.Donchian(highs, lows, 20)
+	// PR-11: Donchian Channel. Mirror the live pipeline; nil until
+	// DonchianPeriod bars of history are available.
+	donU, donL, donM := indicator.Donchian(highs, lows, periods.DonchianPeriod)
 	result.DonchianUpper = floatToPtr(donU)
 	result.DonchianLower = floatToPtr(donL)
 	result.DonchianMiddle = floatToPtr(donM)
@@ -929,10 +925,9 @@ func calculateIndicatorSet(symbolID int64, candles []entity.Candle, periods enti
 	}
 
 	// PR-9: OBV + CMF (volume-based). Mirror the live-pipeline calculator.
-	// PR-C will profile-drive.
 	result.OBV = floatToPtr(indicator.OBV(closes, volumes))
-	result.OBVSlope = floatToPtr(indicator.OBVSlope(closes, volumes, 20))
-	result.CMF = floatToPtr(indicator.CMF(highs, lows, closes, volumes, 20))
+	result.OBVSlope = floatToPtr(indicator.OBVSlope(closes, volumes, periods.OBVSlopePeriod))
+	result.CMF = floatToPtr(indicator.CMF(highs, lows, closes, volumes, periods.CMFPeriod))
 
 	// RecentSqueeze: check if any of the last `bbSqueezeLookback` candles
 	// had BBBandwidth < threshold. cycle44: now honours the profile field

--- a/backend/internal/usecase/backtest/indicator_periods_test.go
+++ b/backend/internal/usecase/backtest/indicator_periods_test.go
@@ -7,35 +7,50 @@ import (
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
 )
 
-// TestCalculateIndicatorSet_PeriodsDriveValues is the PR-B wiring guard:
-// it proves that calculateIndicatorSet actually consumes the IndicatorConfig
-// argument, rather than ignoring it the way SetBBSqueezeLookback was
-// originally a silent no-op (cycle43). Two runs on the same trending
-// candle series with different SMA / EMA / RSI / BB / ATR / VolumeSMA
-// periods must produce numerically distinguishable values.
+// TestCalculateIndicatorSet_PeriodsDriveValues is the PR-B / PR-C wiring
+// guard: it proves that calculateIndicatorSet actually consumes the
+// IndicatorConfig argument, rather than ignoring it the way
+// SetBBSqueezeLookback was originally a silent no-op (cycle43). Two runs
+// on the same noisy candle series with different periods must produce
+// numerically distinguishable values for every indicator.
 //
-// We use a strong linear uptrend so longer lookbacks lag the price
-// noticeably more than shorter ones — every period axis becomes a visible
-// signal. A passive guard (just checking that the values are non-nil)
-// would have missed cycle43-style "the field is set but the period is
-// hardcoded" regressions.
+// We use sinusoidal noise on top of a linear drift so longer lookbacks
+// see different running means / variances than shorter ones — every
+// period axis becomes a visible signal. A passive guard (just checking
+// that the values are non-nil) would have missed cycle43-style "the
+// field is set but the period is hardcoded" regressions.
+//
+// Candle count 320 = scaled IchimokuSenkouB (156) + Kijun (78) + buffer
+// so the longest profile completes warmup.
 func TestCalculateIndicatorSet_PeriodsDriveValues(t *testing.T) {
-	candles := buildTrendingCandles(120)
+	candles := buildTrendingCandles(320)
 
 	defaults := calculateIndicatorSet(42, candles, entity.IndicatorConfig{}, 0)
 	scaled := calculateIndicatorSet(42, candles, entity.IndicatorConfig{
-		SMAShort:        60,
-		SMALong:         100,
-		EMAFast:         36,
-		EMASlow:         78,
-		RSIPeriod:       42,
-		MACDFast:        24,
-		MACDSlow:        52,
-		MACDSignal:      18,
-		BBPeriod:        60,
-		BBMultiplier:    2.0,
-		ATRPeriod:       42,
-		VolumeSMAPeriod: 60,
+		SMAShort:            60,
+		SMALong:             100,
+		EMAFast:             36,
+		EMASlow:             78,
+		RSIPeriod:           42,
+		MACDFast:            24,
+		MACDSlow:            52,
+		MACDSignal:          18,
+		BBPeriod:            60,
+		BBMultiplier:        2.0,
+		ATRPeriod:           42,
+		VolumeSMAPeriod:     60,
+		ADXPeriod:           42,
+		StochKPeriod:        42,
+		StochSmoothK:        9,
+		StochSmoothD:        9,
+		StochRSIRSIPeriod:   42,
+		StochRSIStochPeriod: 42,
+		DonchianPeriod:      60,
+		OBVSlopePeriod:      60,
+		CMFPeriod:           60,
+		IchimokuTenkan:      27,
+		IchimokuKijun:       78,
+		IchimokuSenkouB:     156,
 	}, 0)
 
 	cases := []struct {
@@ -53,6 +68,13 @@ func TestCalculateIndicatorSet_PeriodsDriveValues(t *testing.T) {
 		{"BBMiddle", defaults.BBMiddle, scaled.BBMiddle},
 		{"ATR", defaults.ATR, scaled.ATR},
 		{"VolumeSMA", defaults.VolumeSMA, scaled.VolumeSMA},
+		{"ADX", defaults.ADX, scaled.ADX},
+		{"StochK", defaults.StochK, scaled.StochK},
+		{"StochD", defaults.StochD, scaled.StochD},
+		{"StochRSI", defaults.StochRSI, scaled.StochRSI},
+		{"DonchianUpper", defaults.DonchianUpper, scaled.DonchianUpper},
+		{"OBVSlope", defaults.OBVSlope, scaled.OBVSlope},
+		{"CMF", defaults.CMF, scaled.CMF},
 	}
 
 	for _, tc := range cases {
@@ -65,6 +87,31 @@ func TestCalculateIndicatorSet_PeriodsDriveValues(t *testing.T) {
 			}
 		})
 	}
+
+	// Ichimoku: separate path because its values live inside a nested snapshot.
+	// Tenkan / Kijun must differ between the default 9/26/52 series and the
+	// scaled 27/78/156 series — the longer windows lag the noisy uptrend
+	// noticeably more, so the values land at different points along the same
+	// curve.
+	t.Run("IchimokuTenkan", func(t *testing.T) {
+		if defaults.Ichimoku == nil || scaled.Ichimoku == nil {
+			t.Fatalf("expected non-nil Ichimoku snapshots (defaults=%v scaled=%v)", defaults.Ichimoku, scaled.Ichimoku)
+		}
+		if defaults.Ichimoku.Tenkan == nil || scaled.Ichimoku.Tenkan == nil {
+			t.Fatalf("Tenkan: expected both non-nil (defaults=%v scaled=%v)", defaults.Ichimoku.Tenkan, scaled.Ichimoku.Tenkan)
+		}
+		if math.Abs(*defaults.Ichimoku.Tenkan-*scaled.Ichimoku.Tenkan) < 1e-6 {
+			t.Errorf("Tenkan: defaults=%.6f scaled=%.6f — too close, period likely ignored", *defaults.Ichimoku.Tenkan, *scaled.Ichimoku.Tenkan)
+		}
+	})
+	t.Run("IchimokuKijun", func(t *testing.T) {
+		if defaults.Ichimoku.Kijun == nil || scaled.Ichimoku.Kijun == nil {
+			t.Fatalf("Kijun: expected both non-nil (defaults=%v scaled=%v)", defaults.Ichimoku.Kijun, scaled.Ichimoku.Kijun)
+		}
+		if math.Abs(*defaults.Ichimoku.Kijun-*scaled.Ichimoku.Kijun) < 1e-6 {
+			t.Errorf("Kijun: defaults=%.6f scaled=%.6f — too close, period likely ignored", *defaults.Ichimoku.Kijun, *scaled.Ichimoku.Kijun)
+		}
+	})
 }
 
 // TestCalculateIndicatorSet_DefaultsMatchLegacy proves that an empty
@@ -117,29 +164,37 @@ func TestCalculateIndicatorSet_DefaultsMatchLegacy(t *testing.T) {
 	}
 }
 
-// buildTrendingCandles produces a noisy uptrend that exercises every
-// indicator family — different lookbacks see different running averages,
-// RSI gain/loss balance shifts, ATR window includes more / fewer outlier
-// bars, etc. A pure linear trend was rejected because RSI saturates at
-// 100 and ATR collapses to a constant, masking period-flag regressions.
+// buildTrendingCandles produces a noisy quasi-random walk that exercises
+// every indicator family — RSI gain/loss balance, ATR window, Donchian
+// extremes, Stoch oscillators, etc. all change with the look-back window.
+//
+// Pure linear / monotonic uptrends were rejected because:
+//   - RSI saturates at 100 (no losing bars), masking period changes;
+//   - StochRSI inherits the saturation and stays at 100;
+//   - Donchian's high-of-N collapses to the latest bar's high regardless
+//     of N because the series is monotonic.
+//
+// We use overlapping sinusoids (3 frequencies) plus a mild positive drift
+// so the series advances overall but every window contains genuine
+// max/min variation.
 func buildTrendingCandles(n int) []entity.Candle {
 	out := make([]entity.Candle, n)
 	for i := range out {
-		// Sinusoidal noise on top of a linear drift gives every period
-		// axis a different running mean / variance, so longer lookbacks
-		// produce numerically distinct values from shorter ones.
-		drift := float64(i) * 0.8
-		osc := 5.0 * math.Sin(float64(i)*0.4)
+		drift := float64(i) * 0.05
+		osc := 12.0*math.Sin(float64(i)*0.13) +
+			8.0*math.Sin(float64(i)*0.41) +
+			4.0*math.Sin(float64(i)*1.05)
 		base := 100.0 + drift + osc
-		// Variable bar range so ATR depends on which bars the window
-		// includes, not just the slope.
-		span := 1.0 + 0.5*math.Cos(float64(i)*0.3)
+		span := 1.5 + 1.0*math.Cos(float64(i)*0.27)
+		if span < 0.2 {
+			span = 0.2
+		}
 		out[i] = entity.Candle{
 			Time:   int64(i) * 60_000,
 			Open:   base,
 			High:   base + span,
 			Low:    base - span,
-			Close:  base + 0.3*math.Sin(float64(i)*0.7),
+			Close:  base + 0.6*math.Sin(float64(i)*0.71),
 			Volume: 100 + 30*math.Sin(float64(i)*0.2),
 		}
 	}

--- a/backend/internal/usecase/indicator.go
+++ b/backend/internal/usecase/indicator.go
@@ -44,13 +44,12 @@ func (c *IndicatorCalculator) SetBBSqueezeLookback(n int) {
 	c.bbSqueezeLookback = n
 }
 
-// SetIndicatorPeriods overrides the lookback periods used for SMA / EMA /
-// RSI / MACD / BB / ATR / VolumeSMA. Zero-valued fields are filled in from
-// the legacy hardcoded defaults via IndicatorConfig.WithDefaults so a
-// partial profile still produces a working set.
-//
-// PR-C will extend this to ADX / Stochastics / Donchian / CMF / OBVSlope /
-// Ichimoku; until then those continue to use their hardcoded periods.
+// SetIndicatorPeriods overrides the lookback periods for every indicator
+// the strategy layer consumes — SMA / EMA / RSI / MACD / BB / ATR /
+// VolumeSMA / ADX / Stochastics / StochRSI / Donchian / OBVSlope / CMF /
+// Ichimoku. Zero-valued fields are filled in from the legacy hardcoded
+// defaults via IndicatorConfig.WithDefaults so a partial profile still
+// produces a working set.
 func (c *IndicatorCalculator) SetIndicatorPeriods(p entity.IndicatorConfig) {
 	c.periods = p.WithDefaults()
 }
@@ -110,32 +109,28 @@ func (c *IndicatorCalculator) Calculate(ctx context.Context, symbolID int64, int
 
 	// PR-6: ADX family. ADX/PlusDI/MinusDI return NaN until 2*period+1
 	// bars are available; toPtr collapses that to nil for the caller.
-	// PR-C will profile-drive this period.
-	adxVal, plusDI, minusDI := indicator.ADX(highs, lows, prices, 14)
+	adxVal, plusDI, minusDI := indicator.ADX(highs, lows, prices, periods.ADXPeriod)
 	result.ADX = toPtr(adxVal)
 	result.PlusDI = toPtr(plusDI)
 	result.MinusDI = toPtr(minusDI)
 
-	// PR-7: Stochastics (14, 3, 3) + Stochastic RSI (14, 14). Both return
-	// NaN -> nil pointer when the warmup window is not filled yet.
-	// PR-C will profile-drive these periods.
-	stochK, stochD := indicator.Stochastics(highs, lows, prices, 14, 3, 3)
+	// PR-7: Stochastics + Stochastic RSI. Both return NaN -> nil pointer
+	// when the warmup window is not filled yet.
+	stochK, stochD := indicator.Stochastics(highs, lows, prices, periods.StochKPeriod, periods.StochSmoothK, periods.StochSmoothD)
 	result.StochK = toPtr(stochK)
 	result.StochD = toPtr(stochD)
-	result.StochRSI = toPtr(indicator.StochasticRSI(prices, 14, 14))
+	result.StochRSI = toPtr(indicator.StochasticRSI(prices, periods.StochRSIRSIPeriod, periods.StochRSIStochPeriod))
 
 	// PR-8: Ichimoku. Each of the five lines may be NaN independently during
 	// warmup; buildIchimokuSnapshot returns nil when every line is unknown.
-	// PR-C will profile-drive these periods.
-	if snap := buildIchimokuSnapshot(indicator.Ichimoku(highs, lows, prices, 9, 26, 52)); snap != nil {
+	if snap := buildIchimokuSnapshot(indicator.Ichimoku(highs, lows, prices, periods.IchimokuTenkan, periods.IchimokuKijun, periods.IchimokuSenkouB)); snap != nil {
 		result.Ichimoku = snap
 	}
 
-	// PR-11: Donchian Channel (20-bar default). Mirror the other range-of-N
-	// indicators — NaN until 20 bars of history are available; toPtr
-	// collapses that into nil pointers for downstream gates.
-	// PR-C will profile-drive this period.
-	donU, donL, donM := indicator.Donchian(highs, lows, 20)
+	// PR-11: Donchian Channel. NaN until DonchianPeriod bars of history
+	// are available; toPtr collapses that into nil pointers for downstream
+	// gates.
+	donU, donL, donM := indicator.Donchian(highs, lows, periods.DonchianPeriod)
 	result.DonchianUpper = toPtr(donU)
 	result.DonchianLower = toPtr(donL)
 	result.DonchianMiddle = toPtr(donM)
@@ -153,12 +148,11 @@ func (c *IndicatorCalculator) Calculate(ctx context.Context, symbolID int64, int
 	}
 
 	// PR-9: OBV + CMF (volume-based). OBVSlope carries the gate signal
-	// (cumulative buying volume over 20 bars); raw OBV is exposed for
-	// diagnostics / frontend charting. CMF is bounded in [-1, 1].
-	// PR-C will profile-drive these periods.
+	// (cumulative buying volume over OBVSlopePeriod bars); raw OBV is
+	// exposed for diagnostics / frontend charting. CMF is bounded in [-1, 1].
 	result.OBV = toPtr(indicator.OBV(prices, volumes))
-	result.OBVSlope = toPtr(indicator.OBVSlope(prices, volumes, 20))
-	result.CMF = toPtr(indicator.CMF(highs, lows, prices, volumes, 20))
+	result.OBVSlope = toPtr(indicator.OBVSlope(prices, volumes, periods.OBVSlopePeriod))
+	result.CMF = toPtr(indicator.CMF(highs, lows, prices, volumes, periods.CMFPeriod))
 
 	// RecentSqueeze: check if any of the last `c.bbSqueezeLookback`
 	// candles had BBBandwidth < 0.02. cycle44: profile's stance_rules


### PR DESCRIPTION
## Summary

- 残り全ての指標 (ADX/Stochastics/StochRSI/Donchian/CMF/OBVSlope/Ichimoku) の lookback period を \`StrategyProfile.Indicators\` から駆動するようにした
- PR-B と合わせて、指標期間が全部 profile 駆動になった
- production.json は新フィールドをセットしないので legacy 値 (14/14,3,3/14,14/20/20/20/9,26,52) が継続使用 — bit-identical

## なぜ

PR-B で SMA/EMA/RSI/MACD/BB/ATR/VolumeSMA を profile 駆動にしたが、ADX/Stoch/Donchian/CMF/OBV/Ichimoku はハードコードのままだった。PT5M / PT1M で「14期間 = 70分 / 14分」という意味の歪みが残ると、結局 5分足戦略を最適化しきれない。

## 変更点

### entity.IndicatorConfig 拡張 (12 新フィールド)
\`\`\`json
{
  \"adx_period\": 14,
  \"stoch_k_period\": 14,
  \"stoch_smooth_k\": 3,
  \"stoch_smooth_d\": 3,
  \"stoch_rsi_rsi_period\": 14,
  \"stoch_rsi_stoch_period\": 14,
  \"donchian_period\": 20,
  \"obv_slope_period\": 20,
  \"cmf_period\": 20,
  \"ichimoku_tenkan\": 9,
  \"ichimoku_kijun\": 26,
  \"ichimoku_senkou_b\": 52
}
\`\`\`
全部 0 falls back to legacy。

### Validate の追加チェック
- 負値 reject
- Ichimoku ordering (\`tenkan < kijun < senkou_b\`)

### 計算側
- \`IndicatorCalculator.Calculate\` (live) と \`calculateIndicatorSet\` (backtest) で全指標が \`periods.*\` を参照
- \`SetIndicatorPeriods\` docstring を「全指標カバー」に更新

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./... -count=1\` 全パッケージ pass
- [x] **配線確認テスト** 拡張: \`TestCalculateIndicatorSet_PeriodsDriveValues\` に ADX/StochK/StochD/StochRSI/DonchianUpper/OBVSlope/CMF + IchimokuTenkan/Kijun を追加。全部「異なる期間 = 異なる値」を検証
- [x] テスト fixture を 3-frequency sinusoidal walk (320 bars) に変更。線形 uptrend だと RSI/Donchian が saturate するのを fix
- [x] \`TestStrategyProfile_JSONRoundTrip\` を 12 新フィールド込みで更新

## Next

- PR-D: live 側 (\`cmd/main.go\` / \`event_pipeline.go\`) で \`IndicatorCalculator.SetIndicatorPeriods(profile.Indicators)\` を呼び出す配線。今は backtest だけ profile 駆動で、live は legacy 値のまま
- PR-E: ETH PT5M baseline profile + smoke

🤖 Generated with [Claude Code](https://claude.com/claude-code)