### PR TITLE
feat(decisionlog): PR #8 backtest recorder DI + decision endpoints + UI link

### DIFF
--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -281,6 +281,7 @@ func main() {
 		ExecutionQualityReporter: executionQualityReporter,
 		ExecutionQualityRepo:     executionQualityRepo,
 		DecisionLogRepo:          decisionLogRepo,
+		BacktestDecisionLogRepo:  backtestDecisionLogRepo,
 	})
 
 	sigCh := make(chan os.Signal, 1)

--- a/backend/internal/interfaces/api/handler/backtest.go
+++ b/backend/internal/interfaces/api/handler/backtest.go
@@ -18,6 +18,7 @@ import (
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase"
 	bt "github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/backtest"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/booklimit"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/decisionlog"
 	strategyuc "github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/strategy"
 )
 
@@ -57,6 +58,12 @@ type BacktestHandler struct {
 	// marketDataSvc supplies persisted L2 snapshots for slippageModel="orderbook".
 	// When nil, that model returns 400 ("orderbook replay unavailable").
 	marketDataSvc *usecase.MarketDataService
+
+	// decisionLogRepo (optional). When non-nil, every backtest run attaches
+	// a DecisionRecorder so each cycle's BUY/SELL/HOLD + indicator
+	// snapshot lands in backtest_decision_log scoped to the run id. The
+	// list/delete endpoints become available too.
+	decisionLogRepo repository.BacktestDecisionLogRepository
 }
 
 // BacktestHandlerOption configures optional aspects of a BacktestHandler at
@@ -99,6 +106,15 @@ func WithWalkForwardRepo(repo repository.WalkForwardResultRepository) BacktestHa
 func WithMarketDataService(svc *usecase.MarketDataService) BacktestHandlerOption {
 	return func(h *BacktestHandler) {
 		h.marketDataSvc = svc
+	}
+}
+
+// WithDecisionLogRepo wires the BacktestDecisionLogRepository so every
+// backtest run persists per-cycle decisions and the list / delete
+// endpoints become available. nil keeps backtest runs decision-log-free.
+func WithDecisionLogRepo(repo repository.BacktestDecisionLogRepository) BacktestHandlerOption {
+	return func(h *BacktestHandler) {
+		h.decisionLogRepo = repo
 	}
 }
 
@@ -289,6 +305,7 @@ func (h *BacktestHandler) Run(c *gin.Context) {
 	// mutate h.runner (it is shared across requests) so profile
 	// selection is per-request.
 	runner := h.runner
+	var runOpts []bt.RunnerOption
 	if profile != nil {
 		strat, err := strategyuc.BuildStrategyFromProfile(strategyprofile.NewLoader(baseDir), profile)
 		if err != nil {
@@ -298,7 +315,30 @@ func (h *BacktestHandler) Run(c *gin.Context) {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid profile: " + err.Error()})
 			return
 		}
-		runner = bt.NewBacktestRunner(bt.WithStrategy(strat))
+		runOpts = append(runOpts, bt.WithStrategy(strat))
+	}
+
+	// Pre-allocate the run id so we can scope a DecisionRecorder to it
+	// before the bus dispatches its first event. The runner honours
+	// RunInput.ResultID and falls back to NewULID when empty.
+	var preallocatedRunID string
+	if h.decisionLogRepo != nil {
+		id, err := bt.NewULID()
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "generate run id: " + err.Error()})
+			return
+		}
+		preallocatedRunID = id
+		adapter := decisionlog.NewBacktestRepoAdapter(h.decisionLogRepo, id)
+		recorder := decisionlog.NewRecorder(adapter, decisionlog.RecorderConfig{
+			SymbolID:        cfg.SymbolID,
+			CurrencyPair:    cfg.Symbol,
+			PrimaryInterval: cfg.PrimaryInterval,
+		})
+		runOpts = append(runOpts, bt.WithDecisionRecorder(recorder))
+	}
+	if len(runOpts) > 0 {
+		runner = bt.NewBacktestRunner(runOpts...)
 	}
 
 	// cycle44: plumb the profile's bb_squeeze_lookback into the run so
