### PR TITLE
feat(live): seed CandleBuilder from PT1M at pipeline start

### DIFF
--- a/backend/cmd/event_pipeline.go
+++ b/backend/cmd/event_pipeline.go
@@ -64,6 +64,12 @@ type EventDrivenPipeline struct {
 	// recorder; the rest of the pipeline is unaffected.
 	decisionLogRepo repository.DecisionLogRepository
 
+	// candlestickFetcher is used at event-loop start to seed the LiveSource
+	// CandleBuilder with the in-progress PT15M bar reconstructed from PT1M
+	// candles. Optional — when nil the first emitted bar after a restart
+	// only contains post-restart ticks (legacy behaviour).
+	candlestickFetcher repository.CandlestickFetcher
+
 	// indicatorPeriods / bbSqueezeLookback are the live counterparts of the
 	// per-run RunInput fields the backtest already consumes. They are read
 	// once at startup from the configured StrategyProfile (typically
@@ -107,6 +113,12 @@ type EventDrivenPipelineConfig struct {
 	// SL/TP/Trailing closes) persists into decision_log. nil disables it
 	// without otherwise affecting the pipeline.
 	DecisionLogRepo repository.DecisionLogRepository
+
+	// CandlestickFetcher is used to seed the LiveSource CandleBuilder with
+	// the in-progress PT15M bar (reconstructed from PT1M) at startup so the
+	// first emitted bar after a restart has correct OHLC. nil keeps the
+	// legacy behaviour where the first bar only reflects post-restart ticks.
+	CandlestickFetcher repository.CandlestickFetcher
 }
 
 func NewEventDrivenPipeline(
@@ -139,9 +151,10 @@ func NewEventDrivenPipeline(
 		tradeHistoryRepo:  tradeHistoryRepo,
 		riskStateRepo:     riskStateRepo,
 		clientOrderRepo:   clientOrderRepo,
-		indicatorPeriods:  cfg.IndicatorPeriods,
-		bbSqueezeLookback: cfg.BBSqueezeLookback,
-		decisionLogRepo:   cfg.DecisionLogRepo,
+		indicatorPeriods:   cfg.IndicatorPeriods,
+		bbSqueezeLookback:  cfg.BBSqueezeLookback,
+		decisionLogRepo:    cfg.DecisionLogRepo,
+		candlestickFetcher: cfg.CandlestickFetcher,
 	}
 }
 
@@ -263,6 +276,40 @@ func (p *EventDrivenPipeline) SwitchSymbol(symbolID int64, tradeAmount float64, 
 	}
 }
 
