### PR TITLE
feat(decisionlog): wire StanceResolver into live pipeline recorder

### DIFF
--- a/backend/cmd/event_pipeline.go
+++ b/backend/cmd/event_pipeline.go
@@ -21,6 +21,14 @@ import (
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/sor"
 )
 
+// PipelineStanceResolver is the narrow port the pipeline needs to expose
+// the strategy's stance to the decision recorder. It mirrors the subset of
+// usecase.StanceResolver used here so the pipeline does not pull the whole
+// resolver type into its API.
+type PipelineStanceResolver interface {
+	Resolve(ctx context.Context, indicators entity.IndicatorSet, lastPrice float64) usecase.StanceResult
+}
+
 // EventDrivenPipeline replaces the polling-based TradingPipeline with an
 // EventEngine-driven architecture. LiveSource converts real-time tickers into
 // TickEvent/CandleEvent, and the EventBus dispatches them through the handler
@@ -37,6 +45,7 @@ type EventDrivenPipeline struct {
 	// Existing dependencies (injected at construction)
 	riskMgr          *usecase.RiskManager
 	strategy         port.Strategy
+	stanceResolver   PipelineStanceResolver
 	marketDataSvc    *usecase.MarketDataService
 	orderClient      repository.OrderClient
 	symbolFetcher    repository.SymbolFetcher
@@ -77,6 +86,18 @@ type EventDrivenPipeline struct {
 	// the same lookbacks the strategy was tuned for.
 	indicatorPeriods  entity.IndicatorConfig
 	bbSqueezeLookback int
+
+	// latestIndicators caches the most recent IndicatorEvent payload so
+	// the decision recorder's StanceProvider can re-resolve stance without
+	// reaching into the strategy's internal state. Updated by a side
+	// handler registered on EventTypeIndicator. Guarded by indicatorMu so
+	// the recorder (also on the bus) and the tick path can read it
+	// concurrently with the indicator-handler write. Empty
+	// (hasLatestIndicators=false) until the first IndicatorEvent fires.
+	indicatorMu          sync.RWMutex
+	latestIndicators     entity.IndicatorSet
+	latestLastPrice      float64
+	hasLatestIndicators  bool
 
 	// sleepFn is used by syncState for retry backoff (test-injectable).
 	sleepFn func(time.Duration)
@@ -119,6 +140,16 @@ type EventDrivenPipelineConfig struct {
 	// first emitted bar after a restart has correct OHLC. nil keeps the
 	// legacy behaviour where the first bar only reflects post-restart ticks.
 	CandlestickFetcher repository.CandlestickFetcher
+
+	// StanceResolver, when non-nil, is invoked by the decision recorder's
+	// StanceProvider so every persisted row records the live stance the
+	// strategy is currently classifying against (TREND_FOLLOW / CONTRARIAN /
+	// BREAKOUT / HOLD), instead of the placeholder UNKNOWN.
+	//
+	// nil disables stance reporting; the recorder falls back to "UNKNOWN".
+	// The pipeline shares this resolver with the StrategyEngine wired in
+	// composition.go, so override-driven stance changes apply consistently.
+	StanceResolver PipelineStanceResolver
 }
 
 func NewEventDrivenPipeline(
@@ -155,6 +186,7 @@ func NewEventDrivenPipeline(
 		bbSqueezeLookback:  cfg.BBSqueezeLookback,
 		decisionLogRepo:    cfg.DecisionLogRepo,
 		candlestickFetcher: cfg.CandlestickFetcher,
+		stanceResolver:     cfg.StanceResolver,
 	}
 }
 
@@ -362,6 +394,49 @@ func (p *EventDrivenPipeline) seedIndicatorHistory(
 	)
 }
 
+// indicatorEventTap is a 0-output EventBus handler that copies every
+// IndicatorEvent's primary snapshot into the pipeline's
+// latestIndicators / latestLastPrice cache. The decision recorder's
+// StanceProvider reads from that cache, so by registering this tap before
+// the recorder (priority 25 vs recorder's 99 on EventTypeIndicator) we
+// guarantee the recorder sees the same indicators it is about to record.
+type indicatorEventTap struct {
+	pipeline *EventDrivenPipeline
+}
+
+func (t *indicatorEventTap) Handle(_ context.Context, event entity.Event) ([]entity.Event, error) {
+	ev, ok := event.(entity.IndicatorEvent)
+	if !ok {
+		return nil, nil
+	}
+	t.pipeline.indicatorMu.Lock()
+	t.pipeline.latestIndicators = ev.Primary
+	t.pipeline.latestLastPrice = ev.LastPrice
+	t.pipeline.hasLatestIndicators = true
+	t.pipeline.indicatorMu.Unlock()
+	return nil, nil
+}
+
+// currentStance returns the stance the resolver classifies for the most
+// recently observed IndicatorEvent. Returns "UNKNOWN" when the resolver is
+// not wired or no indicator event has fired yet (e.g. immediately after a
+// restart, before the first PT15M close).
+func (p *EventDrivenPipeline) currentStance(ctx context.Context) string {
+	if p.stanceResolver == nil {
+		return "UNKNOWN"
+	}
+	p.indicatorMu.RLock()
+	if !p.hasLatestIndicators {
+		p.indicatorMu.RUnlock()
+		return "UNKNOWN"
+	}
+	indicators := p.latestIndicators
+	lastPrice := p.latestLastPrice
+	p.indicatorMu.RUnlock()
+	res := p.stanceResolver.Resolve(ctx, indicators, lastPrice)
+	return string(res.Stance)
+}
+
 // liveIntervalToDuration mirrors live.parseInterval but kept private here
 // so cmd doesn't reach into the live package's unexported helpers.
 func liveIntervalToDuration(s string) time.Duration {
@@ -543,11 +618,21 @@ func (p *EventDrivenPipeline) runEventLoop(ctx context.Context, snap eventSnapsh
 	}
 	bus.Register(entity.EventTypeApproved, 40, executionHandler)
 
+	// indicator tap: caches every IndicatorEvent so the recorder's
+	// StanceProvider (and the tick-driven order rows) can re-resolve the
+	// current stance without reaching back through the strategy. Priority
+	// 25 places this between the StrategyHandler (20) and the recorder
+	// (99) so the recorder sees the snapshot it's about to persist.
+	bus.Register(entity.EventTypeIndicator, 25, &indicatorEventTap{pipeline: p})
+
 	if p.decisionLogRepo != nil {
 		recorder := decisionlog.NewRecorder(p.decisionLogRepo, decisionlog.RecorderConfig{
 			SymbolID:        snap.symbolID,
 			CurrencyPair:    p.currencyPair,
 			PrimaryInterval: "PT15M",
+			StanceProvider: func() string {
+				return p.currentStance(ctx)
+			},
 		})
 		bus.Register(entity.EventTypeIndicator, 99, recorder)
 		bus.Register(entity.EventTypeSignal, 99, recorder)
@@ -555,7 +640,8 @@ func (p *EventDrivenPipeline) runEventLoop(ctx context.Context, snap eventSnapsh
 		bus.Register(entity.EventTypeRejected, 99, recorder)
 		bus.Register(entity.EventTypeOrder, 99, recorder)
 		slog.Info("event-pipeline: decision recorder attached",
-			"symbolID", snap.symbolID, "currencyPair", p.currencyPair)
+			"symbolID", snap.symbolID, "currencyPair", p.currencyPair,
+			"stanceResolverWired", p.stanceResolver != nil)
 	}
 
 	engine := eventengine.NewEventEngine(bus)

--- a/backend/cmd/event_pipeline_stance_test.go
+++ b/backend/cmd/event_pipeline_stance_test.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase"
+)
+
+// fakeStanceResolver records the last Resolve call and returns a canned
+// stance, mirroring the contract the live pipeline expects from the
+// rule-based resolver without pulling its full constructor + repo
+// dependency into the test.
+type fakeStanceResolver struct {
+	mu          sync.Mutex
+	calls       int
+	gotIndCount int
+	gotPrice    float64
+	canned      entity.MarketStance
+}
+
+func (f *fakeStanceResolver) Resolve(_ context.Context, indicators entity.IndicatorSet, lastPrice float64) usecase.StanceResult {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	if indicators.SMAShort != nil {
+		f.gotIndCount++
+	}
+	f.gotPrice = lastPrice
+	return usecase.StanceResult{Stance: f.canned, Source: "rule-based"}
+}
+
+// TestCurrentStance_NoResolverReturnsUnknown pins the legacy contract:
+// without a wired resolver the recorder must continue to log "UNKNOWN", so
+// existing integration tests that pre-date PR2 stay bit-identical.
+func TestCurrentStance_NoResolverReturnsUnknown(t *testing.T) {
+	p := &EventDrivenPipeline{}
+	if got := p.currentStance(context.Background()); got != "UNKNOWN" {
+		t.Errorf("currentStance with nil resolver = %q, want UNKNOWN", got)
+	}
+}
+
+// TestCurrentStance_NoIndicatorsYetReturnsUnknown covers the post-restart
+// window where the resolver is wired but no IndicatorEvent has fired. The
+// resolver must NOT be called against an empty IndicatorSet — it would
+// classify HOLD via "insufficient indicator data", which would mask the
+// real "we have no data" state. UNKNOWN tells operators "stance is not
+// observable yet" instead of "stance is HOLD".
+func TestCurrentStance_NoIndicatorsYetReturnsUnknown(t *testing.T) {
+	resolver := &fakeStanceResolver{canned: entity.MarketStanceTrendFollow}
+	p := &EventDrivenPipeline{stanceResolver: resolver}
+
+	if got := p.currentStance(context.Background()); got != "UNKNOWN" {
+		t.Errorf("currentStance before first IndicatorEvent = %q, want UNKNOWN", got)
+	}
+	if resolver.calls != 0 {
+		t.Errorf("resolver.Resolve called %d times before any indicator event, want 0", resolver.calls)
+	}
+}
+
+// TestCurrentStance_AfterTapResolvesViaResolver verifies the end-to-end
+// path: indicatorEventTap caches an IndicatorEvent → currentStance feeds
+// the cached snapshot into the resolver → the result is returned to the
+// recorder.
+func TestCurrentStance_AfterTapResolvesViaResolver(t *testing.T) {
+	resolver := &fakeStanceResolver{canned: entity.MarketStanceContrarian}
+	p := &EventDrivenPipeline{stanceResolver: resolver}
+	tap := &indicatorEventTap{pipeline: p}
+
+	smaShort := 100.5
+	smaLong := 99.0
+	rsi := 28.0
+	ev := entity.IndicatorEvent{
+		SymbolID:  10,
+		Interval:  "PT15M",
+		LastPrice: 8500,
+		Timestamp: 1_700_000_000_000,
+		Primary: entity.IndicatorSet{
+			SymbolID:  10,
+			SMAShort:  &smaShort,
+			SMALong:   &smaLong,
+			RSI:       &rsi,
+			Timestamp: 1_700_000_000_000,
+		},
+	}
+	if _, err := tap.Handle(context.Background(), ev); err != nil {
+		t.Fatalf("tap handle: %v", err)
+	}
+
+	got := p.currentStance(context.Background())
+	if got != string(entity.MarketStanceContrarian) {
+		t.Errorf("currentStance = %q, want %q", got, entity.MarketStanceContrarian)
+	}
+	if resolver.calls != 1 {
+		t.Fatalf("resolver.Resolve calls = %d, want 1", resolver.calls)
+	}
+	if resolver.gotIndCount != 1 {
+		t.Errorf("resolver did not receive the cached IndicatorSet (SMAShort missing)")
+	}
+	if resolver.gotPrice != 8500 {
+		t.Errorf("resolver got lastPrice %v, want 8500", resolver.gotPrice)
+	}
+}
+
+// TestIndicatorEventTap_IgnoresNonIndicatorEvents guards the tap from
+// accidentally caching unrelated event types, which would silently feed
+// stale data into stance resolution if someone widened the registration.
+func TestIndicatorEventTap_IgnoresNonIndicatorEvents(t *testing.T) {
+	p := &EventDrivenPipeline{}
+	tap := &indicatorEventTap{pipeline: p}
+
+	if _, err := tap.Handle(context.Background(), entity.TickEvent{SymbolID: 10, Price: 8500}); err != nil {
+		t.Fatalf("tap handle tick: %v", err)
+	}
+	if p.hasLatestIndicators {
+		t.Errorf("hasLatestIndicators = true after a TickEvent, want false")
+	}
+}

--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -171,6 +171,7 @@ func main() {
 			BBSqueezeLookback:  liveProfileBBSqueezeLookback(liveProfile),
 			DecisionLogRepo:    decisionLogRepo,
 			CandlestickFetcher: restClient,
+			StanceResolver:     stanceResolver,
 		},
 		restClient,
 		restClient, // SymbolFetcher


### PR DESCRIPTION
## Summary

- live `EventDrivenPipeline` の Recorder に **StanceProvider を配線**。
- `IndicatorEvent` を捕まえる小さな tap (`priority=25`) を bus に登録し、最新の `IndicatorSet + lastPrice` を pipeline 上にキャッシュ。
- recorder の `StanceProvider` クロージャがそのキャッシュを `RuleBasedStanceResolver` に渡し、`TREND_FOLLOW / CONTRARIAN / BREAKOUT / HOLD` を返す。

## なぜ必要か

`/history?symbol=LTC_JPY` が `unknown / hold / skipped / noop` だらけになっていた件の **PR1 と並ぶ 2 つ目の根本原因**。

`event_pipeline.go:467` で recorder を組み立てる際 `StanceProvider` を渡しておらず、recorder の `stance()` は `nil 判定 → "UNKNOWN"` フォールバックを返していた。strategy 内部では正しく stance が解決されているが、その結果は recorder に届いていなかった。

## 設計

- **narrow port** `PipelineStanceResolver` を `cmd` パッケージに定義（`Resolve(ctx, IndicatorSet, lastPrice) usecase.StanceResult` の 1 メソッドだけ）。`usecase.RuleBasedStanceResolver` がそのまま満たすので main.go の差分は 1 行（`StanceResolver: stanceResolver` を Config に渡すだけ）。
- **`indicatorEventTap`**: `EventTypeIndicator` を `priority=25` で受信し、`Primary / LastPrice` を `pipeline.indicatorMu` 配下にキャッシュ。`StrategyHandler@20` の後・`Recorder@99` の前に動くよう優先度設定。
- **`currentStance(ctx)`**: 
  - resolver 未配線 → `"UNKNOWN"` （legacy 動作維持）
  - 最初の IndicatorEvent 前 → `"UNKNOWN"` （resolver は空の IndicatorSet で `HOLD` を返す仕様なので、それを見せると「stance 不観測」と「stance=HOLD」が区別できなくなる）
  - それ以外 → resolver の戻り値 `string(result.Stance)`
- これで tick 由来の `persistTickOrder` 行も同じキャッシュ経由で正しい stance を持つ。

## Test plan

- [x] `TestCurrentStance_NoResolverReturnsUnknown` — resolver nil で UNKNOWN
- [x] `TestCurrentStance_NoIndicatorsYetReturnsUnknown` — resolver wired でも IndicatorEvent 前は UNKNOWN（resolver 呼ばれない）
- [x] `TestCurrentStance_AfterTapResolvesViaResolver` — tap が IndicatorEvent をキャッシュ後、resolver に IndicatorSet/lastPrice が渡って結果が返る
- [x] `TestIndicatorEventTap_IgnoresNonIndicatorEvents` — 別イベント（TickEvent）でキャッシュが汚染されない
- [x] `go test ./... -race -count=1` 全 pass
- [x] `go build ./...` OK
- 既存 `decisionlog/recorder_test.go` の `StanceProvider func() string` 契約は不変（テスト無修正で pass）

## 関連

`/history` 表示の根本対応シリーズ PR2/4。前段 PR #213（merged）でヒストリ・プライムが先に入る前提。次の PR で `PrimaryInterval` ハードコード除去（PR3/4）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)