@@ -331,6 +371,7 @@ func (h *BacktestHandler) Run(c *gin.Context) {
 		PositionSizing:    positionSizing,
 		FillPriceSource:   fillSource,
 		BookSource:        bookSource,
+		ResultID:          preallocatedRunID,
 		RiskConfig: entity.RiskConfig{
 			MaxPositionAmount:     req.MaxPositionAmount,
 			MaxDailyLoss:          req.MaxDailyLoss,
@@ -370,6 +411,61 @@ func (h *BacktestHandler) Run(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusOK, result)
+}
+
+// ListDecisions returns the per-cycle decision log for a single backtest
+// run. Newest-first; cursor paging via id < cursor. Returns 503 when the
+// handler was constructed without a BacktestDecisionLogRepository.
+func (h *BacktestHandler) ListDecisions(c *gin.Context) {
+	if h.decisionLogRepo == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "decision log repository not configured"})
+		return
+	}
+	runID := c.Param("id")
+	limit := 500
+	if s := c.Query("limit"); s != "" {
+		if v, err := strconv.Atoi(s); err == nil && v > 0 {
+			if v > 5000 {
+				v = 5000
+			}
+			limit = v
+		}
+	}
+	var cursor int64
+	if s := c.Query("cursor"); s != "" {
+		if v, err := strconv.ParseInt(s, 10, 64); err == nil {
+			cursor = v
+		}
+	}
+	rows, next, err := h.decisionLogRepo.ListByRun(c.Request.Context(), runID, limit, cursor)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	out := make([]gin.H, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, decisionRecordToJSON(r))
+	}
+	c.JSON(http.StatusOK, gin.H{"decisions": out, "nextCursor": next, "hasMore": next != 0})
+}
+
+// DeleteDecisions purges every backtest_decision_log row scoped to the
+// given run id. Idempotent: deleting nothing for an unknown run is fine
+// and returns 200 with deleted=0. The 3-day retention sweep handles
+// untouched rows; this endpoint exists so callers can reclaim space
+// immediately when they know they're done with a run.
+func (h *BacktestHandler) DeleteDecisions(c *gin.Context) {
+	if h.decisionLogRepo == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "decision log repository not configured"})
+		return
+	}
+	runID := c.Param("id")
+	deleted, err := h.decisionLogRepo.DeleteByRun(c.Request.Context(), runID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"deleted": deleted})
 }
 
 // buildExecutionSourcesForCfg returns the FillPriceSource and BookSource for

