### PR TITLE
feat(decisionlog): PR #4 emit RejectedSignalEvent + populate OrderEvent fields

### DIFF
--- a/backend/internal/infrastructure/backtest/simulator.go
+++ b/backend/internal/infrastructure/backtest/simulator.go
@@ -106,14 +106,16 @@ func (s *SimExecutor) Open(symbolID int64, side entity.OrderSide, signalPrice, a
 	s.nextPosID++
 
 	order := entity.OrderEvent{
-		OrderID:   s.nextOrderID,
-		SymbolID:  symbolID,
-		Side:      string(side),
-		Action:    "open",
-		Price:     fill,
-		Amount:    amount,
-		Reason:    reason,
-		Timestamp: timestamp,
+		OrderID:          s.nextOrderID,
+		SymbolID:         symbolID,
+		Side:             string(side),
+		Action:           "open",
+		Price:            fill,
+		Amount:           amount,
+		Reason:           reason,
+		Timestamp:        timestamp,
+		Trigger:          entity.DecisionTriggerBarClose,
+		OpenedPositionID: position.PositionID,
 	}
 	s.nextOrderID++
 	return order, nil
@@ -160,14 +162,18 @@ func (s *SimExecutor) Close(positionID int64, signalPrice float64, reason string
 
 	sideText := string(pos.Side)
 	order := entity.OrderEvent{
-		OrderID:   s.nextOrderID,
-		SymbolID:  pos.SymbolID,
-		Side:      sideText,
-		Action:    "close",
-		Price:     exitFill,
-		Amount:    pos.Amount,
-		Reason:    reason,
-		Timestamp: timestamp,
+		OrderID:          s.nextOrderID,
+		SymbolID:         pos.SymbolID,
+		Side:             sideText,
+		Action:           "close",
+		Price:            exitFill,
+		Amount:           pos.Amount,
+		Reason:           reason,
+		Timestamp:        timestamp,
+		ClosedPositionID: pos.PositionID,
+		// Trigger is left empty here; the caller (TickRiskHandler or
+		// strategy-driven close) sets it to TICK_SLTP / TICK_TRAILING /
+		// BAR_CLOSE before forwarding the OrderEvent to the bus.
 	}
 	s.nextOrderID++
 

--- a/backend/internal/infrastructure/live/real_executor.go
+++ b/backend/internal/infrastructure/live/real_executor.go
@@ -188,14 +188,16 @@ func (r *RealExecutor) openWithStrategy(symbolID int64, side entity.OrderSide, s
 		EntryTimestamp: timestamp,
 	})
 	return entity.OrderEvent{
-		OrderID:   orderID,
-		SymbolID:  symbolID,
-		Side:      string(side),
-		Action:    "open",
-		Price:     fillPrice,
-		Amount:    amount,
-		Reason:    reason,
-		Timestamp: timestamp,
+		OrderID:          orderID,
+		SymbolID:         symbolID,
+		Side:             string(side),
+		Action:           "open",
+		Price:            fillPrice,
+		Amount:           amount,
+		Reason:           reason,
+		Timestamp:        timestamp,
+		Trigger:          entity.DecisionTriggerBarClose,
+		OpenedPositionID: posID,
 	}, nil
 }
 
@@ -250,14 +252,16 @@ func (r *RealExecutor) Open(symbolID int64, side entity.OrderSide, signalPrice, 
 	})
 
 	return entity.OrderEvent{
-		OrderID:   orderID,
-		SymbolID:  symbolID,
-		Side:      string(side),
-		Action:    "open",
-		Price:     fillPrice,
-		Amount:    amount,
-		Reason:    reason,
-		Timestamp: timestamp,
+		OrderID:          orderID,
+		SymbolID:         symbolID,
+		Side:             string(side),
+		Action:           "open",
+		Price:            fillPrice,
+		Amount:           amount,
+		Reason:           reason,
+		Timestamp:        timestamp,
+		Trigger:          entity.DecisionTriggerBarClose,
+		OpenedPositionID: posID,
 	}, nil
 }
 
@@ -358,14 +362,19 @@ func (r *RealExecutor) closeLocked(positionID int64, signalPrice float64, reason
 	}
 
 	return entity.OrderEvent{
-		OrderID:   orderID,
-		SymbolID:  pos.SymbolID,
-		Side:      string(pos.Side),
-		Action:    "close",
-		Price:     exitPrice,
-		Amount:    pos.Amount,
-		Reason:    reason,
-		Timestamp: timestamp,
+		OrderID:          orderID,
+		SymbolID:         pos.SymbolID,
+		Side:             string(pos.Side),
+		Action:           "close",
+		Price:            exitPrice,
+		Amount:           pos.Amount,
+		Reason:           reason,
+		Timestamp:        timestamp,
+		ClosedPositionID: pos.PositionID,
+		// Trigger is left empty here. The caller (TickRiskHandler for SL/TP/
+		// trailing closes; ExecutionHandler-driven reverse for bar-close
+		// closes) sets Trigger to TICK_SLTP / TICK_TRAILING / BAR_CLOSE
+		// before forwarding the event onto the bus.
 	}, trade, nil
 }
 

