### PR TITLE
fix(ws): detect silent WebSocket death via per-message heartbeat

### DIFF
--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -337,6 +337,23 @@ const (
 	wsMaxSessionDuration = 110 * time.Minute // 2時間制限の10分前に事前再接続
 	wsInitialBackoff     = 1 * time.Second
 	wsMaxBackoff         = 60 * time.Second
+
+	// wsHeartbeatStaleAfter is the maximum gap between any two messages
+	// (TICKER / ORDERBOOK / TRADES combined) before we declare the
+	// WebSocket silently dead and force a reconnect. The venue normally
+	// pushes ticker frames sub-second during active markets, so 60s is
+	// well outside the legitimate silence band and tight enough that the
+	// PT15M decision pipeline does not skip a whole bar's worth of data.
+	//
+	// 2026-04-26 incident root cause: a 7-hour silent WS gap left
+	// IndicatorHandler with stale buffers, which combined with the
+	// no-history-warmup bug to fill decision_log with all-HOLD rows.
+	wsHeartbeatStaleAfter = 60 * time.Second
+
+	// wsHeartbeatCheckInterval controls how often the watchdog wakes up
+	// to compare lastMsgAt against now. Picked at 1/4 of the stale
+	// threshold so the worst-case detection latency is bounded.
+	wsHeartbeatCheckInterval = 15 * time.Second
 )
 
 // loadSORConfig reads SOR_* env vars and returns a sor.Config. Unset /
@@ -536,16 +553,35 @@ func startMarketRelay(
 		// 2時間制限の事前再接続タイマー
 		sessionTimer := time.NewTimer(wsMaxSessionDuration)
 
+		// Silent-death watchdog: a 2026-04-26 incident showed the venue
+		// can stop pushing frames for hours without sending a close. The
+		// session timer fires only once per 110 min so it cannot catch
+		// these gaps. We instead track lastMsgAt on every incoming frame
+		// and force a reconnect whenever the gap exceeds the heartbeat
+		// stale threshold.
+		lastMsgAt := time.Now()
+		heartbeatTicker := time.NewTicker(wsHeartbeatCheckInterval)
+
 		reconnect := false
 		for !reconnect {
 			select {
 			case <-ctx.Done():
 				sessionTimer.Stop()
+				heartbeatTicker.Stop()
 				_ = wsClient.Close()
 				return
 			case <-sessionTimer.C:
 				slog.Info("market websocket session approaching 2h limit, reconnecting proactively")
 				reconnect = true
+			case now := <-heartbeatTicker.C:
+				if wsIsSilentlyDead(now, lastMsgAt, wsHeartbeatStaleAfter) {
+					slog.Warn("market websocket silent beyond heartbeat threshold, reconnecting",
+						"symbolID", currentSymbolID,
+						"silenceFor", now.Sub(lastMsgAt).Round(time.Second).String(),
+						"threshold", wsHeartbeatStaleAfter.String(),
+					)
+					reconnect = true
+				}
 			case ids := <-symbolSwitchCh:
 				oldID, newID := ids[0], ids[1]
 				slog.Info("switching websocket symbol subscription", "from", oldID, "to", newID)
@@ -577,11 +613,13 @@ func startMarketRelay(
 					reconnect = true
 					break
 				}
+				lastMsgAt = time.Now()
 				handleMarketMessage(ctx, raw, marketDataSvc, realtimeHub)
 			}
 		}
 
 		sessionTimer.Stop()
+		heartbeatTicker.Stop()
 		slog.Info("market websocket disconnected, reconnecting")
 		_ = wsClient.Close()
 		waitFor(ctx, wsInitialBackoff)
@@ -729,6 +767,15 @@ func handleMarketMessage(ctx context.Context, raw []byte, marketDataSvc *usecase
 		}
 		marketDataSvc.HandleTicker(ctx, ticker)
 	}
