### PR TITLE
fix(pipeline): wire profile ATR multipliers into live TickRiskHandler

### DIFF
--- a/backend/cmd/event_pipeline.go
+++ b/backend/cmd/event_pipeline.go
@@ -61,8 +61,10 @@ type EventDrivenPipeline struct {
 	minOrderAmount    float64
 	minConfidence     float64
 	stateSyncInterval time.Duration
-	stopLossPercent      float64
-	takeProfitPercent    float64
+	stopLossPercent       float64
+	takeProfitPercent     float64
+	stopLossATRMultiplier float64
+	trailingATRMultiplier float64
 	sorConfig            sor.Config
 	circuitBreakerConfig circuitbreaker.Config
 	staleCheckIntervalMs int64
@@ -130,6 +132,16 @@ type EventDrivenPipelineConfig struct {
 	MinConfidence        float64
 	StopLossPercent      float64
 	TakeProfitPercent    float64
+	// StopLossATRMultiplier mirrors profile.Risk.StopLossATRMultiplier so the
+	// live TickRiskHandler computes the SL distance the same way the backtest
+	// runner does (max of percent- and ATR-derived distances). 0 keeps the
+	// legacy percent-only behaviour.
+	StopLossATRMultiplier float64
+	// TrailingATRMultiplier mirrors profile.Risk.TrailingATRMultiplier so the
+	// live trailing distance matches the value the strategy was tuned with.
+	// 0 keeps the legacy percent-only behaviour. Wiring this through closes
+	// the gap that was silently disabling profile-driven trailing in live.
+	TrailingATRMultiplier float64
 	SOR                  sor.Config
 	CircuitBreaker       circuitbreaker.Config
 	StaleCheckIntervalMs int64
@@ -206,8 +218,10 @@ func NewEventDrivenPipeline(
 		tradeAmount:       cfg.TradeAmount,
 		minConfidence:     cfg.MinConfidence,
 		stateSyncInterval: cfg.StateSyncInterval,
-		stopLossPercent:      cfg.StopLossPercent,
-		takeProfitPercent:    cfg.TakeProfitPercent,
+		stopLossPercent:       cfg.StopLossPercent,
+		takeProfitPercent:     cfg.TakeProfitPercent,
+		stopLossATRMultiplier: cfg.StopLossATRMultiplier,
+		trailingATRMultiplier: cfg.TrailingATRMultiplier,
 		sorConfig:            cfg.SOR,
 		circuitBreakerConfig: cfg.CircuitBreaker,
 		staleCheckIntervalMs: cfg.StaleCheckIntervalMs,
@@ -564,24 +578,28 @@ func (p *EventDrivenPipeline) loadSymbolMeta(ctx context.Context, symbolID int64
 
 // eventSnapshot is a copy of config fields taken under lock.
 type eventSnapshot struct {
-	symbolID          int64
-	tradeAmount       float64
-	baseStepAmount    float64
-	minOrderAmount    float64
-	minConfidence     float64
-	stopLossPercent   float64
-	takeProfitPercent float64
+	symbolID              int64
+	tradeAmount           float64
+	baseStepAmount        float64
+	minOrderAmount        float64
+	minConfidence         float64
+	stopLossPercent       float64
+	takeProfitPercent     float64
+	stopLossATRMultiplier float64
+	trailingATRMultiplier float64
 }
 
 func (p *EventDrivenPipeline) snapshotLocked() eventSnapshot {
 	return eventSnapshot{
-		symbolID:          p.symbolID,
-		tradeAmount:       p.tradeAmount,
-		baseStepAmount:    p.baseStepAmount,
-		minOrderAmount:    p.minOrderAmount,
-		minConfidence:     p.minConfidence,
-		stopLossPercent:   p.stopLossPercent,
-		takeProfitPercent: p.takeProfitPercent,
+		symbolID:              p.symbolID,
+		tradeAmount:           p.tradeAmount,
+		baseStepAmount:        p.baseStepAmount,
+		minOrderAmount:        p.minOrderAmount,
+		minConfidence:         p.minConfidence,
+		stopLossPercent:       p.stopLossPercent,
+		takeProfitPercent:     p.takeProfitPercent,
+		stopLossATRMultiplier: p.stopLossATRMultiplier,
+		trailingATRMultiplier: p.trailingATRMultiplier,
 	}
 }
 
@@ -639,6 +657,15 @@ func (p *EventDrivenPipeline) runEventLoop(ctx context.Context, snap eventSnapsh
 		snap.stopLossPercent,
 		snap.takeProfitPercent,
 	)
+	// Mirror the backtest runner's SetATRMultipliers wiring (runner.go:210)
+	// so profile.Risk.{StopLossATRMultiplier,TrailingATRMultiplier} actually
+	// shape live exits. Skipping this call left the strategy's ATR-based
+	// trailing distance silently ignored — every live trailing decision fell
+	// back to the percent path even when the profile asked for ATR. Profiles
+	// with multiplier == 0 retain the legacy percent-only behaviour because
+	// SetATRMultipliers stores the values verbatim and trailingDistance only
+	// engages the ATR branch when multiplier > 0 and currentATR > 0.
+	tickRiskHandler.SetATRMultipliers(snap.stopLossATRMultiplier, snap.trailingATRMultiplier)
 	bus.Register(entity.EventTypeTick, 15, tickRiskHandler)
 
 	// IndicatorHandler: calculates technical indicators on candle close (priority 10).

--- a/backend/cmd/event_pipeline_atr_wiring_test.go
+++ b/backend/cmd/event_pipeline_atr_wiring_test.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+)
+
+// TestNewEventDrivenPipeline_PropagatesATRMultipliers locks in the wiring
+// fix: profile.Risk.{StopLossATRMultiplier,TrailingATRMultiplier} must reach
+// the pipeline so the SetATRMultipliers call inside runEventLoop receives the
+// profile value rather than 0.
+//
+// Before this PR the live pipeline never called SetATRMultipliers, which
+// silently disabled ATR-based trailing distance for every promoted profile
+// (production_ltc_60k.trailing_atr_multiplier=2.5 was effectively ignored).
+// The regression surface is small but invisible: live HOLD/SL/TP looked
+// correct on the dashboard while the trailing exit point was off by an
+// order of magnitude vs the backtest the profile was tuned against.
+func TestNewEventDrivenPipeline_PropagatesATRMultipliers(t *testing.T) {
+	p := NewEventDrivenPipeline(
+		EventDrivenPipelineConfig{
+			SymbolID:              7,
+			StopLossATRMultiplier: 1.5,
+			TrailingATRMultiplier: 2.5,
+		},
+		nil, nil, nil, nil, nil, nil, nil, nil,
+	)
+	if got, want := p.stopLossATRMultiplier, 1.5; got != want {
+		t.Errorf("stopLossATRMultiplier = %v, want %v", got, want)
+	}
+	if got, want := p.trailingATRMultiplier, 2.5; got != want {
+		t.Errorf("trailingATRMultiplier = %v, want %v", got, want)
+	}
+}
+
+// TestNewEventDrivenPipeline_ATRMultipliersZeroByDefault pins the legacy
+// behaviour for profiles that leave the multipliers unset: the percent-only
+// SL/trailing path must remain bit-identical so existing live runs without
+// an ATR multiplier do not change behaviour after this PR.
+func TestNewEventDrivenPipeline_ATRMultipliersZeroByDefault(t *testing.T) {
+	p := NewEventDrivenPipeline(
+		EventDrivenPipelineConfig{SymbolID: 7},
+		nil, nil, nil, nil, nil, nil, nil, nil,
+	)
+	if p.stopLossATRMultiplier != 0 {
+		t.Errorf("stopLossATRMultiplier = %v, want 0", p.stopLossATRMultiplier)
+	}
+	if p.trailingATRMultiplier != 0 {
+		t.Errorf("trailingATRMultiplier = %v, want 0", p.trailingATRMultiplier)
+	}
+}
+
+// TestSnapshotCarriesATRMultipliers ensures runEventLoop's snapshot copy
+// (taken under lock) propagates the multipliers to the TickRiskHandler
+// configuration site. snapshotLocked is the only path through which the
+// SetATRMultipliers call site reads these values.
+func TestSnapshotCarriesATRMultipliers(t *testing.T) {
+	p := NewEventDrivenPipeline(
+		EventDrivenPipelineConfig{
+			SymbolID:              7,
+			StopLossATRMultiplier: 1.5,
+			TrailingATRMultiplier: 2.5,
+		},
+		nil, nil, nil, nil, nil, nil, nil, nil,
+	)
+	snap := p.snapshot()
+	if snap.stopLossATRMultiplier != 1.5 {
+		t.Errorf("snap.stopLossATRMultiplier = %v, want 1.5", snap.stopLossATRMultiplier)
+	}
+	if snap.trailingATRMultiplier != 2.5 {
+		t.Errorf("snap.trailingATRMultiplier = %v, want 2.5", snap.trailingATRMultiplier)
+	}
+}
+
+func TestLiveStopLossATRMultiplier(t *testing.T) {
+	tests := []struct {
+		name    string
+		profile *entity.StrategyProfile
+		want    float64
+	}{
+		{name: "nil profile returns 0", profile: nil, want: 0},
+		{
+			name:    "zero multiplier returns 0",
+			profile: &entity.StrategyProfile{Risk: entity.StrategyRiskConfig{StopLossATRMultiplier: 0}},
+			want:    0,
+		},
+		{
+			name:    "configured multiplier wins",
+			profile: &entity.StrategyProfile{Risk: entity.StrategyRiskConfig{StopLossATRMultiplier: 1.5}},
+			want:    1.5,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := liveStopLossATRMultiplier(tc.profile); got != tc.want {
+				t.Errorf("liveStopLossATRMultiplier = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLiveTrailingATRMultiplier(t *testing.T) {
+	tests := []struct {
+		name    string
+		profile *entity.StrategyProfile
+		want    float64
+	}{
+		{name: "nil profile returns 0", profile: nil, want: 0},
+		{
+			name:    "zero multiplier returns 0",
+			profile: &entity.StrategyProfile{Risk: entity.StrategyRiskConfig{TrailingATRMultiplier: 0}},
+			want:    0,
+		},
+		{
+			name:    "promoted production_ltc_60k value passes through",
+			profile: &entity.StrategyProfile{Risk: entity.StrategyRiskConfig{TrailingATRMultiplier: 2.5}},
+			want:    2.5,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := liveTrailingATRMultiplier(tc.profile); got != tc.want {
+				t.Errorf("liveTrailingATRMultiplier = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -146,8 +146,10 @@ func main() {
 			StateSyncInterval:    time.Duration(cfg.Trading.StateSyncIntervalSec) * time.Second,
 			TradeAmount:          tradeAmount,
 			MinConfidence:        cfg.Trading.MinConfidence,
-			StopLossPercent:      liveStopLossPercent(liveProfile, cfg.Risk.StopLossPercent),
-			TakeProfitPercent:    liveTakeProfitPercent(liveProfile, cfg.Risk.TakeProfitPercent),
+			StopLossPercent:       liveStopLossPercent(liveProfile, cfg.Risk.StopLossPercent),
+			TakeProfitPercent:     liveTakeProfitPercent(liveProfile, cfg.Risk.TakeProfitPercent),
+			StopLossATRMultiplier: liveStopLossATRMultiplier(liveProfile),
+			TrailingATRMultiplier: liveTrailingATRMultiplier(liveProfile),
 			SOR:                  loadSORConfig(),
 			CircuitBreaker:       circuitbreaker.Config{
 				AbnormalSpreadPct:    cfg.CircuitBreaker.AbnormalSpreadPct,
@@ -305,6 +307,9 @@ func main() {
 		"maxPosition", cfg.Risk.MaxPositionAmount,
 		"maxDailyLoss", cfg.Risk.MaxDailyLoss,
 		"stopLoss", liveStopLossPercent(liveProfile, cfg.Risk.StopLossPercent),
+		"takeProfit", liveTakeProfitPercent(liveProfile, cfg.Risk.TakeProfitPercent),
+		"stopLossATR", liveStopLossATRMultiplier(liveProfile),
+		"trailingATR", liveTrailingATRMultiplier(liveProfile),
 		"capital", cfg.Risk.InitialCapital,
 	)
 
@@ -506,6 +511,30 @@ func liveTakeProfitPercent(p *entity.StrategyProfile, envValue float64) float64 
 		return p.Risk.TakeProfitPercent
 	}
 	return envValue
+}
+
+// liveStopLossATRMultiplier returns profile.Risk.StopLossATRMultiplier or 0
+// when the profile is missing / unset. The TickRiskHandler interprets 0 as
+// "fall back to percent SL only", which is the legacy live behaviour, so
+// profiles that opt out of ATR-scaled SL stay bit-identical.
+func liveStopLossATRMultiplier(p *entity.StrategyProfile) float64 {
+	if p == nil {
+		return 0
+	}
+	return p.Risk.StopLossATRMultiplier
+}
+
+// liveTrailingATRMultiplier returns profile.Risk.TrailingATRMultiplier or 0
+// when the profile is missing / unset. Wiring this through the live pipeline
+// closes the gap that previously left every promoted profile's trailing
+// distance silently overridden by the SL percent — backtests honoured the
+// ATR multiplier (runner.go:210) but live ignored it, breaking the PDCA
+// promotion contract. 0 retains the legacy percent-only trailing.
+func liveTrailingATRMultiplier(p *entity.StrategyProfile) float64 {
+	if p == nil {
+		return 0
+	}
+	return p.Risk.TrailingATRMultiplier
 }
 
 // liveProfilePositionSizing returns profile.Risk.PositionSizing or nil when


### PR DESCRIPTION
## Summary

Stop the bleed: `production_ltc_60k.trailing_atr_multiplier=2.5` was silently ignored in live because `event_pipeline.go` constructed `TickRiskHandler` and never called `SetATRMultipliers` (the backtest runner does at runner.go:210). Live trailing distance was being computed off `stop_loss_percent` (~14% of entry) instead of `2.5 × ATR`, breaking the PDCA promotion contract that backtest behaviour matches live.

This PR plumbs the two multipliers through `EventDrivenPipelineConfig`, the snapshot copy taken inside `runEventLoop`, and the `SetATRMultipliers` call site so promoted profiles actually shape live exits.

This is the **stop-the-bleed PR**. The follow-up [`refactor/risk-policy-domain-type`](https://github.com/yui666a/rakuten-api-leverage-exchange/pull/new/refactor/risk-policy-domain-type) eliminates this whole class of bug by promoting the policy to a domain type with a constructor argument so missing wiring becomes a compile error.

## Why this needs to ship first

LTC positions are open right now. Without this fix, trailing exits on those positions are running on the wrong distance.

## Test plan

- [x] `go test ./... -race -count=1` passes (27 packages green)
- [x] New tests in `event_pipeline_atr_wiring_test.go` lock in:
  - `EventDrivenPipelineConfig.{StopLoss,Trailing}ATRMultiplier` propagates into the pipeline struct
  - `snapshot()` carries the multipliers into runEventLoop
  - profile → multiplier helpers handle nil and zero correctly
- [x] Profiles with multiplier == 0 retain legacy percent-only trailing (verified by existing TickRiskHandler tests still passing)
- [x] Build: `go build ./...` clean
- [ ] Live verification: after merge, observe `trailingATR=2.5` in the "Trading Engine started" log line

🤖 Generated with [Claude Code](https://claude.com/claude-code)