### PR TITLE
feat(decisionlog): PR #3 recorder + retention + integration test

### DIFF
--- a/backend/internal/usecase/decisionlog/integration_test.go
+++ b/backend/internal/usecase/decisionlog/integration_test.go
@@ -1,0 +1,92 @@
+package decisionlog_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/repository"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/infrastructure/database"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/decisionlog"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/eventengine"
+)
+
+func TestRecorder_EndToEnd_FullCycleAndHoldBar(t *testing.T) {
+	tmpDir := t.TempDir()
+	db, err := database.NewDB(filepath.Join(tmpDir, "test.db"))
+	if err != nil {
+		t.Fatalf("NewDB: %v", err)
+	}
+	defer db.Close()
+	if err := database.RunMigrations(db); err != nil {
+		t.Fatalf("RunMigrations: %v", err)
+	}
+	repo := database.NewDecisionLogRepository(db)
+
+	rec := decisionlog.NewRecorder(repo, decisionlog.RecorderConfig{
+		SymbolID:        7,
+		CurrencyPair:    "LTC_JPY",
+		PrimaryInterval: "PT15M",
+		StanceProvider:  func() string { return "TREND_FOLLOW" },
+	})
+
+	bus := eventengine.NewEventBus()
+	bus.Register(entity.EventTypeIndicator, 99, rec)
+	bus.Register(entity.EventTypeSignal, 99, rec)
+	bus.Register(entity.EventTypeApproved, 99, rec)
+	bus.Register(entity.EventTypeRejected, 99, rec)
+	bus.Register(entity.EventTypeOrder, 99, rec)
+
+	ctx := context.Background()
+
+	// Bar 1: full BUY cycle.
+	if err := bus.Dispatch(ctx, []entity.Event{
+		entity.IndicatorEvent{SymbolID: 7, Interval: "PT15M", LastPrice: 30210, Timestamp: 1_000},
+		entity.SignalEvent{
+			Signal:    entity.Signal{SymbolID: 7, Action: entity.SignalActionBuy, Confidence: 0.7, Reason: "ema cross"},
+			Price:     30210,
+			Timestamp: 1_000,
+		},
+		entity.ApprovedSignalEvent{
+			Signal:    entity.Signal{SymbolID: 7, Action: entity.SignalActionBuy, Reason: "ema cross"},
+			Price:     30210,
+			Timestamp: 1_000,
+			Amount:    0.5,
+		},
+		entity.OrderEvent{
+			OrderID: 42, SymbolID: 7, Side: "BUY", Action: "open",
+			Price: 30215, Amount: 0.5, Reason: "ema cross", Timestamp: 1_001,
+			Trigger: entity.DecisionTriggerBarClose, OpenedPositionID: 100,
+		},
+	}); err != nil {
+		t.Fatalf("Dispatch bar1: %v", err)
+	}
+
+	// Bar 2: HOLD only. Bar 3 indicator triggers the flush of bar 2's draft.
+	if err := bus.Dispatch(ctx, []entity.Event{
+		entity.IndicatorEvent{SymbolID: 7, Interval: "PT15M", LastPrice: 30220, Timestamp: 2_000},
+	}); err != nil {
+		t.Fatalf("Dispatch bar2: %v", err)
+	}
+	if err := bus.Dispatch(ctx, []entity.Event{
+		entity.IndicatorEvent{SymbolID: 7, Interval: "PT15M", LastPrice: 30230, Timestamp: 3_000},
+	}); err != nil {
+		t.Fatalf("Dispatch bar3: %v", err)
+	}
+
+	rows, _, err := repo.List(ctx, repository.DecisionLogFilter{SymbolID: 7, Limit: 100})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 rows (bar1 + bar2), got %d", len(rows))
+	}
+	// Newest first: bar2 then bar1.
+	if rows[0].BarCloseAt != 2_000 || rows[0].SignalAction != "HOLD" {
+		t.Errorf("bar2 row wrong: %+v", rows[0])
+	}
+	if rows[1].BarCloseAt != 1_000 || rows[1].SignalAction != "BUY" || rows[1].OrderOutcome != entity.DecisionOrderFilled {
+		t.Errorf("bar1 row wrong: %+v", rows[1])
+	}
+}