--- a/backend/internal/infrastructure/live/real_executor_test.go
+++ b/backend/internal/infrastructure/live/real_executor_test.go
@@ -187,6 +187,15 @@ func TestRealExecutor_OpenAndPositions(t *testing.T) {
 	if positions[0].Amount != 0.01 {
 		t.Fatalf("expected amount=0.01, got %f", positions[0].Amount)
 	}
+	if orderEv.Trigger != entity.DecisionTriggerBarClose {
+		t.Errorf("Trigger = %q, want BAR_CLOSE", orderEv.Trigger)
+	}
+	if orderEv.OpenedPositionID != 100 {
+		t.Errorf("OpenedPositionID = %d, want 100", orderEv.OpenedPositionID)
+	}
+	if orderEv.ClosedPositionID != 0 {
+		t.Errorf("ClosedPositionID = %d, want 0 on Open", orderEv.ClosedPositionID)
+	}
 }
 
 func TestRealExecutor_OpenAndClose(t *testing.T) {
@@ -229,6 +238,17 @@ func TestRealExecutor_OpenAndClose(t *testing.T) {
 	}
 	if trade.PnL == 0 {
 		t.Fatal("expected non-zero PnL")
+	}
+	if orderEv.ClosedPositionID == 0 {
+		t.Errorf("ClosedPositionID must be set on Close, got 0")
+	}
+	if orderEv.OpenedPositionID != 0 {
+		t.Errorf("OpenedPositionID must remain 0 on Close, got %d", orderEv.OpenedPositionID)
+	}
+	// Trigger is intentionally left empty by the executor; the caller
+	// (TickRiskHandler etc.) sets it before forwarding the event.
+	if orderEv.Trigger != "" {
+		t.Errorf("Trigger must be empty (caller fills it), got %q", orderEv.Trigger)
 	}
 
 	// Position should be removed.

--- a/backend/internal/usecase/backtest/handler.go
+++ b/backend/internal/usecase/backtest/handler.go
@@ -463,7 +463,19 @@ func (h *RiskHandler) Handle(ctx context.Context, event entity.Event) ([]entity.
 			h.MinConfidence,
 		)
 		if skipReason != "" || sized <= 0 {
-			return nil, nil
+			reason := "sizer skipped"
+			if skipReason != "" {
+				reason = "sizer skipped: " + skipReason
+			} else if sized <= 0 {
+				reason = "sizer returned zero lot"
+			}
+			return []entity.Event{entity.RejectedSignalEvent{
+				Signal:    signalEvent.Signal,
+				Stage:     entity.RejectedStageRisk,
+				Reason:    reason,
+				Price:     signalEvent.Price,
+				Timestamp: signalEvent.Timestamp,
+			}}, nil
 		}
 		amount = sized
 	}
@@ -482,7 +494,13 @@ func (h *RiskHandler) Handle(ctx context.Context, event entity.Event) ([]entity.
 
 	check := h.RiskManager.CheckOrderAt(ctx, time.UnixMilli(signalEvent.Timestamp), proposal)
 	if !check.Approved {
-		return nil, nil
+		return []entity.Event{entity.RejectedSignalEvent{
+			Signal:    signalEvent.Signal,
+			Stage:     entity.RejectedStageRisk,
+			Reason:    check.Reason,
+			Price:     signalEvent.Price,
+			Timestamp: signalEvent.Timestamp,
+		}}, nil
 	}
 
 	// Pre-trade orderbook depth gate. Runs after RiskManager so the gate
@@ -495,7 +513,13 @@ func (h *RiskHandler) Handle(ctx context.Context, event entity.Event) ([]entity.
 				h.BookGateRejects = make(map[string]int)
 			}
 			h.BookGateRejects[decision.Reason]++
-			return nil, nil
+			return []entity.Event{entity.RejectedSignalEvent{
+				Signal:    signalEvent.Signal,
+				Stage:     entity.RejectedStageBookGate,
+				Reason:    decision.Reason,
+				Price:     signalEvent.Price,
+				Timestamp: signalEvent.Timestamp,
+			}}, nil
 		}
 	}
 

--- a/backend/internal/usecase/backtest/handler.go
+++ b/backend/internal/usecase/backtest/handler.go
@@ -688,6 +688,8 @@ func (h *TickRiskHandler) Handle(_ context.Context, event entity.Event) ([]entit
 					}
 					return nil, err
 				}
+				orderEvent.Trigger = entity.DecisionTriggerTickSLTP
+				orderEvent.ClosedPositionID = pos.PositionID
 				emitted = append(emitted, orderEvent)
 				delete(h.highWaterMarks, pos.PositionID)
 				continue
@@ -725,6 +727,8 @@ func (h *TickRiskHandler) Handle(_ context.Context, event entity.Event) ([]entit
 					}
 					return nil, err
 				}
+				orderEvent.Trigger = entity.DecisionTriggerTickTrailing
+				orderEvent.ClosedPositionID = pos.PositionID
 				emitted = append(emitted, orderEvent)
 				delete(h.highWaterMarks, pos.PositionID)
 			}
