### PR TITLE
feat(decisionlog): seed indicator history at pipeline start

### DIFF
--- a/backend/cmd/event_pipeline.go
+++ b/backend/cmd/event_pipeline.go
@@ -310,6 +310,81 @@ func (p *EventDrivenPipeline) seedCandleBuilderFromMinutes(ctx context.Context, 
 	}
 }
 
+// seedIndicatorHistory pulls historical primary-interval candles and folds
+// them into the IndicatorHandler's buffer so the very first CandleEvent
+// emitted from the WebSocket already produces a fully-populated
+// IndicatorSet. Without this, SMA(50) / Ichimoku(52) / MACD signal stay nil
+// for many bars after every restart and the strategy is forced into HOLD —
+// which is exactly the failure mode the decision_log table surfaced
+// (every row UNKNOWN/HOLD/SKIPPED/NOOP).
+//
+// Best-effort: any error path leaves the buffer empty and falls back to
+// "fill indicators as live bars close" (the legacy behaviour).
+//
+// barsToSeed should comfortably exceed the slowest indicator period in use.
+// 64 covers Ichimoku Senkou B (52) + MACD signal warm-up (~9) with margin.
+func (p *EventDrivenPipeline) seedIndicatorHistory(
+	ctx context.Context,
+	symbolID int64,
+	primaryInterval string,
+	indicatorHandler *backtest.IndicatorHandler,
+	barsToSeed int,
+) {
+	if p.candlestickFetcher == nil || indicatorHandler == nil || barsToSeed <= 0 {
+		return
+	}
+	intervalDur := liveIntervalToDuration(primaryInterval)
+	if intervalDur <= 0 {
+		return
+	}
+	now := time.Now().UTC()
+	periodStart := now.Truncate(intervalDur)
+	from := periodStart.Add(-time.Duration(barsToSeed) * intervalDur).UnixMilli()
+	// Stop one millisecond before the *current* bar start so we never feed
+	// the in-progress bar twice (the live source will close it from ticks).
+	to := periodStart.UnixMilli() - 1
+	resp, err := p.candlestickFetcher.GetCandlestick(ctx, symbolID, primaryInterval, &from, &to)
+	if err != nil {
+		slog.Warn("event-pipeline: indicator history fetch failed; first bar will see all-nil indicators",
+			"symbolID", symbolID, "interval", primaryInterval, "error", err)
+		return
+	}
+	if resp == nil || len(resp.Candlesticks) == 0 {
+		return
+	}
+	indicatorHandler.SeedPrimary(symbolID, resp.Candlesticks)
+	slog.Info("event-pipeline: seeded indicator history",
+		"symbolID", symbolID,
+		"interval", primaryInterval,
+		"bars", len(resp.Candlesticks),
+		"oldestTime", resp.Candlesticks[0].Time,
+		"newestTime", resp.Candlesticks[len(resp.Candlesticks)-1].Time,
+	)
+}
+
+// liveIntervalToDuration mirrors live.parseInterval but kept private here
+// so cmd doesn't reach into the live package's unexported helpers.
+func liveIntervalToDuration(s string) time.Duration {
+	switch s {
+	case "PT1M":
+		return time.Minute
+	case "PT5M":
+		return 5 * time.Minute
+	case "PT15M":
+		return 15 * time.Minute
+	case "PT30M":
+		return 30 * time.Minute
+	case "PT1H":
+		return time.Hour
+	case "PT4H":
+		return 4 * time.Hour
+	case "P1D":
+		return 24 * time.Hour
+	default:
+		return 0
+	}
+}
+
 // loadSymbolMeta fetches baseStepAmount / minOrderAmount from the API.
 // Must be called with mu held.
 func (p *EventDrivenPipeline) loadSymbolMeta(ctx context.Context, symbolID int64) {
@@ -431,6 +506,11 @@ func (p *EventDrivenPipeline) runEventLoop(ctx context.Context, snap eventSnapsh
 		// PR-J: feed Microprice / OFI from the live in-memory book cache.
 		indicatorHandler.SetBookSource(p.marketDataSvc, 10_000, 60_000, 5)
 	}
+	// Prime the candle history before subscribing to the WS so the very
+	// first live bar already has SMA/RSI/MACD/BB/ATR populated. Defaults
+	// need 52 bars (Ichimoku Senkou B); 64 gives margin without making the
+	// API call expensive.
+	p.seedIndicatorHistory(ctx, snap.symbolID, "PT15M", indicatorHandler, 64)
 	bus.Register(entity.EventTypeCandle, 10, indicatorHandler)
 
 	// StrategyHandler: signal generation from indicators (priority 20).

--- a/backend/internal/usecase/backtest/handler.go
+++ b/backend/internal/usecase/backtest/handler.go
@@ -195,6 +195,39 @@ func NewIndicatorHandler(primaryInterval, higherTFInterval string, bufferSize in
 	}
 }
 