--- a/backend/internal/usecase/decisionlog/recorder.go
+++ b/backend/internal/usecase/decisionlog/recorder.go
@@ -1,0 +1,256 @@
+// Package decisionlog persists every pipeline decision (BUY/SELL/HOLD plus
+// the reasons each gate produced) into SQLite. Recorder is an EventBus
+// subscriber registered at priority 99 so it runs after all primary
+// handlers; it never blocks or modifies the pipeline.
+package decisionlog
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"time"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/repository"
+)
+
+// RecorderConfig binds the recorder to one pipeline instance.
+//
+// StanceProvider is called every IndicatorEvent to snapshot the pipeline's
+// current stance. A nil provider falls back to "UNKNOWN" — useful for tests
+// and for the wiring step before pipeline integration lands.
+type RecorderConfig struct {
+	SymbolID        int64
+	CurrencyPair    string
+	PrimaryInterval string
+	StanceProvider  func() string
+}
+
+// Recorder observes EventBus events and writes one DecisionRecord per
+// completed cycle. It is NOT goroutine-safe; one Recorder must be bound to
+// exactly one EventBus chain (the EventBus dispatch loop is single-threaded
+// per chain so this matches the runtime invariant).
+type Recorder struct {
+	repo   repository.DecisionLogRepository
+	cfg    RecorderConfig
+	nowFn  func() time.Time
+	logger *slog.Logger
+
+	pending           *draft
+	nextSequenceInBar int
+	lastIndicatorJSON string
+	lastHigherTFJSON  string
+}
+
+func NewRecorder(repo repository.DecisionLogRepository, cfg RecorderConfig) *Recorder {
+	return &Recorder{
+		repo:   repo,
+		cfg:    cfg,
+		nowFn:  time.Now,
+		logger: slog.Default(),
+	}
+}
+
+// SetClock overrides the timestamp source. Tests use this to make CreatedAt
+// deterministic; production never calls it.
+func (r *Recorder) SetClock(fn func() time.Time) { r.nowFn = fn }
+
+// Handle implements eventengine.EventHandler. It returns nil chained events
+// so the bus stays unaffected by recorder activity.
+func (r *Recorder) Handle(ctx context.Context, event entity.Event) ([]entity.Event, error) {
+	switch ev := event.(type) {
+	case entity.IndicatorEvent:
+		r.onIndicator(ev)
+	case entity.SignalEvent:
+		r.onSignal(ev)
+	case entity.ApprovedSignalEvent:
+		r.onApproved()
+	case entity.RejectedSignalEvent:
+		r.onRejected(ctx, ev)
+	case entity.OrderEvent:
+		r.onOrder(ctx, ev)
+	}
+	return nil, nil
+}
+
+// draft is the in-progress record for one bar. Fields are mutated as more
+// events flow in; flush() persists and clears it.
+type draft struct {
+	rec entity.DecisionRecord
+}
+
+func (r *Recorder) stance() string {
+	if r.cfg.StanceProvider == nil {
+		return "UNKNOWN"
+	}
+	return r.cfg.StanceProvider()
+}
+
+func (r *Recorder) onIndicator(ev entity.IndicatorEvent) {
+	// Flushing of the previous bar's pending draft happens lazily on the
+	// next IndicatorEvent so we do not need a goroutine timer to know when
+	// "the bar is over". A residual draft means the strategy returned HOLD
+	// for that bar (no SignalEvent / ApprovedSignalEvent / OrderEvent
+	// arrived) so we persist it as such.
+	r.flushPending(context.Background())
+
+	// Reset sequence numbering for the new bar.
+	r.nextSequenceInBar = 1
+
+	indicatorsJSON, err := json.Marshal(ev.Primary)
+	if err != nil {
+		r.logger.Warn("decisionlog: marshal indicators failed", "error", err)
+		indicatorsJSON = []byte("{}")
+	}
+	var higherJSON []byte
+	if ev.HigherTF != nil {
+		higherJSON, err = json.Marshal(ev.HigherTF)
+		if err != nil {
+			r.logger.Warn("decisionlog: marshal higher-tf indicators failed", "error", err)
+			higherJSON = []byte("{}")
+		}
+	} else {
+		higherJSON = []byte("{}")
+	}
+	r.lastIndicatorJSON = string(indicatorsJSON)
+	r.lastHigherTFJSON = string(higherJSON)
+
+	r.pending = &draft{
+		rec: entity.DecisionRecord{
+			BarCloseAt:             ev.Timestamp,
+			SequenceInBar:          0,
+			TriggerKind:            entity.DecisionTriggerBarClose,
+			SymbolID:               r.cfg.SymbolID,
+			CurrencyPair:           r.cfg.CurrencyPair,
+			PrimaryInterval:        r.cfg.PrimaryInterval,
+			Stance:                 r.stance(),
+			LastPrice:              ev.LastPrice,
+			SignalAction:           string(entity.SignalActionHold),
+			RiskOutcome:            entity.DecisionRiskSkipped,
+			BookGateOutcome:        entity.DecisionBookSkipped,
+			OrderOutcome:           entity.DecisionOrderNoop,
+			IndicatorsJSON:         r.lastIndicatorJSON,
+			HigherTFIndicatorsJSON: r.lastHigherTFJSON,
+		},
+	}
+}
+
+func (r *Recorder) onSignal(ev entity.SignalEvent) {
+	if r.pending == nil {
+		return
+	}
+	r.pending.rec.SignalAction = string(ev.Signal.Action)
+	r.pending.rec.SignalConfidence = ev.Signal.Confidence
+	r.pending.rec.SignalReason = ev.Signal.Reason
+}
+
+func (r *Recorder) onApproved() {
+	if r.pending == nil {
+		return
+	}
+	r.pending.rec.RiskOutcome = entity.DecisionRiskApproved
+	r.pending.rec.BookGateOutcome = entity.DecisionBookAllowed
+}
+
+func (r *Recorder) onRejected(ctx context.Context, ev entity.RejectedSignalEvent) {
+	if r.pending == nil {
+		return
+	}
+	switch ev.Stage {
+	case entity.RejectedStageRisk:
+		r.pending.rec.RiskOutcome = entity.DecisionRiskRejected
+		r.pending.rec.RiskReason = ev.Reason
+	case entity.RejectedStageBookGate:
+		r.pending.rec.RiskOutcome = entity.DecisionRiskApproved
+		r.pending.rec.BookGateOutcome = entity.DecisionBookVetoed
+		r.pending.rec.BookGateReason = ev.Reason
+	}
+	r.flushPending(ctx)
+}
+
+func (r *Recorder) onOrder(ctx context.Context, ev entity.OrderEvent) {
+	switch ev.Trigger {
+	case entity.DecisionTriggerTickSLTP, entity.DecisionTriggerTickTrailing:
+		r.persistTickOrder(ctx, ev)
+	default:
+		// Treat empty Trigger as a bar-close order (legacy callers haven't
+		// been migrated yet — until PR #4 lands, the ExecutionHandler still
+		// emits OrderEvent with Trigger == "").
+		r.persistBarOrder(ctx, ev)
+	}
+}
+
+func (r *Recorder) persistBarOrder(ctx context.Context, ev entity.OrderEvent) {
+	if r.pending == nil {
+		return
+	}
+	if ev.OrderID > 0 {
+		r.pending.rec.OrderOutcome = entity.DecisionOrderFilled
+	} else {
+		r.pending.rec.OrderOutcome = entity.DecisionOrderFailed
+	}
+	r.pending.rec.OrderID = ev.OrderID
+	r.pending.rec.ExecutedAmount = ev.Amount
+	r.pending.rec.ExecutedPrice = ev.Price
+	r.pending.rec.OpenedPositionID = ev.OpenedPositionID
+	r.pending.rec.ClosedPositionID = ev.ClosedPositionID
+	r.flushPending(ctx)
+}
+
+func (r *Recorder) persistTickOrder(ctx context.Context, ev entity.OrderEvent) {
+	rec := entity.DecisionRecord{
+		BarCloseAt:             ev.Timestamp,
+		SequenceInBar:          r.nextSequenceInBar,
+		TriggerKind:            ev.Trigger,
+		SymbolID:               r.cfg.SymbolID,
+		CurrencyPair:           r.cfg.CurrencyPair,
+		PrimaryInterval:        r.cfg.PrimaryInterval,
+		Stance:                 r.stance(),
+		LastPrice:              ev.Price,
+		SignalAction:           string(entity.SignalActionHold),
+		SignalReason:           ev.Reason,
+		RiskOutcome:            entity.DecisionRiskSkipped,
+		BookGateOutcome:        entity.DecisionBookSkipped,
+		OrderOutcome:           entity.DecisionOrderFilled,
+		OrderID:                ev.OrderID,
+		ExecutedAmount:         ev.Amount,
+		ExecutedPrice:          ev.Price,
+		ClosedPositionID:       ev.ClosedPositionID,
+		OpenedPositionID:       ev.OpenedPositionID,
+		IndicatorsJSON:         r.lastIndicatorJSON,
+		HigherTFIndicatorsJSON: r.lastHigherTFJSON,
+		CreatedAt:              r.nowFn().UnixMilli(),
+	}
+	if rec.IndicatorsJSON == "" {
+		rec.IndicatorsJSON = "{}"
+	}
+	if rec.HigherTFIndicatorsJSON == "" {
+		rec.HigherTFIndicatorsJSON = "{}"
+	}
+	if ev.OrderID == 0 {
+		rec.OrderOutcome = entity.DecisionOrderFailed
+	}
+	if err := r.repo.Insert(ctx, rec); err != nil {
+		r.logger.Warn("decisionlog: tick insert failed", "error", err)
+		return
+	}
+	r.nextSequenceInBar++
+}
+
+func (r *Recorder) flushPending(ctx context.Context) {
+	if r.pending == nil {
+		return
+	}
+	rec := r.pending.rec
+	rec.CreatedAt = r.nowFn().UnixMilli()
+	if rec.IndicatorsJSON == "" {
+		rec.IndicatorsJSON = "{}"
+	}
+	if rec.HigherTFIndicatorsJSON == "" {
+		rec.HigherTFIndicatorsJSON = "{}"
+	}
+	if err := r.repo.Insert(ctx, rec); err != nil {
+		r.logger.Warn("decisionlog: insert failed", "error", err)
+	}
+	r.pending = nil
+}