+// seedCandleBuilderFromMinutes pulls PT1M candles covering the current
+// PT15M window and folds them into the LiveSource's CandleBuilder so the
+// first emit after a restart contains the *whole* bar's OHLC, not just
+// post-restart ticks. Best-effort: any error path leaves the builder in
+// its legacy state (next live tick will initialise it from the tick).
+func (p *EventDrivenPipeline) seedCandleBuilderFromMinutes(ctx context.Context, symbolID int64, liveSource *live.LiveSource) {
+	if p.candlestickFetcher == nil {
+		return
+	}
+	now := time.Now().UTC()
+	periodStart := now.Truncate(15 * time.Minute)
+	// Pull a 16-minute window starting at the period boundary so we never
+	// miss the first PT1M bar even if the venue is a few seconds behind.
+	from := periodStart.UnixMilli()
+	to := now.Add(time.Minute).UnixMilli()
+	resp, err := p.candlestickFetcher.GetCandlestick(ctx, symbolID, "PT1M", &from, &to)
+	if err != nil {
+		slog.Warn("event-pipeline: PT1M bootstrap fetch failed; first bar will only see post-restart ticks",
+			"symbolID", symbolID, "error", err)
+		return
+	}
+	if resp == nil || len(resp.Candlesticks) == 0 {
+		return
+	}
+	folded := liveSource.SeedFromMinuteCandles(now, resp.Candlesticks)
+	if folded > 0 {
+		slog.Info("event-pipeline: seeded CandleBuilder from PT1M",
+			"symbolID", symbolID,
+			"foldedMinutes", folded,
+			"periodStart", periodStart.Format(time.RFC3339),
+		)
+	}
+}
+
 // loadSymbolMeta fetches baseStepAmount / minOrderAmount from the API.
 // Must be called with mu held.
 func (p *EventDrivenPipeline) loadSymbolMeta(ctx context.Context, symbolID int64) {
@@ -331,6 +378,12 @@ func (p *EventDrivenPipeline) runEventLoop(ctx context.Context, snap eventSnapsh
 
 	// Create LiveSource for tick-to-candle conversion.
 	liveSource := live.NewLiveSource(snap.symbolID, "PT15M")
+
+	// Bootstrap the in-progress 15-min bar from PT1M candles so the first
+	// emit after a restart has correct OHLC instead of just post-restart
+	// ticks. Best-effort: failures are logged and we fall back to the
+	// legacy "first bar only sees post-restart ticks" behaviour.
+	p.seedCandleBuilderFromMinutes(ctx, snap.symbolID, liveSource)
 
 	// Create RealExecutor for live order execution. The SOR is configured
 	// via env vars at startup (see loadSORConfig in main.go); when the

--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -167,9 +167,10 @@ func main() {
 				BalanceHaltPct:  cfg.Reconcile.BalanceHaltPct,
 				OrderTTL:        time.Duration(cfg.Reconcile.OrderTTLSec) * time.Second,
 			},
-			IndicatorPeriods:  liveProfileIndicators(liveProfile),
-			BBSqueezeLookback: liveProfileBBSqueezeLookback(liveProfile),
-			DecisionLogRepo:   decisionLogRepo,
+			IndicatorPeriods:   liveProfileIndicators(liveProfile),
+			BBSqueezeLookback:  liveProfileBBSqueezeLookback(liveProfile),
+			DecisionLogRepo:    decisionLogRepo,
+			CandlestickFetcher: restClient,
 		},
 		restClient,
 		restClient, // SymbolFetcher

--- a/backend/internal/domain/repository/order.go
+++ b/backend/internal/domain/repository/order.go
@@ -40,3 +40,10 @@ type OrderClient interface {
 type SymbolFetcher interface {
 	GetSymbols(ctx context.Context) ([]entity.Symbol, error)
 }
+
+// CandlestickFetcher は完成済みローソク足の取得インターフェース。
+// EventDrivenPipeline 起動時に PT1M を引いて CandleBuilder の partial bar を
+// 復元するために使う。dateFrom / dateTo は unix ms。nil で venue デフォルト。
+type CandlestickFetcher interface {
+	GetCandlestick(ctx context.Context, symbolID int64, candlestickType string, dateFrom, dateTo *int64) (*entity.CandlestickResponse, error)
+}

--- a/backend/internal/infrastructure/live/live_source.go
+++ b/backend/internal/infrastructure/live/live_source.go
@@ -25,6 +25,61 @@ func NewLiveSource(symbolID int64, primaryInterval string) *LiveSource {
 	}
 }
 
+// SeedFromMinuteCandles primes the LiveSource's CandleBuilder so the first
+// PT15M bar emitted after a restart contains the OHLC from the *whole*
+// 15-minute window, not just the post-restart ticks.
+//
+// minuteCandles must be PT1M candles ordered oldest-first. Only the ones
+// whose Time falls inside the *current* primary period (relative to now)
+// are aggregated; older candles are ignored. If no candles fall in the
+// current period the builder is left untouched (the next live tick will
+// initialise it normally).
+//
+// Returns the number of minute candles that were folded into the seed so
+// the caller can log how much of the partial bar was reconstructed.
+func (s *LiveSource) SeedFromMinuteCandles(now time.Time, minuteCandles []entity.Candle) int {
+	interval := s.candleBuilder.interval
+	if interval <= 0 {
+		return 0
+	}
+	periodStart := now.Truncate(interval)
+	periodEndMs := periodStart.Add(interval).UnixMilli()
+	periodStartMs := periodStart.UnixMilli()
+
+	var folded entity.Candle
+	count := 0
+	for _, c := range minuteCandles {
+		if c.Time < periodStartMs || c.Time >= periodEndMs {
+			continue
+		}
+		if count == 0 {
+			folded = entity.Candle{
+				Open:   c.Open,
+				High:   c.High,
+				Low:    c.Low,
+				Close:  c.Close,
+				Volume: c.Volume,
+				Time:   periodStartMs,
+			}
+		} else {
+			if c.High > folded.High {
+				folded.High = c.High
+			}
+			if c.Low < folded.Low {
+				folded.Low = c.Low
+			}
+			folded.Close = c.Close
+			folded.Volume += c.Volume
+		}
+		count++
+	}
+	if count == 0 {
+		return 0
+	}
+	s.candleBuilder.SeedPartial(periodStart, folded)
+	return count
+}
+
 // HandleTick processes a real-time ticker and returns events to feed into EventEngine.
 // Every ticker produces a TickEvent. When a candle period closes, a CandleEvent is also emitted.
 func (s *LiveSource) HandleTick(ticker entity.Ticker) []entity.Event {
@@ -65,6 +120,23 @@ func NewCandleBuilder(symbolID int64, interval time.Duration) *CandleBuilder {
 		symbolID: symbolID,
 		interval: interval,
 	}
+}
+
+// SeedPartial primes the builder with an in-progress candle so the first
+// emit after a restart includes the OHLC from before the daemon came up.
+// periodStart must be the start of the bar (caller is responsible for
+// truncating to the interval). Subsequent AddTick calls in the same
+// period update the seeded candle's High/Low/Close/Volume; ticks in a
+// later period emit it as usual. A second SeedPartial call replaces the
+// previous seed.
+func (b *CandleBuilder) SeedPartial(periodStart time.Time, candle entity.Candle) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	c := candle
+	c.Time = periodStart.UnixMilli()
+	b.currentStart = periodStart
+	b.currentCandle = &c
 }
 
 // AddTick ingests a ticker. Returns a CandleEvent if the current period has closed, nil otherwise.

