### PR TITLE
feat(rakuten): prioritize orders in rate-limit queue and retry on 20010

### DIFF
--- a/backend/internal/infrastructure/live/real_executor.go
+++ b/backend/internal/infrastructure/live/real_executor.go
@@ -11,6 +11,7 @@ import (
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/repository"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/eventengine"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/orderretry"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/sor"
 )
 
@@ -308,18 +309,15 @@ func (r *RealExecutor) closeLocked(positionID int64, signalPrice float64, reason
 		},
 	}
 
-	orders, err := r.orderClient.CreateOrder(context.Background(), req)
+	closeOrder, err := r.submit(context.Background(), req)
 	if err != nil {
 		return entity.OrderEvent{}, nil, fmt.Errorf("failed to create close order: %w", err)
 	}
 
-	var orderID int64
+	orderID := closeOrder.ID
 	exitPrice := signalPrice
-	if len(orders) > 0 {
-		orderID = orders[0].ID
-		if orders[0].Price > 0 {
-			exitPrice = orders[0].Price
-		}
+	if closeOrder.Price > 0 {
+		exitPrice = closeOrder.Price
 	}
 
 	slog.Info("live position closed",
@@ -690,16 +688,32 @@ func fallbackVWAP(cost, amount, fallback float64) float64 {
 // Errors propagate up unchanged so the caller can decide whether to escalate
 // or surface the failure. Records the submission timestamp so the pipeline
 // can adapt its position-polling cadence.
+//
+// Uses CreateOrderRaw + orderretry.OnRateLimit so a 20010 (rate limit) hit at
+// order-submission time is automatically retried. Other failure modes (transport
+// error, business errors like 50048) propagate unchanged so the post-only
+// rejection path in runPlan keeps working.
 func (r *RealExecutor) submit(ctx context.Context, req entity.OrderRequest) (entity.Order, error) {
-	orders, err := r.orderClient.CreateOrder(ctx, req)
+	out, fnErr := orderretry.OnRateLimit(ctx, time.Sleep, func() (repository.CreateOrderOutcome, error) {
+		return r.orderClient.CreateOrderRaw(ctx, req)
+	})
 	r.lastOrderAtMillis = time.Now().UnixMilli()
-	if err != nil {
-		return entity.Order{}, err
+	if fnErr != nil {
+		return entity.Order{}, fnErr
 	}
-	if len(orders) == 0 {
+	if out.TransportError != nil {
+		return entity.Order{}, out.TransportError
+	}
+	if out.HTTPError != nil {
+		return entity.Order{}, out.HTTPError
+	}
+	if out.ParseError != nil {
+		return entity.Order{}, out.ParseError
+	}
+	if len(out.Orders) == 0 {
 		return entity.Order{}, errors.New("venue returned no order rows")
 	}
-	return orders[0], nil
+	return out.Orders[0], nil
 }
 
 // pollUntilFilledOrDeadline polls GetOrders until the target order is

--- a/backend/internal/infrastructure/live/real_executor_test.go
+++ b/backend/internal/infrastructure/live/real_executor_test.go
@@ -32,7 +32,19 @@ func (m *mockOrderClient) CreateOrder(ctx context.Context, req entity.OrderReque
 }
 
 func (m *mockOrderClient) CreateOrderRaw(ctx context.Context, req entity.OrderRequest) (repository.CreateOrderOutcome, error) {
-	return repository.CreateOrderOutcome{}, fmt.Errorf("not implemented")
+	// real_executor.submit is now CreateOrderRaw-based; mirror createOrderFn
+	// so existing tests that exercise submit() continue to work.
+	orders, err := m.CreateOrder(ctx, req)
+	if err != nil {
+		return repository.CreateOrderOutcome{
+			HTTPStatus: 500,
+			HTTPError:  err,
+		}, nil
+	}
+	return repository.CreateOrderOutcome{
+		HTTPStatus: 200,
+		Orders:     orders,
+	}, nil
 }
 
 func (m *mockOrderClient) CancelOrder(ctx context.Context, symbolID, orderID int64) ([]entity.Order, error) {

--- a/backend/internal/infrastructure/rakuten/private_api.go
+++ b/backend/internal/infrastructure/rakuten/private_api.go
@@ -38,7 +38,8 @@ func (c *RESTClient) GetOrders(ctx context.Context, symbolID int64) ([]entity.Or
 func (c *RESTClient) CreateOrder(ctx context.Context, req entity.OrderRequest) ([]entity.Order, error) {
 	reqBody, err := json.Marshal(req)
 	if err != nil { return nil, fmt.Errorf("CreateOrder marshal: %w", err) }
-	body, err := c.DoPrivate(ctx, "POST", "/api/v1/cfd/order", "", reqBody)
+	// 発注は PriorityHigh で参照系のキューを追い越す。
+	body, err := c.DoPrivateWithPriority(ctx, "POST", "/api/v1/cfd/order", "", reqBody, PriorityHigh)
 	if err != nil { return nil, fmt.Errorf("CreateOrder: %w", err) }
 	var orders []entity.Order
 	if err := json.Unmarshal(body, &orders); err != nil { return nil, fmt.Errorf("CreateOrder unmarshal: %w", err) }
@@ -64,7 +65,8 @@ func (c *RESTClient) CreateOrderRaw(ctx context.Context, req entity.OrderRequest
 		return out, out.TransportError
 	}
 
-	statusCode, body, transportErr := c.DoPrivateRaw(ctx, "POST", "/api/v1/cfd/order", "", reqBody)
+	// 発注は PriorityHigh で参照系のキューを追い越す。
+	statusCode, body, transportErr := c.DoPrivateRawWithPriority(ctx, "POST", "/api/v1/cfd/order", "", reqBody, PriorityHigh)
 	out.HTTPStatus = statusCode
 	out.RawResponse = body
 	if transportErr != nil {
@@ -93,7 +95,8 @@ func (c *RESTClient) CreateOrderRaw(ctx context.Context, req entity.OrderRequest
 
 func (c *RESTClient) CancelOrder(ctx context.Context, symbolID, orderID int64) ([]entity.Order, error) {
 	query := fmt.Sprintf("symbolId=%d&id=%d", symbolID, orderID)
-	body, err := c.DoPrivate(ctx, "DELETE", "/api/v1/cfd/order", query, nil)
+	// キャンセルも発注経路 (post-only エスカレ等) で時間に敏感なので high。
+	body, err := c.DoPrivateWithPriority(ctx, "DELETE", "/api/v1/cfd/order", query, nil, PriorityHigh)
 	if err != nil { return nil, fmt.Errorf("CancelOrder: %w", err) }
 	var orders []entity.Order
 	if err := json.Unmarshal(body, &orders); err != nil { return nil, fmt.Errorf("CancelOrder unmarshal: %w", err) }

--- a/backend/internal/infrastructure/rakuten/rest_client.go
+++ b/backend/internal/infrastructure/rakuten/rest_client.go
@@ -6,9 +6,37 @@ import (
 	"io"
 	"net/http"
 	"strings"
-	"sync"
 	"time"
 )
+
+// Priority はレートリミットキューにおける優先度。
+// 発注 (CreateOrder / CancelOrder) は PriorityHigh、それ以外は PriorityNormal。
+type Priority int
+
+const (
+	PriorityNormal Priority = 0
+	PriorityHigh   Priority = 1
+)
+
+// rateInterval は連続するリクエスト間に開けるべき最小間隔。
+// 楽天 Private API は 200ms 制限のため、サーバー側ジッタを吸収するマージンを 20ms 載せる。
+const rateInterval = 220 * time.Millisecond
+
+// orderBurstShare は high が連続で何個まで normal を追い越せるかの上限。
+// この回数 high を捌いたら、normal が 1 個でも待っていれば優先で通す
+// (= スタベーション防止)。発注バーストは通常 1〜2 個で収まるので 5 は十分余裕。
+const orderBurstShare = 5
+
+// rateRequest は 1 個のリクエストが「次にスロットを使ってよい」通知を
+// 受け取るための受信箱。1 バッファのチャネルにすることで、ticker goroutine の
+// 送信が必ず非ブロックで完了する。
+type rateRequest struct {
+	notify chan struct{}
+}
+
+func newRateRequest() *rateRequest {
+	return &rateRequest{notify: make(chan struct{}, 1)}
+}
 
 type RESTClient struct {
 	httpClient *http.Client
@@ -16,27 +44,139 @@ type RESTClient struct {
 	apiKey     string
 	apiSecret  string
 
-	mu       sync.Mutex
-	lastCall time.Time
+	highQ   chan *rateRequest
+	normalQ chan *rateRequest
 }
 
 func NewRESTClient(baseURL, apiKey, apiSecret string) *RESTClient {
-	return &RESTClient{
+	c := &RESTClient{
 		httpClient: &http.Client{Timeout: 30 * time.Second},
 		baseURL:    baseURL,
 		apiKey:     apiKey,
 		apiSecret:  apiSecret,
+		highQ:      make(chan *rateRequest, 256),
+		normalQ:    make(chan *rateRequest, 256),
+	}
+	go c.dispatchLoop()
+	return c
+}
+
+// dispatchLoop は 220ms 間隔で「次に発射してよい」権を 1 個ずつ発行する。
+//
+// 動作:
+//   - 1 リクエスト目: キューに requester が入った瞬間にすぐ発射 (初回 wait なし)
+//   - それ以降: 直前の発射時刻から rateInterval 経過するまで待ってから「次の req を取り出して」発行
+//   - high が並んでいれば優先で通す。ただし orderBurstShare 連続したら
+//     normal が居る限り 1 個 normal を通す (フェアネス)
+//
+// 重要: 次の req を取り出すタイミングは「rateInterval 経過後」。これにより
+// 直前の発射 → 待機中の間に投入された high が、待機明けでちゃんと拾える。
+//
+// goroutine は RESTClient が GC されるまで生きるが、本サービスはプロセスライフタイム
+// 全体で 1 個の RESTClient を共有するため、明示的な停止は実装しない。
+func (c *RESTClient) dispatchLoop() {
+	var (
+		lastFired time.Time
+		highInRow int
+	)
+	for {
+		// レートインターバルを満たすまで待つ。初回 (lastFired ゼロ値) は即時。
+		if !lastFired.IsZero() {
+			if wait := rateInterval - time.Since(lastFired); wait > 0 {
+				time.Sleep(wait)
+			}
+		}
+		// 待機を終えた直後に「いま並んでいる中で誰を通すか」を決める。
+		req := c.pickNext(&highInRow)
+		// requester に「いまから発射してよい」通知。
+		req.notify <- struct{}{}
+		lastFired = time.Now()
 	}
 }
 
-// DoPublic executes an unauthenticated Public API request.
-func (c *RESTClient) DoPublic(ctx context.Context, method, path, query string, body []byte) ([]byte, error) {
-	return c.do(ctx, method, path, query, body, false)
+// pickNext は次に発射する requester を 1 個選ぶ。
+// orderBurstShare の境界では強制的に normal を選ぶ。
+func (c *RESTClient) pickNext(highInRow *int) *rateRequest {
+	// high のスタベーション保護: 5 連続したら normal を最優先で拾う。
+	if *highInRow >= orderBurstShare {
+		select {
+		case r := <-c.normalQ:
+			*highInRow = 0
+			return r
+		default:
+			// normal は居ない。high のままでよい。
+		}
+	}
+	// 通常時は high 優先。
+	select {
+	case r := <-c.highQ:
+		*highInRow++
+		return r
+	default:
+	}
+	// high なし。normal をブロッキング取得し、もし最後の瞬間に high が
+	// 入ってきても normal が公平に通る (チャネル受信は select 順で安定)。
+	select {
+	case r := <-c.normalQ:
+		*highInRow = 0
+		return r
+	case r := <-c.highQ:
+		*highInRow++
+		return r
+	}
 }
 
-// DoPrivate executes an authenticated Private API request.
+// waitForSlot は当該リクエストの「次の 220ms スロット」を待つ。
+// ctx が死んだ場合は ctx.Err を返す。
+func (c *RESTClient) waitForSlot(ctx context.Context, prio Priority) error {
+	req := newRateRequest()
+	q := c.normalQ
+	if prio == PriorityHigh {
+		q = c.highQ
+	}
+	select {
+	case q <- req:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	select {
+	case <-req.notify:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// DoPublic / DoPrivate は normal 優先度で動作する後方互換ラッパー。
+func (c *RESTClient) DoPublic(ctx context.Context, method, path, query string, body []byte) ([]byte, error) {
+	return c.DoPublicWithPriority(ctx, method, path, query, body, PriorityNormal)
+}
+
 func (c *RESTClient) DoPrivate(ctx context.Context, method, path, query string, body []byte) ([]byte, error) {
-	return c.do(ctx, method, path, query, body, true)
+	return c.DoPrivateWithPriority(ctx, method, path, query, body, PriorityNormal)
+}
+
+func (c *RESTClient) DoPrivateRaw(ctx context.Context, method, path, query string, body []byte) (statusCode int, respBody []byte, transportErr error) {
+	return c.DoPrivateRawWithPriority(ctx, method, path, query, body, PriorityNormal)
+}
+
+// DoPublicWithPriority は明示的に優先度を指定する Public API 呼び出し。
+// テスト用にも使うが、実コードで Public を high にする場面はない。
+func (c *RESTClient) DoPublicWithPriority(ctx context.Context, method, path, query string, body []byte, prio Priority) ([]byte, error) {
+	return c.do(ctx, method, path, query, body, false, prio)
+}
+
+// DoPrivateWithPriority は明示的に優先度を指定する Private API 呼び出し。
+// 発注経路から PriorityHigh で呼ぶことで、参照系で詰まったキューを追い越す。
+func (c *RESTClient) DoPrivateWithPriority(ctx context.Context, method, path, query string, body []byte, prio Priority) ([]byte, error) {
+	return c.do(ctx, method, path, query, body, true, prio)
+}
+
+// DoPrivateRawWithPriority は DoPrivateRaw の優先度指定版。
+// 発注 (CreateOrderRaw) はこれを PriorityHigh で叩く。
+func (c *RESTClient) DoPrivateRawWithPriority(ctx context.Context, method, path, query string, body []byte, prio Priority) (statusCode int, respBody []byte, transportErr error) {
+	ex := c.doRaw(ctx, method, path, query, body, true, prio)
+	return ex.statusCode, ex.body, ex.transportError
 }
 
 // httpExchange は do() の構造化版。トランスポート失敗・非 2xx・本文を区別して返す。
@@ -46,15 +186,8 @@ type httpExchange struct {
 	transportError error
 }
 
-// DoPrivateRaw は DoPrivate の構造化版。レスポンス本文を非 2xx でも返す。
-// 呼び出し側で submitted/failed の判定 (status コード + 本文パース可否) が必要なときに使う。
-func (c *RESTClient) DoPrivateRaw(ctx context.Context, method, path, query string, body []byte) (statusCode int, respBody []byte, transportErr error) {
-	ex := c.doRaw(ctx, method, path, query, body, true)
-	return ex.statusCode, ex.body, ex.transportError
-}
-
-func (c *RESTClient) do(ctx context.Context, method, path, query string, body []byte, authenticated bool) ([]byte, error) {
-	ex := c.doRaw(ctx, method, path, query, body, authenticated)
+func (c *RESTClient) do(ctx context.Context, method, path, query string, body []byte, authenticated bool, prio Priority) ([]byte, error) {
+	ex := c.doRaw(ctx, method, path, query, body, authenticated, prio)
 	if ex.transportError != nil {
 		return nil, ex.transportError
 	}
@@ -64,8 +197,8 @@ func (c *RESTClient) do(ctx context.Context, method, path, query string, body []
 	return ex.body, nil
 }
 
-func (c *RESTClient) doRaw(ctx context.Context, method, path, query string, body []byte, authenticated bool) httpExchange {
-	if err := c.waitForRateLimit(ctx); err != nil {
+func (c *RESTClient) doRaw(ctx context.Context, method, path, query string, body []byte, authenticated bool, prio Priority) httpExchange {
+	if err := c.waitForSlot(ctx, prio); err != nil {
 		return httpExchange{transportError: err}
 	}
 
@@ -115,22 +248,3 @@ func (c *RESTClient) doRaw(ctx context.Context, method, path, query string, body
 	}
 }
 
-// waitForRateLimit enforces the Rakuten API 200ms interval limit.
-// Uses a 220ms margin to absorb clock skew between client and Rakuten server,
-// since requests pacing exactly at 200ms occasionally trip AUTHENTICATION_ERROR_TOO_MANY_REQUESTS (code 20010).
-// Returns an error if the context is cancelled during the wait.
-func (c *RESTClient) waitForRateLimit(ctx context.Context) error {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	elapsed := time.Since(c.lastCall)
-	if wait := 220*time.Millisecond - elapsed; wait > 0 {
-		select {
-		case <-time.After(wait):
-		case <-ctx.Done():
-			return ctx.Err()
-		}
-	}
-	c.lastCall = time.Now()
-	return nil
-}

--- a/backend/internal/infrastructure/rakuten/rest_client_test.go
+++ b/backend/internal/infrastructure/rakuten/rest_client_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -95,6 +97,187 @@ func TestRESTClient_DoPrivate(t *testing.T) {
 
 	if len(body) == 0 {
 		t.Fatal("body should not be empty")
+	}
+}
+
+// TestRESTClient_HighPriorityOvertakesNormal は、normal が複数並んでいる
+// ところに high が割り込んだとき、high が「次の 220ms スロット」で先に通る
+// ことを検証する。
+//
+// シナリオ:
+//   1. normal A を投げる (即時、t=0 で発射)
+//   2. すぐに normal B, normal C を順番に投げる (220, 440 で発射されるはず)
+//   3. その直後に high D を投げる (B が出る前に割り込み: 220 で D, 440 で B)
+//
+// 期待される到達順: A, D, B, C  (D が B/C を追い越す)
+func TestRESTClient_HighPriorityOvertakesNormal(t *testing.T) {
+	var (
+		mu       sync.Mutex
+		arrivals []string
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		arrivals = append(arrivals, r.URL.Path)
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := NewRESTClient(server.URL, "", "")
+	ctx := context.Background()
+
+	var wg sync.WaitGroup
+
+	// A: 最初の normal、即時通過 (lastCall がまだないので t=0 で発射)。
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, _ = client.DoPublicWithPriority(ctx, "GET", "/A", "", nil, PriorityNormal)
+	}()
+
+	// 5 ms 待って、最初のリクエストが先に発射されたことを保証する。
+	time.Sleep(5 * time.Millisecond)
+
+	// B, C を normal で並べる (B = 220ms スロット、C = 440ms スロットのはず)。
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		_, _ = client.DoPublicWithPriority(ctx, "GET", "/B", "", nil, PriorityNormal)
+	}()
+	go func() {
+		defer wg.Done()
+		_, _ = client.DoPublicWithPriority(ctx, "GET", "/C", "", nil, PriorityNormal)
+	}()
+
+	// 5 ms 後 (B/C はまだ待ち中) に high D を割り込ませる。
+	time.Sleep(5 * time.Millisecond)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, _ = client.DoPublicWithPriority(ctx, "GET", "/D", "", nil, PriorityHigh)
+	}()
+
+	wg.Wait()
+
+	mu.Lock()
+	got := append([]string(nil), arrivals...)
+	mu.Unlock()
+
+	if len(got) != 4 {
+		t.Fatalf("expected 4 arrivals, got %v", got)
+	}
+	// A は最初。
+	if got[0] != "/A" {
+		t.Fatalf("expected /A first, got %v", got)
+	}
+	// D は 2 番目 (high が normal を追い越す)。
+	if got[1] != "/D" {
+		t.Fatalf("expected /D second (high priority overtakes normal), got %v", got)
+	}
+	// B, C は順不同で残り。
+	rest := []string{got[2], got[3]}
+	if !((rest[0] == "/B" && rest[1] == "/C") || (rest[0] == "/C" && rest[1] == "/B")) {
+		t.Fatalf("expected /B and /C in any order at positions 2-3, got %v", got)
+	}
+}
+
+// TestRESTClient_OrderBurstShareYieldsToNormal は、high が連続で
+// orderBurstShare 個まで通った後に必ず 1 個 normal が混ざる
+// (= スタベーションしない) ことを検証する。
+//
+// 設計値: orderBurstShare = 5 (5 連続 high を捌いたら 1 個 normal を通す)。
+func TestRESTClient_OrderBurstShareYieldsToNormal(t *testing.T) {
+	var (
+		mu       sync.Mutex
+		arrivals []string
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		arrivals = append(arrivals, r.URL.Path)
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := NewRESTClient(server.URL, "", "")
+	ctx := context.Background()
+
+	// 最初のリクエストは即時通過するため、まず空打ち (= "/seed") で
+	// 内部の lastCall を進めてから本体を投げる。
+	_, _ = client.DoPublicWithPriority(ctx, "GET", "/seed", "", nil, PriorityNormal)
+
+	mu.Lock()
+	arrivals = nil
+	mu.Unlock()
+
+	var wg sync.WaitGroup
+	// normal 1 個を先に並べる (これが「割り込まれる側」)。
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, _ = client.DoPublicWithPriority(ctx, "GET", "/N", "", nil, PriorityNormal)
+	}()
+	time.Sleep(5 * time.Millisecond) // N が確実にキューに入るまで待つ
+
+	// high を 6 連続 (= orderBurstShare(5) + 1) 並べる。
+	for i := 0; i < 6; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			path := "/H" + string(rune('0'+i))
+			_, _ = client.DoPublicWithPriority(ctx, "GET", path, "", nil, PriorityHigh)
+		}()
+		time.Sleep(2 * time.Millisecond) // 順序を安定させる
+	}
+
+	wg.Wait()
+
+	mu.Lock()
+	got := append([]string(nil), arrivals...)
+	mu.Unlock()
+
+	if len(got) != 7 {
+		t.Fatalf("expected 7 arrivals, got %v", got)
+	}
+
+	// 最初の 5 個は high (H0..H4) のはず。次に N が割り込み、最後に H5。
+	for i := 0; i < 5; i++ {
+		if len(got[i]) < 2 || got[i][1] != 'H' {
+			t.Fatalf("expected first %d arrivals to be high-priority, got %v", 5, got)
+		}
+	}
+	if got[5] != "/N" {
+		t.Fatalf("expected /N at position 6 (after %d high bursts), got %v", 5, got)
+	}
+	if got[6] != "/H5" {
+		t.Fatalf("expected /H5 last, got %v", got)
+	}
+}
+
+// TestRESTClient_PriorityRespectsRateLimit は、優先度に関係なく
+// 200ms 間隔は守られることを検証する。
+func TestRESTClient_PriorityRespectsRateLimit(t *testing.T) {
+	var calls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := NewRESTClient(server.URL, "", "")
+	ctx := context.Background()
+
+	start := time.Now()
+	_, _ = client.DoPublicWithPriority(ctx, "GET", "/h1", "", nil, PriorityHigh)
+	_, _ = client.DoPublicWithPriority(ctx, "GET", "/h2", "", nil, PriorityHigh)
+	elapsed := time.Since(start)
+
+	if elapsed < 200*time.Millisecond {
+		t.Fatalf("rate limit violated for high-priority sequence: 2 reqs in %v", elapsed)
+	}
+	if atomic.LoadInt32(&calls) != 2 {
+		t.Fatalf("expected 2 calls, got %d", atomic.LoadInt32(&calls))
 	}
 }
 

--- a/backend/internal/usecase/orderretry/retry.go
+++ b/backend/internal/usecase/orderretry/retry.go
@@ -1,0 +1,96 @@
+// Package orderretry は発注呼び出し (CreateOrderRaw) を 20010 (rate limit)
+// のときだけ安全にリトライするヘルパーを提供する。
+//
+// 通常の参照系は cmd/retry.go の retryOn20010 を使うが、発注は二重発注リスクが
+// あるため文字列マッチでは判定しない: CreateOrderOutcome の構造化情報
+// (HTTPError + RawResponse の JSON code フィールド) だけを見て、
+// 「楽天側で受理されなかった」と確証できる場合のみリトライする。
+package orderretry
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"time"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/repository"
+)
+
+// Backoffs は各リトライ前に挟む待ち時間。長さ = 最大リトライ回数。
+// 参照系の retryOn20010 と同じ値 (300/600/1200ms) を採用。
+// 楽天 API の 200ms 制限 + 220ms クライアントマージンに対し、再送までに
+// 余裕を持たせる目的。
+var Backoffs = []time.Duration{
+	300 * time.Millisecond,
+	600 * time.Millisecond,
+	1200 * time.Millisecond,
+}
+
+// OnRateLimit は fn を最大 len(Backoffs) 回リトライする。リトライするのは
+// CreateOrderOutcome が「楽天側で 20010 として受理拒否されたことが構造的に
+// 確証できる」ケースのみ。
+//
+// リトライしない条件 (= 二重発注リスク):
+//   - 成功 (HTTPStatus 2xx かつ Orders 取得済み)
+//   - TransportError (楽天到達状態が不明)
+//   - HTTPError だが 20010 以外
+//   - HTTPStatus 2xx だが ParseError あり (楽天は受理した可能性)
+//   - fn 自体が error を返した (marshal 失敗等)
+//
+// sleep は time.Sleep と互換だが、テストで時間を消費しないよう DI 可能にしている。
+func OnRateLimit(
+	ctx context.Context,
+	sleep func(time.Duration),
+	fn func() (repository.CreateOrderOutcome, error),
+) (repository.CreateOrderOutcome, error) {
+	var (
+		out repository.CreateOrderOutcome
+		err error
+	)
+	for attempt := 0; attempt <= len(Backoffs); attempt++ {
+		out, err = fn()
+		if err != nil {
+			return out, err
+		}
+		if !isRateLimitOutcome(out) {
+			return out, nil
+		}
+		if attempt == len(Backoffs) {
+			return out, nil
+		}
+		if ctx.Err() != nil {
+			return out, nil
+		}
+		delay := Backoffs[attempt]
+		slog.Warn("order: rakuten rate limit (20010), retrying",
+			"attempt", attempt+1,
+			"next_delay_ms", delay.Milliseconds())
+		sleep(delay)
+	}
+	return out, nil
+}
+
+// isRateLimitOutcome は CreateOrderOutcome が 20010 (rate limit) で楽天側に
+// 受理されなかったことを構造化情報のみで確証できる場合に true を返す。
+//
+// 「文字列に "20010" が含まれる」だけでは不十分: 発注用は二重発注リスクを
+// 避けるため HTTPError + パース可能な JSON ボディ + code == 20010 の3つを
+// 揃えてはじめてリトライ対象とする。
+func isRateLimitOutcome(out repository.CreateOrderOutcome) bool {
+	if out.HTTPError == nil {
+		return false
+	}
+	if len(out.RawResponse) == 0 {
+		return false
+	}
+	var probe struct {
+		Code json.Number `json:"code"`
+	}
+	dec := json.NewDecoder(bytes.NewReader(out.RawResponse))
+	dec.UseNumber()
+	if err := dec.Decode(&probe); err != nil {
+		return false
+	}
+	return probe.Code.String() == "20010"
+}

--- a/backend/internal/usecase/orderretry/retry_test.go
+++ b/backend/internal/usecase/orderretry/retry_test.go
@@ -1,0 +1,176 @@
+package orderretry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/repository"
+)
+
+func noopSleep(time.Duration) {}
+
+func outcome20010() repository.CreateOrderOutcome {
+	body := []byte(`{"code":20010,"message":"too many requests"}`)
+	return repository.CreateOrderOutcome{
+		HTTPStatus:  500,
+		RawResponse: body,
+		HTTPError:   fmt.Errorf("API error (status 500): %s", string(body)),
+	}
+}
+
+func outcomeBusinessError() repository.CreateOrderOutcome {
+	body := []byte(`{"code":50048,"message":"insufficient amount"}`)
+	return repository.CreateOrderOutcome{
+		HTTPStatus:  400,
+		RawResponse: body,
+		HTTPError:   fmt.Errorf("API error (status 400): %s", string(body)),
+	}
+}
+
+func outcomeSuccess() repository.CreateOrderOutcome {
+	return repository.CreateOrderOutcome{
+		HTTPStatus: 200,
+		Orders:     []entity.Order{{ID: 12345}},
+	}
+}
+
+func outcomeTransport() repository.CreateOrderOutcome {
+	return repository.CreateOrderOutcome{
+		HTTPStatus:     0,
+		TransportError: errors.New("dial tcp: i/o timeout"),
+	}
+}
+
+func TestOnRateLimit_RetriesOn20010ThenSucceeds(t *testing.T) {
+	calls := 0
+	got, err := OnRateLimit(context.Background(), noopSleep, func() (repository.CreateOrderOutcome, error) {
+		calls++
+		if calls < 3 {
+			return outcome20010(), nil
+		}
+		return outcomeSuccess(), nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if got.HTTPStatus != 200 {
+		t.Fatalf("expected final outcome to be the successful one, got status %d", got.HTTPStatus)
+	}
+	if calls != 3 {
+		t.Fatalf("expected 3 calls (2 retries + success), got %d", calls)
+	}
+}
+
+func TestOnRateLimit_DoesNotRetryOnSuccess(t *testing.T) {
+	calls := 0
+	got, err := OnRateLimit(context.Background(), noopSleep, func() (repository.CreateOrderOutcome, error) {
+		calls++
+		return outcomeSuccess(), nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if got.HTTPStatus != 200 {
+		t.Fatalf("expected status 200, got %d", got.HTTPStatus)
+	}
+	if calls != 1 {
+		t.Fatalf("expected exactly 1 call on success, got %d", calls)
+	}
+}
+
+func TestOnRateLimit_DoesNotRetryOnTransportError(t *testing.T) {
+	calls := 0
+	got, err := OnRateLimit(context.Background(), noopSleep, func() (repository.CreateOrderOutcome, error) {
+		calls++
+		return outcomeTransport(), nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if got.TransportError == nil {
+		t.Fatalf("expected TransportError to be propagated, got nil")
+	}
+	if calls != 1 {
+		t.Fatalf("transport error must NOT trigger retry (double-submit risk), got %d calls", calls)
+	}
+}
+
+func TestOnRateLimit_DoesNotRetryOnBusinessError(t *testing.T) {
+	calls := 0
+	got, err := OnRateLimit(context.Background(), noopSleep, func() (repository.CreateOrderOutcome, error) {
+		calls++
+		return outcomeBusinessError(), nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if got.HTTPStatus != 400 {
+		t.Fatalf("expected business-error outcome to propagate, got status %d", got.HTTPStatus)
+	}
+	if calls != 1 {
+		t.Fatalf("non-20010 error must NOT trigger retry, got %d calls", calls)
+	}
+}
+
+func TestOnRateLimit_ExhaustsRetries(t *testing.T) {
+	calls := 0
+	got, err := OnRateLimit(context.Background(), noopSleep, func() (repository.CreateOrderOutcome, error) {
+		calls++
+		return outcome20010(), nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if got.HTTPStatus != 500 {
+		t.Fatalf("expected final 20010 outcome to propagate, got status %d", got.HTTPStatus)
+	}
+	if calls != 1+len(Backoffs) {
+		t.Fatalf("expected 1 initial + %d retries = %d calls, got %d", len(Backoffs), 1+len(Backoffs), calls)
+	}
+}
+
+func TestOnRateLimit_ContextCancelStopsRetries(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	calls := 0
+	_, _ = OnRateLimit(ctx, noopSleep, func() (repository.CreateOrderOutcome, error) {
+		calls++
+		return outcome20010(), nil
+	})
+	if calls < 1 {
+		t.Fatalf("expected at least one call before ctx check, got %d", calls)
+	}
+	if calls > 1 {
+		t.Fatalf("expected no retry after ctx cancel, got %d calls", calls)
+	}
+}
+
+func TestOnRateLimit_FnErrorIsPropagated(t *testing.T) {
+	myErr := errors.New("marshal failed")
+	calls := 0
+	_, err := OnRateLimit(context.Background(), noopSleep, func() (repository.CreateOrderOutcome, error) {
+		calls++
+		return repository.CreateOrderOutcome{TransportError: myErr}, myErr
+	})
+	if !errors.Is(err, myErr) {
+		t.Fatalf("expected fn error to propagate, got %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected exactly 1 call on fn-level error, got %d", calls)
+	}
+}
+
+func TestBackoffsNonEmpty(t *testing.T) {
+	if len(Backoffs) == 0 {
+		t.Fatal("Backoffs should not be empty")
+	}
+	for i, d := range Backoffs {
+		if d <= 0 {
+			t.Fatalf("Backoffs[%d] = %v, want positive", i, d)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Rakuten REST client の rate-limit ペーサーを 220ms ticker + 優先度キュー (high/normal) に置き換え。発注 (CreateOrder / CreateOrderRaw / CancelOrder) は high で参照系のキューを追い越して、次の 220ms スロットで楽天に届く。フェアネス制約 `orderBurstShare=5` で参照系のスタベーション防止。
- 発注専用の 20010 リトライヘルパー `internal/usecase/orderretry.OnRateLimit` を新設。`CreateOrderOutcome` の構造化情報のみで「楽天側が 20010 として受理拒否したことが確証できる」ケースだけ最大 3 回 (300/600/1200ms) リトライ。トランスポート失敗や 2xx + parse error は「届いたかも知れない」として絶対にリトライしない (二重発注防止)。
- `RealExecutor.submit` と `closeLocked` を `CreateOrderRaw + OnRateLimit` 経由に統一。post-only リジェクト判定の意味は維持。
- 参照系の `retryOn20010` (文字列マッチ) は変更なし。発注専用の判定ロジックを混ぜないため、新ヘルパーはスコープを限定して同居させる。

## Why
backend ログ観測で、約 90 秒に 1 回 `pipeline: rakuten rate limit (20010), retrying attempt=1` が出ていた。原因は `pnl` (≈4 秒) や `trades/all` (≈2 秒) の Private API が直列キューを長く塞ぎ、サーバ側ジッタで 220ms マージンを稀に切ること。
発注は今まで「20010 を踏んだら 1 ティック諦める」設計だったが、自動売買の発注タイミングで 20010 に当たるとシグナルが取りこぼされる。優先度キューで発注は最大 220ms 待ちまで圧縮、加えて 20010 を踏んだ場合は安全条件下で自動リトライするので、発注失敗のリスクが大きく下がる。

## Design notes
- `RESTClient.dispatchLoop` は「rateInterval 経過後に次の req を取り出す」順序で実装。発射タイミングまでの待機中に投入された high をちゃんと拾える。
- 発注専用 retry は string-match ではなく `HTTPError != nil` + JSON body の `code == 20010` という3条件 AND。`docs/rakuten-api/error-codes.md` のリトライ方針 (発注は構造化判定で安全にだけリトライ) を満たす。
- `orderretry` を `internal/usecase` 配下に置いたのは、`cmd` package と `infrastructure/live` の循環を避けるため。`cmd/retry.go` の参照系ヘルパーは触っていない。

## Test plan
- [x] `cd backend && go test ./... -race -count=1` 全パス (orderretry の 8 テスト + rest_client の優先度系 3 テスト追加)
- [x] `go vet ./...` / `go build ./...` クリーン
- [x] `docker compose up --build -d` で起動 → Healthy。既存 `pipeline:` 系 20010 リトライが `attempt=1` で吸収されているのを実機ログで確認。`trades/all` ≈ 2 秒、`pnl` のレイテンシ悪化なし。
- [ ] 自動売買起動後の発注経路で `order: rakuten rate limit (20010), retrying` が出るかは次回ライブ運用時に観察 (今回の検証では発注は走らなかった)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)