### PR TITLE
docs(config): correct misleading TradeAmount comment

### DIFF
--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -19,7 +19,7 @@ type Config struct {
 
 type TradingConfig struct {
 	SymbolID             int64   // 取引対象シンボルID（デフォルト: 7 = BTC_JPY）
-	TradeAmount          float64 // 1回の注文金額（円）
+	TradeAmount          float64 // 1回の注文数量（base currency 単位、例: LTC なら LTC 枚数）。fixed-amount モードではこの値が proposal.Amount に直接渡る。profile の position_sizing.mode が "risk_pct" 等のときは sizer に上書きされる。
 	PipelineIntervalSec  int     // パイプライン評価間隔（秒）
 	StateSyncIntervalSec int     // ポジション・残高同期間隔（秒）
 	MinConfidence        float64 // シグナル最小信頼度（0.0–1.0, デフォルト 0.3）


### PR DESCRIPTION
## 概要

`backend/config/config.go:22` の `TradeAmount` のコメントが誤りで、**JPY 金額**を表しているように読めるが、実際は `proposal.Amount` として消費される **base currency の数量** (LTC 枚数等)。

このコメントは #217 で修正したライブ pos sizer バグの診断を遅らせた一因。「1000 = 1000円」と読めば、`TRADE_AMOUNT=1000` が live で `1000 LTC ≈ ¥8.8M` の発注として扱われている事実に気づきにくい。

## 変更内容

- コメントを実態に合わせて：
  - 「**1回の注文数量（base currency 単位、例: LTC なら LTC 枚数）**」
  - fixed-amount モードでこの値が `proposal.Amount` に直接渡る旨を明記
  - profile の `position_sizing.mode` が "risk_pct" 等のときは sizer に上書きされることを明記

## 影響範囲

- コメントのみ。コード挙動は完全に同一。

## 検証

- `go build ./...` ✅
- `go test ./config/... ./cmd/...` ✅

## 関連

- #217 (live position sizer wiring)