### PR TITLE
feat(decisionlog): PR #6 GET /api/v1/decisions HTTP endpoint

### DIFF
--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -280,6 +280,7 @@ func main() {
 		DailyPnLCalculator:    dailyPnLCalc,
 		ExecutionQualityReporter: executionQualityReporter,
 		ExecutionQualityRepo:     executionQualityRepo,
+		DecisionLogRepo:          decisionLogRepo,
 	})
 
 	sigCh := make(chan os.Signal, 1)

--- a/backend/internal/interfaces/api/handler/decision.go
+++ b/backend/internal/interfaces/api/handler/decision.go
@@ -1,0 +1,144 @@
+package handler
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/repository"
+)
+
+const (
+	decisionAPIDefaultLimit = 200
+	decisionAPIMaxLimit     = 1000
+)
+
+type DecisionHandler struct {
+	repo repository.DecisionLogRepository
+}
+
+func NewDecisionHandler(repo repository.DecisionLogRepository) *DecisionHandler {
+	return &DecisionHandler{repo: repo}
+}
+
+// repoForTest exposes the underlying repo to in-package tests so they can
+// seed rows without a separate fixture path. Tests only.
+func (h *DecisionHandler) repoForTest() repository.DecisionLogRepository { return h.repo }
+
+func (h *DecisionHandler) List(c *gin.Context) {
+	f, err := parseDecisionFilter(c)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	rows, next, err := h.repo.List(c.Request.Context(), f)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	out := make([]gin.H, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, decisionRecordToJSON(r))
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"decisions":  out,
+		"nextCursor": next,
+		"hasMore":    next != 0,
+	})
+}
+
+func parseDecisionFilter(c *gin.Context) (repository.DecisionLogFilter, error) {
+	var f repository.DecisionLogFilter
+
+	if s := c.Query("symbolId"); s != "" {
+		v, err := strconv.ParseInt(s, 10, 64)
+		if err != nil {
+			return f, fmt.Errorf("invalid symbolId: %w", err)
+		}
+		f.SymbolID = v
+	}
+	if s := c.Query("from"); s != "" {
+		v, err := strconv.ParseInt(s, 10, 64)
+		if err != nil {
+			return f, fmt.Errorf("invalid from: %w", err)
+		}
+		f.From = v
+	}
+	if s := c.Query("to"); s != "" {
+		v, err := strconv.ParseInt(s, 10, 64)
+		if err != nil {
+			return f, fmt.Errorf("invalid to: %w", err)
+		}
+		f.To = v
+	}
+	if s := c.Query("cursor"); s != "" {
+		v, err := strconv.ParseInt(s, 10, 64)
+		if err != nil {
+			return f, fmt.Errorf("invalid cursor: %w", err)
+		}
+		f.Cursor = v
+	}
+	f.Limit = decisionAPIDefaultLimit
+	if s := c.Query("limit"); s != "" {
+		v, err := strconv.Atoi(s)
+		if err != nil {
+			return f, fmt.Errorf("invalid limit: %w", err)
+		}
+		if v > decisionAPIMaxLimit {
+			v = decisionAPIMaxLimit
+		}
+		if v > 0 {
+			f.Limit = v
+		}
+	}
+	return f, nil
+}
+
+// decisionRecordToJSON converts the domain record into the API payload
+// shape. indicators_json / higher_tf_indicators_json are forwarded as
+// json.RawMessage so the recorder's marshalled IndicatorSet is preserved
+// without a re-serialization round trip.
+func decisionRecordToJSON(r entity.DecisionRecord) gin.H {
+	indicators := json.RawMessage(r.IndicatorsJSON)
+	if len(indicators) == 0 {
+		indicators = json.RawMessage("{}")
+	}
+	higher := json.RawMessage(r.HigherTFIndicatorsJSON)
+	if len(higher) == 0 {
+		higher = json.RawMessage("{}")
+	}
+	return gin.H{
+		"id":              r.ID,
+		"barCloseAt":      r.BarCloseAt,
+		"sequenceInBar":   r.SequenceInBar,
+		"triggerKind":     r.TriggerKind,
+		"symbolId":        r.SymbolID,
+		"currencyPair":    r.CurrencyPair,
+		"primaryInterval": r.PrimaryInterval,
+		"stance":          r.Stance,
+		"lastPrice":       r.LastPrice,
+		"signal": gin.H{
+			"action":     r.SignalAction,
+			"confidence": r.SignalConfidence,
+			"reason":     r.SignalReason,
+		},
+		"risk":     gin.H{"outcome": r.RiskOutcome, "reason": r.RiskReason},
+		"bookGate": gin.H{"outcome": r.BookGateOutcome, "reason": r.BookGateReason},
+		"order": gin.H{
+			"outcome": r.OrderOutcome,
+			"orderId": r.OrderID,
+			"amount":  r.ExecutedAmount,
+			"price":   r.ExecutedPrice,
+			"error":   r.OrderError,
+		},
+		"closedPositionId":   r.ClosedPositionID,
+		"openedPositionId":   r.OpenedPositionID,
+		"indicators":         indicators,
+		"higherTfIndicators": higher,
+		"createdAt":          r.CreatedAt,
+	}
+}