--- a/backend/internal/usecase/decisionlog/recorder_test.go
+++ b/backend/internal/usecase/decisionlog/recorder_test.go
@@ -1,0 +1,236 @@
+package decisionlog
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/repository"
+)
+
+type stubRepo struct {
+	inserted  []entity.DecisionRecord
+	insertErr error
+}
+
+func (s *stubRepo) Insert(_ context.Context, rec entity.DecisionRecord) error {
+	if s.insertErr != nil {
+		return s.insertErr
+	}
+	s.inserted = append(s.inserted, rec)
+	return nil
+}
+
+func (s *stubRepo) List(_ context.Context, _ repository.DecisionLogFilter) ([]entity.DecisionRecord, int64, error) {
+	return nil, 0, nil
+}
+
+func newRecorderForTest(repo repository.DecisionLogRepository) *Recorder {
+	return NewRecorder(repo, RecorderConfig{
+		SymbolID:        7,
+		CurrencyPair:    "LTC_JPY",
+		PrimaryInterval: "PT15M",
+		StanceProvider:  func() string { return "TREND_FOLLOW" },
+	})
+}
+
+func indicatorEvent(symbolID int64, ts int64) entity.IndicatorEvent {
+	return entity.IndicatorEvent{
+		SymbolID:  symbolID,
+		Interval:  "PT15M",
+		LastPrice: 30210,
+		Timestamp: ts,
+	}
+}
+
+func TestRecorder_HoldOnlyBarFlushesOnNextIndicator(t *testing.T) {
+	repo := &stubRepo{}
+	rec := newRecorderForTest(repo)
+	ctx := context.Background()
+
+	if _, err := rec.Handle(ctx, indicatorEvent(7, 1_000)); err != nil {
+		t.Fatalf("Handle bar1: %v", err)
+	}
+	if len(repo.inserted) != 0 {
+		t.Fatalf("after bar1 alone, expected 0 inserts, got %d", len(repo.inserted))
+	}
+
+	if _, err := rec.Handle(ctx, indicatorEvent(7, 2_000)); err != nil {
+		t.Fatalf("Handle bar2: %v", err)
+	}
+	if len(repo.inserted) != 1 {
+		t.Fatalf("expected 1 insert (bar1 flushed), got %d", len(repo.inserted))
+	}
+	got := repo.inserted[0]
+	if got.SignalAction != "HOLD" {
+		t.Errorf("SignalAction = %q, want HOLD", got.SignalAction)
+	}
+	if got.RiskOutcome != entity.DecisionRiskSkipped {
+		t.Errorf("RiskOutcome = %q, want SKIPPED", got.RiskOutcome)
+	}
+	if got.OrderOutcome != entity.DecisionOrderNoop {
+		t.Errorf("OrderOutcome = %q, want NOOP", got.OrderOutcome)
+	}
+	if got.TriggerKind != entity.DecisionTriggerBarClose {
+		t.Errorf("TriggerKind = %q, want BAR_CLOSE", got.TriggerKind)
+	}
+	if got.BarCloseAt != 1_000 {
+		t.Errorf("BarCloseAt = %d, want 1_000", got.BarCloseAt)
+	}
+	if got.IndicatorsJSON == "" {
+		t.Errorf("IndicatorsJSON must not be empty")
+	}
+}
+
+func TestRecorder_FullBuyFlushesOnOrder(t *testing.T) {
+	repo := &stubRepo{}
+	rec := newRecorderForTest(repo)
+	ctx := context.Background()
+
+	if _, err := rec.Handle(ctx, indicatorEvent(7, 1_000)); err != nil {
+		t.Fatalf("Handle indicator: %v", err)
+	}
+	if _, err := rec.Handle(ctx, entity.SignalEvent{
+		Signal:    entity.Signal{SymbolID: 7, Action: entity.SignalActionBuy, Confidence: 0.7, Reason: "ema cross", Timestamp: 1_000},
+		Price:     30210,
+		Timestamp: 1_000,
+	}); err != nil {
+		t.Fatalf("Handle signal: %v", err)
+	}
+	if _, err := rec.Handle(ctx, entity.ApprovedSignalEvent{
+		Signal:    entity.Signal{SymbolID: 7, Action: entity.SignalActionBuy, Reason: "ema cross"},
+		Price:     30210,
+		Timestamp: 1_000,
+		Amount:    0.5,
+	}); err != nil {
+		t.Fatalf("Handle approved: %v", err)
+	}
+	if _, err := rec.Handle(ctx, entity.OrderEvent{
+		OrderID: 42, SymbolID: 7, Side: "BUY", Action: "open",
+		Price: 30215, Amount: 0.5, Reason: "ema cross", Timestamp: 1_001,
+		Trigger: entity.DecisionTriggerBarClose, OpenedPositionID: 100,
+	}); err != nil {
+		t.Fatalf("Handle order: %v", err)
+	}
+
+	if len(repo.inserted) != 1 {
+		t.Fatalf("expected 1 insert (flushed on OrderEvent), got %d", len(repo.inserted))
+	}
+	got := repo.inserted[0]
+	if got.SignalAction != "BUY" || got.RiskOutcome != entity.DecisionRiskApproved ||
+		got.BookGateOutcome != entity.DecisionBookAllowed || got.OrderOutcome != entity.DecisionOrderFilled {
+		t.Errorf("flushed record fields wrong: %+v", got)
+	}
+	if got.OpenedPositionID != 100 || got.OrderID != 42 || got.ExecutedAmount != 0.5 {
+		t.Errorf("execution fields wrong: %+v", got)
+	}
+}
+
+func TestRecorder_RiskRejectionFlushesImmediately(t *testing.T) {
+	repo := &stubRepo{}
+	rec := newRecorderForTest(repo)
+	ctx := context.Background()
+
+	_, _ = rec.Handle(ctx, indicatorEvent(7, 1_000))
+	_, _ = rec.Handle(ctx, entity.SignalEvent{
+		Signal:    entity.Signal{SymbolID: 7, Action: entity.SignalActionBuy, Reason: "ema cross"},
+		Price:     30210,
+		Timestamp: 1_000,
+	})
+	_, _ = rec.Handle(ctx, entity.RejectedSignalEvent{
+		Signal:    entity.Signal{SymbolID: 7, Action: entity.SignalActionBuy, Reason: "ema cross"},
+		Stage:     entity.RejectedStageRisk,
+		Reason:    "daily loss limit hit",
+		Price:     30210,
+		Timestamp: 1_000,
+	})
+
+	if len(repo.inserted) != 1 {
+		t.Fatalf("expected 1 insert (flushed on Rejected), got %d", len(repo.inserted))
+	}
+	got := repo.inserted[0]
+	if got.RiskOutcome != entity.DecisionRiskRejected || got.RiskReason != "daily loss limit hit" {
+		t.Errorf("risk fields wrong: %+v", got)
+	}
+	if got.SignalAction != "BUY" {
+		t.Errorf("SignalAction must be preserved as BUY, got %q", got.SignalAction)
+	}
+	if got.OrderOutcome != entity.DecisionOrderNoop {
+		t.Errorf("OrderOutcome must remain NOOP, got %q", got.OrderOutcome)
+	}
+}
+
+func TestRecorder_BookGateVetoMarksApprovedThenVetoed(t *testing.T) {
+	repo := &stubRepo{}
+	rec := newRecorderForTest(repo)
+	ctx := context.Background()
+
+	_, _ = rec.Handle(ctx, indicatorEvent(7, 1_000))
+	_, _ = rec.Handle(ctx, entity.SignalEvent{
+		Signal:    entity.Signal{SymbolID: 7, Action: entity.SignalActionSell, Reason: "rsi extreme"},
+		Price:     30210,
+		Timestamp: 1_000,
+	})
+	_, _ = rec.Handle(ctx, entity.RejectedSignalEvent{
+		Signal:    entity.Signal{SymbolID: 7, Action: entity.SignalActionSell, Reason: "rsi extreme"},
+		Stage:     entity.RejectedStageBookGate,
+		Reason:    "thin book on bid",
+		Price:     30210,
+		Timestamp: 1_000,
+	})
+
+	if len(repo.inserted) != 1 {
+		t.Fatalf("expected 1 insert, got %d", len(repo.inserted))
+	}
+	got := repo.inserted[0]
+	if got.RiskOutcome != entity.DecisionRiskApproved {
+		t.Errorf("RiskOutcome must be APPROVED (book gate is post-risk), got %q", got.RiskOutcome)
+	}
+	if got.BookGateOutcome != entity.DecisionBookVetoed || got.BookGateReason != "thin book on bid" {
+		t.Errorf("book gate fields wrong: %+v", got)
+	}
+}
+
+func TestRecorder_TickSLTPClosePersistedAsSeparateRow(t *testing.T) {
+	repo := &stubRepo{}
+	rec := newRecorderForTest(repo)
+	ctx := context.Background()
+
+	_, _ = rec.Handle(ctx, indicatorEvent(7, 1_000))
+	_, _ = rec.Handle(ctx, entity.OrderEvent{
+		OrderID: 99, SymbolID: 7, Side: "SELL", Action: "close",
+		Price: 30180, Amount: 0.5, Reason: "stop_loss", Timestamp: 1_500,
+		Trigger: entity.DecisionTriggerTickSLTP, ClosedPositionID: 100,
+	})
+
+	if len(repo.inserted) != 1 {
+		t.Fatalf("expected 1 insert (tick row, bar1 still pending), got %d", len(repo.inserted))
+	}
+	got := repo.inserted[0]
+	if got.TriggerKind != entity.DecisionTriggerTickSLTP {
+		t.Errorf("TriggerKind = %q, want TICK_SLTP", got.TriggerKind)
+	}
+	if got.ClosedPositionID != 100 {
+		t.Errorf("ClosedPositionID = %d, want 100", got.ClosedPositionID)
+	}
+	if got.SequenceInBar != 1 {
+		t.Errorf("SequenceInBar = %d, want 1 (bar1 BAR_CLOSE = 0, then this = 1)", got.SequenceInBar)
+	}
+	if got.SignalReason != "stop_loss" {
+		t.Errorf("SignalReason = %q, want %q", got.SignalReason, "stop_loss")
+	}
+}
+
+func TestRecorder_InsertErrorDoesNotPropagate(t *testing.T) {
+	repo := &stubRepo{insertErr: errors.New("db down")}
+	rec := newRecorderForTest(repo)
+	ctx := context.Background()
+
+	if _, err := rec.Handle(ctx, indicatorEvent(7, 1_000)); err != nil {
+		t.Fatalf("Handle indicator returned error: %v", err)
+	}
+	if _, err := rec.Handle(ctx, indicatorEvent(7, 2_000)); err != nil {
+		t.Fatalf("Handle indicator must swallow Insert errors, got: %v", err)
+	}
+}

