### PR TITLE
feat(decisionlog): PR #2 storage layer (migrations + repos)

### DIFF
--- a/backend/internal/infrastructure/database/backtest_decision_log_repo.go
+++ b/backend/internal/infrastructure/database/backtest_decision_log_repo.go
@@ -1,0 +1,146 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/repository"
+)
+
+const backtestDecisionLogDefaultLimit = 500
+
+type backtestDecisionLogRepo struct {
+	db *sql.DB
+}
+
+// NewBacktestDecisionLogRepository returns a repository.BacktestDecisionLogRepository
+// backed by the given *sql.DB. Each row is scoped to a backtest run id; a
+// 3-day retention sweep deletes old rows automatically (see usecase/decisionlog).
+func NewBacktestDecisionLogRepository(db *sql.DB) repository.BacktestDecisionLogRepository {
+	return &backtestDecisionLogRepo{db: db}
+}
+
+func (r *backtestDecisionLogRepo) Insert(ctx context.Context, rec entity.DecisionRecord, runID string) error {
+	const q = `
+		INSERT INTO backtest_decision_log (
+			backtest_run_id,
+			bar_close_at, sequence_in_bar, trigger_kind,
+			symbol_id, currency_pair, primary_interval,
+			stance, last_price,
+			signal_action, signal_confidence, signal_reason,
+			risk_outcome, risk_reason,
+			book_gate_outcome, book_gate_reason,
+			order_outcome, order_id, executed_amount, executed_price, order_error,
+			closed_position_id, opened_position_id,
+			indicators_json, higher_tf_indicators_json,
+			created_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`
+	if _, err := r.db.ExecContext(ctx, q,
+		runID,
+		rec.BarCloseAt, rec.SequenceInBar, rec.TriggerKind,
+		rec.SymbolID, rec.CurrencyPair, rec.PrimaryInterval,
+		rec.Stance, rec.LastPrice,
+		rec.SignalAction, rec.SignalConfidence, rec.SignalReason,
+		rec.RiskOutcome, rec.RiskReason,
+		rec.BookGateOutcome, rec.BookGateReason,
+		rec.OrderOutcome, rec.OrderID, rec.ExecutedAmount, rec.ExecutedPrice, rec.OrderError,
+		rec.ClosedPositionID, rec.OpenedPositionID,
+		rec.IndicatorsJSON, rec.HigherTFIndicatorsJSON,
+		rec.CreatedAt,
+	); err != nil {
+		return fmt.Errorf("backtest_decision_log insert: %w", err)
+	}
+	return nil
+}
+
+func (r *backtestDecisionLogRepo) ListByRun(ctx context.Context, runID string, limit int, cursor int64) ([]entity.DecisionRecord, int64, error) {
+	if limit <= 0 {
+		limit = backtestDecisionLogDefaultLimit
+	}
+	args := []any{runID}
+	where := "backtest_run_id = ?"
+	if cursor > 0 {
+		where += " AND id < ?"
+		args = append(args, cursor)
+	}
+	args = append(args, limit)
+
+	q := fmt.Sprintf(`
+		SELECT id, bar_close_at, sequence_in_bar, trigger_kind,
+		       symbol_id, currency_pair, primary_interval,
+		       stance, last_price,
+		       signal_action, signal_confidence, signal_reason,
+		       risk_outcome, risk_reason,
+		       book_gate_outcome, book_gate_reason,
+		       order_outcome, order_id, executed_amount, executed_price, order_error,
+		       closed_position_id, opened_position_id,
+		       indicators_json, higher_tf_indicators_json,
+		       created_at
+		FROM backtest_decision_log
+		WHERE %s
+		ORDER BY id DESC
+		LIMIT ?
+	`, where)
+
+	rows, err := r.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, 0, fmt.Errorf("backtest_decision_log list: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]entity.DecisionRecord, 0, limit)
+	for rows.Next() {
+		var rec entity.DecisionRecord
+		if err := rows.Scan(
+			&rec.ID, &rec.BarCloseAt, &rec.SequenceInBar, &rec.TriggerKind,
+			&rec.SymbolID, &rec.CurrencyPair, &rec.PrimaryInterval,
+			&rec.Stance, &rec.LastPrice,
+			&rec.SignalAction, &rec.SignalConfidence, &rec.SignalReason,
+			&rec.RiskOutcome, &rec.RiskReason,
+			&rec.BookGateOutcome, &rec.BookGateReason,
+			&rec.OrderOutcome, &rec.OrderID, &rec.ExecutedAmount, &rec.ExecutedPrice, &rec.OrderError,
+			&rec.ClosedPositionID, &rec.OpenedPositionID,
+			&rec.IndicatorsJSON, &rec.HigherTFIndicatorsJSON,
+			&rec.CreatedAt,
+		); err != nil {
+			return nil, 0, fmt.Errorf("backtest_decision_log scan: %w", err)
+		}
+		out = append(out, rec)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, fmt.Errorf("backtest_decision_log rows: %w", err)
+	}
+
+	var next int64
+	if len(out) == limit {
+		next = out[len(out)-1].ID
+	}
+	return out, next, nil
+}
+
+func (r *backtestDecisionLogRepo) DeleteByRun(ctx context.Context, runID string) (int64, error) {
+	res, err := r.db.ExecContext(ctx, `DELETE FROM backtest_decision_log WHERE backtest_run_id = ?`, runID)
+	if err != nil {
+		return 0, fmt.Errorf("backtest_decision_log delete by run: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("backtest_decision_log rows affected: %w", err)
+	}
+	return n, nil
+}
+
+func (r *backtestDecisionLogRepo) DeleteOlderThan(ctx context.Context, cutoff int64) (int64, error) {
+	res, err := r.db.ExecContext(ctx, `DELETE FROM backtest_decision_log WHERE created_at < ?`, cutoff)
+	if err != nil {
+		return 0, fmt.Errorf("backtest_decision_log delete older: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("backtest_decision_log rows affected: %w", err)
+	}
+	return n, nil
+}

--- a/backend/internal/infrastructure/database/backtest_decision_log_repo_test.go
+++ b/backend/internal/infrastructure/database/backtest_decision_log_repo_test.go
@@ -1,0 +1,149 @@
+package database
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+)
+
+func openBacktestDecisionLogTestDB(t *testing.T) (*backtestDecisionLogRepoTestDB, func()) {
+	t.Helper()
+	tmpDir := t.TempDir()
+	db, err := NewDB(filepath.Join(tmpDir, "test.db"))
+	if err != nil {
+		t.Fatalf("NewDB: %v", err)
+	}
+	if err := RunMigrations(db); err != nil {
+		t.Fatalf("RunMigrations: %v", err)
+	}
+	cleanup := func() { db.Close() }
+	return &backtestDecisionLogRepoTestDB{repo: NewBacktestDecisionLogRepository(db)}, cleanup
+}
+
+type backtestDecisionLogRepoTestDB struct {
+	repo interface {
+		Insert(ctx context.Context, rec entity.DecisionRecord, runID string) error
+		ListByRun(ctx context.Context, runID string, limit int, cursor int64) ([]entity.DecisionRecord, int64, error)
+		DeleteByRun(ctx context.Context, runID string) (int64, error)
+		DeleteOlderThan(ctx context.Context, cutoff int64) (int64, error)
+	}
+}
+
+func sampleBacktestDecisionRecord(barTs int64, createdAt int64) entity.DecisionRecord {
+	return entity.DecisionRecord{
+		BarCloseAt:      barTs,
+		TriggerKind:     entity.DecisionTriggerBarClose,
+		SymbolID:        7,
+		CurrencyPair:    "LTC_JPY",
+		PrimaryInterval: "PT15M",
+		Stance:          "TREND_FOLLOW",
+		LastPrice:       30210,
+		SignalAction:    "HOLD",
+		RiskOutcome:     entity.DecisionRiskSkipped,
+		BookGateOutcome: entity.DecisionBookSkipped,
+		OrderOutcome:    entity.DecisionOrderNoop,
+		CreatedAt:       createdAt,
+	}
+}
+
+func TestBacktestDecisionLogRepo_InsertAndListByRun(t *testing.T) {
+	h, cleanup := openBacktestDecisionLogTestDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	runA := "run-aaa"
+	runB := "run-bbb"
+	now := time.Now().UnixMilli()
+
+	for _, runID := range []string{runA, runA, runB} {
+		if err := h.repo.Insert(ctx, sampleBacktestDecisionRecord(1745654700000, now), runID); err != nil {
+			t.Fatalf("Insert: %v", err)
+		}
+	}
+
+	rowsA, _, err := h.repo.ListByRun(ctx, runA, 100, 0)
+	if err != nil {
+		t.Fatalf("ListByRun A: %v", err)
+	}
+	if len(rowsA) != 2 {
+		t.Errorf("runA rows = %d, want 2", len(rowsA))
+	}
+	rowsB, _, err := h.repo.ListByRun(ctx, runB, 100, 0)
+	if err != nil {
+		t.Fatalf("ListByRun B: %v", err)
+	}
+	if len(rowsB) != 1 {
+		t.Errorf("runB rows = %d, want 1", len(rowsB))
+	}
+}
+
+func TestBacktestDecisionLogRepo_DeleteByRun(t *testing.T) {
+	h, cleanup := openBacktestDecisionLogTestDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	runA := "run-aaa"
+	runB := "run-bbb"
+	now := time.Now().UnixMilli()
+
+	for i := 0; i < 5; i++ {
+		if err := h.repo.Insert(ctx, sampleBacktestDecisionRecord(1, now), runA); err != nil {
+			t.Fatalf("Insert A: %v", err)
+		}
+	}
+	if err := h.repo.Insert(ctx, sampleBacktestDecisionRecord(1, now), runB); err != nil {
+		t.Fatalf("Insert B: %v", err)
+	}
+
+	deleted, err := h.repo.DeleteByRun(ctx, runA)
+	if err != nil {
+		t.Fatalf("DeleteByRun: %v", err)
+	}
+	if deleted != 5 {
+		t.Errorf("deleted = %d, want 5", deleted)
+	}
+	rowsA, _, _ := h.repo.ListByRun(ctx, runA, 10, 0)
+	if len(rowsA) != 0 {
+		t.Errorf("runA rows after delete = %d, want 0", len(rowsA))
+	}
+	rowsB, _, _ := h.repo.ListByRun(ctx, runB, 10, 0)
+	if len(rowsB) != 1 {
+		t.Errorf("runB rows after delete = %d, want 1 (untouched)", len(rowsB))
+	}
+}
+
+func TestBacktestDecisionLogRepo_DeleteOlderThan(t *testing.T) {
+	h, cleanup := openBacktestDecisionLogTestDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	now := time.Now().UnixMilli()
+	threeDays := int64(3 * 24 * 60 * 60 * 1000)
+
+	if err := h.repo.Insert(ctx, sampleBacktestDecisionRecord(now-2*threeDays, now-2*threeDays), "run-old"); err != nil {
+		t.Fatalf("Insert old: %v", err)
+	}
+	if err := h.repo.Insert(ctx, sampleBacktestDecisionRecord(now, now), "run-fresh"); err != nil {
+		t.Fatalf("Insert fresh: %v", err)
+	}
+
+	deleted, err := h.repo.DeleteOlderThan(ctx, now-threeDays)
+	if err != nil {
+		t.Fatalf("DeleteOlderThan: %v", err)
+	}
+	if deleted != 1 {
+		t.Errorf("deleted = %d, want 1", deleted)
+	}
+
+	rowsFresh, _, _ := h.repo.ListByRun(ctx, "run-fresh", 10, 0)
+	if len(rowsFresh) != 1 {
+		t.Errorf("fresh rows = %d, want 1", len(rowsFresh))
+	}
+	rowsOld, _, _ := h.repo.ListByRun(ctx, "run-old", 10, 0)
+	if len(rowsOld) != 0 {
+		t.Errorf("old rows = %d, want 0", len(rowsOld))
+	}
+}

--- a/backend/internal/infrastructure/database/decision_log_repo.go
+++ b/backend/internal/infrastructure/database/decision_log_repo.go
@@ -1,0 +1,137 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/repository"
+)
+
+const decisionLogDefaultLimit = 200
+
+// decisionLogRepo persists DecisionRecord rows into the live `decision_log`
+// table. Read-side methods order newest-first by id (autoincrement matches
+// insertion order, which matches creation time for a single-writer pipeline).
+type decisionLogRepo struct {
+	db *sql.DB
+}
+
+// NewDecisionLogRepository returns a repository.DecisionLogRepository backed
+// by the given *sql.DB. The DB must already have the `decision_log` table
+// (run RunMigrations first).
+func NewDecisionLogRepository(db *sql.DB) repository.DecisionLogRepository {
+	return &decisionLogRepo{db: db}
+}
+
+func (r *decisionLogRepo) Insert(ctx context.Context, rec entity.DecisionRecord) error {
+	const q = `
+		INSERT INTO decision_log (
+			bar_close_at, sequence_in_bar, trigger_kind,
+			symbol_id, currency_pair, primary_interval,
+			stance, last_price,
+			signal_action, signal_confidence, signal_reason,
+			risk_outcome, risk_reason,
+			book_gate_outcome, book_gate_reason,
+			order_outcome, order_id, executed_amount, executed_price, order_error,
+			closed_position_id, opened_position_id,
+			indicators_json, higher_tf_indicators_json,
+			created_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`
+	if _, err := r.db.ExecContext(ctx, q,
+		rec.BarCloseAt, rec.SequenceInBar, rec.TriggerKind,
+		rec.SymbolID, rec.CurrencyPair, rec.PrimaryInterval,
+		rec.Stance, rec.LastPrice,
+		rec.SignalAction, rec.SignalConfidence, rec.SignalReason,
+		rec.RiskOutcome, rec.RiskReason,
+		rec.BookGateOutcome, rec.BookGateReason,
+		rec.OrderOutcome, rec.OrderID, rec.ExecutedAmount, rec.ExecutedPrice, rec.OrderError,
+		rec.ClosedPositionID, rec.OpenedPositionID,
+		rec.IndicatorsJSON, rec.HigherTFIndicatorsJSON,
+		rec.CreatedAt,
+	); err != nil {
+		return fmt.Errorf("decision_log insert: %w", err)
+	}
+	return nil
+}
+
+func (r *decisionLogRepo) List(ctx context.Context, f repository.DecisionLogFilter) ([]entity.DecisionRecord, int64, error) {
+	limit := f.Limit
+	if limit <= 0 {
+		limit = decisionLogDefaultLimit
+	}
+
+	args := make([]any, 0, 5)
+	where := "1=1"
+	if f.SymbolID > 0 {
+		where += " AND symbol_id = ?"
+		args = append(args, f.SymbolID)
+	}
+	if f.From > 0 {
+		where += " AND bar_close_at >= ?"
+		args = append(args, f.From)
+	}
+	if f.To > 0 {
+		where += " AND bar_close_at <= ?"
+		args = append(args, f.To)
+	}
+	if f.Cursor > 0 {
+		where += " AND id < ?"
+		args = append(args, f.Cursor)
+	}
+	args = append(args, limit)
+
+	q := fmt.Sprintf(`
+		SELECT id, bar_close_at, sequence_in_bar, trigger_kind,
+		       symbol_id, currency_pair, primary_interval,
+		       stance, last_price,
+		       signal_action, signal_confidence, signal_reason,
+		       risk_outcome, risk_reason,
+		       book_gate_outcome, book_gate_reason,
+		       order_outcome, order_id, executed_amount, executed_price, order_error,
+		       closed_position_id, opened_position_id,
+		       indicators_json, higher_tf_indicators_json,
+		       created_at
+		FROM decision_log
+		WHERE %s
+		ORDER BY id DESC
+		LIMIT ?
+	`, where)
+
+	rows, err := r.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, 0, fmt.Errorf("decision_log list: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]entity.DecisionRecord, 0, limit)
+	for rows.Next() {
+		var rec entity.DecisionRecord
+		if err := rows.Scan(
+			&rec.ID, &rec.BarCloseAt, &rec.SequenceInBar, &rec.TriggerKind,
+			&rec.SymbolID, &rec.CurrencyPair, &rec.PrimaryInterval,
+			&rec.Stance, &rec.LastPrice,
+			&rec.SignalAction, &rec.SignalConfidence, &rec.SignalReason,
+			&rec.RiskOutcome, &rec.RiskReason,
+			&rec.BookGateOutcome, &rec.BookGateReason,
+			&rec.OrderOutcome, &rec.OrderID, &rec.ExecutedAmount, &rec.ExecutedPrice, &rec.OrderError,
+			&rec.ClosedPositionID, &rec.OpenedPositionID,
+			&rec.IndicatorsJSON, &rec.HigherTFIndicatorsJSON,
+			&rec.CreatedAt,
+		); err != nil {
+			return nil, 0, fmt.Errorf("decision_log scan: %w", err)
+		}
+		out = append(out, rec)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, fmt.Errorf("decision_log rows: %w", err)
+	}
+
+	var next int64
+	if len(out) == limit {
+		next = out[len(out)-1].ID
+	}
+	return out, next, nil
+}

--- a/backend/internal/infrastructure/database/decision_log_repo_test.go
+++ b/backend/internal/infrastructure/database/decision_log_repo_test.go
@@ -1,0 +1,148 @@
+package database
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/repository"
+)
+
+func newDecisionRecord(symbolID int64, barTs int64, seq int) entity.DecisionRecord {
+	return entity.DecisionRecord{
+		BarCloseAt:       barTs,
+		SequenceInBar:    seq,
+		TriggerKind:      entity.DecisionTriggerBarClose,
+		SymbolID:         symbolID,
+		CurrencyPair:     "LTC_JPY",
+		PrimaryInterval:  "PT15M",
+		Stance:           "TREND_FOLLOW",
+		LastPrice:        30210,
+		SignalAction:     "HOLD",
+		SignalConfidence: 0,
+		SignalReason:     "trend follow: ADX below threshold",
+		RiskOutcome:      entity.DecisionRiskSkipped,
+		BookGateOutcome:  entity.DecisionBookSkipped,
+		OrderOutcome:     entity.DecisionOrderNoop,
+		IndicatorsJSON:   `{"rsi":48.2}`,
+		CreatedAt:        time.Now().UnixMilli(),
+	}
+}
+
+func TestDecisionLogRepo_InsertAndList(t *testing.T) {
+	tmpDir := t.TempDir()
+	db, err := NewDB(filepath.Join(tmpDir, "test.db"))
+	if err != nil {
+		t.Fatalf("NewDB: %v", err)
+	}
+	defer db.Close()
+	if err := RunMigrations(db); err != nil {
+		t.Fatalf("RunMigrations: %v", err)
+	}
+
+	repo := NewDecisionLogRepository(db)
+	ctx := context.Background()
+
+	base := int64(1745654700000)
+	for i := 0; i < 3; i++ {
+		rec := newDecisionRecord(7, base+int64(i)*900_000, 0)
+		if err := repo.Insert(ctx, rec); err != nil {
+			t.Fatalf("Insert[%d]: %v", i, err)
+		}
+	}
+
+	rows, next, err := repo.List(ctx, repository.DecisionLogFilter{SymbolID: 7, Limit: 10})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(rows) != 3 {
+		t.Fatalf("List len = %d, want 3", len(rows))
+	}
+	if rows[0].BarCloseAt < rows[1].BarCloseAt {
+		t.Errorf("rows must be newest first, got %d before %d", rows[0].BarCloseAt, rows[1].BarCloseAt)
+	}
+	if next != 0 {
+		t.Errorf("nextCursor must be 0 when fewer rows than limit, got %d", next)
+	}
+}
+
+func TestDecisionLogRepo_CursorPaging(t *testing.T) {
+	tmpDir := t.TempDir()
+	db, err := NewDB(filepath.Join(tmpDir, "test.db"))
+	if err != nil {
+		t.Fatalf("NewDB: %v", err)
+	}
+	defer db.Close()
+	if err := RunMigrations(db); err != nil {
+		t.Fatalf("RunMigrations: %v", err)
+	}
+
+	repo := NewDecisionLogRepository(db)
+	ctx := context.Background()
+
+	base := int64(1745654700000)
+	for i := 0; i < 5; i++ {
+		rec := newDecisionRecord(7, base+int64(i)*900_000, 0)
+		if err := repo.Insert(ctx, rec); err != nil {
+			t.Fatalf("Insert[%d]: %v", i, err)
+		}
+	}
+
+	page1, next1, err := repo.List(ctx, repository.DecisionLogFilter{Limit: 2})
+	if err != nil {
+		t.Fatalf("List page1: %v", err)
+	}
+	if len(page1) != 2 || next1 == 0 {
+		t.Fatalf("page1 len=%d next=%d (want 2 / non-zero)", len(page1), next1)
+	}
+
+	page2, _, err := repo.List(ctx, repository.DecisionLogFilter{Limit: 10, Cursor: next1})
+	if err != nil {
+		t.Fatalf("List page2: %v", err)
+	}
+	if len(page2) != 3 {
+		t.Errorf("page2 len = %d, want 3", len(page2))
+	}
+	for _, r := range page2 {
+		if r.ID >= next1 {
+			t.Errorf("page2 row id %d must be < cursor %d", r.ID, next1)
+		}
+	}
+}
+
+func TestDecisionLogRepo_FilterByTimeRange(t *testing.T) {
+	tmpDir := t.TempDir()
+	db, err := NewDB(filepath.Join(tmpDir, "test.db"))
+	if err != nil {
+		t.Fatalf("NewDB: %v", err)
+	}
+	defer db.Close()
+	if err := RunMigrations(db); err != nil {
+		t.Fatalf("RunMigrations: %v", err)
+	}
+
+	repo := NewDecisionLogRepository(db)
+	ctx := context.Background()
+
+	base := int64(1745654700000)
+	for i := 0; i < 5; i++ {
+		rec := newDecisionRecord(7, base+int64(i)*900_000, 0)
+		if err := repo.Insert(ctx, rec); err != nil {
+			t.Fatalf("Insert[%d]: %v", i, err)
+		}
+	}
+
+	rows, _, err := repo.List(ctx, repository.DecisionLogFilter{
+		From:  base + 900_000,
+		To:    base + 3*900_000,
+		Limit: 10,
+	})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(rows) != 3 {
+		t.Errorf("len = %d, want 3 (inclusive on both ends)", len(rows))
+	}
+}

--- a/backend/internal/infrastructure/database/migrations.go
+++ b/backend/internal/infrastructure/database/migrations.go
@@ -426,5 +426,84 @@ func RunMigrations(db *sql.DB) error {
 		}
 	}
 
