### PR TITLE
refactor(pipeline): replace PT15M/PT1H hardcodes with configurable intervals

### DIFF
--- a/backend/cmd/event_pipeline.go
+++ b/backend/cmd/event_pipeline.go
@@ -87,6 +87,15 @@ type EventDrivenPipeline struct {
 	indicatorPeriods  entity.IndicatorConfig
 	bbSqueezeLookback int
 
+	// primaryInterval / higherTFInterval drive the LiveSource, the
+	// IndicatorHandler, and every per-bar handler that needs to know which
+	// timeframe the pipeline is operating on. Sourced from the strategy
+	// profile so a profile tuned for PT5M can run the live pipeline on PT5M
+	// without touching code. Defaults to PT15M / PT1H (the legacy LTC
+	// hardcode) when the config leaves them empty.
+	primaryInterval  string
+	higherTFInterval string
+
 	// latestIndicators caches the most recent IndicatorEvent payload so
 	// the decision recorder's StanceProvider can re-resolve stance without
 	// reaching into the strategy's internal state. Updated by a side
@@ -150,6 +159,16 @@ type EventDrivenPipelineConfig struct {
 	// The pipeline shares this resolver with the StrategyEngine wired in
 	// composition.go, so override-driven stance changes apply consistently.
 	StanceResolver PipelineStanceResolver
+
+	// PrimaryInterval is the timeframe the strategy operates on. Mirrors the
+	// strategy profile's primary period (e.g. "PT15M" for LTC, "PT5M" for
+	// ETH). Empty string falls back to "PT15M" so existing callers stay
+	// bit-identical without explicitly setting it.
+	PrimaryInterval string
+
+	// HigherTFInterval is the optional confirmation timeframe (used by the
+	// HTF gate inside StrategyEngine). Empty falls back to "PT1H".
+	HigherTFInterval string
 }
 
 func NewEventDrivenPipeline(
@@ -187,7 +206,29 @@ func NewEventDrivenPipeline(
 		decisionLogRepo:    cfg.DecisionLogRepo,
 		candlestickFetcher: cfg.CandlestickFetcher,
 		stanceResolver:     cfg.StanceResolver,
+		primaryInterval:    primaryIntervalOrDefault(cfg.PrimaryInterval),
+		higherTFInterval:   higherTFIntervalOrDefault(cfg.HigherTFInterval),
 	}
+}
+
+// primaryIntervalOrDefault returns the configured primary interval, falling
+// back to the legacy LTC PT15M default when the field is left empty so
+// callers that have not yet plumbed a profile-driven value through stay
+// bit-identical.
+func primaryIntervalOrDefault(s string) string {
+	if s == "" {
+		return "PT15M"
+	}
+	return s
+}
+
+// higherTFIntervalOrDefault mirrors primaryIntervalOrDefault for the
+// optional confirmation timeframe.
+func higherTFIntervalOrDefault(s string) string {
+	if s == "" {
+		return "PT1H"
+	}
+	return s
 }
 
 // Start begins the event-driven trading pipeline.
@@ -309,17 +350,28 @@ func (p *EventDrivenPipeline) SwitchSymbol(symbolID int64, tradeAmount float64, 
 }
 
 // seedCandleBuilderFromMinutes pulls PT1M candles covering the current
-// PT15M window and folds them into the LiveSource's CandleBuilder so the
-// first emit after a restart contains the *whole* bar's OHLC, not just
-// post-restart ticks. Best-effort: any error path leaves the builder in
-// its legacy state (next live tick will initialise it from the tick).
+// primary-interval window and folds them into the LiveSource's
+// CandleBuilder so the first emit after a restart contains the *whole*
+// bar's OHLC, not just post-restart ticks. Best-effort: any error path
+// leaves the builder in its legacy state (next live tick will initialise
+// it from the tick).
+//
+// PT1M is used as the universal probe regardless of the primary interval —
+// we just truncate `now` to the primary interval boundary to find the
+// in-progress bar. For sub-minute primaries this would degrade (and the
+// venue does not offer those), so the fetch is skipped when the configured
+// interval is not a clean multiple of one minute.
 func (p *EventDrivenPipeline) seedCandleBuilderFromMinutes(ctx context.Context, symbolID int64, liveSource *live.LiveSource) {
 	if p.candlestickFetcher == nil {
 		return
 	}
+	primaryDur := liveIntervalToDuration(p.primaryInterval)
+	if primaryDur <= 0 || primaryDur < time.Minute {
+		return
+	}
 	now := time.Now().UTC()
-	periodStart := now.Truncate(15 * time.Minute)
-	// Pull a 16-minute window starting at the period boundary so we never
+	periodStart := now.Truncate(primaryDur)
+	// Pull from the period boundary up to one minute past now so we never
 	// miss the first PT1M bar even if the venue is a few seconds behind.
 	from := periodStart.UnixMilli()
 	to := now.Add(time.Minute).UnixMilli()
@@ -336,6 +388,7 @@ func (p *EventDrivenPipeline) seedCandleBuilderFromMinutes(ctx context.Context, 
 	if folded > 0 {
 		slog.Info("event-pipeline: seeded CandleBuilder from PT1M",
 			"symbolID", symbolID,
+			"primaryInterval", p.primaryInterval,
 			"foldedMinutes", folded,
 			"periodStart", periodStart.Format(time.RFC3339),
 		)
@@ -527,7 +580,7 @@ func (p *EventDrivenPipeline) runEventLoop(ctx context.Context, snap eventSnapsh
 	}
 
 	// Create LiveSource for tick-to-candle conversion.
-	liveSource := live.NewLiveSource(snap.symbolID, "PT15M")
+	liveSource := live.NewLiveSource(snap.symbolID, p.primaryInterval)
 
 	// Bootstrap the in-progress 15-min bar from PT1M candles so the first
 	// emit after a restart has correct OHLC instead of just post-restart
@@ -560,7 +613,7 @@ func (p *EventDrivenPipeline) runEventLoop(ctx context.Context, snap eventSnapsh
 
 	// TickRiskHandler: SL/TP on every tick (priority 15).
 	tickRiskHandler := backtest.NewTickRiskHandler(
-		"PT15M",
+		p.primaryInterval,
 		executor,
 		snap.stopLossPercent,
 		snap.takeProfitPercent,
@@ -568,7 +621,7 @@ func (p *EventDrivenPipeline) runEventLoop(ctx context.Context, snap eventSnapsh
 	bus.Register(entity.EventTypeTick, 15, tickRiskHandler)
 
 	// IndicatorHandler: calculates technical indicators on candle close (priority 10).
-	indicatorHandler := backtest.NewIndicatorHandler("PT15M", "PT1H", 500)
+	indicatorHandler := backtest.NewIndicatorHandler(p.primaryInterval, p.higherTFInterval, 500)
 	// PR-D: profile-driven indicator periods + BB squeeze lookback. The
 	// backtest path has been on this since PR-B/C; live now uses the same
 	// knob set so the strategy sees identical indicator values whether it
@@ -585,7 +638,7 @@ func (p *EventDrivenPipeline) runEventLoop(ctx context.Context, snap eventSnapsh
 	// first live bar already has SMA/RSI/MACD/BB/ATR populated. Defaults
 	// need 52 bars (Ichimoku Senkou B); 64 gives margin without making the
 	// API call expensive.
-	p.seedIndicatorHistory(ctx, snap.symbolID, "PT15M", indicatorHandler, 64)
+	p.seedIndicatorHistory(ctx, snap.symbolID, p.primaryInterval, indicatorHandler, 64)
 	bus.Register(entity.EventTypeCandle, 10, indicatorHandler)
 
 	// StrategyHandler: signal generation from indicators (priority 20).
@@ -629,7 +682,7 @@ func (p *EventDrivenPipeline) runEventLoop(ctx context.Context, snap eventSnapsh
 		recorder := decisionlog.NewRecorder(p.decisionLogRepo, decisionlog.RecorderConfig{
 			SymbolID:        snap.symbolID,
 			CurrencyPair:    p.currencyPair,
-			PrimaryInterval: "PT15M",
+			PrimaryInterval: p.primaryInterval,
 			StanceProvider: func() string {
 				return p.currentStance(ctx)
 			},

--- a/backend/cmd/event_pipeline_interval_test.go
+++ b/backend/cmd/event_pipeline_interval_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"testing"
+)
+
+// TestPrimaryIntervalOrDefault pins the legacy PT15M behaviour: callers
+// (including main.go before the env var is set) leave PrimaryInterval
+// empty in EventDrivenPipelineConfig, and the pipeline must keep
+// behaving as it did before this PR.
+func TestPrimaryIntervalOrDefault(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "empty falls back to PT15M", in: "", want: "PT15M"},
+		{name: "explicit PT5M is preserved", in: "PT5M", want: "PT5M"},
+		{name: "explicit PT15M is preserved", in: "PT15M", want: "PT15M"},
+		{name: "exotic interval is preserved verbatim (validation belongs to live source)", in: "PT3M", want: "PT3M"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := primaryIntervalOrDefault(tc.in); got != tc.want {
+				t.Errorf("primaryIntervalOrDefault(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestHigherTFIntervalOrDefault(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{in: "", want: "PT1H"},
+		{in: "PT4H", want: "PT4H"},
+	}
+	for _, tc := range tests {
+		if got := higherTFIntervalOrDefault(tc.in); got != tc.want {
+			t.Errorf("higherTFIntervalOrDefault(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestNewEventDrivenPipeline_FillsIntervalDefaults verifies the constructor
+// applies fallbacks rather than leaving the runtime fields empty (which
+// would crash LiveSource when interval-to-duration parsing fails).
+func TestNewEventDrivenPipeline_FillsIntervalDefaults(t *testing.T) {
+	p := NewEventDrivenPipeline(
+		EventDrivenPipelineConfig{SymbolID: 7},
+		nil, nil, nil, nil, nil, nil, nil, nil,
+	)
+	if p.primaryInterval != "PT15M" {
+		t.Errorf("primaryInterval = %q, want PT15M (legacy default)", p.primaryInterval)
+	}
+	if p.higherTFInterval != "PT1H" {
+		t.Errorf("higherTFInterval = %q, want PT1H (legacy default)", p.higherTFInterval)
+	}
+}
+
+func TestNewEventDrivenPipeline_HonoursConfiguredIntervals(t *testing.T) {
+	p := NewEventDrivenPipeline(
+		EventDrivenPipelineConfig{
+			SymbolID:         7,
+			PrimaryInterval:  "PT5M",
+			HigherTFInterval: "PT4H",
+		},
+		nil, nil, nil, nil, nil, nil, nil, nil,
+	)
+	if p.primaryInterval != "PT5M" {
+		t.Errorf("primaryInterval = %q, want PT5M", p.primaryInterval)
+	}
+	if p.higherTFInterval != "PT4H" {
+		t.Errorf("higherTFInterval = %q, want PT4H", p.higherTFInterval)
+	}
+}

--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -172,6 +172,8 @@ func main() {
 			DecisionLogRepo:    decisionLogRepo,
 			CandlestickFetcher: restClient,
 			StanceResolver:     stanceResolver,
+			PrimaryInterval:    livePrimaryIntervalFromEnv(),
+			HigherTFInterval:   liveHigherTFIntervalFromEnv(),
 		},
 		restClient,
 		restClient, // SymbolFetcher
@@ -459,6 +461,26 @@ func liveProfileBBSqueezeLookback(p *entity.StrategyProfile) int {
 		return 0
 	}
 	return p.StanceRules.BBSqueezeLookback
+}
+
+// livePrimaryIntervalFromEnv reads $LIVE_PRIMARY_INTERVAL with a PT15M
+// fallback. Until profile JSONs declare their primary timeframe natively,
+// an env var is the smallest knob that lets a PT5M-tuned profile run the
+// live pipeline on PT5M without a code change.
+func livePrimaryIntervalFromEnv() string {
+	if v := strings.TrimSpace(os.Getenv("LIVE_PRIMARY_INTERVAL")); v != "" {
+		return v
+	}
+	return "" // empty → pipeline applies the PT15M legacy default
+}
+
+// liveHigherTFIntervalFromEnv mirrors livePrimaryIntervalFromEnv for the
+// optional confirmation timeframe, defaulting to PT1H via the pipeline.
+func liveHigherTFIntervalFromEnv() string {
+	if v := strings.TrimSpace(os.Getenv("LIVE_HIGHER_TF_INTERVAL")); v != "" {
+		return v
+	}
+	return ""
 }
 
 func startMarketRelay(


### PR DESCRIPTION
## Summary

- `EventDrivenPipeline` の **\"PT15M\" / \"PT1H\" ハードコード 5 箇所**（LiveSource, TickRiskHandler, IndicatorHandler, seedIndicatorHistory, RecorderConfig）と `seedCandleBuilderFromMinutes` の `15 * time.Minute` Truncate を **Config 駆動**に置換。
- `EventDrivenPipelineConfig` に `PrimaryInterval` / `HigherTFInterval` を追加。空文字 → \"PT15M\" / \"PT1H\" にフォールバックする `primaryIntervalOrDefault` 経由で legacy 動作を bit-identical に維持。
- `main.go` は `$LIVE_PRIMARY_INTERVAL` / `$LIVE_HIGHER_TF_INTERVAL` を読み取って渡す。env 未設定なら現状の production と完全一致。

## なぜ必要か

ETH PT5M、LTC PT5M など別タイムフレームのプロファイルを live で走らせるたびに、5 箇所のリテラルを書き換える必要があった。`/history` ログ問題の根本対応シリーズ（PR1/PR2 でメイン解決済み）の付随整理。

profile JSON への正式統合は別 PR（スキーマ変更を伴うため）。

## 設計

- 既存の `liveIntervalToDuration` を再利用して、`seedCandleBuilderFromMinutes` の 15-min Truncate を `primaryDur := liveIntervalToDuration(p.primaryInterval)` に置換。サブ分解像度のインターバルは弾く（`primaryDur < time.Minute` で early return）。
- env 関数は \"\" を返したら pipeline 側のデフォルト適用に任せる、という二段階構造。pipeline のテスタビリティを env から切り離せる。

## Test plan

- [x] `TestPrimaryIntervalOrDefault` — 空 → PT15M、明示値はそのまま、未知の値（PT3M など）も verbatim
- [x] `TestHigherTFIntervalOrDefault` — 空 → PT1H、明示値はそのまま
- [x] `TestNewEventDrivenPipeline_FillsIntervalDefaults` — Config 空で構築 → primaryInterval/higherTFInterval が PT15M/PT1H
- [x] `TestNewEventDrivenPipeline_HonoursConfiguredIntervals` — 明示 PT5M/PT4H が伝播
- [x] `go test ./... -race -count=1` 全 pass
- [x] `go build ./...` OK

## 関連

`/history` 表示根本対応シリーズ PR3/4。次は WS サイレント死検出（PR4/4）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)