--- a/backend/internal/usecase/decisionlog/retention.go
+++ b/backend/internal/usecase/decisionlog/retention.go
@@ -1,0 +1,67 @@
+package decisionlog
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/repository"
+)
+
+// RetentionConfig controls the backtest decision-log cleanup loop.
+//
+//   - MaxAge: rows older than now-MaxAge get deleted.
+//   - Interval: how often the loop runs.
+//   - NowFn: clock injection for tests; nil falls back to time.Now.
+type RetentionConfig struct {
+	MaxAge   time.Duration
+	Interval time.Duration
+	NowFn    func() time.Time
+}
+
+// RetentionCleanup periodically deletes backtest decision-log rows older
+// than MaxAge. It runs an initial sweep at start, then sweeps every
+// Interval until the context is cancelled. Errors are logged at warn level
+// and do not abort the loop.
+type RetentionCleanup struct {
+	repo   repository.BacktestDecisionLogRepository
+	cfg    RetentionConfig
+	logger *slog.Logger
+}
+
+func NewRetentionCleanup(repo repository.BacktestDecisionLogRepository, cfg RetentionConfig) *RetentionCleanup {
+	if cfg.NowFn == nil {
+		cfg.NowFn = time.Now
+	}
+	return &RetentionCleanup{repo: repo, cfg: cfg, logger: slog.Default()}
+}
+
+// Run blocks until ctx is cancelled.
+func (c *RetentionCleanup) Run(ctx context.Context) {
+	c.sweep(ctx)
+	if c.cfg.Interval <= 0 {
+		return
+	}
+	ticker := time.NewTicker(c.cfg.Interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			c.sweep(ctx)
+		}
+	}
+}
+
+func (c *RetentionCleanup) sweep(ctx context.Context) {
+	cutoff := c.cfg.NowFn().Add(-c.cfg.MaxAge).UnixMilli()
+	deleted, err := c.repo.DeleteOlderThan(ctx, cutoff)
+	if err != nil {
+		c.logger.Warn("decisionlog retention: sweep failed", "cutoff", cutoff, "error", err)
+		return
+	}
+	if deleted > 0 {
+		c.logger.Info("decisionlog retention: pruned rows", "deleted", deleted, "cutoff", cutoff)
+	}
+}

