### PR TITLE
fix(pipeline): no-op SwitchSymbol when symbol+amount unchanged

### DIFF
--- a/backend/cmd/event_pipeline.go
+++ b/backend/cmd/event_pipeline.go
@@ -226,8 +226,21 @@ func (p *EventDrivenPipeline) SwitchSymbol(symbolID int64, tradeAmount float64, 
 
 	p.mu.RLock()
 	oldID := p.symbolID
+	oldAmount := p.tradeAmount
 	wasRunning := p.cancel != nil
 	p.mu.RUnlock()
+
+	// No-op guard: a switch to the same symbol with the same trade amount
+	// would otherwise tear down and rebuild the event loop, dropping the
+	// in-flight CandleBuilder state and the recorder's pending bar draft.
+	// We saw this in production when the frontend re-PUTs trading-config
+	// on every focus change — a single redundant call destroyed ~30 min of
+	// decision-log accumulation. Cheap to guard here; the SwitchSymbol
+	// contract still allows reordering callers to detect the no-op via the
+	// onSwitch callback (which we still skip below).
+	if symbolID == oldID && (tradeAmount <= 0 || tradeAmount == oldAmount) {
+		return
+	}
 
 	if wasRunning {
 		p.stopLocked()

--- a/backend/cmd/pipeline_test.go
+++ b/backend/cmd/pipeline_test.go
@@ -172,6 +172,52 @@ func TestSwitchSymbol_PreservesRunningState(t *testing.T) {
 	p.Stop()
 }
 
+// TestEventDrivenPipeline_SwitchSymbol_NoOpForSameSymbolAndAmount は、
+// 同じ symbol/amount への SwitchSymbol が event loop を再起動せず、onSwitch
+// コールバックも呼ばない (= no-op) ことを検証する。frontend が trading-config
+// を意図せず再 PUT したときに recorder の pending bar / WS subscription が
+// 破壊されるのを防ぐガード。
+//
+// EventDrivenPipeline 本体は依存 nil で start すると即 ctx.Done を待つだけの
+// goroutine を回すので、ロック/フィールドの整合だけを検証できる。
+func TestEventDrivenPipeline_SwitchSymbol_NoOpForSameSymbolAndAmount(t *testing.T) {
+	p := &EventDrivenPipeline{
+		symbolID:    10,
+		tradeAmount: 2000,
+	}
+
+	// Start で event loop goroutine を起動 (依存 nil なので即 ctx.Done 待ちで block)。
+	p.Start()
+	defer p.Stop()
+	if !p.Running() {
+		t.Fatal("pipeline must be running after Start")
+	}
+
+	switchCalled := 0
+	p.SwitchSymbol(10, 2000, func(_, _ int64) { switchCalled++ })
+	if switchCalled != 0 {
+		t.Errorf("onSwitch must not fire for same symbol+amount, called %d times", switchCalled)
+	}
+	if !p.Running() {
+		t.Error("pipeline must stay running across no-op switch")
+	}
+
+	// tradeAmount==0 (= "keep current") も同 symbol なら no-op。
+	p.SwitchSymbol(10, 0, func(_, _ int64) { switchCalled++ })
+	if switchCalled != 0 {
+		t.Errorf("onSwitch must not fire for same symbol with zero amount, called %d times", switchCalled)
+	}
+
+	// 異なる amount に変える場合は通常通り switch される。
+	p.SwitchSymbol(10, 3000, func(_, _ int64) { switchCalled++ })
+	if switchCalled != 1 {
+		t.Errorf("onSwitch must fire when amount changes, called %d times", switchCalled)
+	}
+	if p.TradeAmount() != 3000 {
+		t.Errorf("tradeAmount should update to 3000, got %f", p.TradeAmount())
+	}
+}
+
 func TestRoundDownToStep(t *testing.T) {
 	tests := []struct {
 		name   string


### PR DESCRIPTION
## Summary
- EventDrivenPipeline.SwitchSymbol unconditionally tore down and rebuilt
  the event loop, even when the request was a no-op (same symbolID + same
  tradeAmount). Each rebuild lost the LiveSource CandleBuilder state and
  the DecisionRecorder's pending bar draft.
- Caught in production tonight when the frontend re-PUTed trading-config
  multiple times in quick succession (separate FE bug, fixed in a follow-up
  PR), wiping ~30 minutes of decision-log accumulation each time.
- Add an early-return guard: \`if symbolID == oldID && (tradeAmount <= 0 || tradeAmount == oldAmount) { return }\`.

\`tradeAmount <= 0\` is treated as "keep current" per the existing
contract (the next mutation only happens when \`tradeAmount > 0\`), so a
caller passing 0 with the same symbol now correctly no-ops instead of
restarting.

## Test plan
- [x] new TestEventDrivenPipeline_SwitchSymbol_NoOpForSameSymbolAndAmount covers all three paths (same+same -> noop, same+0 -> noop, same+different-amount -> normal switch + onSwitch fires)
- [x] go test ./... -race -count=1 is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)