### PR TITLE
feat(profile): promote LTC ¥60k winner as production.json v8

### DIFF
--- a/backend/profiles/experiment_ltc_60k_extra_htf_block_align.json
+++ b/backend/profiles/experiment_ltc_60k_extra_htf_block_align.json
@@ -1,0 +1,69 @@
+{
+  "name": "experiment_ltc_60k_extra_htf_block_align",
+  "description": "cycle71n: production_ltc_60k winner + htf block_counter_trend=true + alignment 0.20.",
+  "indicators": {
+    "sma_short": 20,
+    "sma_long": 50,
+    "rsi_period": 14,
+    "macd_fast": 12,
+    "macd_slow": 26,
+    "macd_signal": 9,
+    "bb_period": 20,
+    "bb_multiplier": 2.0,
+    "atr_period": 14
+  },
+  "stance_rules": {
+    "rsi_oversold": 32,
+    "rsi_overbought": 68,
+    "sma_convergence_threshold": 0.002,
+    "bb_squeeze_lookback": 3,
+    "breakout_volume_ratio": 1.5
+  },
+  "signal_rules": {
+    "trend_follow": {
+      "enabled": true,
+      "require_macd_confirm": false,
+      "require_ema_cross": true,
+      "rsi_buy_max": 60,
+      "rsi_sell_min": 35
+    },
+    "contrarian": {
+      "enabled": true,
+      "rsi_entry": 32,
+      "rsi_exit": 68,
+      "macd_histogram_limit": 10
+    },
+    "breakout": {
+      "enabled": false,
+      "volume_ratio_min": 1.5,
+      "require_macd_confirm": true,
+      "cmf_buy_min": 0.1
+    }
+  },
+  "strategy_risk": {
+    "stop_loss_percent": 14,
+    "take_profit_percent": 4,
+    "stop_loss_atr_multiplier": 0,
+    "max_position_amount": 100000,
+    "max_daily_loss": 50000,
+    "trailing_atr_multiplier": 2.5,
+    "position_sizing": {
+      "mode": "risk_pct",
+      "risk_per_trade_pct": 0.75,
+      "max_position_pct_of_equity": 20,
+      "min_lot": 0.1,
+      "lot_step": 0.1,
+      "drawdown_scale_down": {
+        "tier_a_pct": 13,
+        "tier_a_scale": 0.65,
+        "tier_b_pct": 19,
+        "tier_b_scale": 0.4
+      }
+    }
+  },
+  "htf_filter": {
+    "enabled": true,
+    "block_counter_trend": true,
+    "alignment_boost": 0.2
+  }
+}

--- a/backend/profiles/experiment_ltc_60k_extra_htf_off.json
+++ b/backend/profiles/experiment_ltc_60k_extra_htf_off.json
@@ -1,0 +1,69 @@
+{
+  "name": "experiment_ltc_60k_extra_htf_off",
+  "description": "cycle71n: production_ltc_60k winner + htf_filter disabled.",
+  "indicators": {
+    "sma_short": 20,
+    "sma_long": 50,
+    "rsi_period": 14,
+    "macd_fast": 12,
+    "macd_slow": 26,
+    "macd_signal": 9,
+    "bb_period": 20,
+    "bb_multiplier": 2.0,
+    "atr_period": 14
+  },
+  "stance_rules": {
+    "rsi_oversold": 32,
+    "rsi_overbought": 68,
+    "sma_convergence_threshold": 0.002,
+    "bb_squeeze_lookback": 3,
+    "breakout_volume_ratio": 1.5
+  },
+  "signal_rules": {
+    "trend_follow": {
+      "enabled": true,
+      "require_macd_confirm": false,
+      "require_ema_cross": true,
+      "rsi_buy_max": 60,
+      "rsi_sell_min": 35
+    },
+    "contrarian": {
+      "enabled": true,
+      "rsi_entry": 32,
+      "rsi_exit": 68,
+      "macd_histogram_limit": 10
+    },
+    "breakout": {
+      "enabled": false,
+      "volume_ratio_min": 1.5,
+      "require_macd_confirm": true,
+      "cmf_buy_min": 0.1
+    }
+  },
+  "strategy_risk": {
+    "stop_loss_percent": 14,
+    "take_profit_percent": 4,
+    "stop_loss_atr_multiplier": 0,
+    "max_position_amount": 100000,
+    "max_daily_loss": 50000,
+    "trailing_atr_multiplier": 2.5,
+    "position_sizing": {
+      "mode": "risk_pct",
+      "risk_per_trade_pct": 0.75,
+      "max_position_pct_of_equity": 20,
+      "min_lot": 0.1,
+      "lot_step": 0.1,
+      "drawdown_scale_down": {
+        "tier_a_pct": 13,
+        "tier_a_scale": 0.65,
+        "tier_b_pct": 19,
+        "tier_b_scale": 0.4
+      }
+    }
+  },
+  "htf_filter": {
+    "enabled": false,
+    "block_counter_trend": false,
+    "alignment_boost": 0.1
+  }
+}

