### PR TITLE
feat(dashboard): localize decision log reasons and outcome labels to Japanese

### DIFF
--- a/frontend/src/components/AppFrame.tsx
+++ b/frontend/src/components/AppFrame.tsx
@@ -21,7 +21,7 @@ const navItems = [
 export function AppFrame({ title, subtitle, children }: AppFrameProps) {
   const rootSearch = useSearch({ from: '__root__' }) as { symbol?: string }
   return (
-    <main className="mx-auto min-h-screen w-full max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+    <main className="mx-auto min-h-screen w-full max-w-[1440px] px-4 py-6 sm:px-6 lg:px-8">
       <header className="mb-6 overflow-hidden rounded-3xl border border-white/8 bg-[linear-gradient(135deg,rgba(55,66,250,0.24),rgba(8,12,32,0.92)_45%,rgba(0,212,170,0.18))] p-5 sm:p-6 shadow-[0_20px_80px_rgba(0,0,0,0.35)]">
         <div className="flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
           <div>

--- a/frontend/src/components/DecisionLogTable.tsx
+++ b/frontend/src/components/DecisionLogTable.tsx
@@ -1,8 +1,27 @@
 import { useState } from 'react'
 import type { DecisionLogItem } from '../lib/api'
+import { translateReason } from '../lib/decisionReasonI18n'
 import { DecisionDetailPanel } from './DecisionDetailPanel'
 
 type Props = { decisions: DecisionLogItem[] }
+
+const RISK_LABEL: Record<DecisionLogItem['risk']['outcome'], string> = {
+  APPROVED: '承認',
+  REJECTED: '却下',
+  SKIPPED: '対象外',
+}
+
+const BOOK_GATE_LABEL: Record<DecisionLogItem['bookGate']['outcome'], string> = {
+  ALLOWED: '通過',
+  VETOED: '拒否',
+  SKIPPED: '対象外',
+}
+
+const ORDER_LABEL: Record<DecisionLogItem['order']['outcome'], string> = {
+  FILLED: '約定',
+  FAILED: '失敗',
+  NOOP: '発注なし',
+}
 
 export function DecisionLogTable({ decisions }: Props) {
   const [expandedId, setExpandedId] = useState<number | null>(null)
@@ -55,8 +74,9 @@ function Row({
   onClick: () => void
 }) {
   const bg = rowBackground(item)
-  const reason =
+  const rawReason =
     item.signal.reason || item.risk.reason || item.bookGate.reason || item.order.error || '—'
+  const reason = translateReason(rawReason)
   return (
     <>
       <tr className={`cursor-pointer border-t border-white/8 ${bg}`} onClick={onClick}>
@@ -67,17 +87,23 @@ function Row({
         <td className="px-4 py-3">{item.stance || '—'}</td>
         <td className="px-4 py-3 font-medium">{item.signal.action}</td>
         <td className="px-4 py-3 text-right">
-          {item.signal.action === 'HOLD' ? '—' : item.signal.confidence.toFixed(2)}
+          {item.signal.action === 'HOLD'
+            ? '—'
+            : `${(item.signal.confidence * 100).toFixed(1)}%`}
         </td>
-        <td className="px-4 py-3">{item.risk.outcome}</td>
-        <td className="px-4 py-3">{item.bookGate.outcome}</td>
-        <td className="px-4 py-3">{item.order.outcome}</td>
+        <td className="px-4 py-3">{RISK_LABEL[item.risk.outcome] ?? item.risk.outcome}</td>
+        <td className="px-4 py-3">
+          {BOOK_GATE_LABEL[item.bookGate.outcome] ?? item.bookGate.outcome}
+        </td>
+        <td className="px-4 py-3">{ORDER_LABEL[item.order.outcome] ?? item.order.outcome}</td>
         <td className="px-4 py-3 text-right">
           {item.order.outcome === 'NOOP'
             ? '—'
             : `${item.order.amount} @ ${item.order.price.toLocaleString('ja-JP')}`}
         </td>
-        <td className="max-w-[24rem] truncate px-4 py-3">{reason}</td>
+        <td className="max-w-[24rem] truncate px-4 py-3" title={rawReason}>
+          {reason}
+        </td>
       </tr>
       {expanded && (
         <tr className="border-t border-white/8 bg-white/3">

--- a/frontend/src/lib/decisionReasonI18n.ts
+++ b/frontend/src/lib/decisionReasonI18n.ts
@@ -1,0 +1,159 @@
+const STATIC_REASONS: Record<string, string> = {
+  // --- TREND_FOLLOW ---
+  'trend follow: disabled by profile': '順張り: プロファイルで無効化',
+  'trend follow: ADX below threshold': '順張り: ADXがしきい値未満（トレンド不足）',
+  'trend follow: EMA cross but SMA not aligned': '順張り: EMAクロス発生もSMAの方向が不一致',
+  'trend follow: SMAShort < SMALong, RSI not oversold':
+    '順張り: 短期SMA<長期SMAだがRSIは売られすぎでない',
+  'trend follow: SMAShort > SMALong, RSI not overbought':
+    '順張り: 短期SMA>長期SMAだがRSIは買われすぎでない',
+  'trend follow: MACD histogram negative, skipping buy':
+    '順張り: MACDヒストグラムが陰、買い見送り',
+  'trend follow: MACD histogram positive, skipping sell':
+    '順張り: MACDヒストグラムが陽、売り見送り',
+  'trend follow: no clear signal': '順張り: 明確なシグナルなし',
+  'trend follow': '順張り',
+  trend: 'トレンド',
+  'ema cross': 'EMAクロス',
+
+  // --- CONTRARIAN ---
+  'contrarian: disabled by profile': '逆張り: プロファイルで無効化',
+  'contrarian: RSI in neutral zone': '逆張り: RSIが中立ゾーン',
+  'contrarian: RSI oversold but MACD momentum still strongly negative':
+    '逆張り: RSI売られすぎだがMACDモメンタムが強い陰',
+  'contrarian: RSI overbought but MACD momentum still strongly positive':
+    '逆張り: RSI買われすぎだがMACDモメンタムが強い陽',
+  'contrarian: RSI oversold, expecting bounce, MACD not strongly against':
+    '逆張り: RSI売られすぎで反発期待、MACDの逆向きは弱い',
+  'contrarian: RSI overbought, expecting pullback, MACD not strongly against':
+    '逆張り: RSI買われすぎで押し目期待、MACDの逆向きは弱い',
+  contrarian: '逆張り',
+  'rsi extreme': 'RSI極端',
+
+  // --- BREAKOUT ---
+  'breakout: disabled by profile': 'ブレイク: プロファイルで無効化',
+  'breakout: insufficient BB/volume data': 'ブレイク: BB/出来高データ不足',
+  'breakout: MACD histogram negative, skipping buy':
+    'ブレイク: MACDヒストグラムが陰、買い見送り',
+  'breakout: MACD histogram positive, skipping sell':
+    'ブレイク: MACDヒストグラムが陽、売り見送り',
+  'breakout: price above BB upper with volume confirmation':
+    'ブレイク: BB上限を出来高伴って上抜け',
+  'breakout: price below BB lower with volume confirmation':
+    'ブレイク: BB下限を出来高伴って下抜け',
+  'breakout: no clear breakout signal': 'ブレイク: 明確なブレイクなし',
+
+  // --- 共通シグナル ---
+  'stance is HOLD': 'スタンスがHOLD',
+  'signal is HOLD, no action': 'シグナルHOLD、アクションなし',
+  'insufficient indicator data': '指標データ不足',
+  'volume filter: volume ratio too low, signal unreliable':
+    '出来高フィルタ: 出来高比が低くシグナル信頼性不足',
+  'MTF filter: higher timeframe inside cloud blocks buy':
+    'MTFフィルタ: 上位足が雲の中で買いブロック',
+  'MTF filter: higher timeframe inside cloud blocks sell':
+    'MTFフィルタ: 上位足が雲の中で売りブロック',
+  'trading is manually stopped': '取引が手動停止中',
+
+  // --- リスク（静的） ---
+  'daily loss limit hit': '日次損失上限到達',
+  'sizer returned zero lot': 'サイザーが0ロットを返却',
+
+  // --- BookGate ---
+  empty_book: '板が空',
+  'empty book side': '板の片側が空',
+  empty_book_side: '板の片側が空',
+  stale_book: '板情報が古い',
+  stale_book_pass: '板情報が古い（通過）',
+  'no snapshot within stale window': '許容ウィンドウ内に板スナップショットなし',
+  no_book: '板情報なし',
+  no_book_pass: '板情報なし（通過）',
+  thin_book_pre_trade: '発注前に板が薄い',
+  'thin book on bid': '買い板が薄い',
+  'insufficient depth': '板の厚みが不足',
+  lot_exceeds_book_side_ratio: 'ロットが板厚比の上限を超過',
+  slippage_exceeds_threshold: '想定スリッページが上限超過',
+
+  // --- 注文/クローズ ---
+  'REST API order': 'REST API発注',
+  stop_loss: 'ストップロス',
+  trailing_stop: 'トレイリングストップ',
+  'circuit_breaker:price_jump': 'サーキットブレーカー: 価格急変',
+}
+
+type DynamicRule = { regex: RegExp; replace: (m: RegExpMatchArray) => string }
+
+const DYNAMIC_RULES: DynamicRule[] = [
+  {
+    regex: /^position limit exceeded:\s*([\d.]+)\+([\d.]+)\s*>\s*([\d.]+)$/,
+    replace: (m) => `ポジション上限超過: ${m[1]}+${m[2]} > ${m[3]}`,
+  },
+  {
+    regex: /^insufficient balance:\s*([\d.]+)\s*>\s*([\d.]+)$/,
+    replace: (m) => `残高不足: ${m[1]} > ${m[2]}`,
+  },
+  {
+    regex: /^daily loss limit exceeded:\s*([\d.]+)\/([\d.]+)$/,
+    replace: (m) => `日次損失上限超過: ${m[1]} / ${m[2]}`,
+  },
+  {
+    regex: /^cooldown:\s*(\d+)\s*consecutive losses, trading paused until\s*(.+)$/,
+    replace: (m) => `クールダウン: ${m[1]}連敗、${m[2]}まで取引停止`,
+  },
+  {
+    regex: /^cooldown started for\s*(\d+)\s*min after\s*(\d+)\s*losses$/,
+    replace: (m) => `${m[2]}連敗のため${m[1]}分のクールダウン開始`,
+  },
+  {
+    regex: /^(\d+)\s*consecutive losses$/,
+    replace: (m) => `${m[1]}連敗`,
+  },
+  {
+    regex: /^MaxDD warning:\s*([\d.]+)%\s*\(peak\s*([\d.]+)\s*→\s*([\d.]+)\)$/,
+    replace: (m) => `最大DD警告: ${m[1]}% (ピーク ${m[2]} → ${m[3]})`,
+  },
+  {
+    regex: /^MaxDD critical:\s*([\d.]+)%\s*\(peak\s*([\d.]+)\s*→\s*([\d.]+)\)$/,
+    replace: (m) => `最大DD危険: ${m[1]}% (ピーク ${m[2]} → ${m[3]})`,
+  },
+  {
+    regex: /^daily loss reached\s*([\d.]+)\s*\/\s*max\s*([\d.]+)\s*\(([\d.]+)%\)$/,
+    replace: (m) => `日次損失 ${m[1]} / 上限 ${m[2]} (${m[3]}%) に到達`,
+  },
+  {
+    regex: /^sizer skipped:\s*invalid input:\s*equity=(\S+)\s*price=(\S+)\s*sl=(\S+)$/,
+    replace: (m) => `サイザー停止: 入力不正 (equity=${m[1]} price=${m[2]} sl=${m[3]})`,
+  },
+  {
+    regex: /^sizer skipped:\s*computed lot\s*([\d.]+)\s*below min_lot\s*([\d.]+)$/,
+    replace: (m) => `サイザー停止: 算出ロット ${m[1]} が最小ロット ${m[2]} 未満`,
+  },
+  {
+    regex: /^sizer skipped:\s*(.+)$/,
+    replace: (m) => `サイザー停止: ${m[1]}`,
+  },
+  {
+    regex: /^risk rejected close:\s*(.+)$/,
+    replace: (m) => `クローズリスク却下: ${translateReason(m[1])}`,
+  },
+  {
+    regex: /^risk rejected:\s*(.+)$/,
+    replace: (m) => `リスク却下: ${translateReason(m[1])}`,
+  },
+]
+
+export function translateReason(reason: string | undefined | null): string {
+  if (!reason) return '—'
+  const trimmed = reason.trim()
+  if (trimmed === '' || trimmed === '—') return '—'
+
+  const fixed = STATIC_REASONS[trimmed]
+  if (fixed) return fixed
+
+  for (const rule of DYNAMIC_RULES) {
+    const m = trimmed.match(rule.regex)
+    if (m) return rule.replace(m)
+  }
+
+  return trimmed
+}


### PR DESCRIPTION
## Summary
- 判断ログの信頼度を `%` 表示（小数1桁）に変更
- リスク / BookGate / 結果の outcome を日本語ラベル化（承認/却下/通過/拒否/約定/発注なし 等）
- signal / risk / bookGate の `reason` 文を辞書ベースで日本語化
  - 静的辞書 ~40件 + 動的フォーマット用 regex ルール ~13種
  - `risk rejected: <inner>` 形式は再帰的に翻訳
  - 未登録文言は原文を fallback、原文は `title` 属性で確認可能
- AppFrame の最大幅を `max-w-7xl` → `max-w-[1440px]` に拡張（テーブル列が多くなった分の余裕確保）

## Test plan
- [ ] `http://localhost:33000/history?symbol=LTC_JPY` で
  - [ ] 「信頼度」列が `XX.X%` 表示になっている
  - [ ] 「リスク」「BookGate」「結果」列が日本語表示になっている
  - [ ] 「理由」列が日本語表示で、ホバーすると原文（英語）がツールチップで出る
  - [ ] `position limit exceeded: 0+8812800 > 12000` のような数値入り reason が `ポジション上限超過: 0+8812800 > 12000` に翻訳されている
- [ ] 各 stance 行の背景色（FILLED 緑 / REJECTED 赤 / HOLD 黄）が従来通り

🤖 Generated with [Claude Code](https://claude.com/claude-code)