### PR TITLE
fix(pipeline): honour profile strategy_risk for live SL / TP

### DIFF
--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -146,8 +146,8 @@ func main() {
 			StateSyncInterval:    time.Duration(cfg.Trading.StateSyncIntervalSec) * time.Second,
 			TradeAmount:          tradeAmount,
 			MinConfidence:        cfg.Trading.MinConfidence,
-			StopLossPercent:      cfg.Risk.StopLossPercent,
-			TakeProfitPercent:    cfg.Risk.TakeProfitPercent,
+			StopLossPercent:      liveStopLossPercent(liveProfile, cfg.Risk.StopLossPercent),
+			TakeProfitPercent:    liveTakeProfitPercent(liveProfile, cfg.Risk.TakeProfitPercent),
 			SOR:                  loadSORConfig(),
 			CircuitBreaker:       circuitbreaker.Config{
 				AbnormalSpreadPct:    cfg.CircuitBreaker.AbnormalSpreadPct,
@@ -304,7 +304,7 @@ func main() {
 	slog.Info("Trading Engine started",
 		"maxPosition", cfg.Risk.MaxPositionAmount,
 		"maxDailyLoss", cfg.Risk.MaxDailyLoss,
-		"stopLoss", cfg.Risk.StopLossPercent,
+		"stopLoss", liveStopLossPercent(liveProfile, cfg.Risk.StopLossPercent),
 		"capital", cfg.Risk.InitialCapital,
 	)
 
@@ -480,6 +480,32 @@ func liveProfileBBSqueezeLookback(p *entity.StrategyProfile) int {
 		return 0
 	}
 	return p.StanceRules.BBSqueezeLookback
+}
+
+// liveStopLossPercent picks the strategy SL the live pipeline should run
+// against. Profile values win over env so a profile tuned for sl=14% (e.g.
+// production_ltc_60k) is honoured even when the operator left
+// RISK_STOP_LOSS_PERCENT=0 — the same precedence the backtest CLI applies
+// (cmd/backtest/main.go:664). envValue is the legacy fallback when the
+// profile leaves the field unset (== 0).
+//
+// This is critical for position sizing: positionsize.Sizer rejects with
+// "invalid input: sl=0" when StopLossPercent reaches it as 0, which would
+// otherwise leave the live pipeline silently HOLD-only.
+func liveStopLossPercent(p *entity.StrategyProfile, envValue float64) float64 {
+	if p != nil && p.Risk.StopLossPercent > 0 {
+		return p.Risk.StopLossPercent
+	}
+	return envValue
+}
+
+// liveTakeProfitPercent mirrors liveStopLossPercent for the TP knob so the
+// live tick path uses the same TP distance the strategy was tuned with.
+func liveTakeProfitPercent(p *entity.StrategyProfile, envValue float64) float64 {
+	if p != nil && p.Risk.TakeProfitPercent > 0 {
+		return p.Risk.TakeProfitPercent
+	}
+	return envValue
 }
 
 // liveProfilePositionSizing returns profile.Risk.PositionSizing or nil when


### PR DESCRIPTION
## 概要

#217 の follow-up。Live RiskHandler が sizer 経路を通るようになったのち、22:00 の bar close で観測された次の reject:

\`\`\`
risk: REJECTED  reason=\"sizer skipped: invalid input: equity=59984 price=8812.8 sl=0\"
\`\`\`

sizer は \`stop_loss_percent\` で除算するため \`sl=0\` で必ず invalid input。production_ltc_60k v8 profile は \`strategy_risk.stop_loss_percent=14\` を持っているが、live は env \`RISK_STOP_LOSS_PERCENT=0\` を直接使うので 0 が sizer に渡っていた。

## 変更内容

backtest CLI (\`cmd/backtest/main.go:664-665\`) は既に「flag が未指定 && profile が値を持つ → profile を採用」のセマンティクスで実装済み。live も同じ precedence を採用：

- \`liveStopLossPercent(profile, envValue)\` / \`liveTakeProfitPercent(profile, envValue)\` helper を追加
- profile が \`> 0\` ならそちらを採用、それ以外は env のまま（後方互換）
- \`EventDrivenPipelineConfig.StopLossPercent\` / \`TakeProfitPercent\` と起動ログに反映

## 影響範囲

| 観点 | Before | After |
|---|---|---|
| profile が SL/TP を持つ場合 | env 値（多くは 0）→ sizer skip | profile 値が sizer / tick risk に届く |
| profile が SL/TP を持たない | env 値 | env 値（変化なし） |
| 起動バナー | env 値を表示 | 採用された値を表示（運用観測性向上） |

## 検証

- \`go build ./...\` ✅
- \`go test ./cmd/...\` ✅

## 反映後の期待挙動

production_ltc_60k v8 (sl=14, tp=4) の値が sizer に届き、\`risk_pct=0.75\` × \`equity=59984\` × \`sl=14\` の式で \`risk_jpy ≈ 449\` → \`amount ≈ 0.36 LTC\` (min_lot=0.1 切り上げ) が proposal.Amount に渡る。orderValue ≈ ¥3,170 < MaxPositionAmount ¥12,000 で APPROVED まで通る見込み。

## 関連

- #217 (live position sizer wiring)
- \`docs/pdca/2026-04-26_cycle70-71_60k_promotion.md\` (sl=14 の根拠)