--- a/backend/internal/infrastructure/live/live_source_test.go
+++ b/backend/internal/infrastructure/live/live_source_test.go
@@ -286,3 +286,90 @@ func TestParseInterval(t *testing.T) {
 		}
 	}
 }
+
+func TestLiveSource_SeedFromMinuteCandles_FoldsCurrentPeriodOnly(t *testing.T) {
+	src := NewLiveSource(7, "PT15M")
+	// "now" sits inside the 10:15-10:30 window.
+	now := time.Date(2026, 4, 27, 10, 23, 0, 0, time.UTC)
+	periodStart := time.Date(2026, 4, 27, 10, 15, 0, 0, time.UTC)
+
+	minutes := []entity.Candle{
+		// Earlier period (10:00-10:15) — must be ignored.
+		{Open: 100, High: 110, Low: 95, Close: 105, Volume: 1, Time: time.Date(2026, 4, 27, 10, 14, 0, 0, time.UTC).UnixMilli()},
+		// Current period — three minute bars at 10:15, 10:16, 10:17.
+		{Open: 200, High: 210, Low: 195, Close: 205, Volume: 2, Time: time.Date(2026, 4, 27, 10, 15, 0, 0, time.UTC).UnixMilli()},
+		{Open: 205, High: 220, Low: 200, Close: 215, Volume: 3, Time: time.Date(2026, 4, 27, 10, 16, 0, 0, time.UTC).UnixMilli()},
+		{Open: 215, High: 218, Low: 190, Close: 192, Volume: 4, Time: time.Date(2026, 4, 27, 10, 17, 0, 0, time.UTC).UnixMilli()},
+	}
+
+	folded := src.SeedFromMinuteCandles(now, minutes)
+	if folded != 3 {
+		t.Fatalf("folded count = %d, want 3", folded)
+	}
+
+	// Drive an in-period tick so the seeded candle becomes observable via
+	// the same path live ticks travel through.
+	tick := entity.Ticker{
+		SymbolID:  7,
+		Last:      193,
+		Volume:    5,
+		Timestamp: time.Date(2026, 4, 27, 10, 24, 0, 0, time.UTC).UnixMilli(),
+	}
+	events := src.HandleTick(tick)
+	if len(events) != 1 {
+		t.Fatalf("in-period tick should not emit a CandleEvent, got %d events", len(events))
+	}
+
+	// Cross the boundary (10:30) — the seeded + updated bar should now emit.
+	closeTick := entity.Ticker{
+		SymbolID:  7,
+		Last:      230,
+		Volume:    1,
+		Timestamp: time.Date(2026, 4, 27, 10, 30, 1, 0, time.UTC).UnixMilli(),
+	}
+	events = src.HandleTick(closeTick)
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events (Tick + Candle), got %d", len(events))
+	}
+	candleEv, ok := events[1].(entity.CandleEvent)
+	if !ok {
+		t.Fatalf("second event = %T, want CandleEvent", events[1])
+	}
+	c := candleEv.Candle
+	if c.Time != periodStart.UnixMilli() {
+		t.Errorf("candle.Time = %d, want %d (period start)", c.Time, periodStart.UnixMilli())
+	}
+	if c.Open != 200 {
+		t.Errorf("Open = %f, want 200 (first seeded minute open)", c.Open)
+	}
+	if c.High != 220 {
+		t.Errorf("High = %f, want 220 (max across seeded minutes)", c.High)
+	}
+	if c.Low != 190 {
+		t.Errorf("Low = %f, want 190 (min across seeded minutes including the third)", c.Low)
+	}
+	// Close = last live tick that landed inside the bar (193), since the
+	// boundary-crossing tick at 230 starts the *next* bar.
+	if c.Close != 193 {
+		t.Errorf("Close = %f, want 193 (last in-period live tick)", c.Close)
+	}
+}
+
+func TestLiveSource_SeedFromMinuteCandles_NoCandlesIsNoOp(t *testing.T) {
+	src := NewLiveSource(7, "PT15M")
+	now := time.Date(2026, 4, 27, 10, 23, 0, 0, time.UTC)
+	folded := src.SeedFromMinuteCandles(now, nil)
+	if folded != 0 {
+		t.Errorf("nil minute slice should fold 0, got %d", folded)
+	}
+	// Builder must still behave normally on the next live tick (i.e.
+	// initialise from the tick's price as before).
+	events := src.HandleTick(entity.Ticker{
+		SymbolID:  7,
+		Last:      999,
+		Timestamp: now.UnixMilli(),
+	})
+	if len(events) != 1 {
+		t.Errorf("expected just TickEvent (no seed -> no candle), got %d", len(events))
+	}
+}


### PR DESCRIPTION
## Summary
After a restart, the first PT15M bar only contained ticks observed
post-startup. Open/High/Low were all the post-restart price, and the
first decision_log row was effectively garbage.

This PR fetches PT1M candles for the current 15-min window from Rakuten
REST at event-loop start and folds them into CandleBuilder via the new
\`LiveSource.SeedFromMinuteCandles\` method. The next period boundary
then emits a candle with full-window OHLC.

Failures during the bootstrap fetch are logged and the builder falls back
to the legacy behaviour, so this is strictly additive.

## Test plan
- [x] new TestLiveSource_SeedFromMinuteCandles_FoldsCurrentPeriodOnly verifies OHLC aggregation across 3 minute bars + an in-period live tick
- [x] new TestLiveSource_SeedFromMinuteCandles_NoCandlesIsNoOp verifies the fallback path
- [x] go test ./... -race -count=1 green
- [ ] After deploy: docker compose logs backend | grep "seeded CandleBuilder from PT1M" should appear once per pipeline start

🤖 Generated with [Claude Code](https://claude.com/claude-code)