### PR TITLE
feat(decisionlog): PR #7 frontend 判断ログ tab on /history

### DIFF
--- a/frontend/src/components/DecisionDetailPanel.tsx
+++ b/frontend/src/components/DecisionDetailPanel.tsx
@@ -1,0 +1,44 @@
+import type { DecisionLogItem } from '../lib/api'
+
+type Props = { item: DecisionLogItem }
+
+export function DecisionDetailPanel({ item }: Props) {
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      <Section title="主要指標" data={item.indicators} />
+      <Section title="上位足指標" data={item.higherTfIndicators} />
+    </div>
+  )
+}
+
+function Section({ title, data }: { title: string; data: Record<string, unknown> }) {
+  const entries = Object.entries(data ?? {})
+  if (entries.length === 0) {
+    return (
+      <div className="rounded-2xl border border-white/8 p-4">
+        <h3 className="text-xs uppercase tracking-[0.2em] text-text-secondary">{title}</h3>
+        <p className="mt-2 text-sm text-text-secondary">データなし</p>
+      </div>
+    )
+  }
+  return (
+    <div className="rounded-2xl border border-white/8 p-4">
+      <h3 className="mb-3 text-xs uppercase tracking-[0.2em] text-text-secondary">{title}</h3>
+      <dl className="grid grid-cols-2 gap-x-4 gap-y-1 text-sm">
+        {entries.map(([k, v]) => (
+          <div key={k} className="contents">
+            <dt className="truncate text-text-secondary">{k}</dt>
+            <dd className="truncate text-right">{formatValue(v)}</dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  )
+}
+
+function formatValue(v: unknown): string {
+  if (v === null || v === undefined) return '—'
+  if (typeof v === 'number') return Number.isFinite(v) ? v.toFixed(4) : String(v)
+  if (typeof v === 'object') return JSON.stringify(v)
+  return String(v)
+}

--- a/frontend/src/components/DecisionLogTable.tsx
+++ b/frontend/src/components/DecisionLogTable.tsx
@@ -1,0 +1,100 @@
+import { useState } from 'react'
+import type { DecisionLogItem } from '../lib/api'
+import { DecisionDetailPanel } from './DecisionDetailPanel'
+
+type Props = { decisions: DecisionLogItem[] }
+
+export function DecisionLogTable({ decisions }: Props) {
+  const [expandedId, setExpandedId] = useState<number | null>(null)
+
+  if (decisions.length === 0) {
+    return (
+      <div className="rounded-2xl border border-white/8 bg-bg-card/90 p-8 text-center text-text-secondary">
+        判断ログがまだありません。
+      </div>
+    )
+  }
+  return (
+    <div className="overflow-hidden rounded-3xl border border-white/8 bg-bg-card/90">
+      <table className="w-full text-sm">
+        <thead className="bg-white/5 text-xs uppercase tracking-[0.18em] text-text-secondary">
+          <tr>
+            <th className="px-4 py-3 text-left">時刻</th>
+            <th className="px-4 py-3 text-left">スタンス</th>
+            <th className="px-4 py-3 text-left">シグナル</th>
+            <th className="px-4 py-3 text-right">信頼度</th>
+            <th className="px-4 py-3 text-left">リスク</th>
+            <th className="px-4 py-3 text-left">BookGate</th>
+            <th className="px-4 py-3 text-left">結果</th>
+            <th className="px-4 py-3 text-right">数量/価格</th>
+            <th className="px-4 py-3 text-left">理由</th>
+          </tr>
+        </thead>
+        <tbody>
+          {decisions.map((d) => (
+            <Row
+              key={d.id}
+              item={d}
+              expanded={expandedId === d.id}
+              onClick={() => setExpandedId(expandedId === d.id ? null : d.id)}
+            />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function Row({
+  item,
+  expanded,
+  onClick,
+}: {
+  item: DecisionLogItem
+  expanded: boolean
+  onClick: () => void
+}) {
+  const bg = rowBackground(item)
+  const reason =
+    item.signal.reason || item.risk.reason || item.bookGate.reason || item.order.error || '—'
+  return (
+    <>
+      <tr className={`cursor-pointer border-t border-white/8 ${bg}`} onClick={onClick}>
+        <td className="px-4 py-3">
+          <div>{new Date(item.barCloseAt).toLocaleString('ja-JP')}</div>
+          <div className="text-xs text-text-secondary">{item.triggerKind}</div>
+        </td>
+        <td className="px-4 py-3">{item.stance || '—'}</td>
+        <td className="px-4 py-3 font-medium">{item.signal.action}</td>
+        <td className="px-4 py-3 text-right">
+          {item.signal.action === 'HOLD' ? '—' : item.signal.confidence.toFixed(2)}
+        </td>
+        <td className="px-4 py-3">{item.risk.outcome}</td>
+        <td className="px-4 py-3">{item.bookGate.outcome}</td>
+        <td className="px-4 py-3">{item.order.outcome}</td>
+        <td className="px-4 py-3 text-right">
+          {item.order.outcome === 'NOOP'
+            ? '—'
+            : `${item.order.amount} @ ${item.order.price.toLocaleString('ja-JP')}`}
+        </td>
+        <td className="max-w-[24rem] truncate px-4 py-3">{reason}</td>
+      </tr>
+      {expanded && (
+        <tr className="border-t border-white/8 bg-white/3">
+          <td colSpan={9} className="px-4 py-4">
+            <DecisionDetailPanel item={item} />
+          </td>
+        </tr>
+      )}
+    </>
+  )
+}
+
+function rowBackground(item: DecisionLogItem): string {
+  if (item.order.outcome === 'FILLED') return 'bg-accent-green/8'
+  if (item.risk.outcome === 'REJECTED' || item.bookGate.outcome === 'VETOED')
+    return 'bg-accent-red/8'
+  if (item.triggerKind !== 'BAR_CLOSE') return 'bg-white/3'
+  if (item.signal.action === 'HOLD') return 'bg-accent-yellow/6'
+  return ''
+}

--- a/frontend/src/hooks/useDecisionLog.ts
+++ b/frontend/src/hooks/useDecisionLog.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query'
+import { fetchApi, type DecisionLogResponse } from '../lib/api'
+
+export function useDecisionLog(symbolId: number, limit = 200) {
+  return useQuery({
+    queryKey: ['decisions', symbolId, limit],
+    queryFn: () => fetchApi<DecisionLogResponse>(`/decisions?symbolId=${symbolId}&limit=${limit}`),
+    refetchInterval: 15_000,
+  })
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -678,6 +678,33 @@ export async function createManualOrder(req: ManualOrderRequest): Promise<Manual
   return sendApi<ManualOrderResponse, ManualOrderRequest>('/orders', 'POST', req)
 }
 
+export type DecisionLogItem = {
+  id: number
+  barCloseAt: number
+  sequenceInBar: number
+  triggerKind: 'BAR_CLOSE' | 'TICK_SLTP' | 'TICK_TRAILING'
+  symbolId: number
+  currencyPair: string
+  primaryInterval: string
+  stance: string
+  lastPrice: number
+  signal: { action: 'BUY' | 'SELL' | 'HOLD'; confidence: number; reason: string }
+  risk: { outcome: 'APPROVED' | 'REJECTED' | 'SKIPPED'; reason: string }
+  bookGate: { outcome: 'ALLOWED' | 'VETOED' | 'SKIPPED'; reason: string }
+  order: { outcome: 'FILLED' | 'FAILED' | 'NOOP'; orderId: number; amount: number; price: number; error: string }
+  closedPositionId: number
+  openedPositionId: number
+  indicators: Record<string, unknown>
+  higherTfIndicators: Record<string, unknown>
+  createdAt: number
+}
+
+export type DecisionLogResponse = {
+  decisions: DecisionLogItem[]
+  nextCursor: number
+  hasMore: boolean
+}
+
 export function buildRealtimeWebSocketUrl(symbolId: number): string {
   if (typeof window === 'undefined') {
     return `${WS_BASE}/ws?symbolId=${symbolId}`

--- a/frontend/src/routes/history.tsx
+++ b/frontend/src/routes/history.tsx
@@ -1,15 +1,17 @@
 import { useMemo, useState } from 'react'
 import { createFileRoute } from '@tanstack/react-router'
 import { AppFrame } from '../components/AppFrame'
+import { DecisionLogTable } from '../components/DecisionLogTable'
 import { TradeHistoryTable, type TradeHistoryRow } from '../components/TradeHistoryTable'
 import { useMarketTickerStream } from '../hooks/useMarketTickerStream'
 import { useTradeHistory } from '../hooks/useTradeHistory'
 import { useAllTrades } from '../hooks/useAllTrades'
+import { useDecisionLog } from '../hooks/useDecisionLog'
 import { useSymbolContext } from '../contexts/SymbolContext'
 
 export const Route = createFileRoute('/history')({ component: HistoryPage })
 
-type TabKey = 'all' | 'single'
+type TabKey = 'all' | 'single' | 'decisions'
 
 function HistoryPage() {
   const { symbolId, currentSymbol } = useSymbolContext()
@@ -19,6 +21,7 @@ function HistoryPage() {
 
   const { data: singleTrades } = useTradeHistory(symbolId)
   const { data: allTradesData } = useAllTrades()
+  const { data: decisionData } = useDecisionLog(symbolId)
 
   const rows = useMemo<TradeHistoryRow[]>(() => {
     if (tab === 'single') {
@@ -46,36 +49,47 @@ function HistoryPage() {
   const subtitle =
     tab === 'all'
       ? '楽天 private API から全通貨の約定をまとめて REST 経由で表示します。'
-      : `現在選択中の ${currentSymbol?.currencyPair ?? ''} に絞った約定一覧です。`
+      : tab === 'single'
+      ? `現在選択中の ${currentSymbol?.currencyPair ?? ''} に絞った約定一覧です。`
+      : `${currentSymbol?.currencyPair ?? ''} の 15 分足ごとの売買判断ログです。`
 
   return (
     <AppFrame title="Trade History" subtitle={subtitle}>
       <div className="mb-4 flex gap-2">
         <TabButton active={tab === 'all'} onClick={() => setTab('all')}>
-          全通貨
+          全通貨の約定
         </TabButton>
         <TabButton active={tab === 'single'} onClick={() => setTab('single')}>
-          {currentSymbol?.currencyPair ?? '個別通貨'}
+          {currentSymbol?.currencyPair ?? '個別通貨'}の約定
+        </TabButton>
+        <TabButton active={tab === 'decisions'} onClick={() => setTab('decisions')}>
+          {currentSymbol?.currencyPair ?? '個別通貨'}の判断ログ
         </TabButton>
       </div>
-      <div className="mb-4 grid gap-4 md:grid-cols-3">
-        <SummaryCard label="約定件数" value={rows.length.toLocaleString()} />
-        <SummaryCard
-          label="累計損益"
-          value={`¥${totalProfit.toLocaleString('ja-JP', { maximumFractionDigits: 0 })}`}
-          color={totalProfit >= 0 ? 'text-accent-green' : 'text-accent-red'}
-        />
-        <SummaryCard
-          label="最新更新"
-          value={rows[0] ? new Date(rows[0].createdAt).toLocaleString('ja-JP') : '\u2014'}
-        />
-      </div>
+      {tab !== 'decisions' && (
+        <div className="mb-4 grid gap-4 md:grid-cols-3">
+          <SummaryCard label="約定件数" value={rows.length.toLocaleString()} />
+          <SummaryCard
+            label="累計損益"
+            value={`¥${totalProfit.toLocaleString('ja-JP', { maximumFractionDigits: 0 })}`}
+            color={totalProfit >= 0 ? 'text-accent-green' : 'text-accent-red'}
+          />
+          <SummaryCard
+            label="最新更新"
+            value={rows[0] ? new Date(rows[0].createdAt).toLocaleString('ja-JP') : '—'}
+          />
+        </div>
+      )}
       {failedSymbols.length > 0 && (
         <div className="mb-4 rounded-2xl border border-accent-red/40 bg-accent-red/10 px-5 py-3 text-sm text-accent-red">
           一部通貨の取得に失敗しました: {failedSymbols.map((e) => e.currencyPair).join(', ')}
         </div>
       )}
-      <TradeHistoryTable trades={rows} showCurrencyPair={tab === 'all'} />
+      {tab === 'decisions' ? (
+        <DecisionLogTable decisions={decisionData?.decisions ?? []} />
+      ) : (
+        <TradeHistoryTable trades={rows} showCurrencyPair={tab === 'all'} />
+      )}
     </AppFrame>
   )
 }


### PR DESCRIPTION
## Summary
- Adds the third tab on /history (alongside 全通貨の約定 / 選択通貨の約定): 判断ログ.
- Uses GET /api/v1/decisions added in #202; 15-second polling via TanStack Query.
- Timeline table with newest-first ordering; row colors:
  - 緑: order_outcome == FILLED
  - 赤: risk_outcome == REJECTED or book_gate_outcome == VETOED
  - グレー: tick-driven SL/TP/trailing rows
  - 黄: bar-close HOLD rows
- Click a row to expand the indicator snapshot (主要指標 + 上位足指標) inline.
- Trade-history summary cards (約定件数 / 累計損益 / 最新更新) hidden when the 判断ログ tab is active because the metrics do not apply.

Closes the foundation work end-to-end: pipeline writes rows (PR #5) → API serves them (PR #6) → UI displays them (this PR).

Spec: \`docs/superpowers/specs/2026-04-26-decision-log-design.md\`
Plan: \`docs/superpowers/plans/2026-04-26-decision-log-pipeline-api-frontend.md\`

Stacked PRs:
- PR #5 (merged): wire DecisionRecorder into live pipeline + retention
- PR #6 (merged): GET /api/v1/decisions
- **PR #7 (this)**: 判断ログ tab on /history

## Test plan
- [x] cd frontend && pnpm test is green (47 tests)
- [x] cd frontend && pnpm build is green
- [x] After live deploy, /history -> 選択通貨の判断ログ tab shows real BAR_CLOSE rows after each PT15M close

🤖 Generated with [Claude Code](https://claude.com/claude-code)