### PR TITLE
fix(pipeline): wire position sizer into live event pipeline

### DIFF
--- a/backend/cmd/event_pipeline.go
+++ b/backend/cmd/event_pipeline.go
@@ -17,6 +17,7 @@ import (
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/circuitbreaker"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/decisionlog"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/eventengine"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/positionsize"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/reconcile"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/sor"
 )
@@ -86,6 +87,15 @@ type EventDrivenPipeline struct {
 	// the same lookbacks the strategy was tuned for.
 	indicatorPeriods  entity.IndicatorConfig
 	bbSqueezeLookback int
+
+	// positionSizing mirrors the profile's PositionSizing block so the live
+	// RiskHandler runs through the same sizer the backtest does. nil (or
+	// Mode == "" / "fixed") falls back to the legacy fixed-amount path
+	// where TradeAmount is used as proposal.Amount verbatim.
+	positionSizing *entity.PositionSizingConfig
+	// initialBalance seeds the PeakTracker for drawdown-based lot scaling.
+	// Sourced from cfg.Risk.InitialCapital at startup.
+	initialBalance float64
 
 	// primaryInterval / higherTFInterval drive the LiveSource, the
 	// IndicatorHandler, and every per-bar handler that needs to know which
@@ -169,6 +179,15 @@ type EventDrivenPipelineConfig struct {
 	// HigherTFInterval is the optional confirmation timeframe (used by the
 	// HTF gate inside StrategyEngine). Empty falls back to "PT1H".
 	HigherTFInterval string
+
+	// PositionSizing mirrors profile.Risk.PositionSizing so the live
+	// RiskHandler computes per-trade lot size via the same sizer the
+	// backtest uses. nil keeps the legacy fixed-amount behaviour.
+	PositionSizing *entity.PositionSizingConfig
+
+	// InitialBalance seeds the PeakTracker for drawdown-aware lot scaling.
+	// Typically cfg.Risk.InitialCapital. 0 disables PeakTracker.
+	InitialBalance float64
 }
 
 func NewEventDrivenPipeline(
@@ -208,6 +227,8 @@ func NewEventDrivenPipeline(
 		stanceResolver:     cfg.StanceResolver,
 		primaryInterval:    primaryIntervalOrDefault(cfg.PrimaryInterval),
 		higherTFInterval:   higherTFIntervalOrDefault(cfg.HigherTFInterval),
+		positionSizing:     cfg.PositionSizing,
+		initialBalance:     cfg.InitialBalance,
 	}
 }
 
@@ -646,9 +667,35 @@ func (p *EventDrivenPipeline) runEventLoop(ctx context.Context, snap eventSnapsh
 	bus.Register(entity.EventTypeIndicator, 20, strategyHandler)
 
 	// RiskHandler: risk gating for signals (priority 30).
+	//
+	// The backtest runner attaches a positionsize.Sizer + EquityFunc + PeakTracker
+	// here so the strategy's profile-driven position_sizing block actually shapes
+	// per-trade lot. Live used to skip this wiring, which left every signal
+	// hitting the risk manager with TradeAmount as a literal coin count
+	// (e.g. 1000 LTC × ¥8.8k = ¥8.8M) and the position-limit guard rejecting
+	// every BUY. Live now mirrors the runner's wiring so the sizer the strategy
+	// was tuned against is the same one production runs against.
 	riskHandler := &backtest.RiskHandler{
-		RiskManager: p.riskMgr,
-		TradeAmount: snap.tradeAmount,
+		RiskManager:     p.riskMgr,
+		TradeAmount:     snap.tradeAmount,
+		StopLossPercent: snap.stopLossPercent,
+		MinConfidence:   snap.minConfidence,
+	}
+	if ps := p.positionSizing; ps != nil && ps.Mode != "" && ps.Mode != "fixed" {
+		defaults := positionsize.VenueDefaults(p.currencyPair)
+		riskHandler.Sizer = positionsize.New(ps, defaults)
+		rm := p.riskMgr
+		riskHandler.Equity = backtest.EquityFunc(func() float64 { return rm.LocalBalance() })
+		if p.initialBalance > 0 {
+			riskHandler.Peak = backtest.NewPeakTracker(p.initialBalance)
+		}
+		slog.Info("event-pipeline: position sizer attached",
+			"mode", ps.Mode,
+			"riskPerTradePct", ps.RiskPerTradePct,
+			"minLot", ps.MinLot,
+			"initialBalance", p.initialBalance,
+			"currencyPair", p.currencyPair,
+		)
 	}
 	// Pre-trade orderbook depth gate. Live mode keeps the gate forgiving on
 	// missing/stale snapshots (AllowOnMissingBook=true) so a transient WS

--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -174,6 +174,8 @@ func main() {
 			StanceResolver:     stanceResolver,
 			PrimaryInterval:    livePrimaryIntervalFromEnv(),
 			HigherTFInterval:   liveHigherTFIntervalFromEnv(),
+			PositionSizing:     liveProfilePositionSizing(liveProfile),
+			InitialBalance:     cfg.Risk.InitialCapital,
 		},
 		restClient,
 		restClient, // SymbolFetcher
@@ -478,6 +480,18 @@ func liveProfileBBSqueezeLookback(p *entity.StrategyProfile) int {
 		return 0
 	}
 	return p.StanceRules.BBSqueezeLookback
+}
+
+// liveProfilePositionSizing returns profile.Risk.PositionSizing or nil when
+// the profile is missing / unset. nil means the live RiskHandler keeps the
+// legacy fixed-amount path; a non-nil pointer routes the live signal through
+// the same positionsize.Sizer the backtest runner uses, so the profile that
+// was tuned in PDCA actually shapes production lot size.
+func liveProfilePositionSizing(p *entity.StrategyProfile) *entity.PositionSizingConfig {
+	if p == nil {
+		return nil
+	}
+	return p.Risk.PositionSizing
 }
 
 // livePrimaryIntervalFromEnv reads $LIVE_PRIMARY_INTERVAL with a PT15M


### PR DESCRIPTION
## 概要

Live `EventDrivenPipeline` が `RiskHandler` を構築する際に `Sizer` / `Equity` / `Peak` をまったく wiring していなかったため、**すべてのシグナルが固定値 `TRADE_AMOUNT=1000` を proposal.Amount に渡し、`1000 × price` がそのまま orderValue として `MaxPositionAmount=12,000` を超過 → 全 reject** という壊れ方をしていた。

backtest runner (`internal/usecase/backtest/runner.go:240-244`) は既に sizer を wiring しており、本 PR は live 側を同じ wiring に揃える。

## 症状（修正前）

直近の `decision_log` (LTC_JPY, 4/27, RSI=16 oversold) に4本連続で同じ拒否：

```json
{
  "signal":  {"action":"BUY","reason":"contrarian: RSI oversold..."},
  "risk":    {"outcome":"REJECTED","reason":"position limit exceeded: 0+8812800 > 12000"},
  "order":   {"outcome":"NOOP"}
}
```

`8,812,800 = 1000 × ¥8,812.8` の式。本来 `production_ltc_60k` profile の `position_sizing.risk_per_trade_pct=0.75 + min_lot=0.1` で `≈ 0.1 LTC ≈ ¥880` に正規化されるべきだった。

## 変更内容

- `backend/cmd/event_pipeline.go`
  - `EventDrivenPipeline` に `positionSizing *entity.PositionSizingConfig` / `initialBalance float64` フィールド追加
  - `EventDrivenPipelineConfig` に同名フィールド追加
  - `runEventLoop` の `RiskHandler` 構築で：
    - `StopLossPercent` / `MinConfidence` を必ず設定
    - profile が `position_sizing.mode != ""/"fixed"` のとき `positionsize.New(ps, VenueDefaults(pair))` + `backtest.EquityFunc(rm.LocalBalance)` + `NewPeakTracker(initialBalance)` を attach
    - sizer 装着時に `slog.Info` で運用ログ出力（mode / risk_pct / min_lot / equity / pair）
- `backend/cmd/main.go`
  - `liveProfilePositionSizing(*entity.StrategyProfile)` helper 追加
  - `EventDrivenPipelineConfig` に `PositionSizing` / `InitialBalance: cfg.Risk.InitialCapital` を渡す

## 影響範囲

| 観点 | Before | After |
|---|---|---|
| Live trading | sizer 無視 → 全 reject (実発注 0) | profile 通り `risk_pct=0.75 + DD scale-down` で発注 |
| Backtest | 影響なし（既に sizer 経路） | 影響なし |
| profile が `position_sizing` 未指定 | 影響なし（fixed-amount fallback） | 影響なし（同上） |

## 検証

- `go build ./...` ✅
- `go test ./...` ✅（全パッケージ）
- `go test -race ./cmd/... ./internal/usecase/backtest/...` ✅
- `go vet ./...` ✅

## 反映確認手順

```bash
docker compose up --build -d backend
docker logs rakuten-api-leverage-exchange-backend-1 --tail 50 | grep "position sizer attached"
# → mode=risk_pct riskPerTradePct=0.75 minLot=0.1 ... が出れば成功
```

## 関連

- `docs/pdca/2026-04-26_cycle70-71_60k_promotion.md` (production v8, position_sizing.mode=risk_pct)
- バックテスト 4-window: 3m +5.09%/DD6.26, 6m +5.09%/DD7.37, 1y +45.16%/DD17.52, 2y +38.82%/DD18.78（全期間 positive・MaxDD 20% 以下）
- 修正前は live でこの数値を再現できていなかった

## 残作業（別 PR）

- `backend/config/config.go:22` のコメント「1回の注文金額（円）」が誤り（実態は数量）。同 PR では触らず別 PR で修正予定。
- shadow run 1〜4 週で実 trade と backtest の乖離検証（cycle72）。