+// SeedPrimary primes the primary-interval candle buffer for symbolID with
+// historical bars. Live mode uses this at pipeline start so the very first
+// CandleEvent emitted from the WebSocket already has enough history to
+// compute SMA / RSI / MACD / BB / ATR — without it, those indicators stay
+// nil for ~20-26 bars and every decision logs as HOLD.
+//
+// candles must be PT-PrimaryInterval bars ordered oldest-first. Bars are
+// appended in order and capped at BufferSize. Calling SeedPrimary after
+// CandleEvents have already arrived is allowed but unusual; it appends as if
+// the seeded bars came in next, which would corrupt indicator paths — so
+// callers should seed before subscribing to live ticks.
+//
+// SeedHigherTF mirrors this for the higher-TF buffer.
+func (h *IndicatorHandler) SeedPrimary(symbolID int64, candles []entity.Candle) {
+	if len(candles) == 0 {
+		return
+	}
+	for _, c := range candles {
+		h.primaryCandles[symbolID] = appendCapped(h.primaryCandles[symbolID], c, h.BufferSize)
+	}
+}
+
+// SeedHigherTF primes the higher-TF candle buffer for symbolID. See
+// SeedPrimary for the contract.
+func (h *IndicatorHandler) SeedHigherTF(symbolID int64, candles []entity.Candle) {
+	if len(candles) == 0 {
+		return
+	}
+	for _, c := range candles {
+		h.higherCandles[symbolID] = appendCapped(h.higherCandles[symbolID], c, h.BufferSize)
+	}
+}
+
 // SetIndicatorPeriods overrides every indicator lookback used inside
 // calculateIndicatorSet — SMA / EMA / RSI / MACD / BB / ATR / VolumeSMA /
 // ADX / Stochastics / StochRSI / Donchian / OBVSlope / CMF / Ichimoku.

--- a/backend/internal/usecase/backtest/handler_test.go
+++ b/backend/internal/usecase/backtest/handler_test.go
@@ -483,3 +483,96 @@ func TestIndicatorHandler_NilBookSourceLeavesFieldsUnset(t *testing.T) {
 			indEv.Primary.Microprice, indEv.Primary.OFIShort, indEv.Primary.OFILong)
 	}
 }
+
+// TestIndicatorHandler_SeedPrimary_FillsIndicatorsOnFirstLiveCandle pins down
+// the live-restart fix: after SeedPrimary primes enough historical PT15M
+// bars (defaults need 52 for Ichimoku Senkou B, the slowest period), the
+// very first CandleEvent emitted by the live source must already produce an
+// IndicatorSet with SMA/RSI/MACD populated, instead of the all-nil
+// indicators that previously stranded every bar at HOLD for hours.
+func TestIndicatorHandler_SeedPrimary_FillsIndicatorsOnFirstLiveCandle(t *testing.T) {
+	h := NewIndicatorHandler("PT15M", "", 500)
+
+	const symbolID int64 = 10
+	const seedCount = 60 // > Ichimoku SenkouB (52) so every default-period indicator can resolve
+	const intervalMs int64 = 15 * 60 * 1000
+	startMs := int64(1_700_000_000_000)
+
+	seed := make([]entity.Candle, seedCount)
+	for i := 0; i < seedCount; i++ {
+		// Slight upward drift so SMAShort != SMALong and the resolver can
+		// classify TREND_FOLLOW; values themselves don't matter, only that
+		// the indicator math has enough samples to produce non-nil output.
+		price := 8000.0 + float64(i)*1.5
+		seed[i] = entity.Candle{
+			Open:   price,
+			High:   price + 5,
+			Low:    price - 5,
+			Close:  price + 1,
+			Volume: 1,
+			Time:   startMs + int64(i)*intervalMs,
+		}
+	}
+	h.SeedPrimary(symbolID, seed)
+
+	live := entity.Candle{
+		Open: 8050, High: 8060, Low: 8045, Close: 8055,
+		Volume: 1,
+		Time:   startMs + int64(seedCount)*intervalMs,
+	}
+	out, err := h.Handle(context.Background(), entity.CandleEvent{
+		SymbolID:  symbolID,
+		Interval:  "PT15M",
+		Candle:    live,
+		Timestamp: live.Time,
+	})
+	if err != nil {
+		t.Fatalf("handle: %v", err)
+	}
+	if len(out) != 1 {
+		t.Fatalf("expected 1 indicator event, got %d", len(out))
+	}
+	indEv := out[0].(entity.IndicatorEvent)
+	if indEv.Primary.SMAShort == nil {
+		t.Error("SMAShort must be non-nil after seeding ~30 bars (was nil)")
+	}
+	if indEv.Primary.SMALong == nil {
+		t.Error("SMALong must be non-nil after seeding ~30 bars (was nil)")
+	}
+	if indEv.Primary.RSI == nil {
+		t.Error("RSI must be non-nil after seeding ~30 bars (was nil)")
+	}
+	if indEv.Primary.MACDLine == nil {
+		t.Error("MACDLine must be non-nil after seeding ~30 bars (was nil)")
+	}
+	if indEv.Primary.BBUpper == nil {
+		t.Error("BBUpper must be non-nil after seeding ~30 bars (was nil)")
+	}
+	if indEv.Primary.ATR == nil {
+		t.Error("ATR must be non-nil after seeding ~30 bars (was nil)")
+	}
+}
+
+// TestIndicatorHandler_SeedPrimary_NopOnEmpty guards against a no-op call
+// path corrupting the buffer state.
+func TestIndicatorHandler_SeedPrimary_NopOnEmpty(t *testing.T) {
+	h := NewIndicatorHandler("PT15M", "", 500)
+	h.SeedPrimary(7, nil)
+	h.SeedPrimary(7, []entity.Candle{})
+
+	out, err := h.Handle(context.Background(), entity.CandleEvent{
+		SymbolID: 7, Interval: "PT15M",
+		Candle:    entity.Candle{Open: 100, High: 101, Low: 99, Close: 100, Time: 1_000, Volume: 1},
+		Timestamp: 1_000,
+	})
+	if err != nil {
+		t.Fatalf("handle: %v", err)
+	}
+	if len(out) != 1 {
+		t.Fatalf("expected 1 indicator event, got %d", len(out))
+	}
+	indEv := out[0].(entity.IndicatorEvent)
+	if indEv.Primary.SMAShort != nil {
+		t.Errorf("SMAShort should still be nil after no-op seed + 1 candle, got %v", *indEv.Primary.SMAShort)
+	}
+}