--- a/backend/internal/usecase/decisionlog/retention_test.go
+++ b/backend/internal/usecase/decisionlog/retention_test.go
@@ -1,0 +1,124 @@
+package decisionlog
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+)
+
+type stubBacktestRepo struct {
+	mu      sync.Mutex
+	cutoffs []int64
+	err     error
+}
+
+func (s *stubBacktestRepo) Insert(_ context.Context, _ entity.DecisionRecord, _ string) error {
+	return nil
+}
+func (s *stubBacktestRepo) ListByRun(_ context.Context, _ string, _ int, _ int64) ([]entity.DecisionRecord, int64, error) {
+	return nil, 0, nil
+}
+func (s *stubBacktestRepo) DeleteByRun(_ context.Context, _ string) (int64, error) { return 0, nil }
+func (s *stubBacktestRepo) DeleteOlderThan(_ context.Context, cutoff int64) (int64, error) {
+	s.mu.Lock()
+	s.cutoffs = append(s.cutoffs, cutoff)
+	s.mu.Unlock()
+	return 1, s.err
+}
+
+func TestRetention_RunsImmediatelyAndOnTicker(t *testing.T) {
+	repo := &stubBacktestRepo{}
+	fixedNow := int64(10_000_000)
+	cleanup := NewRetentionCleanup(repo, RetentionConfig{
+		MaxAge:   3 * 24 * time.Hour,
+		Interval: 20 * time.Millisecond,
+		NowFn:    func() time.Time { return time.UnixMilli(fixedNow) },
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		cleanup.Run(ctx)
+	}()
+
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for {
+		repo.mu.Lock()
+		n := len(repo.cutoffs)
+		repo.mu.Unlock()
+		if n >= 2 || time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	cancel()
+	wg.Wait()
+
+	repo.mu.Lock()
+	defer repo.mu.Unlock()
+	if len(repo.cutoffs) < 2 {
+		t.Fatalf("expected >=2 sweeps, got %d", len(repo.cutoffs))
+	}
+	expected := fixedNow - int64(3*24*time.Hour/time.Millisecond)
+	for _, c := range repo.cutoffs {
+		if c != expected {
+			t.Errorf("cutoff = %d, want %d", c, expected)
+		}
+	}
+}
+
+type countingErrorRepo struct {
+	stub  *stubBacktestRepo
+	count *atomic.Int32
+}
+
+func (c *countingErrorRepo) Insert(ctx context.Context, rec entity.DecisionRecord, runID string) error {
+	return c.stub.Insert(ctx, rec, runID)
+}
+func (c *countingErrorRepo) ListByRun(ctx context.Context, runID string, limit int, cursor int64) ([]entity.DecisionRecord, int64, error) {
+	return c.stub.ListByRun(ctx, runID, limit, cursor)
+}
+func (c *countingErrorRepo) DeleteByRun(ctx context.Context, runID string) (int64, error) {
+	return c.stub.DeleteByRun(ctx, runID)
+}
+func (c *countingErrorRepo) DeleteOlderThan(ctx context.Context, cutoff int64) (int64, error) {
+	c.count.Add(1)
+	return c.stub.DeleteOlderThan(ctx, cutoff)
+}
+
+func TestRetention_DeleteErrorDoesNotKillLoop(t *testing.T) {
+	repo := &stubBacktestRepo{err: errors.New("db down")}
+	var sweeps atomic.Int32
+	wrapped := &countingErrorRepo{stub: repo, count: &sweeps}
+
+	cleanup := NewRetentionCleanup(wrapped, RetentionConfig{
+		MaxAge:   3 * 24 * time.Hour,
+		Interval: 10 * time.Millisecond,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		cleanup.Run(ctx)
+	}()
+
+	deadline := time.Now().Add(200 * time.Millisecond)
+	for sweeps.Load() < 3 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	cancel()
+	wg.Wait()
+
+	if sweeps.Load() < 3 {
+		t.Errorf("loop must continue after errors, sweeps = %d", sweeps.Load())
+	}
+}


### PR DESCRIPTION
## Summary
- Foundation PR #3 of 4. Builds on #198.
- Adds \`DecisionRecorder\` — an EventBus subscriber (priority 99) that observes \`IndicatorEvent\` / \`SignalEvent\` / \`ApprovedSignalEvent\` / \`RejectedSignalEvent\` / \`OrderEvent\` and assembles one \`DecisionRecord\` per pipeline cycle.
- HOLD-only bars flush lazily on the next \`IndicatorEvent\`. Risk/BookGate rejections flush immediately. Tick-driven SL/TP closes are persisted as separate rows with \`sequence_in_bar > 0\`.
- \`Insert\` errors are logged at warn level and never propagate up the bus — the recorder is a pure observer.
- Adds \`RetentionCleanup\` goroutine that runs every interval (intended: 1h) and deletes backtest decision-log rows older than \`MaxAge\` (intended: 3 days). Errors do not kill the loop.
- End-to-end integration test exercises a full BUY cycle and a HOLD-only bar through real \`EventBus\` + SQLite repo.

The recorder is constructed and tested but **not yet wired into \`EventDrivenPipeline\` / Backtest \`Runner\`** — that wiring is part of the upcoming follow-up plan, after PR #4 lands the executor-side fields.

Spec: \`docs/superpowers/specs/2026-04-26-decision-log-design.md\`
Plan: \`docs/superpowers/plans/2026-04-26-decision-log-foundation.md\`

Stacked PRs:
- PR #1 (merged): entity layer
- PR #2 (merged): SQLite migrations + repos
- **PR #3 (this)**: Recorder + retention goroutine + integration test
- PR #4: Wire RejectedSignalEvent emission + populate new OrderEvent fields

## Test plan
- [x] \`go test ./internal/usecase/decisionlog/ -count=1 -race\` is green (state-machine + retention loop + end-to-end integration)
- [x] \`go test ./... -count=1\` (full backend suite) is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)