### PR TITLE
feat(frontend): add RecentDecisionsCard to dashboard (UI redesign PR1/4)

### DIFF
--- a/frontend/src/components/RecentDecisionsCard.tsx
+++ b/frontend/src/components/RecentDecisionsCard.tsx
@@ -1,0 +1,167 @@
+import { Link } from '@tanstack/react-router'
+import type { DecisionLogItem, StrategyResponse } from '../lib/api'
+import { useDecisionLog } from '../hooks/useDecisionLog'
+import { translateReason } from '../lib/decisionReasonI18n'
+import { StanceLegendPopover } from './StanceLegendPopover'
+
+const RECENT_LIMIT = 10
+
+type Props = {
+  symbolId: number
+  strategy: StrategyResponse | undefined
+  rootSearch: { symbol?: string }
+}
+
+export function RecentDecisionsCard({ symbolId, strategy, rootSearch }: Props) {
+  const { data, isLoading } = useDecisionLog(symbolId, RECENT_LIMIT)
+  const decisions = data?.decisions ?? []
+
+  const stance = strategy?.stance ?? null
+  const reasoningLabel = pickReasoningLabel(strategy?.reasoning)
+  const lastEvaluatedAt = decisions[0]?.barCloseAt ?? null
+
+  return (
+    <section className="rounded-3xl border border-white/8 bg-bg-card/90 p-5 shadow-[0_12px_40px_rgba(0,0,0,0.22)]">
+      <header className="flex flex-wrap items-start justify-between gap-3">
+        <div className="flex flex-col gap-1">
+          <p className="text-xs uppercase tracking-[0.28em] text-text-secondary">直近の判断</p>
+          <div className="flex flex-wrap items-center gap-3">
+            <span
+              className={`text-3xl font-bold tracking-wide ${stanceColorClass(stance)}`}
+            >
+              {stance ?? '—'}
+            </span>
+            <StanceLegendPopover />
+            {lastEvaluatedAt !== null && (
+              <span className="text-xs text-text-secondary">
+                最終評価: {new Date(lastEvaluatedAt).toLocaleString('ja-JP')}
+              </span>
+            )}
+          </div>
+        </div>
+        <Link
+          to="/history"
+          search={{ ...rootSearch, tab: 'decisions' }}
+          className="text-sm text-cyan-200 transition hover:text-cyan-100"
+        >
+          全件を見る →
+        </Link>
+      </header>
+
+      <p className="mt-3 text-sm leading-7 text-slate-300">{reasoningLabel}</p>
+
+      <div className="mt-4">
+        {isLoading && decisions.length === 0 ? (
+          <div className="rounded-2xl border border-white/8 bg-white/3 p-4 text-center text-xs text-text-secondary">
+            読み込み中…
+          </div>
+        ) : decisions.length === 0 ? (
+          <div className="rounded-2xl border border-white/8 bg-white/3 p-4 text-center text-xs text-text-secondary">
+            まだ判断履歴がありません。
+          </div>
+        ) : (
+          <MiniDecisionTable decisions={decisions} />
+        )}
+      </div>
+    </section>
+  )
+}
+
+function MiniDecisionTable({ decisions }: { decisions: DecisionLogItem[] }) {
+  return (
+    <div className="overflow-hidden rounded-2xl border border-white/8">
+      <table className="w-full text-xs">
+        <thead className="bg-white/5 text-[0.65rem] uppercase tracking-[0.18em] text-text-secondary">
+          <tr>
+            <th className="px-3 py-2 text-left">時刻</th>
+            <th className="px-3 py-2 text-left">スタンス</th>
+            <th className="px-3 py-2 text-left">シグナル</th>
+            <th className="px-3 py-2 text-right">信頼度</th>
+            <th className="px-3 py-2 text-left">結果</th>
+            <th className="px-3 py-2 text-right">数量/価格</th>
+            <th className="px-3 py-2 text-left">理由</th>
+          </tr>
+        </thead>
+        <tbody>
+          {decisions.map((d) => (
+            <MiniRow key={d.id} item={d} />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function MiniRow({ item }: { item: DecisionLogItem }) {
+  const bg = rowBackground(item)
+  const rawReason =
+    item.signal.reason || item.risk.reason || item.bookGate.reason || item.order.error || '—'
+  const reason = translateReason(rawReason)
+  const outcome = outcomeLabel(item)
+  return (
+    <tr className={`border-t border-white/8 ${bg}`}>
+      <td className="px-3 py-2 whitespace-nowrap">
+        {new Date(item.barCloseAt).toLocaleTimeString('ja-JP', {
+          hour: '2-digit',
+          minute: '2-digit',
+        })}
+      </td>
+      <td className="px-3 py-2">{item.stance || '—'}</td>
+      <td className="px-3 py-2 font-medium">{item.signal.action}</td>
+      <td className="px-3 py-2 text-right">
+        {item.signal.action === 'HOLD'
+          ? '—'
+          : `${(item.signal.confidence * 100).toFixed(1)}%`}
+      </td>
+      <td className="px-3 py-2 whitespace-nowrap">{outcome}</td>
+      <td className="px-3 py-2 text-right whitespace-nowrap">
+        {item.order.outcome === 'NOOP'
+          ? '—'
+          : `${item.order.amount} @ ${item.order.price.toLocaleString('ja-JP')}`}
+      </td>
+      <td className="max-w-[18rem] truncate px-3 py-2 text-text-secondary" title={rawReason}>
+        {reason}
+      </td>
+    </tr>
+  )
+}
+
+function pickReasoningLabel(reasoning: string | undefined): string {
+  if (!reasoning) return '戦略コメントはまだ生成されていません。'
+  if (reasoning === 'insufficient indicator data') return '指標データが不足しています'
+  return reasoning
+}
+
+function stanceColorClass(stance: string | null): string {
+  switch (stance) {
+    case 'TREND_FOLLOW':
+      return 'text-accent-green'
+    case 'CONTRARIAN':
+      return 'text-amber-300'
+    case 'BREAKOUT':
+      return 'text-fuchsia-300'
+    case 'HOLD':
+      return 'text-cyan-200'
+    default:
+      return 'text-text-secondary'
+  }
+}
+
+function rowBackground(item: DecisionLogItem): string {
+  if (item.order.outcome === 'FILLED') return 'bg-accent-green/8'
+  if (item.risk.outcome === 'REJECTED' || item.bookGate.outcome === 'VETOED')
+    return 'bg-accent-red/8'
+  if (item.triggerKind !== 'BAR_CLOSE') return 'bg-white/3'
+  if (item.signal.action === 'HOLD') return 'bg-accent-yellow/6'
+  return ''
+}
+
+function outcomeLabel(item: DecisionLogItem): string {
+  if (item.order.outcome === 'FILLED') return `約定`
+  if (item.order.outcome === 'FAILED') return '失敗'
+  if (item.risk.outcome === 'REJECTED') return '却下(リスク)'
+  if (item.bookGate.outcome === 'VETOED') return '却下(板)'
+  if (item.signal.action === 'HOLD') return 'HOLD'
+  if (item.triggerKind !== 'BAR_CLOSE') return item.triggerKind
+  return '発注なし'
+}

--- a/frontend/src/routes/history.tsx
+++ b/frontend/src/routes/history.tsx
@@ -1,5 +1,5 @@
-import { useMemo, useState } from 'react'
-import { createFileRoute } from '@tanstack/react-router'
+import { useMemo } from 'react'
+import { createFileRoute, useNavigate, useSearch } from '@tanstack/react-router'
 import { AppFrame } from '../components/AppFrame'
 import { DecisionLogTable } from '../components/DecisionLogTable'
 import { TradeHistoryTable, type TradeHistoryRow } from '../components/TradeHistoryTable'
@@ -9,15 +9,39 @@ import { useAllTrades } from '../hooks/useAllTrades'
 import { useDecisionLog } from '../hooks/useDecisionLog'
 import { useSymbolContext } from '../contexts/SymbolContext'
 
-export const Route = createFileRoute('/history')({ component: HistoryPage })
-
 type TabKey = 'all' | 'single' | 'decisions'
+
+const TAB_KEYS: TabKey[] = ['all', 'single', 'decisions']
+
+type HistorySearch = {
+  symbol?: string
+  tab?: TabKey
+}
+
+export const Route = createFileRoute('/history')({
+  component: HistoryPage,
+  validateSearch: (search: Record<string, unknown>): HistorySearch => ({
+    symbol: typeof search.symbol === 'string' ? search.symbol : undefined,
+    tab:
+      typeof search.tab === 'string' && (TAB_KEYS as string[]).includes(search.tab)
+        ? (search.tab as TabKey)
+        : undefined,
+  }),
+})
 
 function HistoryPage() {
   const { symbolId, currentSymbol } = useSymbolContext()
   useMarketTickerStream(symbolId)
 
-  const [tab, setTab] = useState<TabKey>('all')
+  const search = useSearch({ from: '/history' })
+  const navigate = useNavigate({ from: '/history' })
+  const tab: TabKey = search.tab ?? 'all'
+  const setTab = (next: TabKey) => {
+    navigate({
+      search: (prev) => ({ ...prev, tab: next === 'all' ? undefined : next }),
+      replace: true,
+    })
+  }
 
   const { data: singleTrades } = useTradeHistory(symbolId)
   const { data: allTradesData } = useAllTrades()

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, Link, useSearch } from "@tanstack/react-router";
+import { createFileRoute, useSearch } from "@tanstack/react-router";
 import { AppFrame } from "../components/AppFrame";
 import { KpiCard } from "../components/KpiCard";
 import { CandlestickChart } from "../components/CandlestickChart";
@@ -7,10 +7,10 @@ import { PositionPanel } from "../components/PositionPanel";
 import { BotControlCard } from "../components/BotControlCard";
 import { LiveTickerCard } from "../components/LiveTickerCard";
 import { ManualTradeCard } from "../components/ManualTradeCard";
-import { StanceLegendPopover } from "../components/StanceLegendPopover";
 import { OrderbookPanel } from "../components/OrderbookPanel";
 import { ExecutionQualityCard } from "../components/ExecutionQualityCard";
 import { HaltReasonBadge } from "../components/HaltReasonBadge";
+import { RecentDecisionsCard } from "../components/RecentDecisionsCard";
 import { useStatus } from "../hooks/useStatus";
 import { usePnl } from "../hooks/usePnl";
 import { useStrategy } from "../hooks/useStrategy";
@@ -62,24 +62,6 @@ function Dashboard() {
       ? "—"
       : `${v < 0 ? "-" : "+"}¥${Math.abs(Math.round(v)).toLocaleString()}`;
 
-  const reasoningLabel = strategy?.reasoning
-    ? strategy.reasoning === "insufficient indicator data"
-      ? "指標データが不足しています"
-      : strategy.reasoning
-    : "戦略コメントはまだ生成されていません。";
-
-  const stance = strategy?.stance ?? null;
-  const stanceColorClass =
-    stance === "TREND_FOLLOW"
-      ? "text-accent-green"
-      : stance === "CONTRARIAN"
-        ? "text-amber-300"
-        : stance === "BREAKOUT"
-          ? "text-fuchsia-300"
-          : stance === "HOLD"
-            ? "text-cyan-200"
-            : "text-text-secondary";
-
   return (
     <AppFrame
       title="トレーディングダッシュボード"
@@ -91,14 +73,12 @@ function Dashboard() {
         tradingHalted={status?.tradingHalted}
       />
 
-      <div className="mt-3 flex items-center gap-4 rounded-3xl border border-white/8 bg-bg-card/90 px-5 py-4 shadow-[0_12px_40px_rgba(0,0,0,0.22)]">
-        <p className="text-[0.65rem] uppercase tracking-[0.32em] text-text-secondary">
-          戦略方針
-        </p>
-        <p className={`text-3xl font-bold tracking-wide ${stanceColorClass}`}>
-          {stance ?? "—"}
-        </p>
-        <StanceLegendPopover />
+      <div className="mt-3">
+        <RecentDecisionsCard
+          symbolId={symbolId}
+          strategy={strategy}
+          rootSearch={rootSearch}
+        />
       </div>
 
       <div className="mt-4">
@@ -151,28 +131,6 @@ function Dashboard() {
             currencyPair={currentSymbol?.currencyPair?.replace("_", "/")}
           />
           <CandlestickChart symbolId={symbolId} />
-          <div className="rounded-3xl border border-white/8 bg-bg-card/90 p-5 shadow-[0_12px_40px_rgba(0,0,0,0.22)]">
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="text-xs uppercase tracking-[0.28em] text-text-secondary">
-                  戦略インサイト
-                </p>
-                <h2 className="mt-2 text-xl font-semibold text-white">
-                  LLM判断理由
-                </h2>
-              </div>
-              <Link
-                to="/history"
-                search={rootSearch}
-                className="text-sm text-cyan-200 transition hover:text-cyan-100"
-              >
-                履歴を見る
-              </Link>
-            </div>
-            <p className="mt-4 text-sm leading-7 text-slate-300">
-              {reasoningLabel}
-            </p>
-          </div>
         </section>
 
         <aside className="space-y-4">


### PR DESCRIPTION
## Summary

UI/UX 再設計の **Stacked PR 1/4**。「判断の透明性」を改善する最小改修。

ダッシュボード上部の `戦略方針` カードと `LLM判断理由` カードを 1 枚の `RecentDecisionsCard` に統合し、stance / 最新の理由 / 直近 10 件の判断ログを 1 か所で把握できるようにする。HOLD ばかりでも「なぜ HOLD か」を別画面（`/history` の 3 番目タブ）に掘りに行く必要がなくなる。

## 含まれる変更

1. **\`/history\` に \`tab\` クエリパラメータを追加** — \`?tab=decisions\` でディープリンク可能。未指定時は従来通り「全通貨の約定」タブ。
2. **\`RecentDecisionsCard\` コンポーネントを新設** — stance + 理由 + 直近 10 件のミニテーブル（既存 \`DecisionLogTable\` と同じ行カラーリング規則）を統合。
3. **ダッシュボードに配置** — 戦略方針/LLM判断理由カードを削除して新カードを一等地に配置。

## Stacked PR 計画

\`\`\`
main
 └─ feat/ui-recent-decisions          ← 本PR (PR1/4) - 直近の判断カード
     └─ feat/ui-live-layout           ← PR2/4 - 監視画面レイアウト改善
         └─ feat/ui-nav-restructure   ← PR3/4 - ナビ再編 (3+1構成)
             └─ feat/ui-analysis-merge ← PR4/4 - 分析画面統合
\`\`\`

## Test plan

- [x] \`pnpm test\` (Vitest 47 件 pass)
- [x] \`pnpm exec tsc --noEmit\` で本PRの新規型エラーなし（既存 4 件は無関係）
- [x] \`docker compose up --build -d\` で実画面確認
  - [x] ダッシュボード上部に「直近の判断」カードが描画される
  - [x] stance (HOLD) / 最終評価時刻 / 理由 (BB squeeze without breakout) / 直近 10 件のミニテーブルが表示
  - [x] 約定行は緑、却下行は赤、HOLD 行は黄、tick イベント行は灰の行背景色
  - [x] 「全件を見る →」 が \`/history?symbol=LTC_JPY&tab=decisions\` へ遷移
  - [x] \`/history?tab=decisions\` 直リンクで判断ログタブが選択された状態で開く
  - [x] \`/history\` (tab 未指定) は従来通り「全通貨の約定」タブで開く

🤖 Generated with [Claude Code](https://claude.com/claude-code)