--- a/backend/internal/interfaces/api/handler/decision_test.go
+++ b/backend/internal/interfaces/api/handler/decision_test.go
@@ -1,0 +1,129 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/repository"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/infrastructure/database"
+)
+
+func newDecisionHandlerForTest(t *testing.T) (*DecisionHandler, func()) {
+	t.Helper()
+	tmpDir := t.TempDir()
+	db, err := database.NewDB(filepath.Join(tmpDir, "test.db"))
+	if err != nil {
+		t.Fatalf("NewDB: %v", err)
+	}
+	if err := database.RunMigrations(db); err != nil {
+		t.Fatalf("RunMigrations: %v", err)
+	}
+	repo := database.NewDecisionLogRepository(db)
+	cleanup := func() { db.Close() }
+	return NewDecisionHandler(repo), cleanup
+}
+
+func seedDecision(t *testing.T, repo repository.DecisionLogRepository, ts int64, action string) {
+	t.Helper()
+	rec := entity.DecisionRecord{
+		BarCloseAt:      ts,
+		TriggerKind:     entity.DecisionTriggerBarClose,
+		SymbolID:        7,
+		CurrencyPair:    "LTC_JPY",
+		PrimaryInterval: "PT15M",
+		Stance:          "TREND_FOLLOW",
+		LastPrice:       30210,
+		SignalAction:    action,
+		RiskOutcome:     entity.DecisionRiskApproved,
+		BookGateOutcome: entity.DecisionBookAllowed,
+		OrderOutcome:    entity.DecisionOrderFilled,
+		IndicatorsJSON:  `{"rsi":48.2}`,
+		CreatedAt:       time.Now().UnixMilli(),
+	}
+	if err := repo.Insert(context.Background(), rec); err != nil {
+		t.Fatalf("seed Insert: %v", err)
+	}
+}
+
+func TestDecisionHandler_List_ReturnsRowsNewestFirst(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h, cleanup := newDecisionHandlerForTest(t)
+	defer cleanup()
+
+	repo := h.repoForTest()
+	seedDecision(t, repo, 1_000, "BUY")
+	seedDecision(t, repo, 2_000, "HOLD")
+
+	r := gin.New()
+	r.GET("/decisions", h.List)
+	req := httptest.NewRequest(http.MethodGet, "/decisions?symbolId=7&limit=10", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Decisions []map[string]any `json:"decisions"`
+		HasMore   bool             `json:"hasMore"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(resp.Decisions) != 2 {
+		t.Fatalf("len = %d, want 2", len(resp.Decisions))
+	}
+	first := resp.Decisions[0]
+	signal := first["signal"].(map[string]any)
+	if got := signal["action"].(string); got != "HOLD" {
+		t.Errorf("first row signal.action = %q, want HOLD (newest)", got)
+	}
+}
+
+func TestDecisionHandler_List_RejectsBadSymbolID(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h, cleanup := newDecisionHandlerForTest(t)
+	defer cleanup()
+
+	r := gin.New()
+	r.GET("/decisions", h.List)
+	req := httptest.NewRequest(http.MethodGet, "/decisions?symbolId=not-a-number", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "symbolId") {
+		t.Errorf("body should mention symbolId; got %s", w.Body.String())
+	}
+}
+
+func TestDecisionHandler_List_PreservesIndicatorsJSON(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h, cleanup := newDecisionHandlerForTest(t)
+	defer cleanup()
+
+	seedDecision(t, h.repoForTest(), 1_000, "BUY")
+
+	r := gin.New()
+	r.GET("/decisions", h.List)
+	req := httptest.NewRequest(http.MethodGet, "/decisions?symbolId=7", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), `"rsi":48.2`) {
+		t.Errorf("indicators_json must be passed through verbatim; body = %s", w.Body.String())
+	}
+}

--- a/backend/internal/interfaces/api/router.go
+++ b/backend/internal/interfaces/api/router.go
@@ -53,6 +53,9 @@ type Dependencies struct {
 	// most recent persisted snapshot (cheap) and only falls back to the
 	// reporter on cache miss / `?fresh=true`.
 	ExecutionQualityRepo repository.ExecutionQualityRepository
+
+	// DecisionLogRepo (optional). When set, GET /api/v1/decisions is exposed.
+	DecisionLogRepo repository.DecisionLogRepository
 }
 
 func NewRouter(deps Dependencies) *gin.Engine {
@@ -203,6 +206,11 @@ func NewRouter(deps Dependencies) *gin.Engine {
 			v1.GET("/backtest/walk-forward", backtestHandler.ListWalkForward)
 			v1.GET("/backtest/walk-forward/:id", backtestHandler.GetWalkForward)
 		}
+	}
+
+	if deps.DecisionLogRepo != nil {
+		decisionHandler := handler.NewDecisionHandler(deps.DecisionLogRepo)
+		v1.GET("/decisions", decisionHandler.List)
 	}
 
 	return r


### PR DESCRIPTION
## Summary
- Adds GET /api/v1/decisions backed by the live decision_log SQLite table.
- Query parameters: symbolId (optional), from/to (unix ms, optional), cursor (id, optional, paging), limit (default 200, max 1000).
- Response is JSON with newest-first ordering. indicators_json / higher_tf_indicators_json are forwarded as json.RawMessage so the recorder's marshalled IndicatorSet is preserved without round-tripping through Go structs.
- Backtest run-scoped endpoints (GET/DELETE /backtest/results/:id/decisions) are deferred to a follow-up PR alongside the backtest-side recorder DI — until that lands, backtest_decision_log is empty so the endpoints would always return [].

Spec: \`docs/superpowers/specs/2026-04-26-decision-log-design.md\`
Plan: \`docs/superpowers/plans/2026-04-26-decision-log-pipeline-api-frontend.md\`

Stacked PRs:
- PR #5 (merged): wire DecisionRecorder into live pipeline + retention
- **PR #6 (this)**: GET /api/v1/decisions
- PR #7: frontend 判断ログ tab on /history

## Test plan
- [x] go test ./... -race -count=1 is green
- [x] new TestDecisionHandler_List_* covers happy path, bad symbolId rejection, indicators_json passthrough
- [x] curl http://localhost:38080/api/v1/decisions returns rows after PT15M close (verified post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)