### PR TITLE
feat(decisionlog): immediate INSERT + in-place UPDATE recorder model

### DIFF
--- a/backend/internal/domain/repository/decision_log.go
+++ b/backend/internal/domain/repository/decision_log.go
@@ -24,6 +24,16 @@ type DecisionLogFilter struct {
 // must be safe for concurrent reads but a single recorder writes serially.
 type DecisionLogRepository interface {
 	Insert(ctx context.Context, record entity.DecisionRecord) error
+	// InsertAndID is identical to Insert but returns the new row's id so
+	// callers can update the row in place later (eg. the immediate-flush
+	// recorder writes a HOLD/SKIPPED/NOOP row at IndicatorEvent time and
+	// updates it when SignalEvent / OrderEvent arrives within the bar).
+	InsertAndID(ctx context.Context, record entity.DecisionRecord) (int64, error)
+	// Update overwrites the row identified by record.ID. Returns
+	// sql.ErrNoRows-equivalent or a wrapped error when the id no longer
+	// exists. Used by the immediate-flush recorder to refine a previously
+	// inserted BAR_CLOSE row in place.
+	Update(ctx context.Context, record entity.DecisionRecord) error
 	// List returns rows newest-first along with the next cursor (the id of
 	// the oldest row in the page, suitable as Cursor for the next call).
 	// nextCursor == 0 means "no more rows".
@@ -36,6 +46,13 @@ type DecisionLogRepository interface {
 // scheduled cleanup.
 type BacktestDecisionLogRepository interface {
 	Insert(ctx context.Context, record entity.DecisionRecord, runID string) error
+	// InsertAndID mirrors DecisionLogRepository.InsertAndID for backtest
+	// scoping. Returns the new row's id so the recorder can later UPDATE
+	// it in place.
+	InsertAndID(ctx context.Context, record entity.DecisionRecord, runID string) (int64, error)
+	// Update overwrites the row identified by record.ID (run scoping is
+	// inferred from the existing row, not re-checked).
+	Update(ctx context.Context, record entity.DecisionRecord) error
 	ListByRun(ctx context.Context, runID string, limit int, cursor int64) (records []entity.DecisionRecord, nextCursor int64, err error)
 	DeleteByRun(ctx context.Context, runID string) (deleted int64, err error)
 	DeleteOlderThan(ctx context.Context, cutoff int64) (deleted int64, err error)

--- a/backend/internal/domain/repository/decision_log_test.go
+++ b/backend/internal/domain/repository/decision_log_test.go
@@ -10,6 +10,10 @@ import (
 type minimalRepo struct{}
 
 func (*minimalRepo) Insert(_ context.Context, _ entity.DecisionRecord) error { return nil }
+func (*minimalRepo) InsertAndID(_ context.Context, _ entity.DecisionRecord) (int64, error) {
+	return 0, nil
+}
+func (*minimalRepo) Update(_ context.Context, _ entity.DecisionRecord) error { return nil }
 func (*minimalRepo) List(_ context.Context, _ DecisionLogFilter) ([]entity.DecisionRecord, int64, error) {
 	return nil, 0, nil
 }
@@ -19,6 +23,10 @@ type minimalBacktestRepo struct{}
 func (*minimalBacktestRepo) Insert(_ context.Context, _ entity.DecisionRecord, _ string) error {
 	return nil
 }
+func (*minimalBacktestRepo) InsertAndID(_ context.Context, _ entity.DecisionRecord, _ string) (int64, error) {
+	return 0, nil
+}
+func (*minimalBacktestRepo) Update(_ context.Context, _ entity.DecisionRecord) error { return nil }
 func (*minimalBacktestRepo) ListByRun(_ context.Context, _ string, _ int, _ int64) ([]entity.DecisionRecord, int64, error) {
 	return nil, 0, nil
 }

--- a/backend/internal/infrastructure/database/backtest_decision_log_repo.go
+++ b/backend/internal/infrastructure/database/backtest_decision_log_repo.go
@@ -23,6 +23,11 @@ func NewBacktestDecisionLogRepository(db *sql.DB) repository.BacktestDecisionLog
 }
 
 func (r *backtestDecisionLogRepo) Insert(ctx context.Context, rec entity.DecisionRecord, runID string) error {
+	_, err := r.InsertAndID(ctx, rec, runID)
+	return err
+}
+
+func (r *backtestDecisionLogRepo) InsertAndID(ctx context.Context, rec entity.DecisionRecord, runID string) (int64, error) {
 	const q = `
 		INSERT INTO backtest_decision_log (
 			backtest_run_id,
@@ -38,7 +43,7 @@ func (r *backtestDecisionLogRepo) Insert(ctx context.Context, rec entity.Decisio
 			created_at
 		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`
-	if _, err := r.db.ExecContext(ctx, q,
+	res, err := r.db.ExecContext(ctx, q,
 		runID,
 		rec.BarCloseAt, rec.SequenceInBar, rec.TriggerKind,
 		rec.SymbolID, rec.CurrencyPair, rec.PrimaryInterval,
@@ -50,8 +55,54 @@ func (r *backtestDecisionLogRepo) Insert(ctx context.Context, rec entity.Decisio
 		rec.ClosedPositionID, rec.OpenedPositionID,
 		rec.IndicatorsJSON, rec.HigherTFIndicatorsJSON,
 		rec.CreatedAt,
-	); err != nil {
-		return fmt.Errorf("backtest_decision_log insert: %w", err)
+	)
+	if err != nil {
+		return 0, fmt.Errorf("backtest_decision_log insert: %w", err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return 0, fmt.Errorf("backtest_decision_log insert last id: %w", err)
+	}
+	return id, nil
+}
+
+func (r *backtestDecisionLogRepo) Update(ctx context.Context, rec entity.DecisionRecord) error {
+	const q = `
+		UPDATE backtest_decision_log SET
+			bar_close_at = ?, sequence_in_bar = ?, trigger_kind = ?,
+			symbol_id = ?, currency_pair = ?, primary_interval = ?,
+			stance = ?, last_price = ?,
+			signal_action = ?, signal_confidence = ?, signal_reason = ?,
+			risk_outcome = ?, risk_reason = ?,
+			book_gate_outcome = ?, book_gate_reason = ?,
+			order_outcome = ?, order_id = ?, executed_amount = ?, executed_price = ?, order_error = ?,
+			closed_position_id = ?, opened_position_id = ?,
+			indicators_json = ?, higher_tf_indicators_json = ?,
+			created_at = ?
+		WHERE id = ?
+	`
+	res, err := r.db.ExecContext(ctx, q,
+		rec.BarCloseAt, rec.SequenceInBar, rec.TriggerKind,
+		rec.SymbolID, rec.CurrencyPair, rec.PrimaryInterval,
+		rec.Stance, rec.LastPrice,
+		rec.SignalAction, rec.SignalConfidence, rec.SignalReason,
+		rec.RiskOutcome, rec.RiskReason,
+		rec.BookGateOutcome, rec.BookGateReason,
+		rec.OrderOutcome, rec.OrderID, rec.ExecutedAmount, rec.ExecutedPrice, rec.OrderError,
+		rec.ClosedPositionID, rec.OpenedPositionID,
+		rec.IndicatorsJSON, rec.HigherTFIndicatorsJSON,
+		rec.CreatedAt,
+		rec.ID,
+	)
+	if err != nil {
+		return fmt.Errorf("backtest_decision_log update: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("backtest_decision_log update rows affected: %w", err)
+	}
+	if n == 0 {
+		return fmt.Errorf("backtest_decision_log update: id %d not found", rec.ID)
 	}
 	return nil
 }

--- a/backend/internal/infrastructure/database/decision_log_repo.go
+++ b/backend/internal/infrastructure/database/decision_log_repo.go
@@ -26,6 +26,11 @@ func NewDecisionLogRepository(db *sql.DB) repository.DecisionLogRepository {
 }
 
 func (r *decisionLogRepo) Insert(ctx context.Context, rec entity.DecisionRecord) error {
+	_, err := r.InsertAndID(ctx, rec)
+	return err
+}
+
+func (r *decisionLogRepo) InsertAndID(ctx context.Context, rec entity.DecisionRecord) (int64, error) {
 	const q = `
 		INSERT INTO decision_log (
 			bar_close_at, sequence_in_bar, trigger_kind,
@@ -40,7 +45,7 @@ func (r *decisionLogRepo) Insert(ctx context.Context, rec entity.DecisionRecord)
 			created_at
 		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`
-	if _, err := r.db.ExecContext(ctx, q,
+	res, err := r.db.ExecContext(ctx, q,
 		rec.BarCloseAt, rec.SequenceInBar, rec.TriggerKind,
 		rec.SymbolID, rec.CurrencyPair, rec.PrimaryInterval,
 		rec.Stance, rec.LastPrice,
@@ -51,8 +56,54 @@ func (r *decisionLogRepo) Insert(ctx context.Context, rec entity.DecisionRecord)
 		rec.ClosedPositionID, rec.OpenedPositionID,
 		rec.IndicatorsJSON, rec.HigherTFIndicatorsJSON,
 		rec.CreatedAt,
-	); err != nil {
-		return fmt.Errorf("decision_log insert: %w", err)
+	)
+	if err != nil {
+		return 0, fmt.Errorf("decision_log insert: %w", err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return 0, fmt.Errorf("decision_log insert last id: %w", err)
+	}
+	return id, nil
+}
+
+func (r *decisionLogRepo) Update(ctx context.Context, rec entity.DecisionRecord) error {
+	const q = `
+		UPDATE decision_log SET
+			bar_close_at = ?, sequence_in_bar = ?, trigger_kind = ?,
+			symbol_id = ?, currency_pair = ?, primary_interval = ?,
+			stance = ?, last_price = ?,
+			signal_action = ?, signal_confidence = ?, signal_reason = ?,
+			risk_outcome = ?, risk_reason = ?,
+			book_gate_outcome = ?, book_gate_reason = ?,
+			order_outcome = ?, order_id = ?, executed_amount = ?, executed_price = ?, order_error = ?,
+			closed_position_id = ?, opened_position_id = ?,
+			indicators_json = ?, higher_tf_indicators_json = ?,
+			created_at = ?
+		WHERE id = ?
+	`
+	res, err := r.db.ExecContext(ctx, q,
+		rec.BarCloseAt, rec.SequenceInBar, rec.TriggerKind,
+		rec.SymbolID, rec.CurrencyPair, rec.PrimaryInterval,
+		rec.Stance, rec.LastPrice,
+		rec.SignalAction, rec.SignalConfidence, rec.SignalReason,
+		rec.RiskOutcome, rec.RiskReason,
+		rec.BookGateOutcome, rec.BookGateReason,
+		rec.OrderOutcome, rec.OrderID, rec.ExecutedAmount, rec.ExecutedPrice, rec.OrderError,
+		rec.ClosedPositionID, rec.OpenedPositionID,
+		rec.IndicatorsJSON, rec.HigherTFIndicatorsJSON,
+		rec.CreatedAt,
+		rec.ID,
+	)
+	if err != nil {
+		return fmt.Errorf("decision_log update: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("decision_log update rows affected: %w", err)
+	}
+	if n == 0 {
+		return fmt.Errorf("decision_log update: id %d not found", rec.ID)
 	}
 	return nil
 }

--- a/backend/internal/usecase/decisionlog/backtest_adapter.go
+++ b/backend/internal/usecase/decisionlog/backtest_adapter.go
@@ -26,6 +26,14 @@ func (a *backtestRepoAdapter) Insert(ctx context.Context, rec entity.DecisionRec
 	return a.repo.Insert(ctx, rec, a.runID)
 }
 
+func (a *backtestRepoAdapter) InsertAndID(ctx context.Context, rec entity.DecisionRecord) (int64, error) {
+	return a.repo.InsertAndID(ctx, rec, a.runID)
+}
+
+func (a *backtestRepoAdapter) Update(ctx context.Context, rec entity.DecisionRecord) error {
+	return a.repo.Update(ctx, rec)
+}
+
 func (a *backtestRepoAdapter) List(_ context.Context, _ repository.DecisionLogFilter) ([]entity.DecisionRecord, int64, error) {
 	return nil, 0, nil
 }

--- a/backend/internal/usecase/decisionlog/backtest_adapter_test.go
+++ b/backend/internal/usecase/decisionlog/backtest_adapter_test.go
@@ -20,6 +20,16 @@ func (s *stubBacktestRepoForAdapter) Insert(_ context.Context, rec entity.Decisi
 	s.seen = true
 	return nil
 }
+func (s *stubBacktestRepoForAdapter) InsertAndID(_ context.Context, rec entity.DecisionRecord, runID string) (int64, error) {
+	s.rec = rec
+	s.runID = runID
+	s.seen = true
+	return 1, nil
+}
+func (s *stubBacktestRepoForAdapter) Update(_ context.Context, rec entity.DecisionRecord) error {
+	s.rec = rec
+	return nil
+}
 func (s *stubBacktestRepoForAdapter) ListByRun(_ context.Context, _ string, _ int, _ int64) ([]entity.DecisionRecord, int64, error) {
 	return nil, 0, nil
 }

--- a/backend/internal/usecase/decisionlog/integration_test.go
+++ b/backend/internal/usecase/decisionlog/integration_test.go
@@ -79,14 +79,20 @@ func TestRecorder_EndToEnd_FullCycleAndHoldBar(t *testing.T) {
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
-	if len(rows) != 2 {
-		t.Fatalf("expected 2 rows (bar1 + bar2), got %d", len(rows))
+	// Immediate-flush model: every IndicatorEvent inserts a row right
+	// away, so bar1, bar2, bar3 each produce exactly one row (3 total),
+	// independent of subsequent Signal/Order events landing on bar1.
+	if len(rows) != 3 {
+		t.Fatalf("expected 3 rows (bar1 + bar2 + bar3, all inserted immediately), got %d", len(rows))
 	}
-	// Newest first: bar2 then bar1.
-	if rows[0].BarCloseAt != 2_000 || rows[0].SignalAction != "HOLD" {
-		t.Errorf("bar2 row wrong: %+v", rows[0])
+	// Newest first: bar3 then bar2 then bar1.
+	if rows[0].BarCloseAt != 3_000 || rows[0].SignalAction != "HOLD" {
+		t.Errorf("bar3 row wrong: %+v", rows[0])
 	}
-	if rows[1].BarCloseAt != 1_000 || rows[1].SignalAction != "BUY" || rows[1].OrderOutcome != entity.DecisionOrderFilled {
-		t.Errorf("bar1 row wrong: %+v", rows[1])
+	if rows[1].BarCloseAt != 2_000 || rows[1].SignalAction != "HOLD" {
+		t.Errorf("bar2 row wrong: %+v", rows[1])
+	}
+	if rows[2].BarCloseAt != 1_000 || rows[2].SignalAction != "BUY" || rows[2].OrderOutcome != entity.DecisionOrderFilled {
+		t.Errorf("bar1 row wrong: %+v", rows[2])
 	}
 }

--- a/backend/internal/usecase/decisionlog/recorder.go
+++ b/backend/internal/usecase/decisionlog/recorder.go
@@ -27,16 +27,30 @@ type RecorderConfig struct {
 }
 
 // Recorder observes EventBus events and writes one DecisionRecord per
-// completed cycle. It is NOT goroutine-safe; one Recorder must be bound to
-// exactly one EventBus chain (the EventBus dispatch loop is single-threaded
-// per chain so this matches the runtime invariant).
+// completed cycle.
+//
+// Flush model: every IndicatorEvent immediately INSERTs a row with HOLD /
+// SKIPPED / NOOP defaults. Subsequent SignalEvent / ApprovedSignalEvent /
+// RejectedSignalEvent / OrderEvent within the same bar UPDATE that row in
+// place. The trade-off vs. the legacy "wait for next IndicatorEvent to
+// flush" model is one extra UPDATE per active bar, in exchange for: (1)
+// HOLD bars become visible immediately (no 15-min delay), (2) a daemon
+// crash mid-bar still leaves the BAR_CLOSE row persisted.
+//
+// Recorder is NOT goroutine-safe; one Recorder must be bound to exactly
+// one EventBus chain (the EventBus dispatch loop is single-threaded per
+// chain so this matches the runtime invariant).
 type Recorder struct {
 	repo   repository.DecisionLogRepository
 	cfg    RecorderConfig
 	nowFn  func() time.Time
 	logger *slog.Logger
 
-	pending           *draft
+	// pendingRec carries the most recent BAR_CLOSE row for in-place UPDATE
+	// as later events arrive. ID == 0 means "no row yet for the current
+	// bar" (e.g. immediately after construction or after an Insert error).
+	pendingRec        entity.DecisionRecord
+	hasPending        bool
 	nextSequenceInBar int
 	lastIndicatorJSON string
 	lastHigherTFJSON  string
@@ -60,23 +74,17 @@ func (r *Recorder) SetClock(fn func() time.Time) { r.nowFn = fn }
 func (r *Recorder) Handle(ctx context.Context, event entity.Event) ([]entity.Event, error) {
 	switch ev := event.(type) {
 	case entity.IndicatorEvent:
-		r.onIndicator(ev)
+		r.onIndicator(ctx, ev)
 	case entity.SignalEvent:
-		r.onSignal(ev)
+		r.onSignal(ctx, ev)
 	case entity.ApprovedSignalEvent:
-		r.onApproved()
+		r.onApproved(ctx)
 	case entity.RejectedSignalEvent:
 		r.onRejected(ctx, ev)
 	case entity.OrderEvent:
 		r.onOrder(ctx, ev)
 	}
 	return nil, nil
-}
-
-// draft is the in-progress record for one bar. Fields are mutated as more
-// events flow in; flush() persists and clears it.
-type draft struct {
-	rec entity.DecisionRecord
 }
 
 func (r *Recorder) stance() string {
@@ -86,15 +94,10 @@ func (r *Recorder) stance() string {
 	return r.cfg.StanceProvider()
 }
 
-func (r *Recorder) onIndicator(ev entity.IndicatorEvent) {
-	// Flushing of the previous bar's pending draft happens lazily on the
-	// next IndicatorEvent so we do not need a goroutine timer to know when
-	// "the bar is over". A residual draft means the strategy returned HOLD
-	// for that bar (no SignalEvent / ApprovedSignalEvent / OrderEvent
-	// arrived) so we persist it as such.
-	r.flushPending(context.Background())
-
-	// Reset sequence numbering for the new bar.
+func (r *Recorder) onIndicator(ctx context.Context, ev entity.IndicatorEvent) {
+	// New bar: discard the previous bar's pending state (it's already
+	// persisted with whatever final values we knew) and start fresh.
+	r.hasPending = false
 	r.nextSequenceInBar = 1
 
 	indicatorsJSON, err := json.Marshal(ev.Primary)
@@ -115,57 +118,66 @@ func (r *Recorder) onIndicator(ev entity.IndicatorEvent) {
 	r.lastIndicatorJSON = string(indicatorsJSON)
 	r.lastHigherTFJSON = string(higherJSON)
 
-	r.pending = &draft{
-		rec: entity.DecisionRecord{
-			BarCloseAt:             ev.Timestamp,
-			SequenceInBar:          0,
-			TriggerKind:            entity.DecisionTriggerBarClose,
-			SymbolID:               r.cfg.SymbolID,
-			CurrencyPair:           r.cfg.CurrencyPair,
-			PrimaryInterval:        r.cfg.PrimaryInterval,
-			Stance:                 r.stance(),
-			LastPrice:              ev.LastPrice,
-			SignalAction:           string(entity.SignalActionHold),
-			RiskOutcome:            entity.DecisionRiskSkipped,
-			BookGateOutcome:        entity.DecisionBookSkipped,
-			OrderOutcome:           entity.DecisionOrderNoop,
-			IndicatorsJSON:         r.lastIndicatorJSON,
-			HigherTFIndicatorsJSON: r.lastHigherTFJSON,
-		},
+	rec := entity.DecisionRecord{
+		BarCloseAt:             ev.Timestamp,
+		SequenceInBar:          0,
+		TriggerKind:            entity.DecisionTriggerBarClose,
+		SymbolID:               r.cfg.SymbolID,
+		CurrencyPair:           r.cfg.CurrencyPair,
+		PrimaryInterval:        r.cfg.PrimaryInterval,
+		Stance:                 r.stance(),
+		LastPrice:              ev.LastPrice,
+		SignalAction:           string(entity.SignalActionHold),
+		RiskOutcome:            entity.DecisionRiskSkipped,
+		BookGateOutcome:        entity.DecisionBookSkipped,
+		OrderOutcome:           entity.DecisionOrderNoop,
+		IndicatorsJSON:         r.lastIndicatorJSON,
+		HigherTFIndicatorsJSON: r.lastHigherTFJSON,
+		CreatedAt:              r.nowFn().UnixMilli(),
 	}
-}
-
-func (r *Recorder) onSignal(ev entity.SignalEvent) {
-	if r.pending == nil {
+	id, err := r.repo.InsertAndID(ctx, rec)
+	if err != nil {
+		r.logger.Warn("decisionlog: bar-close insert failed", "error", err, "barCloseAt", ev.Timestamp)
 		return
 	}
-	r.pending.rec.SignalAction = string(ev.Signal.Action)
-	r.pending.rec.SignalConfidence = ev.Signal.Confidence
-	r.pending.rec.SignalReason = ev.Signal.Reason
+	rec.ID = id
+	r.pendingRec = rec
+	r.hasPending = true
 }
 
-func (r *Recorder) onApproved() {
-	if r.pending == nil {
+func (r *Recorder) onSignal(ctx context.Context, ev entity.SignalEvent) {
+	if !r.hasPending {
 		return
 	}
-	r.pending.rec.RiskOutcome = entity.DecisionRiskApproved
-	r.pending.rec.BookGateOutcome = entity.DecisionBookAllowed
+	r.pendingRec.SignalAction = string(ev.Signal.Action)
+	r.pendingRec.SignalConfidence = ev.Signal.Confidence
+	r.pendingRec.SignalReason = ev.Signal.Reason
+	r.persistPending(ctx, "signal")
+}
+
+func (r *Recorder) onApproved(ctx context.Context) {
+	if !r.hasPending {
+		return
+	}
+	r.pendingRec.RiskOutcome = entity.DecisionRiskApproved
+	r.pendingRec.BookGateOutcome = entity.DecisionBookAllowed
+	r.persistPending(ctx, "approved")
 }
 
 func (r *Recorder) onRejected(ctx context.Context, ev entity.RejectedSignalEvent) {
-	if r.pending == nil {
+	if !r.hasPending {
 		return
 	}
 	switch ev.Stage {
 	case entity.RejectedStageRisk:
-		r.pending.rec.RiskOutcome = entity.DecisionRiskRejected
-		r.pending.rec.RiskReason = ev.Reason
+		r.pendingRec.RiskOutcome = entity.DecisionRiskRejected
+		r.pendingRec.RiskReason = ev.Reason
 	case entity.RejectedStageBookGate:
-		r.pending.rec.RiskOutcome = entity.DecisionRiskApproved
-		r.pending.rec.BookGateOutcome = entity.DecisionBookVetoed
-		r.pending.rec.BookGateReason = ev.Reason
+		r.pendingRec.RiskOutcome = entity.DecisionRiskApproved
+		r.pendingRec.BookGateOutcome = entity.DecisionBookVetoed
+		r.pendingRec.BookGateReason = ev.Reason
 	}
-	r.flushPending(ctx)
+	r.persistPending(ctx, "rejected")
 }
 
 func (r *Recorder) onOrder(ctx context.Context, ev entity.OrderEvent) {
@@ -173,28 +185,25 @@ func (r *Recorder) onOrder(ctx context.Context, ev entity.OrderEvent) {
 	case entity.DecisionTriggerTickSLTP, entity.DecisionTriggerTickTrailing:
 		r.persistTickOrder(ctx, ev)
 	default:
-		// Treat empty Trigger as a bar-close order (legacy callers haven't
-		// been migrated yet — until PR #4 lands, the ExecutionHandler still
-		// emits OrderEvent with Trigger == "").
-		r.persistBarOrder(ctx, ev)
+		r.applyBarOrder(ctx, ev)
 	}
 }
 
-func (r *Recorder) persistBarOrder(ctx context.Context, ev entity.OrderEvent) {
-	if r.pending == nil {
+func (r *Recorder) applyBarOrder(ctx context.Context, ev entity.OrderEvent) {
+	if !r.hasPending {
 		return
 	}
 	if ev.OrderID > 0 {
-		r.pending.rec.OrderOutcome = entity.DecisionOrderFilled
+		r.pendingRec.OrderOutcome = entity.DecisionOrderFilled
 	} else {
-		r.pending.rec.OrderOutcome = entity.DecisionOrderFailed
+		r.pendingRec.OrderOutcome = entity.DecisionOrderFailed
 	}
-	r.pending.rec.OrderID = ev.OrderID
-	r.pending.rec.ExecutedAmount = ev.Amount
-	r.pending.rec.ExecutedPrice = ev.Price
-	r.pending.rec.OpenedPositionID = ev.OpenedPositionID
-	r.pending.rec.ClosedPositionID = ev.ClosedPositionID
-	r.flushPending(ctx)
+	r.pendingRec.OrderID = ev.OrderID
+	r.pendingRec.ExecutedAmount = ev.Amount
+	r.pendingRec.ExecutedPrice = ev.Price
+	r.pendingRec.OpenedPositionID = ev.OpenedPositionID
+	r.pendingRec.ClosedPositionID = ev.ClosedPositionID
+	r.persistPending(ctx, "order")
 }
 
 func (r *Recorder) persistTickOrder(ctx context.Context, ev entity.OrderEvent) {
@@ -237,20 +246,14 @@ func (r *Recorder) persistTickOrder(ctx context.Context, ev entity.OrderEvent) {
 	r.nextSequenceInBar++
 }
 
-func (r *Recorder) flushPending(ctx context.Context) {
-	if r.pending == nil {
+// persistPending UPDATEs the in-DB row with the current pending state.
+// stage is included in the warn log so operators can tell which event
+// triggered a failed update.
+func (r *Recorder) persistPending(ctx context.Context, stage string) {
+	if !r.hasPending {
 		return
 	}
-	rec := r.pending.rec
-	rec.CreatedAt = r.nowFn().UnixMilli()
-	if rec.IndicatorsJSON == "" {
-		rec.IndicatorsJSON = "{}"
+	if err := r.repo.Update(ctx, r.pendingRec); err != nil {
+		r.logger.Warn("decisionlog: update failed", "stage", stage, "id", r.pendingRec.ID, "error", err)
 	}
-	if rec.HigherTFIndicatorsJSON == "" {
-		rec.HigherTFIndicatorsJSON = "{}"
-	}
-	if err := r.repo.Insert(ctx, rec); err != nil {
-		r.logger.Warn("decisionlog: insert failed", "error", err)
-	}
-	r.pending = nil
 }

--- a/backend/internal/usecase/decisionlog/recorder_test.go
+++ b/backend/internal/usecase/decisionlog/recorder_test.go
@@ -3,6 +3,7 @@ package decisionlog
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
@@ -20,6 +21,30 @@ func (s *stubRepo) Insert(_ context.Context, rec entity.DecisionRecord) error {
 	}
 	s.inserted = append(s.inserted, rec)
 	return nil
+}
+
+func (s *stubRepo) InsertAndID(_ context.Context, rec entity.DecisionRecord) (int64, error) {
+	if s.insertErr != nil {
+		return 0, s.insertErr
+	}
+	s.inserted = append(s.inserted, rec)
+	// id starts at 1 and matches the insertion order so tests can correlate
+	// later Update calls back to a specific row.
+	return int64(len(s.inserted)), nil
+}
+
+func (s *stubRepo) Update(_ context.Context, rec entity.DecisionRecord) error {
+	if s.insertErr != nil {
+		// Reuse the same fault-injection knob — tests only need one switch.
+		return s.insertErr
+	}
+	for i := range s.inserted {
+		if int64(i+1) == rec.ID {
+			s.inserted[i] = rec
+			return nil
+		}
+	}
+	return fmt.Errorf("stub Update: id %d not found", rec.ID)
 }
 
 func (s *stubRepo) List(_ context.Context, _ repository.DecisionLogFilter) ([]entity.DecisionRecord, int64, error) {
@@ -44,7 +69,10 @@ func indicatorEvent(symbolID int64, ts int64) entity.IndicatorEvent {
 	}
 }
 
-func TestRecorder_HoldOnlyBarFlushesOnNextIndicator(t *testing.T) {
+func TestRecorder_HoldOnlyBarInsertsImmediatelyOnIndicator(t *testing.T) {
+	// New flush model: every IndicatorEvent INSERTs a row right away with
+	// HOLD/SKIPPED/NOOP defaults, so HOLD-only bars are visible without
+	// waiting for the next bar.
 	repo := &stubRepo{}
 	rec := newRecorderForTest(repo)
 	ctx := context.Background()
@@ -52,15 +80,15 @@ func TestRecorder_HoldOnlyBarFlushesOnNextIndicator(t *testing.T) {
 	if _, err := rec.Handle(ctx, indicatorEvent(7, 1_000)); err != nil {
 		t.Fatalf("Handle bar1: %v", err)
 	}
-	if len(repo.inserted) != 0 {
-		t.Fatalf("after bar1 alone, expected 0 inserts, got %d", len(repo.inserted))
+	if len(repo.inserted) != 1 {
+		t.Fatalf("after bar1 indicator, expected 1 insert, got %d", len(repo.inserted))
 	}
-
+	// A second bar adds another row; the first row stays as HOLD/SKIPPED/NOOP.
 	if _, err := rec.Handle(ctx, indicatorEvent(7, 2_000)); err != nil {
 		t.Fatalf("Handle bar2: %v", err)
 	}
-	if len(repo.inserted) != 1 {
-		t.Fatalf("expected 1 insert (bar1 flushed), got %d", len(repo.inserted))
+	if len(repo.inserted) != 2 {
+		t.Fatalf("after bar2 indicator, expected 2 inserts, got %d", len(repo.inserted))
 	}
 	got := repo.inserted[0]
 	if got.SignalAction != "HOLD" {
@@ -114,20 +142,22 @@ func TestRecorder_FullBuyFlushesOnOrder(t *testing.T) {
 		t.Fatalf("Handle order: %v", err)
 	}
 
+	// Immediate-flush model: 1 INSERT (Indicator) + 3 UPDATEs (Signal,
+	// Approved, Order) all on the same row id.
 	if len(repo.inserted) != 1 {
-		t.Fatalf("expected 1 insert (flushed on OrderEvent), got %d", len(repo.inserted))
+		t.Fatalf("expected 1 insert (single row UPDATEd in place), got %d", len(repo.inserted))
 	}
 	got := repo.inserted[0]
 	if got.SignalAction != "BUY" || got.RiskOutcome != entity.DecisionRiskApproved ||
 		got.BookGateOutcome != entity.DecisionBookAllowed || got.OrderOutcome != entity.DecisionOrderFilled {
-		t.Errorf("flushed record fields wrong: %+v", got)
+		t.Errorf("final record fields wrong: %+v", got)
 	}
 	if got.OpenedPositionID != 100 || got.OrderID != 42 || got.ExecutedAmount != 0.5 {
 		t.Errorf("execution fields wrong: %+v", got)
 	}
 }
 
-func TestRecorder_RiskRejectionFlushesImmediately(t *testing.T) {
+func TestRecorder_RiskRejectionUpdatesInPlace(t *testing.T) {
 	repo := &stubRepo{}
 	rec := newRecorderForTest(repo)
 	ctx := context.Background()
@@ -147,7 +177,7 @@ func TestRecorder_RiskRejectionFlushesImmediately(t *testing.T) {
 	})
 
 	if len(repo.inserted) != 1 {
-		t.Fatalf("expected 1 insert (flushed on Rejected), got %d", len(repo.inserted))
+		t.Fatalf("expected 1 row (Indicator inserted, then UPDATEd by Signal+Rejected), got %d", len(repo.inserted))
 	}
 	got := repo.inserted[0]
 	if got.RiskOutcome != entity.DecisionRiskRejected || got.RiskReason != "daily loss limit hit" {
@@ -204,10 +234,11 @@ func TestRecorder_TickSLTPClosePersistedAsSeparateRow(t *testing.T) {
 		Trigger: entity.DecisionTriggerTickSLTP, ClosedPositionID: 100,
 	})
 
-	if len(repo.inserted) != 1 {
-		t.Fatalf("expected 1 insert (tick row, bar1 still pending), got %d", len(repo.inserted))
+	// Immediate-flush model: bar1 INSERT (BAR_CLOSE) + tick INSERT = 2 rows.
+	if len(repo.inserted) != 2 {
+		t.Fatalf("expected 2 inserts (BAR_CLOSE + tick row), got %d", len(repo.inserted))
 	}
-	got := repo.inserted[0]
+	got := repo.inserted[1]
 	if got.TriggerKind != entity.DecisionTriggerTickSLTP {
 		t.Errorf("TriggerKind = %q, want TICK_SLTP", got.TriggerKind)
 	}

--- a/backend/internal/usecase/decisionlog/retention_test.go
+++ b/backend/internal/usecase/decisionlog/retention_test.go
@@ -20,6 +20,12 @@ type stubBacktestRepo struct {
 func (s *stubBacktestRepo) Insert(_ context.Context, _ entity.DecisionRecord, _ string) error {
 	return nil
 }
+func (s *stubBacktestRepo) InsertAndID(_ context.Context, _ entity.DecisionRecord, _ string) (int64, error) {
+	return 1, nil
+}
+func (s *stubBacktestRepo) Update(_ context.Context, _ entity.DecisionRecord) error {
+	return nil
+}
 func (s *stubBacktestRepo) ListByRun(_ context.Context, _ string, _ int, _ int64) ([]entity.DecisionRecord, int64, error) {
 	return nil, 0, nil
 }
@@ -81,6 +87,12 @@ type countingErrorRepo struct {
 
 func (c *countingErrorRepo) Insert(ctx context.Context, rec entity.DecisionRecord, runID string) error {
 	return c.stub.Insert(ctx, rec, runID)
+}
+func (c *countingErrorRepo) InsertAndID(ctx context.Context, rec entity.DecisionRecord, runID string) (int64, error) {
+	return c.stub.InsertAndID(ctx, rec, runID)
+}
+func (c *countingErrorRepo) Update(ctx context.Context, rec entity.DecisionRecord) error {
+	return c.stub.Update(ctx, rec)
 }
 func (c *countingErrorRepo) ListByRun(ctx context.Context, runID string, limit int, cursor int64) ([]entity.DecisionRecord, int64, error) {
 	return c.stub.ListByRun(ctx, runID, limit, cursor)


### PR DESCRIPTION
## Summary
The legacy recorder buffered each bar in memory and only flushed when
the *next* IndicatorEvent arrived. HOLD-only bars took up to ~30 minutes
to appear in decision_log:

\`\`\`
bar A close → buffer in memory
bar B close → buffer A still pending → next indicator finally flushes A
bar C close → flush B
\`\`\`

This PR rewrites the recorder around an INSERT-then-UPDATE model:

- Every \`IndicatorEvent\` INSERTs a row immediately with
  HOLD/SKIPPED/NOOP defaults and remembers the new row id.
- Subsequent \`SignalEvent\` / \`ApprovedSignalEvent\` / \`RejectedSignalEvent\`
  / \`OrderEvent\` UPDATE that row in place.
- Tick-driven SL/TP/Trailing rows still INSERT directly (sequence_in_bar
  > 0), unchanged.

Cost per bar: 1 INSERT + 0..3 UPDATEs. Trade-off accepted because (1)
HOLD bars become visible the moment the indicator runs, (2) a daemon
crash mid-bar still leaves the BAR_CLOSE row safely persisted.

### Interface additions
- \`DecisionLogRepository.InsertAndID\` returns the new row id for
  later UPDATE
- \`DecisionLogRepository.Update\` overwrites by id
- \`BacktestDecisionLogRepository\` mirrors both
- \`backtestRepoAdapter\` forwards both, so the existing per-run
  recorder wiring on the backtest path keeps working

### Test plan
- [x] go test ./... -race -count=1 green
- [x] new TestRecorder_HoldOnlyBarInsertsImmediatelyOnIndicator
- [x] existing TestRecorder_FullBuyFlushesOnOrder, TestRecorder_BookGateVeto*, TestRecorder_TickSLTP* updated to the new "1 INSERT + N UPDATE" expectations
- [x] integration_test asserts 3 rows after 3 IndicatorEvents (no longer needs an extra bar to flush)

🤖 Generated with [Claude Code](https://claude.com/claude-code)