### PR DESCRIPTION
## Summary

- Live `IndicatorHandler` の primary 候補バッファに過去 PT15M バーをロードする `SeedPrimary` / `SeedHigherTF` を追加し、pipeline 起動時に 64 本フェッチして注入。
- これにより WS 接続直後の最初の `CandleEvent` で SMA/RSI/MACD/BB/ATR/Ichimoku が即座に非 nil になる。

## なぜ必要か

`/history?symbol=LTC_JPY` の判断ログが `unknown / hold / skipped / noop` で埋まっていた根本原因の一つ。

`backtest.IndicatorHandler` の `primaryCandles` は **ライブ起動時に空** で、PT15M バーが時間経過で閉じるたびに 1 本ずつ積む設計。デフォルト期間（SMA 50、Ichimoku Senkou B = 52、MACD Signal ≈ 35）が揃うまで **13 時間以上**必要で、その間 Strategy が nil 指標を見て HOLD を返すため SignalEvent が発火せず、recorder の row は INSERT 時のデフォ `HOLD/SKIPPED/SKIPPED/NOOP` のまま固定されていた。

PR #211 の `seedCandleBuilderFromMinutes` は **進行中バーの OHLC 復元のみ**で、過去バー履歴は触らない。

## 設計

- `IndicatorHandler.SeedPrimary(symbolID, candles)` / `SeedHigherTF(symbolID, candles)`：oldest-first の候補列を `BufferSize` 上限で `appendCapped` する純粋なヘルパ。Live 起動時の **WS 購読より前**に呼ぶ前提（後から呼ぶと indicator path が壊れるので docstring で明示）。
- `event_pipeline.seedIndicatorHistory()`：`candlestickFetcher.GetCandlestick(PT15M, from, to)` で `now - 64*15min` 〜 `now - 1ms`（進行中バー除外）を取得し `SeedPrimary` に渡す。fetch 失敗は warn ログだけ出して legacy fallback。
- `barsToSeed = 64`：Ichimoku Senkou B (52) + MACD signal warmup (≈9) + マージン。

## Test plan

- [x] `TestIndicatorHandler_SeedPrimary_FillsIndicatorsOnFirstLiveCandle` — 60 本シード → 1 本目の live candle で SMAShort/SMALong/RSI/MACDLine/BBUpper/ATR が全て非 nil
- [x] `TestIndicatorHandler_SeedPrimary_NopOnEmpty` — `nil` / 空スライスを渡しても buffer が壊れない
- [x] `go test ./... -race -count=1` 全 pass
- [x] `go build ./...` OK

## 関連

`/history` 表示の根本対応シリーズ PR1/4。次の PR で recorder の StanceProvider を配線する（PR2/4）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)