--- a/backend/internal/interfaces/api/handler/backtest_decision_test.go
+++ b/backend/internal/interfaces/api/handler/backtest_decision_test.go
@@ -1,0 +1,147 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/infrastructure/database"
+	bt "github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/backtest"
+)
+
+func newBacktestHandlerForDecisionTest(t *testing.T) (*BacktestHandler, func()) {
+	t.Helper()
+	tmpDir := t.TempDir()
+	db, err := database.NewDB(filepath.Join(tmpDir, "test.db"))
+	if err != nil {
+		t.Fatalf("NewDB: %v", err)
+	}
+	if err := database.RunMigrations(db); err != nil {
+		t.Fatalf("RunMigrations: %v", err)
+	}
+	resultRepo := struct {
+		// We don't exercise the result-save path here, only the decision
+		// log endpoints, so we pass nil for the result repo. The handler
+		// nil-guards on result-related code paths and the decision
+		// endpoints don't touch h.repo at all.
+	}{}
+	_ = resultRepo
+	decisionRepo := database.NewBacktestDecisionLogRepository(db)
+	handler := NewBacktestHandler(
+		bt.NewBacktestRunner(),
+		nil,
+		WithDecisionLogRepo(decisionRepo),
+	)
+	cleanup := func() { db.Close() }
+	return handler, cleanup
+}
+
+func seedBacktestDecision(t *testing.T, h *BacktestHandler, runID string, ts int64) {
+	t.Helper()
+	rec := entity.DecisionRecord{
+		BarCloseAt:      ts,
+		TriggerKind:     entity.DecisionTriggerBarClose,
+		SymbolID:        7,
+		CurrencyPair:    "LTC_JPY",
+		PrimaryInterval: "PT15M",
+		Stance:          "TREND_FOLLOW",
+		LastPrice:       30210,
+		SignalAction:    "BUY",
+		RiskOutcome:     entity.DecisionRiskApproved,
+		BookGateOutcome: entity.DecisionBookAllowed,
+		OrderOutcome:    entity.DecisionOrderFilled,
+		IndicatorsJSON:  `{"rsi":48.2}`,
+		CreatedAt:       time.Now().UnixMilli(),
+	}
+	if err := h.decisionLogRepo.Insert(context.Background(), rec, runID); err != nil {
+		t.Fatalf("seed insert: %v", err)
+	}
+}
+
+func TestBacktestHandler_ListDecisions_FiltersByRunID(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h, cleanup := newBacktestHandlerForDecisionTest(t)
+	defer cleanup()
+
+	seedBacktestDecision(t, h, "run-aaa", 1_000)
+	seedBacktestDecision(t, h, "run-aaa", 2_000)
+	seedBacktestDecision(t, h, "run-bbb", 1_500)
+
+	r := gin.New()
+	r.GET("/backtest/results/:id/decisions", h.ListDecisions)
+	req := httptest.NewRequest(http.MethodGet, "/backtest/results/run-aaa/decisions", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Decisions []map[string]any `json:"decisions"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(resp.Decisions) != 2 {
+		t.Errorf("len = %d, want 2 (run-aaa only)", len(resp.Decisions))
+	}
+}
+
+func TestBacktestHandler_DeleteDecisions_RemovesOnlyTargetRun(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h, cleanup := newBacktestHandlerForDecisionTest(t)
+	defer cleanup()
+
+	seedBacktestDecision(t, h, "run-aaa", 1_000)
+	seedBacktestDecision(t, h, "run-aaa", 2_000)
+	seedBacktestDecision(t, h, "run-bbb", 1_500)
+
+	r := gin.New()
+	r.DELETE("/backtest/results/:id/decisions", h.DeleteDecisions)
+	r.GET("/backtest/results/:id/decisions", h.ListDecisions)
+
+	req := httptest.NewRequest(http.MethodDelete, "/backtest/results/run-aaa/decisions", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("delete status = %d, body = %s", w.Code, w.Body.String())
+	}
+	var del struct {
+		Deleted int `json:"deleted"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &del)
+	if del.Deleted != 2 {
+		t.Errorf("deleted = %d, want 2", del.Deleted)
+	}
+
+	// run-bbb must remain.
+	req = httptest.NewRequest(http.MethodGet, "/backtest/results/run-bbb/decisions", nil)
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	var listResp struct {
+		Decisions []map[string]any `json:"decisions"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &listResp)
+	if len(listResp.Decisions) != 1 {
+		t.Errorf("run-bbb rows after delete = %d, want 1 (untouched)", len(listResp.Decisions))
+	}
+}
+
+func TestBacktestHandler_ListDecisions_Returns503WhenRepoMissing(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	handler := NewBacktestHandler(bt.NewBacktestRunner(), nil)
+	r := gin.New()
+	r.GET("/backtest/results/:id/decisions", handler.ListDecisions)
+	req := httptest.NewRequest(http.MethodGet, "/backtest/results/run-xyz/decisions", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", w.Code)
+	}
+}

--- a/backend/internal/interfaces/api/router.go
+++ b/backend/internal/interfaces/api/router.go
@@ -56,6 +56,11 @@ type Dependencies struct {
 
 	// DecisionLogRepo (optional). When set, GET /api/v1/decisions is exposed.
 	DecisionLogRepo repository.DecisionLogRepository
+
+	// BacktestDecisionLogRepo (optional). When set, every backtest run
+	// persists per-cycle decisions and the GET/DELETE
+	// /backtest/results/:id/decisions endpoints become available.
+	BacktestDecisionLogRepo repository.BacktestDecisionLogRepository
 }
 
 func NewRouter(deps Dependencies) *gin.Engine {
@@ -181,6 +186,9 @@ func NewRouter(deps Dependencies) *gin.Engine {
 		if deps.MarketDataService != nil {
 			opts = append(opts, handler.WithMarketDataService(deps.MarketDataService))
 		}
+		if deps.BacktestDecisionLogRepo != nil {
+			opts = append(opts, handler.WithDecisionLogRepo(deps.BacktestDecisionLogRepo))
+		}
 		backtestHandler := handler.NewBacktestHandler(deps.BacktestRunner, deps.BacktestResultRepo, opts...)
 		// PR-12: profile discovery endpoints used by the FE backtest picker.
 		// The same profilesBaseDir default is used so /profiles and
@@ -205,6 +213,10 @@ func NewRouter(deps Dependencies) *gin.Engine {
 		if deps.WalkForwardResultRepo != nil {
 			v1.GET("/backtest/walk-forward", backtestHandler.ListWalkForward)
 			v1.GET("/backtest/walk-forward/:id", backtestHandler.GetWalkForward)
+		}
+		if deps.BacktestDecisionLogRepo != nil {
+			v1.GET("/backtest/results/:id/decisions", backtestHandler.ListDecisions)
+			v1.DELETE("/backtest/results/:id/decisions", backtestHandler.DeleteDecisions)
 		}
 	}
 

--- a/backend/internal/usecase/backtest/runner.go
+++ b/backend/internal/usecase/backtest/runner.go
@@ -62,6 +62,14 @@ type RunInput struct {
 	// confidence scaling matches the live path. 0 disables confidence
 	// scaling (the sizer passes the multiplier through as 1.0).
 	MinConfidence float64
+
+	// ResultID, when non-empty, overrides the auto-generated ULID assigned
+	// at the end of Run. Callers wire this when they need to know the run
+	// id *before* Run starts — e.g. to bind a DecisionRecorder to it via
+	// BacktestRepoAdapter so per-run decision rows can be scoped before the
+	// first event flows through the bus. Empty preserves the legacy
+	// behaviour (Run allocates a fresh ULID).
+	ResultID string
 }
 
 // RunnerOption tunes optional aspects of a BacktestRunner at construction.
@@ -351,9 +359,13 @@ func (r *BacktestRunner) Run(ctx context.Context, input RunInput) (*entity.Backt
 	}
 	summary.ThinBookSkips = executionHandler.ThinBookSkips + tickRiskHandler.ThinBookSkips
 
-	id, err := NewULID()
-	if err != nil {
-		return nil, err
+	id := input.ResultID
+	if id == "" {
+		generated, err := NewULID()
+		if err != nil {
+			return nil, err
+		}
+		id = generated
 	}
 	result := &entity.BacktestResult{
 		ID:        id,

--- a/backend/internal/usecase/backtest/runner_decision_log_test.go
+++ b/backend/internal/usecase/backtest/runner_decision_log_test.go
@@ -77,6 +77,33 @@ func TestRunner_WithDecisionRecorder_ForwardsBusEvents(t *testing.T) {
 	}
 }
 
+func TestRunner_PreAllocatedResultID_IsHonoured(t *testing.T) {
+	primary := []entity.Candle{
+		{Open: 100, High: 101, Low: 99, Close: 100, Time: 1_770_000_000_000},
+	}
+	runner := NewBacktestRunner()
+	res, err := runner.Run(context.Background(), RunInput{
+		Config: entity.BacktestConfig{
+			Symbol:          "BTC_JPY",
+			SymbolID:        7,
+			PrimaryInterval: "PT15M",
+			FromTimestamp:   primary[0].Time,
+			ToTimestamp:     primary[0].Time,
+			InitialBalance:  100000,
+		},
+		RiskConfig:     entity.RiskConfig{InitialCapital: 100000, StopLossPercent: 5},
+		TradeAmount:    0.01,
+		PrimaryCandles: primary,
+		ResultID:       "preallocated-123",
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.ID != "preallocated-123" {
+		t.Errorf("result.ID = %q, want preallocated value", res.ID)
+	}
+}
+
 func TestRunner_WithDecisionRecorder_NilDoesNotPanic(t *testing.T) {
 	primary := []entity.Candle{
 		{Open: 100, High: 101, Low: 99, Close: 100, Time: 1_770_000_000_000},

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -13,6 +13,7 @@ import { Route as WalkForwardRouteImport } from './routes/walk-forward'
 import { Route as SettingsRouteImport } from './routes/settings'
 import { Route as HistoryRouteImport } from './routes/history'
 import { Route as BacktestMultiRouteImport } from './routes/backtest-multi'
+import { Route as BacktestDecisionsRouteImport } from './routes/backtest-decisions'
 import { Route as BacktestRouteImport } from './routes/backtest'
 import { Route as IndexRouteImport } from './routes/index'
 
@@ -36,6 +37,11 @@ const BacktestMultiRoute = BacktestMultiRouteImport.update({
   path: '/backtest-multi',
   getParentRoute: () => rootRouteImport,
 } as any)
+const BacktestDecisionsRoute = BacktestDecisionsRouteImport.update({
+  id: '/backtest-decisions',
+  path: '/backtest-decisions',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const BacktestRoute = BacktestRouteImport.update({
   id: '/backtest',
   path: '/backtest',
@@ -50,6 +56,7 @@ const IndexRoute = IndexRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/backtest': typeof BacktestRoute
+  '/backtest-decisions': typeof BacktestDecisionsRoute
   '/backtest-multi': typeof BacktestMultiRoute
   '/history': typeof HistoryRoute
   '/settings': typeof SettingsRoute
@@ -58,6 +65,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/backtest': typeof BacktestRoute
+  '/backtest-decisions': typeof BacktestDecisionsRoute
   '/backtest-multi': typeof BacktestMultiRoute
   '/history': typeof HistoryRoute
   '/settings': typeof SettingsRoute
@@ -67,6 +75,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/backtest': typeof BacktestRoute
+  '/backtest-decisions': typeof BacktestDecisionsRoute
   '/backtest-multi': typeof BacktestMultiRoute
   '/history': typeof HistoryRoute
   '/settings': typeof SettingsRoute
@@ -77,6 +86,7 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/backtest'
+    | '/backtest-decisions'
     | '/backtest-multi'
     | '/history'
     | '/settings'
@@ -85,6 +95,7 @@ export interface FileRouteTypes {
   to:
     | '/'
     | '/backtest'
+    | '/backtest-decisions'
     | '/backtest-multi'
     | '/history'
     | '/settings'
@@ -93,6 +104,7 @@ export interface FileRouteTypes {
     | '__root__'
     | '/'
     | '/backtest'
+    | '/backtest-decisions'
     | '/backtest-multi'
     | '/history'
     | '/settings'
@@ -102,6 +114,7 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   BacktestRoute: typeof BacktestRoute
+  BacktestDecisionsRoute: typeof BacktestDecisionsRoute
   BacktestMultiRoute: typeof BacktestMultiRoute
   HistoryRoute: typeof HistoryRoute
   SettingsRoute: typeof SettingsRoute
@@ -138,6 +151,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof BacktestMultiRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/backtest-decisions': {
+      id: '/backtest-decisions'
+      path: '/backtest-decisions'
+      fullPath: '/backtest-decisions'
+      preLoaderRoute: typeof BacktestDecisionsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/backtest': {
       id: '/backtest'
       path: '/backtest'
@@ -158,6 +178,7 @@ declare module '@tanstack/react-router' {
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   BacktestRoute: BacktestRoute,
+  BacktestDecisionsRoute: BacktestDecisionsRoute,
   BacktestMultiRoute: BacktestMultiRoute,
   HistoryRoute: HistoryRoute,
   SettingsRoute: SettingsRoute,

--- a/frontend/src/routes/backtest-decisions.tsx
+++ b/frontend/src/routes/backtest-decisions.tsx
@@ -1,0 +1,68 @@
+import { createFileRoute, Link } from '@tanstack/react-router'
+import { useQuery } from '@tanstack/react-query'
+import { AppFrame } from '../components/AppFrame'
+import { DecisionLogTable } from '../components/DecisionLogTable'
+import { fetchApi, type DecisionLogResponse } from '../lib/api'
+
+type Search = { id: string }
+
+export const Route = createFileRoute('/backtest-decisions')({
+  validateSearch: (raw: Record<string, unknown>): Search => ({
+    id: typeof raw.id === 'string' ? raw.id : '',
+  }),
+  component: BacktestDecisionsPage,
+})
+
+function BacktestDecisionsPage() {
+  const { id } = Route.useSearch()
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['backtest-decisions', id],
+    queryFn: () => fetchApi<DecisionLogResponse>(`/backtest/results/${id}/decisions?limit=1000`),
+    enabled: id !== '',
+  })
+
+  return (
+    <AppFrame
+      title="Backtest Decision Log"
+      subtitle={`Run ${id || '(no id)'} の 15 分足ごとの売買判断ログ`}
+    >
+      <div className="mb-4">
+        <Link
+          to="/backtest"
+          className="text-sm text-cyan-200 underline-offset-2 hover:underline"
+        >
+          ← バックテスト結果一覧へ戻る
+        </Link>
+      </div>
+
+      {id === '' && (
+        <div className="rounded-2xl border border-accent-red/40 bg-accent-red/10 px-5 py-3 text-sm text-accent-red">
+          run id が指定されていません。バックテスト結果一覧から開いてください。
+        </div>
+      )}
+
+      {error && (
+        <div className="rounded-2xl border border-accent-red/40 bg-accent-red/10 px-5 py-3 text-sm text-accent-red">
+          取得に失敗しました: {(error as Error).message}
+        </div>
+      )}
+
+      {isLoading && (
+        <div className="rounded-2xl border border-white/8 bg-bg-card/90 p-8 text-center text-text-secondary">
+          読み込み中...
+        </div>
+      )}
+
+      {data && (
+        <>
+          <div className="mb-4 text-xs text-text-secondary">
+            {data.decisions.length.toLocaleString()} 件
+            {data.hasMore ? ' (上限 1000 件まで表示)' : ''}
+          </div>
+          <DecisionLogTable decisions={data.decisions} />
+        </>
+      )}
+    </AppFrame>
+  )
+}

--- a/frontend/src/routes/backtest.tsx
+++ b/frontend/src/routes/backtest.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState, type FormEvent, type ReactNode } from 'react'
-import { createFileRoute } from '@tanstack/react-router'
+import { createFileRoute, Link } from '@tanstack/react-router'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { AppFrame } from '../components/AppFrame'
 import {
@@ -993,6 +993,13 @@ function DetailPanel({ result }: { result: BacktestResult }) {
         <h2 className="text-xl font-semibold text-white">
           {config.symbol} / {periodFrom} - {periodTo}
         </h2>
+        <Link
+          to="/backtest-decisions"
+          search={{ id: result.id }}
+          className="ml-auto rounded-full border border-cyan-300/30 bg-cyan-500/10 px-3 py-1 text-xs font-medium text-cyan-200 transition hover:bg-cyan-500/20"
+        >
+          判断ログを見る →
+        </Link>
       </div>
 
       {/* Config info */}


### PR DESCRIPTION
## Summary
Final PR of the decision-log series. Closes the loop on the backtest side:

- **runner**: \`RunInput.ResultID\` lets callers pre-allocate the run id, so a DecisionRecorder bound to that id can attach to the EventBus *before* the first event flies. When ResultID is empty the runner allocates a fresh ULID as before.
- **backtest handler**: when constructed with WithDecisionLogRepo, every POST /backtest/run pre-allocates the run id, attaches a DecisionRecorder via BacktestRepoAdapter, and the run's per-cycle decisions land in backtest_decision_log scoped to that id.
- **API**: GET /api/v1/backtest/results/:id/decisions (list, cursor paging) and DELETE /api/v1/backtest/results/:id/decisions (immediate purge — the 3-day retention sweep handles untouched runs). Both return 503 when the repo is not wired so legacy deployments stay clean.
- **frontend**: new /backtest-decisions route receives ?id=runID, fetches up to 1000 rows, and renders them with the same DecisionLogTable + DecisionDetailPanel components used on /history. The backtest result detail panel gets a "判断ログを見る →" link.

After this PR, every backtest run automatically captures and surfaces the why-did-it-(not)-trade story for every PT15M cycle, with the same depth as the live recorder.

Spec: \`docs/superpowers/specs/2026-04-26-decision-log-design.md\`

## Test plan
- [x] go test ./... -race -count=1 is green (full backend suite)
- [x] new TestRunner_PreAllocatedResultID_IsHonoured covers the new RunInput field
- [x] new TestBacktestHandler_ListDecisions_FiltersByRunID + DeleteDecisions_RemovesOnlyTargetRun + Returns503WhenRepoMissing cover the API
- [x] cd frontend && pnpm test is green
- [x] cd frontend && pnpm build is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)