### PR TITLE
feat(dashboard): explain stance values via HTML Popover

### DIFF
--- a/frontend/src/components/StanceLegendPopover.tsx
+++ b/frontend/src/components/StanceLegendPopover.tsx
@@ -1,0 +1,98 @@
+type StanceEntry = {
+  key: "TREND_FOLLOW" | "CONTRARIAN" | "BREAKOUT" | "HOLD";
+  title: string;
+  summary: string;
+  buy: string;
+  sell: string;
+};
+
+const STANCE_ENTRIES: StanceEntry[] = [
+  {
+    key: "TREND_FOLLOW",
+    title: "TREND_FOLLOW（順張り）",
+    summary:
+      "SMA / EMA のトレンド方向に沿ってエントリーする方針。市場が一方向に動いているときに乗る。",
+    buy: "EMA12 が EMA26 を上抜け + SMA20 > SMA50 で BUY",
+    sell: "EMA12 が EMA26 を下抜け + SMA20 < SMA50 で SELL",
+  },
+  {
+    key: "CONTRARIAN",
+    title: "CONTRARIAN（逆張り）",
+    summary:
+      '行き過ぎた価格の反発・反落を狙う方針。"群衆と逆方向" に張る。CONTRARIAN だから売る、ではない点に注意。',
+    buy: "RSI が oversold 閾値（例: 32）を下回ったら反発期待で BUY",
+    sell: "RSI が overbought 閾値（例: 68）を上回ったら反落期待で SELL",
+  },
+  {
+    key: "BREAKOUT",
+    title: "BREAKOUT（抜け追い）",
+    summary:
+      "BB スクイーズ解消 + 出来高急増のときに、抜けた方向へ追随する方針。",
+    buy: "価格が BB Upper を上抜け + VolumeRatio が閾値以上で BUY",
+    sell: "価格が BB Lower を下抜け + VolumeRatio が閾値以上で SELL",
+  },
+  {
+    key: "HOLD",
+    title: "HOLD（待機）",
+    summary:
+      "トレンド不明瞭・指標発表直前など、エントリー条件を満たさないときの待機状態。新規シグナルは出ない。",
+    buy: "—",
+    sell: "—",
+  },
+];
+
+const POPOVER_ID = "stance-legend-popover";
+
+export function StanceLegendPopover() {
+  return (
+    <>
+      <button
+        type="button"
+        // @ts-expect-error popovertarget is part of the HTML Popover API; not yet in React's typed attribute set.
+        popovertarget={POPOVER_ID}
+        aria-label="戦略方針の説明を表示"
+        className="inline-flex h-5 w-5 items-center justify-center rounded-full border border-white/20 text-[10px] font-semibold text-text-secondary transition hover:border-cyan-300 hover:text-cyan-200"
+      >
+        ?
+      </button>
+      <div
+        id={POPOVER_ID}
+        popover="auto"
+        className="m-0 w-[min(420px,calc(100vw-2rem))] rounded-2xl border border-white/10 bg-bg-card/95 p-5 text-left text-sm text-text-primary shadow-[0_24px_64px_rgba(0,0,0,0.45)] backdrop-blur"
+      >
+        <h3 className="text-base font-semibold text-white">
+          戦略方針 (Stance) について
+        </h3>
+        <p className="mt-1 text-xs text-text-secondary">
+          指標から自動判定される現在の方針。各 stance ごとに BUY / SELL
+          の出方が変わります。
+        </p>
+        <ul className="mt-4 space-y-3">
+          {STANCE_ENTRIES.map((s) => (
+            <li
+              key={s.key}
+              className="rounded-xl border border-white/8 bg-white/[0.02] p-3"
+            >
+              <p className="text-sm font-semibold text-cyan-200">{s.title}</p>
+              <p className="mt-1 text-xs leading-5 text-text-secondary">
+                {s.summary}
+              </p>
+              {s.buy !== "—" || s.sell !== "—" ? (
+                <dl className="mt-2 space-y-1 text-xs leading-5">
+                  <div className="flex gap-2">
+                    <dt className="shrink-0 text-accent-green">BUY:</dt>
+                    <dd className="text-text-primary">{s.buy}</dd>
+                  </div>
+                  <div className="flex gap-2">
+                    <dt className="shrink-0 text-accent-red">SELL:</dt>
+                    <dd className="text-text-primary">{s.sell}</dd>
+                  </div>
+                </dl>
+              ) : null}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -1,58 +1,60 @@
-import { createFileRoute, Link, useSearch } from '@tanstack/react-router'
-import { AppFrame } from '../components/AppFrame'
-import { KpiCard } from '../components/KpiCard'
-import { CandlestickChart } from '../components/CandlestickChart'
-import { IndicatorPanel } from '../components/IndicatorPanel'
-import { PositionPanel } from '../components/PositionPanel'
-import { BotControlCard } from '../components/BotControlCard'
-import { LiveTickerCard } from '../components/LiveTickerCard'
-import { ManualTradeCard } from '../components/ManualTradeCard'
-import { OrderbookPanel } from '../components/OrderbookPanel'
-import { ExecutionQualityCard } from '../components/ExecutionQualityCard'
-import { HaltReasonBadge } from '../components/HaltReasonBadge'
-import { useStatus } from '../hooks/useStatus'
-import { usePnl } from '../hooks/usePnl'
-import { useStrategy } from '../hooks/useStrategy'
-import { useIndicators } from '../hooks/useIndicators'
-import { usePositions } from '../hooks/usePositions'
-import { useStartBot, useStopBot } from '../hooks/useBotControl'
-import { useMarketTickerStream } from '../hooks/useMarketTickerStream'
-import { useSymbolContext } from '../contexts/SymbolContext'
+import { createFileRoute, Link, useSearch } from "@tanstack/react-router";
+import { AppFrame } from "../components/AppFrame";
+import { KpiCard } from "../components/KpiCard";
+import { CandlestickChart } from "../components/CandlestickChart";
+import { IndicatorPanel } from "../components/IndicatorPanel";
+import { PositionPanel } from "../components/PositionPanel";
+import { BotControlCard } from "../components/BotControlCard";
+import { LiveTickerCard } from "../components/LiveTickerCard";
+import { ManualTradeCard } from "../components/ManualTradeCard";
+import { StanceLegendPopover } from "../components/StanceLegendPopover";
+import { OrderbookPanel } from "../components/OrderbookPanel";
+import { ExecutionQualityCard } from "../components/ExecutionQualityCard";
+import { HaltReasonBadge } from "../components/HaltReasonBadge";
+import { useStatus } from "../hooks/useStatus";
+import { usePnl } from "../hooks/usePnl";
+import { useStrategy } from "../hooks/useStrategy";
+import { useIndicators } from "../hooks/useIndicators";
+import { usePositions } from "../hooks/usePositions";
+import { useStartBot, useStopBot } from "../hooks/useBotControl";
+import { useMarketTickerStream } from "../hooks/useMarketTickerStream";
+import { useSymbolContext } from "../contexts/SymbolContext";
 
-export const Route = createFileRoute('/')({ component: Dashboard })
+export const Route = createFileRoute("/")({ component: Dashboard });
 
 function Dashboard() {
-  const { symbolId, currentSymbol } = useSymbolContext()
-  const rootSearch = useSearch({ from: '__root__' }) as { symbol?: string }
-  const { data: status } = useStatus()
-  const { data: pnl } = usePnl()
-  const { data: strategy } = useStrategy()
-  const { data: indicators } = useIndicators(symbolId)
-  const { data: positions } = usePositions(symbolId)
-  const startBot = useStartBot()
-  const stopBot = useStopBot()
-  const { ticker, orderbook, connectionState } = useMarketTickerStream(symbolId)
+  const { symbolId, currentSymbol } = useSymbolContext();
+  const rootSearch = useSearch({ from: "__root__" }) as { symbol?: string };
+  const { data: status } = useStatus();
+  const { data: pnl } = usePnl();
+  const { data: strategy } = useStrategy();
+  const { data: indicators } = useIndicators(symbolId);
+  const { data: positions } = usePositions(symbolId);
+  const startBot = useStartBot();
+  const stopBot = useStopBot();
+  const { ticker, orderbook, connectionState } =
+    useMarketTickerStream(symbolId);
 
   const statusLabel = status?.tradingHalted
-    ? 'リスク停止'
+    ? "リスク停止"
     : status?.manuallyStopped
-      ? '手動停止'
-      : status?.status === 'running'
-        ? '稼働中'
-        : '\u2014'
+      ? "手動停止"
+      : status?.status === "running"
+        ? "稼働中"
+        : "\u2014";
 
-  const dailyPnlTotal = pnl?.dailyPnl?.total ?? null
-  const dailyPnlStale = pnl?.dailyPnl?.stale ?? false
+  const dailyPnlTotal = pnl?.dailyPnl?.total ?? null;
+  const dailyPnlStale = pnl?.dailyPnl?.stale ?? false;
   const dailyPnlLabel =
     dailyPnlTotal === null
-      ? '\u2014'
-      : `${dailyPnlTotal < 0 ? '-' : ''}¥${Math.abs(dailyPnlTotal).toLocaleString()}${dailyPnlStale ? '*' : ''}`
+      ? "\u2014"
+      : `${dailyPnlTotal < 0 ? "-" : ""}¥${Math.abs(dailyPnlTotal).toLocaleString()}${dailyPnlStale ? "*" : ""}`;
 
   const reasoningLabel = strategy?.reasoning
-    ? strategy.reasoning === 'insufficient indicator data'
-      ? '指標データが不足しています'
+    ? strategy.reasoning === "insufficient indicator data"
+      ? "指標データが不足しています"
       : strategy.reasoning
-    : '戦略コメントはまだ生成されていません。'
+    : "戦略コメントはまだ生成されていません。";
 
   return (
     <AppFrame
@@ -68,23 +70,36 @@ function Dashboard() {
       <div className="mt-3 grid grid-cols-2 gap-3 sm:gap-4 xl:grid-cols-4">
         <KpiCard
           label="残高"
-          value={pnl ? `¥${pnl.balance.toLocaleString()}` : '\u2014'}
+          value={pnl ? `¥${pnl.balance.toLocaleString()}` : "\u2014"}
           color="text-accent-green"
         />
         <KpiCard
           label="日次損益"
           value={dailyPnlLabel}
-          color={dailyPnlTotal !== null && dailyPnlTotal < 0 ? 'text-accent-red' : 'text-accent-green'}
+          color={
+            dailyPnlTotal !== null && dailyPnlTotal < 0
+              ? "text-accent-red"
+              : "text-accent-green"
+          }
         />
-        <KpiCard
-          label="戦略方針"
-          value={strategy?.stance ?? '\u2014'}
-          color="text-cyan-200"
-        />
+        <div className="relative">
+          <KpiCard
+            label="戦略方針"
+            value={strategy?.stance ?? "\u2014"}
+            color="text-cyan-200"
+          />
+          <div className="absolute right-3 top-3">
+            <StanceLegendPopover />
+          </div>
+        </div>
         <KpiCard
           label="ステータス"
           value={statusLabel}
-          color={status?.tradingHalted || status?.manuallyStopped ? 'text-accent-red' : 'text-accent-green'}
+          color={
+            status?.tradingHalted || status?.manuallyStopped
+              ? "text-accent-red"
+              : "text-accent-green"
+          }
         />
       </div>
 
@@ -94,14 +109,18 @@ function Dashboard() {
             ticker={ticker}
             orderbook={orderbook}
             connectionState={connectionState}
-            currencyPair={currentSymbol?.currencyPair?.replace('_', '/')}
+            currencyPair={currentSymbol?.currencyPair?.replace("_", "/")}
           />
           <CandlestickChart symbolId={symbolId} />
           <div className="rounded-3xl border border-white/8 bg-bg-card/90 p-5 shadow-[0_12px_40px_rgba(0,0,0,0.22)]">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-xs uppercase tracking-[0.28em] text-text-secondary">戦略インサイト</p>
-                <h2 className="mt-2 text-xl font-semibold text-white">LLM判断理由</h2>
+                <p className="text-xs uppercase tracking-[0.28em] text-text-secondary">
+                  戦略インサイト
+                </p>
+                <h2 className="mt-2 text-xl font-semibold text-white">
+                  LLM判断理由
+                </h2>
               </div>
               <Link
                 to="/history"
@@ -143,5 +162,5 @@ function Dashboard() {
         </aside>
       </div>
     </AppFrame>
-  )
+  );
 }


### PR DESCRIPTION
## 概要

ダッシュボードの「戦略方針」KPI に TREND_FOLLOW / CONTRARIAN / BREAKOUT / HOLD の説明を表示する Popover を追加する。

実運用中に「CONTRARIAN なのに long で買ったの？」という混乱が出たため、UI 側で各 stance の哲学と実際の BUY/SELL トリガーを示す。

## 変更内容

- 新規 `StanceLegendPopover.tsx`：4 stance の説明を表示。BUY/SELL の発火条件は `usecase/strategy.go` (`evaluateContrarian` 等) と `usecase/stance.go` の実装に揃えた。
- `routes/index.tsx`：「戦略方針」KpiCard を `relative` ラッパーで囲み、右上に `?` ボタンを設置。

### Popover 実装

[HTML Popover API](https://developer.mozilla.org/ja/docs/Web/API/Popover_API) (`popover` / `popovertarget` 属性) を採用。Popover ライブラリの追加なし。対応ブラウザは Chrome 114+ / Safari 17+ / Firefox 125+。運用 PC は満たしている前提。

## 表示内容

| Stance | 哲学 | BUY | SELL |
|---|---|---|---|
| TREND_FOLLOW | 順張り | EMA12↑EMA26 + SMA20>SMA50 | EMA12↓EMA26 + SMA20<SMA50 |
| CONTRARIAN | 逆張り（"群衆と逆方向"） | RSI < oversold (例 32) で反発期待 | RSI > overbought (例 68) で反落期待 |
| BREAKOUT | 抜け追い | BB Upper 上抜け + 出来高急増 | BB Lower 下抜け + 出来高急増 |
| HOLD | 待機 | — | — |

## 検証

- `pnpm tsc --noEmit`：今回追加分にエラーなし（既存の backtest.tsx / usePositions.test.tsx の型/未使用エラーは main にも存在）
- `pnpm test --run`：47/47 pass

## ⚠️ レビュー注意点

`frontend/src/routes/index.tsx` には **本変更（Popover 配置）以外に Prettier の整形差分**（single quote → double quote、末尾セミコロン追加）が混入しています。これはローカルの PostToolUse フォーマッタが import 文追加の保存に反応して全体を整形したため。

実質的なロジック変更は以下の数行のみです：

- `import { StanceLegendPopover } ...` の追加
- 「戦略方針」KpiCard を `<div className="relative">` で囲み、右上に `<StanceLegendPopover />` を配置

レビューはこの2点を中心に確認してください。整形を分離した PR が望ましければ revert + 再 push します。