### PR TITLE
fix(execution-quality): retry on rakuten rate limit (20010)

### DIFF
--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -827,7 +827,15 @@ func startExecutionQualitySnapshotWorker(
 		if symbolID <= 0 {
 			return
 		}
-		report, err := reporter.Build(ctx, symbolID, 86400)
+		var report entity.ExecutionQualityReport
+		err := retryOn20010(ctx, time.Sleep, func() error {
+			r, e := reporter.Build(ctx, symbolID, 86400)
+			if e != nil {
+				return e
+			}
+			report = r
+			return nil
+		})
 		if err != nil {
 			slog.Warn("execution-quality snapshot failed", "error", err)
 			return


### PR DESCRIPTION
## Summary
- `execution-quality` snapshot worker (`startExecutionQualitySnapshotWorker` in `backend/cmd/main.go`) was the only consumer of the rakuten Private API path that did **not** retry on code 20010.
- Wrap `reporter.Build` with the existing `retryOn20010` helper (300/600/1200ms backoff), matching the pipeline state-sync policy.
- 20010 以外のエラーは即返す（既存挙動と同等）。リトライ中は `pipeline: rakuten rate limit (20010), retrying ...` の WARN が出る。

## Why
過去 24h のログを確認したところ、起動直後の 4 分間に code 20010 が 4 件発生していた:

```
13:47:35 WARN pipeline: rakuten rate limit (20010), retrying attempt=1
13:48:48 WARN execution-quality snapshot failed error="GetMyTrades: ... code:20010"  ← retry なし
13:50:48 WARN pipeline: rakuten rate limit (20010), retrying attempt=1
13:51:03 WARN pipeline: rakuten rate limit (20010), retrying attempt=1
```

pipeline 経路は retry で 300ms 後に成功するため影響なし。一方 execution-quality は retry が無いため一発で snapshot を 1 サイクル取りこぼしていた。フロントエンドの初期ロードバーストと state sync (15s) / snapshot worker (60s) が重なる起動直後に踏みやすい。

## Test plan
- [x] `go build ./...` 通過
- [x] `go test ./cmd/... -race -count=1` 通過
- [ ] CI green
- [ ] 起動後しばらく観察し `execution-quality snapshot failed` が消えること