### PR TITLE
fix(fe): 通知ポップアップが overflow:hidden でクリップされる問題を修正

### DIFF
--- a/frontend/src/components/NotificationToggle.tsx
+++ b/frontend/src/components/NotificationToggle.tsx
@@ -1,21 +1,48 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { useNotificationSettings, type BrowserPermission } from '../hooks/useNotificationSettings'
 
-// Bell-with-popover that lives in the header. Kept lightweight (no external
-// popover lib) — the popover is just an absolutely positioned panel that
-// toggles on click and closes on outside-click.
+// Bell-with-popover that lives in the header. The popover is rendered in a
+// portal anchored to <body> so it isn't clipped by the header's overflow-hidden
+// (needed for the rounded gradient background).
+
+const POPOVER_WIDTH = 288 // matches w-72 (18rem)
+const POPOVER_GAP = 8 // px gap between bell and popover
 
 export function NotificationToggle() {
   const { settings, permission, setEnabled, setSoundEnabled, requestPermission } =
     useNotificationSettings()
   const [open, setOpen] = useState(false)
-  const ref = useRef<HTMLDivElement>(null)
+  const buttonRef = useRef<HTMLButtonElement>(null)
+  const popoverRef = useRef<HTMLDivElement>(null)
+  const [pos, setPos] = useState<{ top: number; left: number } | null>(null)
+
+  useLayoutEffect(() => {
+    if (!open) return
+    const update = () => {
+      const btn = buttonRef.current
+      if (!btn) return
+      const r = btn.getBoundingClientRect()
+      const left = Math.max(8, Math.min(window.innerWidth - POPOVER_WIDTH - 8, r.right - POPOVER_WIDTH))
+      const top = r.bottom + POPOVER_GAP
+      setPos({ top, left })
+    }
+    update()
+    window.addEventListener('resize', update)
+    window.addEventListener('scroll', update, true)
+    return () => {
+      window.removeEventListener('resize', update)
+      window.removeEventListener('scroll', update, true)
+    }
+  }, [open])
 
   useEffect(() => {
     if (!open) return
     const onClick = (e: MouseEvent) => {
-      if (!ref.current) return
-      if (!ref.current.contains(e.target as Node)) setOpen(false)
+      const target = e.target as Node
+      if (buttonRef.current?.contains(target)) return
+      if (popoverRef.current?.contains(target)) return
+      setOpen(false)
     }
     document.addEventListener('mousedown', onClick)
     return () => document.removeEventListener('mousedown', onClick)
@@ -25,8 +52,9 @@ export function NotificationToggle() {
   const ariaLabel = isOn ? '通知設定 (オン)' : '通知設定 (オフ)'
 
   return (
-    <div ref={ref} className="relative">
+    <div className="relative">
       <button
+        ref={buttonRef}
         type="button"
         onClick={() => setOpen((v) => !v)}
         aria-label={ariaLabel}
@@ -38,8 +66,12 @@ export function NotificationToggle() {
       >
         <BellIcon active={isOn} />
       </button>
-      {open && (
-        <div className="absolute right-0 top-11 z-30 w-72 rounded-2xl border border-white/10 bg-bg-card/95 p-4 shadow-[0_20px_60px_rgba(0,0,0,0.5)] backdrop-blur">
+      {open && pos && typeof document !== 'undefined' && createPortal(
+        <div
+          ref={popoverRef}
+          style={{ position: 'fixed', top: pos.top, left: pos.left, width: POPOVER_WIDTH }}
+          className="z-50 rounded-2xl border border-white/10 bg-bg-card/95 p-4 shadow-[0_20px_60px_rgba(0,0,0,0.5)] backdrop-blur"
+        >
           <p className="text-xs uppercase tracking-[0.28em] text-text-secondary">通知設定</p>
           <h3 className="mt-1 text-base font-semibold text-white">取引イベント通知</h3>
 
@@ -79,7 +111,8 @@ export function NotificationToggle() {
           <p className="mt-3 text-[11px] leading-relaxed text-text-secondary">
             エントリー / クローズ / リスク警告 (DD・連敗・日次損失) を OS 通知で表示します。
           </p>
-        </div>
+        </div>,
+        document.body,
       )}
     </div>
   )


### PR DESCRIPTION
## Summary
- ヘッダー (`AppFrame`) は角丸グラデを綺麗に出すために `overflow-hidden` が必須だが、その影響で `NotificationToggle` のポップアップがベルのすぐ下〜数px の高さでクリップされ、ほとんど見えていなかった
- ポップアップを `createPortal` で `document.body` 配下にレンダリングし、`position: fixed` + ベルの `getBoundingClientRect()` で配置するように変更
- resize / scroll に追従し、右端では画面内に収まるようクランプ
- 外側クリック判定は bell と popover 両方を対象に

## Test plan
- [x] `pnpm test` (47 件 pass)
- [x] `pnpm exec tsc --noEmit` で本変更起因のエラーなし
- [ ] ブラウザでベルクリック → ポップアップ全体が表示されることを確認
- [ ] 画面リサイズ・スクロール時に追従することを確認
- [ ] ポップアップ外クリックで閉じることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)