@@ -739,6 +743,8 @@ func (h *TickRiskHandler) Handle(_ context.Context, event entity.Event) ([]entit
 					}
 					return nil, err
 				}
+				orderEvent.Trigger = entity.DecisionTriggerTickTrailing
+				orderEvent.ClosedPositionID = pos.PositionID
 				emitted = append(emitted, orderEvent)
 				delete(h.highWaterMarks, pos.PositionID)
 			}

--- a/backend/internal/usecase/backtest/handler_test.go
+++ b/backend/internal/usecase/backtest/handler_test.go
@@ -236,6 +236,54 @@ func TestRiskHandler_EmitsApprovedSignalEvent(t *testing.T) {
 	}
 }
 
+func TestRiskHandler_EmitsRejectedOnRiskManagerVeto(t *testing.T) {
+	// Daily loss already exceeds the cap so any new BUY proposal is rejected
+	// by RiskManager.CheckOrderAt with a non-empty Reason.
+	riskMgr := usecase.NewRiskManager(entity.RiskConfig{
+		MaxPositionAmount:    1000000,
+		MaxDailyLoss:         100,
+		StopLossPercent:      5,
+		TakeProfitPercent:    10,
+		InitialCapital:       1000000,
+		MaxConsecutiveLosses: 3,
+		CooldownMinutes:      30,
+	})
+	riskMgr.RecordLoss(500) // push past MaxDailyLoss=100
+	handler := &RiskHandler{
+		RiskManager: riskMgr,
+		TradeAmount: 0.01,
+	}
+
+	events, err := handler.Handle(context.Background(), entity.SignalEvent{
+		Signal: entity.Signal{
+			SymbolID: 7,
+			Action:   entity.SignalActionBuy,
+			Reason:   "ema cross",
+		},
+		Price:     10000,
+		Timestamp: time.Now().UnixMilli(),
+	})
+	if err != nil {
+		t.Fatalf("handle error: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected 1 emitted event, got %d", len(events))
+	}
+	rej, ok := events[0].(entity.RejectedSignalEvent)
+	if !ok {
+		t.Fatalf("expected RejectedSignalEvent, got %T", events[0])
+	}
+	if rej.Stage != entity.RejectedStageRisk {
+		t.Errorf("Stage = %q, want %q", rej.Stage, entity.RejectedStageRisk)
+	}
+	if rej.Reason == "" {
+		t.Errorf("Reason must be populated from RiskManager check")
+	}
+	if rej.Signal.Action != entity.SignalActionBuy {
+		t.Errorf("Signal must be carried through, got action %q", rej.Signal.Action)
+	}
+}
+
 type fakeTickRiskExecutor struct {
 	positions []eventengine.Position
 	closedIDs []int64


### PR DESCRIPTION
## Summary
- Foundation PR #4 of 4 — final PR of the decision-log foundation. Builds on #199.
- \`RiskHandler\` now emits \`RejectedSignalEvent\` on all three rejection branches (sizer, RiskManager veto, BookGate veto) instead of silently dropping the signal. Approved-path callers see no change.
- \`OrderEvent\` is now populated with \`Trigger\`, \`OpenedPositionID\`, \`ClosedPositionID\`:
  - Live \`RealExecutor.Open\` / \`OpenWithUrgency\` set \`Trigger=BAR_CLOSE\` and \`OpenedPositionID\`.
  - Live \`RealExecutor.closeLocked\` sets \`ClosedPositionID\` (Trigger left empty for the caller to fill).
  - \`SimExecutor.Open\` / \`Close\` set the same fields symmetrically.
  - \`TickRiskHandler\` mutates the returned \`OrderEvent\` to set \`Trigger=TICK_SLTP\` (SL/TP exit) or \`Trigger=TICK_TRAILING\` (trailing stop) and re-asserts \`ClosedPositionID\` before forwarding the event.
- Existing tests already in place; new assertions added on \`TestRealExecutor_OpenAndClose\` for the new fields, and a new \`TestRiskHandler_EmitsRejectedOnRiskManagerVeto\` covers the rejection-emission path.

This PR completes the decision-log foundation. The recorder (#199) is now ready to be wired into \`EventDrivenPipeline\` and the backtest \`Runner\`; that wiring + the HTTP API + the frontend tab live in the upcoming follow-up plan.

Spec: \`docs/superpowers/specs/2026-04-26-decision-log-design.md\`
Plan: \`docs/superpowers/plans/2026-04-26-decision-log-foundation.md\`

Stacked PRs:
- PR #1 (merged): entity layer
- PR #2 (merged): SQLite migrations + repos
- PR #3 (merged): Recorder + retention goroutine + integration test
- **PR #4 (this)**: Wire RejectedSignalEvent emission + populate new OrderEvent fields

## Test plan
- [x] \`go test ./internal/usecase/backtest/ -count=1\` is green (incl. new RejectedSignalEvent assertion)
- [x] \`go test ./internal/infrastructure/live/ -count=1\` is green (incl. updated OpenAndClose assertions)
- [x] \`go test ./... -count=1\` (full backend suite) is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)