### PR TITLE
feat(dashboard): refresh finance overview KPIs and consolidate bot control card

### DIFF
--- a/frontend/src/components/BotControlCard.tsx
+++ b/frontend/src/components/BotControlCard.tsx
@@ -17,7 +17,6 @@ function getStatusLabel(status: StatusResponse | undefined): string {
 
 export function BotControlCard({ status, onStart, onStop, isPending }: BotControlCardProps) {
   const current = getStatusLabel(status)
-  const disabled = isPending
   const isRunning = status?.status === 'running' && !status?.manuallyStopped && !status?.tradingHalted
   const badgeClass = !status
     ? 'bg-white/6 text-slate-300'
@@ -27,31 +26,30 @@ export function BotControlCard({ status, onStart, onStop, isPending }: BotContro
 
   return (
     <section className="rounded-3xl border border-white/8 bg-bg-card/90 p-5 shadow-[0_12px_40px_rgba(0,0,0,0.22)]">
-      <div className="flex items-start justify-between gap-4">
-        <div>
-          <p className="text-xs uppercase tracking-[0.28em] text-text-secondary">ボット制御</p>
-          <h2 className="mt-2 text-xl font-semibold text-white">起動 / 停止</h2>
-          <p className="mt-2 text-sm text-slate-300">現在状態: <span className="font-medium text-white">{current}</span></p>
-        </div>
-        <div className={`rounded-full border border-white/10 px-3 py-1 text-xs ${badgeClass}`}>
-          {current}
-        </div>
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-xs uppercase tracking-[0.28em] text-text-secondary">ボット制御</p>
+        <p className="flex items-center gap-2 text-sm text-slate-300">
+          現在状態:
+          <span className={`rounded-full border border-white/10 px-3 py-1 text-xs ${badgeClass}`}>
+            {current}
+          </span>
+        </p>
       </div>
 
       <div className="mt-5 flex gap-3">
         <button
           type="button"
           onClick={onStart}
-          disabled={disabled}
-          className="rounded-full bg-accent-green px-4 py-2 text-sm font-semibold text-slate-950 transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-50"
+          disabled={isPending || isRunning}
+          className="rounded-full bg-accent-green px-4 py-2 text-sm font-semibold text-slate-950 transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-40"
         >
           起動
         </button>
         <button
           type="button"
           onClick={onStop}
-          disabled={disabled}
-          className="rounded-full bg-accent-red px-4 py-2 text-sm font-semibold text-white transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-50"
+          disabled={isPending || !isRunning}
+          className="rounded-full bg-accent-red px-4 py-2 text-sm font-semibold text-white transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-40"
         >
           停止
         </button>

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -35,26 +35,50 @@ function Dashboard() {
   const { ticker, orderbook, connectionState } =
     useMarketTickerStream(symbolId);
 
-  const statusLabel = status?.tradingHalted
-    ? "リスク停止"
-    : status?.manuallyStopped
-      ? "手動停止"
-      : status?.status === "running"
-        ? "稼働中"
-        : "\u2014";
-
   const dailyPnlTotal = pnl?.dailyPnl?.total ?? null;
   const dailyPnlStale = pnl?.dailyPnl?.stale ?? false;
   const dailyPnlLabel =
     dailyPnlTotal === null
-      ? "\u2014"
+      ? "—"
       : `${dailyPnlTotal < 0 ? "-" : ""}¥${Math.abs(dailyPnlTotal).toLocaleString()}${dailyPnlStale ? "*" : ""}`;
+
+  const balance = pnl?.balance ?? null;
+  const positionValue = pnl?.totalPosition ?? null;
+  const floatingPnl =
+    positions?.reduce((sum, p) => sum + p.floatingProfit, 0) ?? null;
+  const totalEquity =
+    balance !== null && floatingPnl !== null ? balance + floatingPnl : null;
+  const freeBalance =
+    balance !== null && positionValue !== null
+      ? balance - positionValue
+      : null;
+
+  const formatYen = (v: number | null) =>
+    v === null
+      ? "—"
+      : `${v < 0 ? "-" : ""}¥${Math.abs(Math.round(v)).toLocaleString()}`;
+  const formatSignedYen = (v: number | null) =>
+    v === null
+      ? "—"
+      : `${v < 0 ? "-" : "+"}¥${Math.abs(Math.round(v)).toLocaleString()}`;
 
   const reasoningLabel = strategy?.reasoning
     ? strategy.reasoning === "insufficient indicator data"
       ? "指標データが不足しています"
       : strategy.reasoning
     : "戦略コメントはまだ生成されていません。";
+
+  const stance = strategy?.stance ?? null;
+  const stanceColorClass =
+    stance === "TREND_FOLLOW"
+      ? "text-accent-green"
+      : stance === "CONTRARIAN"
+        ? "text-amber-300"
+        : stance === "BREAKOUT"
+          ? "text-fuchsia-300"
+          : stance === "HOLD"
+            ? "text-cyan-200"
+            : "text-text-secondary";
 
   return (
     <AppFrame
@@ -67,40 +91,55 @@ function Dashboard() {
         tradingHalted={status?.tradingHalted}
       />
 
-      <div className="mt-3 grid grid-cols-2 gap-3 sm:gap-4 xl:grid-cols-4">
-        <KpiCard
-          label="残高"
-          value={pnl ? `¥${pnl.balance.toLocaleString()}` : "\u2014"}
-          color="text-accent-green"
-        />
-        <KpiCard
-          label="日次損益"
-          value={dailyPnlLabel}
-          color={
-            dailyPnlTotal !== null && dailyPnlTotal < 0
-              ? "text-accent-red"
-              : "text-accent-green"
-          }
-        />
-        <div className="relative">
+      <div className="mt-3 flex items-center gap-4 rounded-3xl border border-white/8 bg-bg-card/90 px-5 py-4 shadow-[0_12px_40px_rgba(0,0,0,0.22)]">
+        <p className="text-[0.65rem] uppercase tracking-[0.32em] text-text-secondary">
+          戦略方針
+        </p>
+        <p className={`text-3xl font-bold tracking-wide ${stanceColorClass}`}>
+          {stance ?? "—"}
+        </p>
+        <StanceLegendPopover />
+      </div>
+
+      <div className="mt-4">
+        <p className="mb-2 text-[0.65rem] uppercase tracking-[0.32em] text-text-secondary">
+          資金状況
+        </p>
+        <div className="grid grid-cols-2 gap-3 sm:gap-4 sm:grid-cols-3 xl:grid-cols-5">
           <KpiCard
-            label="戦略方針"
-            value={strategy?.stance ?? "\u2014"}
+            label="総資産"
+            value={formatYen(totalEquity)}
+            color="text-accent-green"
+          />
+          <KpiCard
+            label="建玉評価額"
+            value={formatYen(positionValue)}
+            color="text-text-primary"
+          />
+          <KpiCard
+            label="拘束外残高"
+            value={formatYen(freeBalance)}
             color="text-cyan-200"
           />
-          <div className="absolute right-3 top-3">
-            <StanceLegendPopover />
-          </div>
+          <KpiCard
+            label="含み損益"
+            value={formatSignedYen(floatingPnl)}
+            color={
+              floatingPnl !== null && floatingPnl < 0
+                ? "text-accent-red"
+                : "text-accent-green"
+            }
+          />
+          <KpiCard
+            label="日次損益"
+            value={dailyPnlLabel}
+            color={
+              dailyPnlTotal !== null && dailyPnlTotal < 0
+                ? "text-accent-red"
+                : "text-accent-green"
+            }
+          />
         </div>
-        <KpiCard
-          label="ステータス"
-          value={statusLabel}
-          color={
-            status?.tradingHalted || status?.manuallyStopped
-              ? "text-accent-red"
-              : "text-accent-green"
-          }
-        />
       </div>
 
       <div className="mt-4 grid gap-4 xl:grid-cols-[minmax(0,2fr)_minmax(320px,1fr)]">


### PR DESCRIPTION
## Summary

- ダッシュボードのトップにある資金関連 KPI を「**総資産 / 建玉評価額 / 拘束外残高 / 含み損益 / 日次損益**」の 5 枚に再構成し、「資金状況」セクションとして括り直し
- 「戦略方針」を専用のヘッダ行に切り出して大きく表示 (TREND_FOLLOW / CONTRARIAN / BREAKOUT / HOLD ごとに色分け)、StanceLegendPopover をその右に常設
- ボット制御カードのステータス表示を 1 行に統合してチップ化、`稼働中` のときは「起動」ボタンを、停止中のときは「停止」ボタンを disabled にして誤操作を防ぐ

## 背景

旧レイアウトでは

- ダッシュボード上部の KPI が「残高 / 日次損益 / 戦略方針 / ステータス」の 4 枚で、戦略方針が他と同サイズの 1 枚に押し込まれていて視認性が悪かった
- ボット制御カードに「ステータス」と「現在状態」が二重に出ていて冗長 (前セッションでの指摘)
- 「起動 / 停止」という見出しテキストが不要、稼働中でも「起動」が押せるなど誤操作の余地があった

## 変更内容

### `frontend/src/routes/index.tsx`

- 戦略方針を独立した横長カードに切り出し、`text-3xl font-bold` で大きく表示。`StanceLegendPopover` を併設
- 「資金状況」セクション (5 枚 KPI) を新設:
  - **総資産** = `balance + 含み損益`
  - **建玉評価額** = `pnl.totalPosition`
  - **拘束外残高** = `balance - 建玉評価額`
  - **含み損益** = `Σ position.floatingProfit` (符号付き)
  - **日次損益** = `pnl.dailyPnl.total`
- 数値整形ヘルパ (`formatYen` / `formatSignedYen`) を追加。`null` は `—` 表示

### `frontend/src/components/BotControlCard.tsx`

- ヘッダを `ボット制御` ラベル + 「現在状態: <チップ>」の 1 行構成に集約
- 「起動 / 停止」見出し h2 を削除
- 起動ボタン: `disabled = isPending || isRunning`
- 停止ボタン: `disabled = isPending || !isRunning`

## Test plan

- [x] `pnpm test --run` 全 pass (47/47)
- [x] 稼働中: 「起動」が disabled, 「停止」が enabled
- [x] 停止中: 「停止」が disabled, 「起動」が enabled
- [x] 戦略方針が stance に応じて色変化することをローカルで確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)