### PR TITLE
feat(live): wire profile-driven indicator periods into the live pipeline

### DIFF
--- a/backend/cmd/event_pipeline.go
+++ b/backend/cmd/event_pipeline.go
@@ -57,6 +57,14 @@ type EventDrivenPipeline struct {
 	reconcileConfig      reconcile.Config
 	clientOrderRepo      repository.ClientOrderRepository
 
+	// indicatorPeriods / bbSqueezeLookback are the live counterparts of the
+	// per-run RunInput fields the backtest already consumes. They are read
+	// once at startup from the configured StrategyProfile (typically
+	// production.json) so the live IndicatorHandler computes indicators on
+	// the same lookbacks the strategy was tuned for.
+	indicatorPeriods  entity.IndicatorConfig
+	bbSqueezeLookback int
+
 	// sleepFn is used by syncState for retry backoff (test-injectable).
 	sleepFn func(time.Duration)
 }
@@ -73,6 +81,19 @@ type EventDrivenPipelineConfig struct {
 	CircuitBreaker       circuitbreaker.Config
 	StaleCheckIntervalMs int64
 	Reconcile            reconcile.Config
+
+	// IndicatorPeriods drives the live IndicatorHandler's lookback periods
+	// for SMA / EMA / RSI / MACD / BB / ATR / VolumeSMA / ADX / Stochastics /
+	// StochRSI / Donchian / OBVSlope / CMF / Ichimoku. Zero-valued fields
+	// fall back to the legacy LTC PT15M defaults via WithDefaults so a
+	// missing profile keeps the pre-PR-D behaviour bit-identical.
+	IndicatorPeriods entity.IndicatorConfig
+
+	// BBSqueezeLookback mirrors profile.StanceRules.BBSqueezeLookback so
+	// the live handler's RecentSqueeze gate respects the profile (cycle44
+	// fix for the backtest path; this PR brings the same plumbing to live).
+	// 0 keeps the legacy default of 5.
+	BBSqueezeLookback int
 }
 
 func NewEventDrivenPipeline(
@@ -105,6 +126,8 @@ func NewEventDrivenPipeline(
 		tradeHistoryRepo:  tradeHistoryRepo,
 		riskStateRepo:     riskStateRepo,
 		clientOrderRepo:   clientOrderRepo,
+		indicatorPeriods:  cfg.IndicatorPeriods,
+		bbSqueezeLookback: cfg.BBSqueezeLookback,
 	}
 }
 
