### PR TITLE
feat(profile): add ETH PT5M baseline profile (period-rescaled production v7)

### DIFF
--- a/backend/profiles/experiment_eth_pt5m_baseline.json
+++ b/backend/profiles/experiment_eth_pt5m_baseline.json
@@ -1,0 +1,78 @@
+{
+  "name": "experiment_eth_pt5m_baseline",
+  "description": "ETH/JPY PT5M ベースライン候補。production v7 (LTC PT15M) の指標期間を 3x にスケール (15m/5m=3) して PT15M 等価のスパンに揃えた構成。Stance / Signal / Risk ルールはまず production と同じにし、PDCA サイクルで PT5M 向けに再チューニングする。指標期間は ETH の 5分足ノイズに合わせて経験的に sweep する想定 (1x=PT5Mネイティブ, 3x=PT15M等価, 中間値も検証対象)。Position sizing は production と同じ risk_pct=0.50 / max=20% / min_lot=0.1 (ETH も 0.1 で venue 一致) を流用。Indicator periods が profile 駆動になった PR-A〜PR-D の上に成立する。",
+  "indicators": {
+    "sma_short": 60,
+    "sma_long": 150,
+    "ema_fast": 36,
+    "ema_slow": 78,
+    "rsi_period": 42,
+    "macd_fast": 36,
+    "macd_slow": 78,
+    "macd_signal": 27,
+    "bb_period": 60,
+    "bb_multiplier": 2.0,
+    "atr_period": 42,
+    "volume_sma_period": 60,
+    "adx_period": 42,
+    "stoch_k_period": 42,
+    "stoch_smooth_k": 9,
+    "stoch_smooth_d": 9,
+    "stoch_rsi_rsi_period": 42,
+    "stoch_rsi_stoch_period": 42,
+    "donchian_period": 60,
+    "obv_slope_period": 60,
+    "cmf_period": 60,
+    "ichimoku_tenkan": 27,
+    "ichimoku_kijun": 78,
+    "ichimoku_senkou_b": 156
+  },
+  "stance_rules": {
+    "rsi_oversold": 32,
+    "rsi_overbought": 68,
+    "sma_convergence_threshold": 0.002,
+    "bb_squeeze_lookback": 3,
+    "breakout_volume_ratio": 1.5
+  },
+  "signal_rules": {
+    "trend_follow": {
+      "enabled": true,
+      "require_macd_confirm": false,
+      "require_ema_cross": true,
+      "rsi_buy_max": 60,
+      "rsi_sell_min": 35
+    },
+    "contrarian": {
+      "enabled": true,
+      "rsi_entry": 32,
+      "rsi_exit": 68,
+      "macd_histogram_limit": 10
+    },
+    "breakout": {
+      "enabled": true,
+      "volume_ratio_min": 1.5,
+      "require_macd_confirm": true,
+      "cmf_buy_min": 0.1
+    }
+  },
+  "strategy_risk": {
+    "stop_loss_percent": 14,
+    "take_profit_percent": 4,
+    "stop_loss_atr_multiplier": 0,
+    "max_position_amount": 100000,
+    "max_daily_loss": 50000,
+    "trailing_atr_multiplier": 2.5,
+    "position_sizing": {
+      "mode": "risk_pct",
+      "risk_per_trade_pct": 0.50,
+      "max_position_pct_of_equity": 20,
+      "min_lot": 0.1,
+      "lot_step": 0.1
+    }
+  },
+  "htf_filter": {
+    "enabled": true,
+    "block_counter_trend": false,
+    "alignment_boost": 0.1
+  }
+}


### PR DESCRIPTION
## Summary

- production v7 (LTC PT15M) の指標期間を 3x にスケールした ETH PT5M ベースライン profile (\`experiment_eth_pt5m_baseline.json\`) を追加
- 信号/Stance/Risk ルールは production v7 と同一 — 「タイムフレーム + 期間スケールだけで成立するか」を切り分けるため
- PR-A〜PR-D の配線が live まで貫通したことを backtest 数値で実証 (45pp 差)

## なぜ

PR-B/C/D で indicator 期間を profile 駆動にした上で、最初の ETH PT5M 戦略候補を作る必要がある。production の \"15m/14期間=210分\" を PT5M に持ってくるには 3x にスケールしないと \"5m/14期間=70分\" で意味が変わる。

## Smoke 検証 (3 ヶ月, 2026-01-16〜2026-04-16, initial=¥1M)

| Profile | Trades | Return | MaxDD | Sharpe |
|---|---|---|---|---|
| **baseline (本 PR, 3x scaled)** | 2158 | **+38.87%** | 9.69% | 3.49 |
| production (PT15M periods on PT5M data) | 822 | -6.39% | 11.84% | -1.54 |

→ 45pp 差。PR-B/C/D の配線が実際に効いていて、3x スケールが PT5M で意味のある結果を生む。

## 注意点

- ETH min_lot=0.1 ≈ 37k JPY なので、risk_pct=0.50 + SL=14% で \`initialBalance ≥ ~400k JPY\` が無いと sizer が min_lot 下回りで全 trade を skip する (trades=0 になる)。**LTC で使った \`initialBalance=100k\` を ETH に流用すると silent failure**。今後の ETH PDCA は default \`initialBalance=1M\` で回すべき
- 単一 3 ヶ月 window の +38.87% は出来過ぎ感あり。promote 前に 4-period verification (3m/6m/1y/2y from 2026-04-16) が必要
- profile は \`min_lot=0.1\` のまま (LTC/ETH で venue minimum が一致するため)。XLM/DOT/XTZ/XRP に展開する際は sizer fallback バグに注意 (memory に記録済)

## Next

- PDCA cycle60+: 4-period verification → signal/stance/risk の再チューニング
- promote 判定: 「2y MaxDD ≤ 20% & 全期間 positive」(LTC v7 と同じ基準)

## Test plan

- [x] \`backtest run --profile experiment_eth_pt5m_baseline\` smoke pass (上記 +38.87%/9.69%DD)
- [x] production と並べて、profile 期間が実際に効いてることを差分で確認
- [x] go build (PR-D で merge 済の wiring を経由)

🤖 Generated with [Claude Code](https://claude.com/claude-code)