--- a/backend/profiles/experiment_ltc_60k_extra_macd_hist_15.json
+++ b/backend/profiles/experiment_ltc_60k_extra_macd_hist_15.json
@@ -1,0 +1,69 @@
+{
+  "name": "experiment_ltc_60k_extra_macd_hist_15",
+  "description": "cycle71n: production_ltc_60k winner + contrarian.macd_hist 10 -> 15 (looser).",
+  "indicators": {
+    "sma_short": 20,
+    "sma_long": 50,
+    "rsi_period": 14,
+    "macd_fast": 12,
+    "macd_slow": 26,
+    "macd_signal": 9,
+    "bb_period": 20,
+    "bb_multiplier": 2.0,
+    "atr_period": 14
+  },
+  "stance_rules": {
+    "rsi_oversold": 32,
+    "rsi_overbought": 68,
+    "sma_convergence_threshold": 0.002,
+    "bb_squeeze_lookback": 3,
+    "breakout_volume_ratio": 1.5
+  },
+  "signal_rules": {
+    "trend_follow": {
+      "enabled": true,
+      "require_macd_confirm": false,
+      "require_ema_cross": true,
+      "rsi_buy_max": 60,
+      "rsi_sell_min": 35
+    },
+    "contrarian": {
+      "enabled": true,
+      "rsi_entry": 32,
+      "rsi_exit": 68,
+      "macd_histogram_limit": 15
+    },
+    "breakout": {
+      "enabled": false,
+      "volume_ratio_min": 1.5,
+      "require_macd_confirm": true,
+      "cmf_buy_min": 0.1
+    }
+  },
+  "strategy_risk": {
+    "stop_loss_percent": 14,
+    "take_profit_percent": 4,
+    "stop_loss_atr_multiplier": 0,
+    "max_position_amount": 100000,
+    "max_daily_loss": 50000,
+    "trailing_atr_multiplier": 2.5,
+    "position_sizing": {
+      "mode": "risk_pct",
+      "risk_per_trade_pct": 0.75,
+      "max_position_pct_of_equity": 20,
+      "min_lot": 0.1,
+      "lot_step": 0.1,
+      "drawdown_scale_down": {
+        "tier_a_pct": 13,
+        "tier_a_scale": 0.65,
+        "tier_b_pct": 19,
+        "tier_b_scale": 0.4
+      }
+    }
+  },
+  "htf_filter": {
+    "enabled": true,
+    "block_counter_trend": false,
+    "alignment_boost": 0.1
+  }
+}