+}
+
+// wsIsSilentlyDead returns true when the gap between now and the most
+// recent message timestamp exceeds the heartbeat threshold. Extracted so
+// the threshold logic stays unit-testable without spinning up a real
+// WebSocket — the production caller is the watchdog branch in
+// startMarketRelay's select.
+func wsIsSilentlyDead(now, lastMsgAt time.Time, threshold time.Duration) bool {
+	return now.Sub(lastMsgAt) > threshold
 }
 
 func waitFor(ctx context.Context, d time.Duration) {

--- a/backend/cmd/ws_heartbeat_test.go
+++ b/backend/cmd/ws_heartbeat_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+// TestWsIsSilentlyDead pins the watchdog's stale-detection contract: only
+// gaps strictly greater than the threshold trigger a reconnect, so a venue
+// that pushes one frame per minute exactly at the boundary does not
+// thrash the connection.
+func TestWsIsSilentlyDead(t *testing.T) {
+	threshold := 60 * time.Second
+	base := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name  string
+		gap   time.Duration
+		stale bool
+	}{
+		{name: "fresh frame", gap: 0, stale: false},
+		{name: "well within threshold", gap: 30 * time.Second, stale: false},
+		{name: "exactly at threshold", gap: 60 * time.Second, stale: false},
+		{name: "1ms past threshold", gap: 60*time.Second + time.Millisecond, stale: true},
+		{name: "long silence", gap: 5 * time.Minute, stale: true},
+		{name: "incident-scale silence (7h)", gap: 7 * time.Hour, stale: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := wsIsSilentlyDead(base.Add(tc.gap), base, threshold)
+			if got != tc.stale {
+				t.Errorf("wsIsSilentlyDead(gap=%v, threshold=%v) = %v, want %v", tc.gap, threshold, got, tc.stale)
+			}
+		})
+	}
+}
+
+// TestWsHeartbeatThresholdSanity guards the constants from regression to
+// values that would either thrash on legitimate quiet markets or fail to
+// catch the kind of multi-hour silent gap the 2026-04-26 incident
+// exhibited.
+func TestWsHeartbeatThresholdSanity(t *testing.T) {
+	if wsHeartbeatStaleAfter < 30*time.Second {
+		t.Errorf("wsHeartbeatStaleAfter = %v, want >= 30s (legitimate market lulls can exceed shorter windows)", wsHeartbeatStaleAfter)
+	}
+	if wsHeartbeatStaleAfter > 5*time.Minute {
+		t.Errorf("wsHeartbeatStaleAfter = %v, want <= 5m (longer windows lose entire PT15M decision bars)", wsHeartbeatStaleAfter)
+	}
+	if wsHeartbeatCheckInterval >= wsHeartbeatStaleAfter {
+		t.Errorf("wsHeartbeatCheckInterval (%v) must be smaller than wsHeartbeatStaleAfter (%v) so the watchdog can actually fire before the gap doubles",
+			wsHeartbeatCheckInterval, wsHeartbeatStaleAfter)
+	}
+}


### PR DESCRIPTION
## Summary

- `startMarketRelay` の select に **silent-death watchdog** を追加。`lastMsgAt` を全フレーム受信時に更新し、15 秒ごとに stale チェックして 60 秒以上沈黙していたら reconnect。
- 既存の 110-min session timer / disconnect 検出経路と同じ reconnect パスを通すので backoff・re-subscribe ロジックは共有。

## なぜ必要か

`/history` の判断ログ調査中、4/26 から 4/27 にかけて backend ログに **disconnect イベント無しで 7 時間 WS が無音**だった事象が見つかった：

\`\`\`
19:00:23 UTC  market websocket subscribed symbolID=10  ← 正常 reconnect 直後
[7時間サイレント]
02:02:04 UTC  market websocket disconnected, reconnecting
\`\`\`

その間 IndicatorHandler のバッファに何も流れず、PT15M バーが 1 本も close せず、`decision_log` は `HOLD/SKIPPED/SKIPPED/NOOP` で固定された。session timer は 110 分間隔で 1 回しか発火しないので、この種の沈黙は検知できない。

## 設計

- 定数 2 本：
  - `wsHeartbeatStaleAfter = 60s`：通常市場では sub-second でフレームが来るため十分マージン
  - `wsHeartbeatCheckInterval = 15s`：worst-case 検出遅延を threshold/4 に bound
- `select` に `case now := <-heartbeatTicker.C:` を追加し、`wsIsSilentlyDead(now, lastMsgAt, threshold)` で判定。
- 純粋関数 `wsIsSilentlyDead` を抽出してユニットテスト可能に。
- `lastMsgAt = time.Now()` を msgCh 受信ブロックで更新。

## Test plan

- [x] `TestWsIsSilentlyDead` — boundary（30s OK / 60s OK / 60s+1ms NG / 7h NG）
- [x] `TestWsHeartbeatThresholdSanity` — 定数が thrash と miss の両方から守られている
- [x] `go test ./... -race -count=1` 全 pass
- [x] `go build ./...` OK
- 統合テストは現状の `startMarketRelay` 直接テスト基盤が無いため、純粋関数 + sanity guard で覆う。実際の WS 沈黙再現は手動 / 観測ログで確認する想定。

## 関連

`/history` 表示根本対応シリーズ PR4/4（最終）。PR1（ヒストリ・プライム）+ PR2（StanceProvider）+ PR3（インターバル可変化）+ PR4（WS 監視）で一連の根本対応完了。

🤖 Generated with [Claude Code](https://claude.com/claude-code)