### PR TITLE
fix(fe): stop SymbolContext useEffect from re-PUTing trading-config

### DIFF
--- a/frontend/src/contexts/SymbolContext.tsx
+++ b/frontend/src/contexts/SymbolContext.tsx
@@ -98,17 +98,26 @@ export function SymbolProvider({ children }: { children: ReactNode }) {
   //   - both URL and backend config are settled (no race during boot)
   //   - the symbols differ
   //   - no PUT is already in-flight (avoid loops on transient errors)
+  //
+  // The deps array intentionally only depends on the resolved IDs (primitive
+  // values) — putting the mutation object or queryClient in deps would
+  // re-fire this effect on every mutation status change and re-PUT the same
+  // value, which silently restarted the EventDrivenPipeline event loop and
+  // wiped the decision recorder's pending bar. The mutate / invalidate calls
+  // are accessed via the closure but their identities don't drive the effect.
+  const urlResolvedId = resolvedFromUrl?.id
+  const backendSymbolId = tradingConfig?.symbolId
+  const backendTradeAmount = tradingConfig?.tradeAmount
   useEffect(() => {
-    if (!tradingConfig) return
-    if (!resolvedFromUrl) return
+    if (urlResolvedId === undefined || backendSymbolId === undefined) return
     if (updateConfig.isPending) return
-    if (resolvedFromUrl.id === tradingConfig.symbolId) return
+    if (urlResolvedId === backendSymbolId) return
     console.warn(
       '[SymbolContext] mismatch between URL symbol and backend trading_config; auto-syncing',
-      { urlSymbolId: resolvedFromUrl.id, backendSymbolId: tradingConfig.symbolId },
+      { urlSymbolId: urlResolvedId, backendSymbolId },
     )
     updateConfig.mutate(
-      { symbolId: resolvedFromUrl.id, tradeAmount: tradingConfig.tradeAmount },
+      { symbolId: urlResolvedId, tradeAmount: backendTradeAmount ?? 0 },
       {
         onSuccess: () => {
           void queryClient.invalidateQueries({ queryKey: ['candles'] })
@@ -116,7 +125,8 @@ export function SymbolProvider({ children }: { children: ReactNode }) {
         },
       },
     )
-  }, [resolvedFromUrl, tradingConfig, updateConfig, queryClient])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [urlResolvedId, backendSymbolId])
 
   const switchSymbol = useCallback(
     (newSymbolId: number) => {


### PR DESCRIPTION
## Summary
SymbolContext.tsx had a defense-in-depth useEffect that PUT
/api/v1/trading-config whenever the URL symbol diverged from the backend
trading_config. The deps array included \`updateConfig\` (the mutation
object) and \`queryClient\`, so every mutation status flip re-ran the
effect; in some interleavings it caught a stale \`tradingConfig\`
snapshot and re-PUT the same symbolId+amount.

The backend then unconditionally tore down EventDrivenPipeline (event
loop + WS subscription + recorder pending bar). Caught this tonight when
new decision_log rows stopped arriving every 15-30 minutes.

Fix: pin the effect's deps to the primitive IDs only and access mutate /
invalidate via closure. ESLint exhaustive-deps disabled with a one-line
comment explaining why (adding \`updateConfig\` back reintroduces the
loop).

The companion backend fix #208 adds a no-op guard inside
EventDrivenPipeline.SwitchSymbol so even if a redundant PUT slips through
in the future, the event loop is no longer destroyed.

## Test plan
- [x] cd frontend && pnpm test (47/47 green)
- [x] cd frontend && pnpm build green
- [ ] After deploy, confirm /api/v1/decisions accumulates rows steadily across multiple PT15M closes (no more 30+ min gaps from spurious restarts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)