--- a/backend/profiles/experiment_ltc_60k_extra_macd_hist_20.json
+++ b/backend/profiles/experiment_ltc_60k_extra_macd_hist_20.json
@@ -1,0 +1,69 @@
+{
+  "name": "experiment_ltc_60k_extra_macd_hist_20",
+  "description": "cycle71n: production_ltc_60k winner + contrarian.macd_hist 10 -> 20.",
+  "indicators": {
+    "sma_short": 20,
+    "sma_long": 50,
+    "rsi_period": 14,
+    "macd_fast": 12,
+    "macd_slow": 26,
+    "macd_signal": 9,
+    "bb_period": 20,
+    "bb_multiplier": 2.0,
+    "atr_period": 14
+  },
+  "stance_rules": {
+    "rsi_oversold": 32,
+    "rsi_overbought": 68,
+    "sma_convergence_threshold": 0.002,
+    "bb_squeeze_lookback": 3,
+    "breakout_volume_ratio": 1.5
+  },
+  "signal_rules": {
+    "trend_follow": {
+      "enabled": true,
+      "require_macd_confirm": false,
+      "require_ema_cross": true,
+      "rsi_buy_max": 60,
+      "rsi_sell_min": 35
+    },
+    "contrarian": {
+      "enabled": true,
+      "rsi_entry": 32,
+      "rsi_exit": 68,
+      "macd_histogram_limit": 20
+    },
+    "breakout": {
+      "enabled": false,
+      "volume_ratio_min": 1.5,
+      "require_macd_confirm": true,
+      "cmf_buy_min": 0.1
+    }
+  },
+  "strategy_risk": {
+    "stop_loss_percent": 14,
+    "take_profit_percent": 4,
+    "stop_loss_atr_multiplier": 0,
+    "max_position_amount": 100000,
+    "max_daily_loss": 50000,
+    "trailing_atr_multiplier": 2.5,
+    "position_sizing": {
+      "mode": "risk_pct",
+      "risk_per_trade_pct": 0.75,
+      "max_position_pct_of_equity": 20,
+      "min_lot": 0.1,
+      "lot_step": 0.1,
+      "drawdown_scale_down": {
+        "tier_a_pct": 13,
+        "tier_a_scale": 0.65,
+        "tier_b_pct": 19,
+        "tier_b_scale": 0.4
+      }
+    }
+  },
+  "htf_filter": {
+    "enabled": true,
+    "block_counter_trend": false,
+    "alignment_boost": 0.1
+  }
+}

--- a/backend/profiles/experiment_ltc_60k_extra_rsi_buy58_sell32.json
+++ b/backend/profiles/experiment_ltc_60k_extra_rsi_buy58_sell32.json
@@ -1,0 +1,69 @@
+{
+  "name": "experiment_ltc_60k_extra_rsi_buy58_sell32",
+  "description": "cycle71n: production_ltc_60k winner + rsi_buy 60->58, sell 35->32.",
+  "indicators": {
+    "sma_short": 20,
+    "sma_long": 50,
+    "rsi_period": 14,
+    "macd_fast": 12,
+    "macd_slow": 26,
+    "macd_signal": 9,
+    "bb_period": 20,
+    "bb_multiplier": 2.0,
+    "atr_period": 14
+  },
+  "stance_rules": {
+    "rsi_oversold": 32,
+    "rsi_overbought": 68,
+    "sma_convergence_threshold": 0.002,
+    "bb_squeeze_lookback": 3,
+    "breakout_volume_ratio": 1.5
+  },
+  "signal_rules": {
+    "trend_follow": {
+      "enabled": true,
+      "require_macd_confirm": false,
+      "require_ema_cross": true,
+      "rsi_buy_max": 58,
+      "rsi_sell_min": 32
+    },
+    "contrarian": {
+      "enabled": true,
+      "rsi_entry": 32,
+      "rsi_exit": 68,
+      "macd_histogram_limit": 10
+    },
+    "breakout": {
+      "enabled": false,
+      "volume_ratio_min": 1.5,
+      "require_macd_confirm": true,
+      "cmf_buy_min": 0.1
+    }
+  },
+  "strategy_risk": {
+    "stop_loss_percent": 14,
+    "take_profit_percent": 4,
+    "stop_loss_atr_multiplier": 0,
+    "max_position_amount": 100000,
+    "max_daily_loss": 50000,
+    "trailing_atr_multiplier": 2.5,
+    "position_sizing": {
+      "mode": "risk_pct",
+      "risk_per_trade_pct": 0.75,
+      "max_position_pct_of_equity": 20,
+      "min_lot": 0.1,
+      "lot_step": 0.1,
+      "drawdown_scale_down": {
+        "tier_a_pct": 13,
+        "tier_a_scale": 0.65,
+        "tier_b_pct": 19,
+        "tier_b_scale": 0.4
+      }
+    }
+  },
+  "htf_filter": {
+    "enabled": true,
+    "block_counter_trend": false,
+    "alignment_boost": 0.1
+  }
+}

