### PR TITLE
feat(frontend): unified analysis hub at /analysis (UI redesign PR4/4)

### DIFF
--- a/frontend/src/components/AppFrame.tsx
+++ b/frontend/src/components/AppFrame.tsx
@@ -14,12 +14,9 @@ type AppFrameProps = {
 //   分析 (Analysis) ... 過去データに対するバックテスト・WFO・マルチ期間
 //   運用 (Operations) ... ボット制御・リスク設定・通知設定
 //   履歴 (Journal)  ... 取引と判断の証跡
-//
-// 「分析」リンクは現状 /backtest を指している。バックテスト系 3 画面の
-// 統合は後続 PR で /analysis ルートに移し替え予定。
 const navItems = [
   { to: '/', label: '監視' },
-  { to: '/backtest', label: '分析' },
+  { to: '/analysis', label: '分析' },
   { to: '/operations', label: '運用' },
   { to: '/history', label: '履歴' },
 ] as const

--- a/frontend/src/routes/analysis.tsx
+++ b/frontend/src/routes/analysis.tsx
@@ -1,0 +1,81 @@
+import { createFileRoute, useNavigate, useSearch } from '@tanstack/react-router'
+import { AppFrame } from '../components/AppFrame'
+import { BacktestBody } from './backtest'
+import { BacktestMultiBody } from './backtest-multi'
+import { WalkForwardBody } from './walk-forward'
+
+type ViewKey = 'runs' | 'multi' | 'wfo'
+
+const VIEW_KEYS: ViewKey[] = ['runs', 'multi', 'wfo']
+
+const VIEW_TABS: { key: ViewKey; label: string; subtitle: string }[] = [
+  {
+    key: 'runs',
+    label: '単発バックテスト',
+    subtitle: '過去のバックテスト結果の一覧と詳細を確認できます。',
+  },
+  {
+    key: 'multi',
+    label: 'マルチ期間',
+    subtitle: 'POST /api/v1/backtest/run-multi の envelope を RobustnessScore でランキング表示',
+  },
+  {
+    key: 'wfo',
+    label: 'WFO',
+    subtitle: '/backtest/walk-forward の envelope を参照。窓別 OOS リターンと Best パラメータ頻度を表示',
+  },
+]
+
+type AnalysisSearch = {
+  symbol?: string
+  view?: ViewKey
+}
+
+export const Route = createFileRoute('/analysis')({
+  component: AnalysisPage,
+  validateSearch: (search: Record<string, unknown>): AnalysisSearch => ({
+    symbol: typeof search.symbol === 'string' ? search.symbol : undefined,
+    view:
+      typeof search.view === 'string' && (VIEW_KEYS as string[]).includes(search.view)
+        ? (search.view as ViewKey)
+        : undefined,
+  }),
+})
+
+function AnalysisPage() {
+  const search = useSearch({ from: '/analysis' })
+  const navigate = useNavigate({ from: '/analysis' })
+  const view: ViewKey = search.view ?? 'runs'
+  const tab = VIEW_TABS.find((t) => t.key === view) ?? VIEW_TABS[0]
+
+  const setView = (next: ViewKey) => {
+    navigate({
+      search: (prev) => ({ ...prev, view: next === 'runs' ? undefined : next }),
+      replace: true,
+    })
+  }
+
+  return (
+    <AppFrame title="分析" subtitle={tab.subtitle}>
+      <div className="mb-4 flex flex-wrap gap-2">
+        {VIEW_TABS.map((t) => (
+          <button
+            key={t.key}
+            type="button"
+            onClick={() => setView(t.key)}
+            className={`rounded-full border px-4 py-2 text-sm font-medium transition ${
+              view === t.key
+                ? 'border-white/20 bg-white/10 text-white'
+                : 'border-white/8 bg-transparent text-text-secondary hover:text-white'
+            }`}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+      {view === 'runs' && <BacktestBody />}
+      {view === 'multi' && <BacktestMultiBody />}
+      {view === 'wfo' && <WalkForwardBody />}
+    </AppFrame>
+  )
+}

--- a/frontend/src/routes/backtest-multi.tsx
+++ b/frontend/src/routes/backtest-multi.tsx
@@ -12,6 +12,18 @@ export const Route = createFileRoute('/backtest-multi')({
 })
 
 function BacktestMultiPage() {
+  return (
+    <AppFrame
+      title="マルチ期間バックテスト"
+      subtitle="`/backtest/run-multi` で保存された envelope を RobustnessScore でランキング表示"
+    >
+      <BacktestMultiBody />
+    </AppFrame>
+  )
+}
+
+// Body without AppFrame — usable by /analysis tabbed view.
+export function BacktestMultiBody() {
   const [profileFilter, setProfileFilter] = useState('')
   const [pdcaFilter, setPdcaFilter] = useState('')
   const [selectedId, setSelectedId] = useState('')
@@ -38,10 +50,7 @@ function BacktestMultiPage() {
   }, [data])
 
   return (
-    <AppFrame
-      title="マルチ期間バックテスト"
-      subtitle="`/backtest/run-multi` で保存された envelope を RobustnessScore でランキング表示"
-    >
+    <>
       <section className="rounded-3xl border border-white/8 bg-bg-card p-5 sm:p-6">
         <div className="mb-4 flex flex-wrap items-end gap-3">
           <label className="flex flex-col gap-1 text-xs text-text-secondary">
@@ -83,7 +92,7 @@ function BacktestMultiPage() {
           {detail && <MultiResultDetail detail={detail} />}
         </section>
       )}
-    </AppFrame>
+    </>
   )
 }
 

--- a/frontend/src/routes/backtest-multi.tsx
+++ b/frontend/src/routes/backtest-multi.tsx
@@ -1,26 +1,18 @@
-import { createFileRoute } from '@tanstack/react-router'
+import { createFileRoute, redirect } from '@tanstack/react-router'
 import { useMemo, useState } from 'react'
-import { AppFrame } from '../components/AppFrame'
 import {
   useMultiPeriodResult,
   useMultiPeriodResults,
 } from '../hooks/useMultiPeriod'
 import type { LabeledBacktestResult, MultiPeriodResult } from '../lib/api'
 
+// /backtest-multi は /analysis?view=multi に統合された。本体ロジックは
+// BacktestMultiBody として export しており、新ルートから再利用される。
 export const Route = createFileRoute('/backtest-multi')({
-  component: BacktestMultiPage,
+  beforeLoad: ({ search }) => {
+    throw redirect({ to: '/analysis', search: { ...search, view: 'multi' } })
+  },
 })
-
-function BacktestMultiPage() {
-  return (
-    <AppFrame
-      title="マルチ期間バックテスト"
-      subtitle="`/backtest/run-multi` で保存された envelope を RobustnessScore でランキング表示"
-    >
-      <BacktestMultiBody />
-    </AppFrame>
-  )
-}
 
 // Body without AppFrame — usable by /analysis tabbed view.
 export function BacktestMultiBody() {

--- a/frontend/src/routes/backtest.tsx
+++ b/frontend/src/routes/backtest.tsx
@@ -24,6 +24,17 @@ import { formatAmount } from '../lib/format'
 
 export const Route = createFileRoute('/backtest')({ component: BacktestPage })
 
+function BacktestPage() {
+  return (
+    <AppFrame
+      title="Backtest Results"
+      subtitle="過去のバックテスト結果の一覧と詳細を確認できます。"
+    >
+      <BacktestBody />
+    </AppFrame>
+  )
+}
+
 type BacktestRunForm = {
   data: string
   dataHtf: string
@@ -167,7 +178,7 @@ function getErrorMessage(error: unknown): string {
   return 'バックテスト実行に失敗しました。'
 }
 
-function BacktestPage() {
+export function BacktestBody() {
   const { data: symbols } = useSymbols()
   const pairOptions = useMemo(() => {
     const values = [...fallbackBacktestPairs]
@@ -328,10 +339,7 @@ function BacktestPage() {
   }
 
   return (
-    <AppFrame
-      title="Backtest Results"
-      subtitle="過去のバックテスト結果の一覧と詳細を確認できます。"
-    >
+    <>
       {isError && (
         <div className="mb-4 rounded-2xl border border-accent-red/40 bg-accent-red/10 px-5 py-3 text-sm text-accent-red">
           バックテスト結果の取得に失敗しました。
@@ -687,7 +695,7 @@ function BacktestPage() {
           )}
         </section>
       )}
-    </AppFrame>
+    </>
   )
 }
 

--- a/frontend/src/routes/backtest.tsx
+++ b/frontend/src/routes/backtest.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useMemo, useRef, useState, type FormEvent, type ReactNode } from 'react'
-import { createFileRoute, Link } from '@tanstack/react-router'
+import { createFileRoute, Link, redirect } from '@tanstack/react-router'
 import { useVirtualizer } from '@tanstack/react-virtual'
-import { AppFrame } from '../components/AppFrame'
 import {
   useBacktestCSVMeta,
   useBacktestResults,
@@ -22,18 +21,14 @@ import type {
 } from '../lib/api'
 import { formatAmount } from '../lib/format'
 
-export const Route = createFileRoute('/backtest')({ component: BacktestPage })
-
-function BacktestPage() {
-  return (
-    <AppFrame
-      title="Backtest Results"
-      subtitle="過去のバックテスト結果の一覧と詳細を確認できます。"
-    >
-      <BacktestBody />
-    </AppFrame>
-  )
-}
+// /backtest は /analysis?view=runs に統合された。本体ロジックは
+// BacktestBody として export しており、新ルート (/analysis) から再
+// 利用される。直アクセスはハブ画面へ恒久 redirect する。
+export const Route = createFileRoute('/backtest')({
+  beforeLoad: ({ search }) => {
+    throw redirect({ to: '/analysis', search })
+  },
+})
 
 type BacktestRunForm = {
   data: string

--- a/frontend/src/routes/walk-forward.tsx
+++ b/frontend/src/routes/walk-forward.tsx
@@ -15,6 +15,18 @@ export const Route = createFileRoute('/walk-forward')({
 })
 
 function WalkForwardPage() {
+  return (
+    <AppFrame
+      title="ウォークフォワード最適化"
+      subtitle="/backtest/walk-forward の envelope を参照。窓別 OOS リターンと Best パラメータ頻度を表示"
+    >
+      <WalkForwardBody />
+    </AppFrame>
+  )
+}
+
+// Body without AppFrame — usable by /analysis tabbed view.
+export function WalkForwardBody() {
   const [profileFilter, setProfileFilter] = useState('')
   const [pdcaFilter, setPdcaFilter] = useState('')
   const [selectedId, setSelectedId] = useState('')
@@ -39,10 +51,7 @@ function WalkForwardPage() {
   }, [data])
 
   return (
-    <AppFrame
-      title="ウォークフォワード最適化"
-      subtitle="/backtest/walk-forward の envelope を参照。窓別 OOS リターンと Best パラメータ頻度を表示"
-    >
+    <>
       <section className="rounded-3xl border border-white/8 bg-bg-card p-5 sm:p-6">
         <div className="mb-4 flex flex-wrap items-end gap-3">
           <label className="flex flex-col gap-1 text-xs text-text-secondary">
@@ -88,7 +97,7 @@ function WalkForwardPage() {
           {detail && <WalkForwardDetail env={detail} />}
         </section>
       )}
-    </AppFrame>
+    </>
   )
 }
 

--- a/frontend/src/routes/walk-forward.tsx
+++ b/frontend/src/routes/walk-forward.tsx
@@ -1,6 +1,5 @@
-import { createFileRoute } from '@tanstack/react-router'
+import { createFileRoute, redirect } from '@tanstack/react-router'
 import { useMemo, useState } from 'react'
-import { AppFrame } from '../components/AppFrame'
 import {
   useWalkForwardResult,
   useWalkForwardResults,
@@ -10,20 +9,13 @@ import type {
   WalkForwardWindowResult,
 } from '../lib/api'
 
+// /walk-forward は /analysis?view=wfo に統合された。本体ロジックは
+// WalkForwardBody として export しており、新ルートから再利用される。
 export const Route = createFileRoute('/walk-forward')({
-  component: WalkForwardPage,
+  beforeLoad: ({ search }) => {
+    throw redirect({ to: '/analysis', search: { ...search, view: 'wfo' } })
+  },
 })
-
-function WalkForwardPage() {
-  return (
-    <AppFrame
-      title="ウォークフォワード最適化"
-      subtitle="/backtest/walk-forward の envelope を参照。窓別 OOS リターンと Best パラメータ頻度を表示"
-    >
-      <WalkForwardBody />
-    </AppFrame>
-  )
-}
 
 // Body without AppFrame — usable by /analysis tabbed view.
 export function WalkForwardBody() {


### PR DESCRIPTION
## Summary

UI/UX 再設計の **Stacked PR 4/4 (最終)**。バックテスト系 3 画面 (\`/backtest\`, \`/backtest-multi\`, \`/walk-forward\`) を 1 つのハブ \`/analysis\` に統合する。タブ切替で同じ実験を異なる視点から横断的に確認できるようになる。

## 含まれる変更

1. **本体を AppFrame から分離** — 既存 3 ページの本体を \`BacktestBody\`, \`BacktestMultiBody\`, \`WalkForwardBody\` として named export し、AppFrame は薄いラッパーに残す。
2. **\`/analysis\` 新ルート + タブ切替** — \`?view=runs|multi|wfo\` でタブ状態を URL 管理。デフォルト=runs。
3. **旧 3 ルートを redirect 化** — \`/backtest\`, \`/backtest-multi\`, \`/walk-forward\` は適切な view クエリを付与して \`/analysis\` へ恒久 redirect。Body は引き続き named export として残るので新ルートから再利用される。
4. **ナビの「分析」を /analysis へ** — Stacked PR シリーズで仮置きしていた \`/backtest\` リンクを \`/analysis\` に正式切替。

## 実現した状態

ナビが本来の意図 (監視 / 分析 / 運用 / 履歴) で動作:
- 監視 → \`/\` (PR1+PR2)
- 分析 → \`/analysis\` (本PR)
- 運用 → \`/operations\` (PR3)
- 履歴 → \`/history\` (PR1で判断ログタブもディープリンク化)

## 既知の制限 (本PRスコープ外)

- 1421 行の \`backtest.tsx\` 本体は分割していない (将来別 PR で components/analysis/ に分解予定)
- 共通フィルタの抽出は未実装 (タブごとに独自のフィルタを持つ現状維持)
- run 詳細ページ (\`/analysis/run/:id\`) は未着手 (将来別 PR)
- 実行フォームのモーダル化も未着手 (将来別 PR)
- \`/backtest-decisions?id=...\` は維持 (将来 \`/analysis/run/:id?tab=decisions\` へ移行検討)

## Stacked PR 計画

\`\`\`
main
 └─ feat/ui-recent-decisions          ← PR1/4 ✅ merged (#227)
     └─ feat/ui-live-layout           ← PR2/4 ✅ merged (#228)
         └─ feat/ui-nav-restructure   ← PR3/4 ✅ merged (#229)
             └─ feat/ui-analysis-merge ← 本PR (PR4/4)
\`\`\`

## Test plan

- [x] \`pnpm test\` (Vitest 47 件 pass)
- [x] \`pnpm exec tsc --noEmit\` で本PRの新規型エラーなし
- [x] \`docker compose up --build -d\` で実画面確認
  - [x] \`/analysis\` に直接アクセスしてタブストリップ + 単発バックテスト本体が表示
  - [x] タブ切替 (単発 → マルチ → WFO) で本体内容が切り替わり、URL が \`?view=...\` に同期する
  - [x] \`/backtest\` → \`/analysis\` に redirect される
  - [x] \`/backtest-multi\` → \`/analysis?view=multi\` に redirect される
  - [x] \`/walk-forward\` → \`/analysis?view=wfo\` に redirect される
  - [x] ナビの「分析」をクリックすると \`/analysis\` に遷移
  - [x] 各タブのフィルタ・テーブル・実行フォーム・詳細パネルなど既存機能が動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)