+	// Decision log tables. One row per pipeline decision (BAR_CLOSE) plus
+	// extra rows for tick-driven SL/TP/trailing closes. The indicators
+	// snapshot is stored as TEXT so the recorder can write the marshalled
+	// IndicatorSet verbatim without coupling the schema to the indicator
+	// struct shape.
+	decisionLogTables := []string{
+		`CREATE TABLE IF NOT EXISTS decision_log (
+			id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+			bar_close_at       INTEGER NOT NULL,
+			sequence_in_bar    INTEGER NOT NULL DEFAULT 0,
+			trigger_kind       TEXT    NOT NULL,
+			symbol_id          INTEGER NOT NULL,
+			currency_pair      TEXT    NOT NULL,
+			primary_interval   TEXT    NOT NULL,
+			stance             TEXT    NOT NULL,
+			last_price         REAL    NOT NULL,
+			signal_action      TEXT    NOT NULL,
+			signal_confidence  REAL    NOT NULL DEFAULT 0,
+			signal_reason      TEXT    NOT NULL DEFAULT '',
+			risk_outcome       TEXT    NOT NULL,
+			risk_reason        TEXT    NOT NULL DEFAULT '',
+			book_gate_outcome  TEXT    NOT NULL DEFAULT 'SKIPPED',
+			book_gate_reason   TEXT    NOT NULL DEFAULT '',
+			order_outcome      TEXT    NOT NULL,
+			order_id           INTEGER NOT NULL DEFAULT 0,
+			executed_amount    REAL    NOT NULL DEFAULT 0,
+			executed_price     REAL    NOT NULL DEFAULT 0,
+			order_error        TEXT    NOT NULL DEFAULT '',
+			closed_position_id INTEGER NOT NULL DEFAULT 0,
+			opened_position_id INTEGER NOT NULL DEFAULT 0,
+			indicators_json           TEXT NOT NULL DEFAULT '{}',
+			higher_tf_indicators_json TEXT NOT NULL DEFAULT '{}',
+			created_at         INTEGER NOT NULL
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_decision_log_symbol_time
+			ON decision_log(symbol_id, bar_close_at DESC, sequence_in_bar)`,
+		`CREATE INDEX IF NOT EXISTS idx_decision_log_created
+			ON decision_log(created_at)`,
+
+		`CREATE TABLE IF NOT EXISTS backtest_decision_log (
+			id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+			backtest_run_id    TEXT    NOT NULL,
+			bar_close_at       INTEGER NOT NULL,
+			sequence_in_bar    INTEGER NOT NULL DEFAULT 0,
+			trigger_kind       TEXT    NOT NULL,
+			symbol_id          INTEGER NOT NULL,
+			currency_pair      TEXT    NOT NULL,
+			primary_interval   TEXT    NOT NULL,
+			stance             TEXT    NOT NULL,
+			last_price         REAL    NOT NULL,
+			signal_action      TEXT    NOT NULL,
+			signal_confidence  REAL    NOT NULL DEFAULT 0,
+			signal_reason      TEXT    NOT NULL DEFAULT '',
+			risk_outcome       TEXT    NOT NULL,
+			risk_reason        TEXT    NOT NULL DEFAULT '',
+			book_gate_outcome  TEXT    NOT NULL DEFAULT 'SKIPPED',
+			book_gate_reason   TEXT    NOT NULL DEFAULT '',
+			order_outcome      TEXT    NOT NULL,
+			order_id           INTEGER NOT NULL DEFAULT 0,
+			executed_amount    REAL    NOT NULL DEFAULT 0,
+			executed_price     REAL    NOT NULL DEFAULT 0,
+			order_error        TEXT    NOT NULL DEFAULT '',
+			closed_position_id INTEGER NOT NULL DEFAULT 0,
+			opened_position_id INTEGER NOT NULL DEFAULT 0,
+			indicators_json           TEXT NOT NULL DEFAULT '{}',
+			higher_tf_indicators_json TEXT NOT NULL DEFAULT '{}',
+			created_at         INTEGER NOT NULL
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_backtest_decision_log_run
+			ON backtest_decision_log(backtest_run_id, bar_close_at, sequence_in_bar)`,
+		`CREATE INDEX IF NOT EXISTS idx_backtest_decision_log_created
+			ON backtest_decision_log(created_at)`,
+	}
+	for _, stmt := range decisionLogTables {
+		if _, err := db.Exec(stmt); err != nil {
+			return fmt.Errorf("create decision_log: %w", err)
+		}
+	}
+
 	return nil
 }