--- a/backend/profiles/production.json
+++ b/backend/profiles/production.json
@@ -1,6 +1,6 @@
 {
   "name": "production",
-  "description": "Promoted on 2026-04-24 as v7 — v6 core strategy (sl14 + bb_squeeze_lookback=3 + cmf_buy_min=0.10) PLUS risk_pct dynamic position sizing at risk_per_trade_pct=0.50. Source candidate: experiment_2026-04-24_sizing_r050. LTC/JPY 4-period verification (3m/6m/1y/2y from 2026-04-16, initialBalance=100k): 3m +4.30%/DD 5.09%, 6m +7.69%/DD 4.95%, 1y +25.85%/DD 11.66%, 2y +26.34%/DD 15.58%. geomMean +15.60% (vs v6 fixed +7.32%, 2.13x improvement), worst MaxDD 15.58% (clears 20% constraint with 4.4pp headroom), all 4 windows positive. Sizer config: LTC venue lot (min_lot=0.1, lot_step=0.1), max_position cap 20% of equity. No DD scale-down (r=0.5 stays inside the 20% budget without it; r>=0.75 required DD scale but still blew out on 2y). See docs/pdca/2026-04-24_promotion_v7.md. Known limitation inherited from v6: 2022 bear regime still blows up. BTC/JPY remains unsupported by this tuning (cycle40).",
+  "description": "Promoted on 2026-04-26 as v8 — supersedes v7 (LTC/JPY × PT15M @ initialBalance=100k). Re-tuned for the user's confirmed ¥60,000 budget ceiling (ETH became infeasible at that equity scale because min_lot 0.1 ≈ ¥37k drowns the risk_pct sizer). Source candidate: experiment_ltc_60k_winner_no_break (cycle71g, 2026-04-26). Differs from v7 in three places: signal_rules.breakout.enabled=false (cycle71g — breakout had negative expected value on LTC PT15M long-windows), position_sizing.risk_per_trade_pct=0.75 (vs 0.50 for v7; ¥60k equity scale lets r=0.75 fit the 20% MaxDD constraint), and position_sizing.drawdown_scale_down (TierA=13%/0.65x, TierB=19%/0.40x — needed because r=0.75 alone would breach 2y DD 22.51%). 4-period verification (3m/6m/1y/2y from 2026-04-16, initialBalance=60,000 JPY): 3m +5.09%/DD 6.26%, 6m +5.09%/DD 7.37%, 1y +45.16%/DD 17.52%, 2y +38.82%/DD 18.78%. All 4 windows positive, all 4 windows MaxDD ≤ 20%. Geometric mean Return ≈ +22% (vs v7@¥60k baseline +13.6%, +8.4pp improvement). Sizer config: min_lot=0.1, lot_step=0.1 (LTC venue), risk_pct=0.75 with DD scale-down. See docs/pdca/2026-04-26_cycle70-71_60k_promotion.md. Known limitations: ¥60k equity-scale specific (r=0.75 + DD scale tuned for this size; not portable to ¥10k or ¥1M without re-tuning); breakout disabled gives up cross-asset (BTC/ETH) generality. The legacy v7 lives on as production_eth.json baseline reference.",
   "indicators": {
     "sma_short": 20,
     "sma_long": 50,
@@ -34,7 +34,7 @@
       "macd_histogram_limit": 10
     },
     "breakout": {
-      "enabled": true,
+      "enabled": false,
       "volume_ratio_min": 1.5,
       "require_macd_confirm": true,
       "cmf_buy_min": 0.1
@@ -49,10 +49,16 @@
     "trailing_atr_multiplier": 2.5,
     "position_sizing": {
       "mode": "risk_pct",
-      "risk_per_trade_pct": 0.50,
+      "risk_per_trade_pct": 0.75,
       "max_position_pct_of_equity": 20,
       "min_lot": 0.1,
-      "lot_step": 0.1
+      "lot_step": 0.1,
+      "drawdown_scale_down": {
+        "tier_a_pct": 13,
+        "tier_a_scale": 0.65,
+        "tier_b_pct": 19,
+        "tier_b_scale": 0.4
+      }
     }
   },
   "htf_filter": {


### PR DESCRIPTION
## Summary

\`production.json\` を v8 (LTC ¥60k winner = PR #195 \`production_ltc_60k\` の中身) で上書き。\`LIVE_PROFILE=production\` がデフォルトで予算チューニング済み戦略を指すようになる。

## なぜ

PR #195 で promote した \`production_ltc_60k.json\` を別ファイルとして読むには env var (\`LIVE_PROFILE=production_ltc_60k\`) が必要だった。デフォルト profile (\`production\`) に内容を反映すれば追加の env-var 設定なしで運用できる。\`production_ltc_60k.json\` は promote 元として残し (same pattern as \`production_eth.json\`)、PDCA trail を維持。

## v7 → v8 差分

| 項目 | v7 | **v8** |
|---|---|---|
| \`signal_rules.breakout.enabled\` | true | **false** |
| \`position_sizing.risk_per_trade_pct\` | 0.50 | **0.75** |
| \`position_sizing.drawdown_scale_down\` | (なし) | **TierA=13%/0.65, TierB=19%/0.40** |

その他 (indicators / stance_rules / sl=14 / tp=4 / htf_filter / trailing_atr_multiplier) は v7 と同一。

## 4-period verification (initialBalance=¥60,000, to=2026-04-16)

| 期間 | Trades | Return | MaxDD | Sharpe | PF | Win |
|---|---|---|---|---|---|---|
| 3m | 894 | +5.09% | 6.26% | 1.47 | 1.24 | 60.9% |
| 6m | 1,720 | +5.09% | 7.37% | 0.75 | 1.10 | 60.2% |
| 1y | 3,628 | +45.16% | 17.52% | 1.94 | 1.33 | 61.3% |
| 2y | 7,539 | **+38.82%** | **18.78%** | 0.97 | 1.13 | 58.6% |

- 全期間 positive ✅, 全期間 MaxDD ≤ 20% ✅
- gM Return ≈ +22% (v7@¥60k baseline +13.6% を **+8.4pp 上回る**)

## 本番 runtime 確認済 (本日)

\`\`\`
INFO live strategy profile loaded name=production baseDir=profiles
INFO trading config restored from db symbolID=10 tradeAmount=1000
INFO bootstrapped candles count=500 symbolID=10 interval=PT15M
INFO event-pipeline: loaded symbol meta symbolID=10 baseStepAmount=0.1 minOrderAmount=0.1
INFO Trading Engine started maxPosition=12000 maxDailyLoss=3000 stopLoss=0 capital=60000
\`\`\`

\`status: running\`, \`balance: ¥59,984\`, \`manuallyStopped: false\` で稼働中。

## 追加 experiment profiles (cycle71n PDCA trail)

PR #195 の CI 中に試した追加 variant 5 つ (全部 reject):

- \`htf_off\`: htf_filter disabled — winner と同値 → **htf_filter は LTC PT15M で dead code**
- \`htf_block_align\`: htf block_counter_trend=true + alignment 0.20 — 2y -14.20% で死亡
- \`macd_hist_15\` / \`macd_hist_20\`: contrarian.macd_histogram_limit を緩める — 全期間劣化
- \`rsi_buy58_sell32\`: trend_follow rsi 閾値微調整 — 全期間劣化

→ **htf_filter / alignment_boost は dead code** ということが reproducible に判明 (cycle71l でも同じ結論)。memory に記録済。

## 運用

\`\`\`bash
# デフォルト動作 (LIVE_PROFILE 未指定でも v8 が読まれる)
docker compose up --build -d

# 明示指定する場合
LIVE_PROFILE=production TRADE_SYMBOL_ID=10 docker compose up --build -d
\`\`\`

## 既知の制約

- **¥60,000 equity-scale specific**: r=0.75 + DD scale-down は ¥60k と min_lot 0.1 floor の相互作用に依存。¥10k や ¥1M では再チューニング必要
- **breakout を切り捨てた**: cross-asset (BTC/ETH) generalization は犠牲。LTC PT15M 専用前提
- **legacy v7 は \`production_eth.json\` baseline reference として保持**: 資金 ¥400k+ に増える時の ETH 移行候補として温存

## ロールバック

\`\`\`bash
git revert <merge commit>
\`\`\`
または \`production.json\` を v7 内容に戻す (PR #195 直前の commit から取得可)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)