@@ -314,6 +337,14 @@ func (p *EventDrivenPipeline) runEventLoop(ctx context.Context, snap eventSnapsh
 
 	// IndicatorHandler: calculates technical indicators on candle close (priority 10).
 	indicatorHandler := backtest.NewIndicatorHandler("PT15M", "PT1H", 500)
+	// PR-D: profile-driven indicator periods + BB squeeze lookback. The
+	// backtest path has been on this since PR-B/C; live now uses the same
+	// knob set so the strategy sees identical indicator values whether it
+	// is being backtested or run for real.
+	indicatorHandler.SetIndicatorPeriods(p.indicatorPeriods)
+	if p.bbSqueezeLookback > 0 {
+		indicatorHandler.SetBBSqueezeLookback(p.bbSqueezeLookback)
+	}
 	if p.marketDataSvc != nil {
 		// PR-J: feed Microprice / OFI from the live in-memory book cache.
 		indicatorHandler.SetBookSource(p.marketDataSvc, 10_000, 60_000, 5)

--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -18,6 +18,7 @@ import (
 	backtestinfra "github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/infrastructure/backtest"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/infrastructure/database"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/infrastructure/rakuten"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/infrastructure/strategyprofile"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/interfaces/api"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase"
 	backtestuc "github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/backtest"
@@ -113,6 +114,20 @@ func main() {
 		slog.Info("trading config restored from db", "symbolID", symbolID, "tradeAmount", tradeAmount)
 	}
 
+	// Load the live strategy profile so the IndicatorCalculator (used by API
+	// /indicators handlers + bootstrap) and the EventDrivenPipeline both see
+	// the same lookback periods the strategy was tuned for. Failure falls
+	// back to legacy defaults so a missing / malformed profile does not
+	// prevent the live pipeline from starting — but we log the error so
+	// operators see what happened.
+	liveProfile := loadLiveProfile()
+	if liveProfile != nil {
+		indicatorCalc.SetIndicatorPeriods(liveProfile.Indicators)
+		if liveProfile.StanceRules.BBSqueezeLookback > 0 {
+			indicatorCalc.SetBBSqueezeLookback(liveProfile.StanceRules.BBSqueezeLookback)
+		}
+	}
+
 	if err := bootstrapCandles(context.Background(), restClient, marketDataSvc, symbolID, "PT15M", 500); err != nil {
 		slog.Warn("initial candle bootstrap failed", "error", err)
 	}
@@ -149,6 +164,8 @@ func main() {
 				BalanceHaltPct:  cfg.Reconcile.BalanceHaltPct,
 				OrderTTL:        time.Duration(cfg.Reconcile.OrderTTLSec) * time.Second,
 			},
+			IndicatorPeriods:  liveProfileIndicators(liveProfile),
+			BBSqueezeLookback: liveProfileBBSqueezeLookback(liveProfile),
 		},
 		restClient,
 		restClient, // SymbolFetcher
@@ -378,6 +395,53 @@ func loadPersistenceConfig() usecase.PersistenceConfig {
 		cfg.QueueSize = v
 	}
 	return cfg
+}
+
+// loadLiveProfile reads the live strategy profile from
+// $LIVE_PROFILE (default: "production") under $PROFILES_BASE_DIR
+// (default: "profiles"). Returns nil on any failure — the caller treats
+// nil as "use legacy hardcoded defaults" so a malformed JSON or missing
+// file does not block the live pipeline from starting; the error is
+// logged loudly so operators see it.
+//
+// The profile is loaded once at startup. Hot-swapping requires a process
+// restart, mirroring how the backtest path resolves a profile per run.
+func loadLiveProfile() *entity.StrategyProfile {
+	name := os.Getenv("LIVE_PROFILE")
+	if name == "" {
+		name = "production"
+	}
+	baseDir := os.Getenv("PROFILES_BASE_DIR")
+	if baseDir == "" {
+		baseDir = "profiles"
+	}
+	loader := strategyprofile.NewLoader(baseDir)
+	profile, err := loader.Load(name)
+	if err != nil {
+		slog.Warn("live strategy profile load failed; falling back to legacy defaults", "name", name, "baseDir", baseDir, "error", err)
+		return nil
+	}
+	slog.Info("live strategy profile loaded", "name", profile.Name, "baseDir", baseDir)
+	return profile
+}
+
+// liveProfileIndicators returns the IndicatorConfig from a loaded profile,
+// or the zero value (which WithDefaults turns into legacy values) when no
+// profile is available.
+func liveProfileIndicators(p *entity.StrategyProfile) entity.IndicatorConfig {
+	if p == nil {
+		return entity.IndicatorConfig{}
+	}
+	return p.Indicators
+}
+
+// liveProfileBBSqueezeLookback returns profile.StanceRules.BBSqueezeLookback
+// or 0 (legacy fallback) when no profile is available.
+func liveProfileBBSqueezeLookback(p *entity.StrategyProfile) int {
+	if p == nil {
+		return 0
+	}
+	return p.StanceRules.BBSqueezeLookback
 }
 
 func startMarketRelay(


### PR DESCRIPTION
## Summary

- Live (\`cmd/main.go\` + \`event_pipeline.go\`) で profile を読み込み、\`IndicatorCalculator\` と \`IndicatorHandler\` 両方に \`SetIndicatorPeriods\` を呼ぶ配線を追加
- これで PR-B/C で実装した profile-driven indicator periods が live でも実際に効くようになる
- 環境変数 \`LIVE_PROFILE\` (default: \`production\`) で profile 名を指定

## なぜ

PR-B/C で indicator 期間を profile 駆動にしたが、live 側は \`indicatorCalc\` も \`indicatorHandler\` も \`SetIndicatorPeriods\` を呼んでいなかった → live は legacy 値のまま (silent regression)。PT5M 戦略の本番投入には live 側の配線が必須。

## 変更点

### \`cmd/main.go\`
- \`loadLiveProfile()\` ヘルパ追加: \`$LIVE_PROFILE\` (default: \`production\`) と \`$PROFILES_BASE_DIR\` (default: \`profiles\`) から profile を読む
- 失敗時は warn ログ + nil 返却で legacy fallback (live を起動できる方を優先)
- \`indicatorCalc.SetIndicatorPeriods(profile.Indicators)\` + \`SetBBSqueezeLookback(profile.StanceRules.BBSqueezeLookback)\`
- \`EventDrivenPipelineConfig\` に \`IndicatorPeriods\` / \`BBSqueezeLookback\` を渡す

### \`cmd/event_pipeline.go\`
- \`EventDrivenPipelineConfig\` / 構造体に \`IndicatorPeriods\` / \`BBSqueezeLookback\` フィールド追加
- \`runEventLoop\` 内の \`indicatorHandler\` 構築直後で \`SetIndicatorPeriods\` / \`SetBBSqueezeLookback\` 呼び出し

## scope outside this PR

- \`cmd/mcp/main.go\` の \`IndicatorCalculator\` も同じ問題があるが、別 binary・別 composition root なので follow-up PR とした。MCP は read-only metadata 系なので影響範囲は限定的
- profile の hot-swap (再起動なし) は対応せず。backtest runner も \"resolve per run\" なので live も \"resolve at startup\" で揃える

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./... -count=1\` 全パッケージ pass
- [x] production.json は新コードで loader 経由 load 可能 (\`strategyprofile/loader_test.go\` が引き続き green)

## 全体の進捗

| PR | 内容 | Status |
|---|---|---|
| #189 PR-A | IndicatorSet rename | ✅ merged |
| #190 PR-B | core 指標を profile 駆動 | ✅ merged |
| #191 PR-C | 残り全指標を profile 駆動 | ✅ merged |
| **本 PR (D)** | live 側で profile を注入 | 👈 |
| 今後 PR-E | ETH PT5M baseline profile + smoke | pending |
| 今後 PDCA | ETH PT5M PDCA cycle (60+) | pending |

🤖 Generated with [Claude Code](https://claude.com/claude-code)