--- a/backend/internal/infrastructure/database/migrations_test.go
+++ b/backend/internal/infrastructure/database/migrations_test.go
@@ -288,3 +288,51 @@ func TestRunMigrations_PDCABacktestResultsColumnsAndIndexes(t *testing.T) {
 		}
 	}
 }
+
+func TestRunMigrations_DecisionLogTablesAndIndexes(t *testing.T) {
+	tmpDir := t.TempDir()
+	db, err := NewDB(filepath.Join(tmpDir, "test.db"))
+	if err != nil {
+		t.Fatalf("failed to create db: %v", err)
+	}
+	defer db.Close()
+
+	if err := RunMigrations(db); err != nil {
+		t.Fatalf("migration failed: %v", err)
+	}
+	// Idempotency.
+	if err := RunMigrations(db); err != nil {
+		t.Fatalf("re-run migration failed: %v", err)
+	}
+
+	for _, table := range []string{"decision_log", "backtest_decision_log"} {
+		var count int
+		err := db.QueryRow(
+			`SELECT count(*) FROM sqlite_master WHERE type='table' AND name=?`, table,
+		).Scan(&count)
+		if err != nil {
+			t.Fatalf("query table %s: %v", table, err)
+		}
+		if count != 1 {
+			t.Errorf("table %s should exist", table)
+		}
+	}
+
+	for _, idx := range []string{
+		"idx_decision_log_symbol_time",
+		"idx_decision_log_created",
+		"idx_backtest_decision_log_run",
+		"idx_backtest_decision_log_created",
+	} {
+		var count int
+		err := db.QueryRow(
+			`SELECT count(*) FROM sqlite_master WHERE type='index' AND name=?`, idx,
+		).Scan(&count)
+		if err != nil {
+			t.Fatalf("query index %s: %v", idx, err)
+		}
+		if count != 1 {
+			t.Errorf("index %s should exist", idx)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Foundation PR #2 of 4. Builds on #197.
- Adds \`decision_log\` and \`backtest_decision_log\` SQLite tables + indexes via \`RunMigrations\` (idempotent).
- Implements live \`decisionLogRepo\` (cursor paging, time-range filter, newest-first ordering).
- Implements \`backtestDecisionLogRepo\` (run-scoped CRUD + \`DeleteByRun\` for immediate cleanup + \`DeleteOlderThan\` for the upcoming 3-day retention sweep).

No live wiring yet — repositories are constructed only by their tests so far.

Spec: \`docs/superpowers/specs/2026-04-26-decision-log-design.md\`
Plan: \`docs/superpowers/plans/2026-04-26-decision-log-foundation.md\`

Stacked PRs:
- PR #1 (merged): entity layer
- **PR #2 (this)**: SQLite migrations + repos
- PR #3: Recorder + retention goroutine + integration test
- PR #4: Wire RejectedSignalEvent emission + populate new OrderEvent fields

## Test plan
- [x] \`go test ./internal/infrastructure/database/ -count=1\` is green (migrations idempotent + repo CRUD/paging/retention)
- [x] \`go test ./... -count=1\` (full backend suite) is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)