### PR TITLE
fix(backend): truthful /status and auto-resume on restart

### DIFF
--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -344,7 +344,17 @@ func main() {
 		"intervalSec", cfg.Trading.PipelineIntervalSec,
 		"stateSyncIntervalSec", cfg.Trading.StateSyncIntervalSec,
 	)
-	slog.Info("Trading pipeline ready. Use POST /api/v1/start to begin auto-trading.")
+
+	// 再起動後の自動再開: ユーザが明示的に /api/v1/stop を押していない限り、
+	// プロセス起動時に pipeline を自動で立ち上げる。これがないと、コード変更や
+	// docker compose up での再起動のたびに手動で /start を叩かないと判定が
+	// 走らず、画面 running 表示と実体の食い違いが起きる (2026-04-28 の事故)。
+	if !riskMgr.GetStatus().ManuallyStopped {
+		pipeline.Start()
+		slog.Info("auto-trading resumed automatically (manuallyStopped=false)")
+	} else {
+		slog.Info("auto-trading paused: manuallyStopped=true. Use POST /api/v1/start to resume.")
+	}
 
 	// シグナル待機
 	select {

--- a/backend/internal/interfaces/api/api_test.go
+++ b/backend/internal/interfaces/api/api_test.go
@@ -99,8 +99,18 @@ func TestGetStatus(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
-	if body["status"] != "running" {
-		t.Fatalf("expected status 'running', got %v", body["status"])
+	// Pipeline is nil in this test setup, so /status must report stopped
+	// even though manuallyStopped=false. This guards against the 2026-04-28
+	// regression where status only looked at the manuallyStopped flag and
+	// claimed running while no pipeline goroutine existed.
+	if body["status"] != "stopped" {
+		t.Fatalf("expected status 'stopped' (no pipeline), got %v", body["status"])
+	}
+	if body["manuallyStopped"] != false {
+		t.Fatalf("expected manuallyStopped false, got %v", body["manuallyStopped"])
+	}
+	if body["pipelineRunning"] != false {
+		t.Fatalf("expected pipelineRunning false, got %v", body["pipelineRunning"])
 	}
 }
 

--- a/backend/internal/interfaces/api/handler/handler_test.go
+++ b/backend/internal/interfaces/api/handler/handler_test.go
@@ -171,7 +171,8 @@ func newRiskManager() *usecase.RiskManager {
 
 func TestStatusHandler_GetStatus(t *testing.T) {
 	riskMgr := newRiskManager()
-	h := NewStatusHandler(riskMgr)
+	pipeline := &mockPipeline{running: true}
+	h := NewStatusHandler(riskMgr, pipeline)
 
 	w := doRequest(h.GetStatus, http.MethodGet, "/status", nil)
 	if w.Code != http.StatusOK {
@@ -185,12 +186,16 @@ func TestStatusHandler_GetStatus(t *testing.T) {
 	if body["manuallyStopped"] != false {
 		t.Fatalf("expected manuallyStopped false, got %v", body["manuallyStopped"])
 	}
+	if body["pipelineRunning"] != true {
+		t.Fatalf("expected pipelineRunning true, got %v", body["pipelineRunning"])
+	}
 }
 
 func TestStatusHandler_GetStatus_Stopped(t *testing.T) {
 	riskMgr := newRiskManager()
 	riskMgr.StopTrading()
-	h := NewStatusHandler(riskMgr)
+	pipeline := &mockPipeline{running: false}
+	h := NewStatusHandler(riskMgr, pipeline)
 
 	w := doRequest(h.GetStatus, http.MethodGet, "/status", nil)
 	if w.Code != http.StatusOK {
@@ -203,6 +208,51 @@ func TestStatusHandler_GetStatus_Stopped(t *testing.T) {
 	}
 	if body["manuallyStopped"] != true {
 		t.Fatalf("expected manuallyStopped true, got %v", body["manuallyStopped"])
+	}
+}
+
+// 再起動直後など、manuallyStopped=false でも pipeline goroutine が動いていない
+// 状態を "running" と詐称してはならない。"stopped" を返し、pipelineRunning=false
+// で実体を表現する。
+func TestStatusHandler_GetStatus_PipelineNotRunning(t *testing.T) {
+	riskMgr := newRiskManager()
+	pipeline := &mockPipeline{running: false} // not started yet
+	h := NewStatusHandler(riskMgr, pipeline)
+
+	w := doRequest(h.GetStatus, http.MethodGet, "/status", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	body := decodeBody(t, w)
+	if body["status"] != "stopped" {
+		t.Fatalf("expected status 'stopped' when pipeline not running, got %v", body["status"])
+	}
+	if body["manuallyStopped"] != false {
+		t.Fatalf("expected manuallyStopped false, got %v", body["manuallyStopped"])
+	}
+	if body["pipelineRunning"] != false {
+		t.Fatalf("expected pipelineRunning false, got %v", body["pipelineRunning"])
+	}
+}
+
+// pipeline が nil (テスト用途・古い構成) でも /status は壊れず、
+// pipelineRunning=false を返す。
+func TestStatusHandler_GetStatus_NilPipeline(t *testing.T) {
+	riskMgr := newRiskManager()
+	h := NewStatusHandler(riskMgr, nil)
+
+	w := doRequest(h.GetStatus, http.MethodGet, "/status", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	body := decodeBody(t, w)
+	if body["pipelineRunning"] != false {
+		t.Fatalf("expected pipelineRunning false when pipeline is nil, got %v", body["pipelineRunning"])
+	}
+	if body["status"] != "stopped" {
+		t.Fatalf("expected status 'stopped' when pipeline is nil, got %v", body["status"])
 	}
 }
 
@@ -552,7 +602,7 @@ func TestPositionHandler_ClosePosition_IdempotencyDuplicate(t *testing.T) {
 
 func TestRiskHandler_GetConfig(t *testing.T) {
 	riskMgr := newRiskManager()
-	h := NewRiskHandler(riskMgr, nil, nil)
+	h := NewRiskHandler(riskMgr, nil, nil, nil)
 
 	w := doRequest(h.GetConfig, http.MethodGet, "/config", nil)
 	if w.Code != http.StatusOK {
@@ -573,7 +623,7 @@ func TestRiskHandler_GetConfig(t *testing.T) {
 
 func TestRiskHandler_UpdateConfig_OK(t *testing.T) {
 	riskMgr := newRiskManager()
-	h := NewRiskHandler(riskMgr, nil, nil)
+	h := NewRiskHandler(riskMgr, nil, nil, nil)
 
 	body := jsonBody(entity.RiskConfig{
 		MaxPositionAmount:    8000,
@@ -602,7 +652,7 @@ func TestRiskHandler_UpdateConfig_OK(t *testing.T) {
 func TestRiskHandler_UpdateConfig_WithRealtimeHub(t *testing.T) {
 	riskMgr := newRiskManager()
 	hub := usecase.NewRealtimeHub()
-	h := NewRiskHandler(riskMgr, hub, nil)
+	h := NewRiskHandler(riskMgr, hub, nil, nil)
 
 	body := jsonBody(entity.RiskConfig{
 		MaxPositionAmount:    8000,
@@ -622,7 +672,7 @@ func TestRiskHandler_UpdateConfig_WithRealtimeHub(t *testing.T) {
 
 func TestRiskHandler_UpdateConfig_InvalidBody(t *testing.T) {
 	riskMgr := newRiskManager()
-	h := NewRiskHandler(riskMgr, nil, nil)
+	h := NewRiskHandler(riskMgr, nil, nil, nil)
 
 	w := doRequest(h.UpdateConfig, http.MethodPut, "/config", []byte("not-json"))
 	if w.Code != http.StatusBadRequest {
@@ -632,7 +682,7 @@ func TestRiskHandler_UpdateConfig_InvalidBody(t *testing.T) {
 
 func TestRiskHandler_UpdateConfig_ZeroMaxPositionAmount(t *testing.T) {
 	riskMgr := newRiskManager()
-	h := NewRiskHandler(riskMgr, nil, nil)
+	h := NewRiskHandler(riskMgr, nil, nil, nil)
 
 	body := jsonBody(entity.RiskConfig{
 		MaxPositionAmount: 0,
@@ -654,7 +704,7 @@ func TestRiskHandler_UpdateConfig_ZeroMaxPositionAmount(t *testing.T) {
 
 func TestRiskHandler_UpdateConfig_ZeroMaxDailyLoss(t *testing.T) {
 	riskMgr := newRiskManager()
-	h := NewRiskHandler(riskMgr, nil, nil)
+	h := NewRiskHandler(riskMgr, nil, nil, nil)
 
 	body := jsonBody(entity.RiskConfig{
 		MaxPositionAmount: 5000,
@@ -675,7 +725,7 @@ func TestRiskHandler_UpdateConfig_ZeroMaxDailyLoss(t *testing.T) {
 
 func TestRiskHandler_UpdateConfig_ZeroStopLoss(t *testing.T) {
 	riskMgr := newRiskManager()
-	h := NewRiskHandler(riskMgr, nil, nil)
+	h := NewRiskHandler(riskMgr, nil, nil, nil)
 
 	body := jsonBody(entity.RiskConfig{
 		MaxPositionAmount: 5000,
@@ -692,7 +742,7 @@ func TestRiskHandler_UpdateConfig_ZeroStopLoss(t *testing.T) {
 
 func TestRiskHandler_UpdateConfig_NegativeTakeProfit(t *testing.T) {
 	riskMgr := newRiskManager()
-	h := NewRiskHandler(riskMgr, nil, nil)
+	h := NewRiskHandler(riskMgr, nil, nil, nil)
 
 	body := jsonBody(entity.RiskConfig{
 		MaxPositionAmount: 5000,
@@ -714,7 +764,7 @@ func TestRiskHandler_UpdateConfig_NegativeTakeProfit(t *testing.T) {
 
 func TestRiskHandler_UpdateConfig_ZeroInitialCapital(t *testing.T) {
 	riskMgr := newRiskManager()
-	h := NewRiskHandler(riskMgr, nil, nil)
+	h := NewRiskHandler(riskMgr, nil, nil, nil)
 
 	body := jsonBody(entity.RiskConfig{
 		MaxPositionAmount: 5000,
@@ -736,7 +786,7 @@ func TestRiskHandler_UpdateConfig_ZeroInitialCapital(t *testing.T) {
 
 func TestRiskHandler_UpdateConfig_NegativeMaxConsecutiveLosses(t *testing.T) {
 	riskMgr := newRiskManager()
-	h := NewRiskHandler(riskMgr, nil, nil)
+	h := NewRiskHandler(riskMgr, nil, nil, nil)
 
 	body := jsonBody(entity.RiskConfig{
 		MaxPositionAmount:    5000,
@@ -759,7 +809,7 @@ func TestRiskHandler_UpdateConfig_NegativeMaxConsecutiveLosses(t *testing.T) {
 
 func TestRiskHandler_UpdateConfig_NegativeCooldownMinutes(t *testing.T) {
 	riskMgr := newRiskManager()
-	h := NewRiskHandler(riskMgr, nil, nil)
+	h := NewRiskHandler(riskMgr, nil, nil, nil)
 
 	body := jsonBody(entity.RiskConfig{
 		MaxPositionAmount:    5000,
@@ -783,7 +833,7 @@ func TestRiskHandler_UpdateConfig_NegativeCooldownMinutes(t *testing.T) {
 
 func TestRiskHandler_GetPnL_OK(t *testing.T) {
 	riskMgr := newRiskManager()
-	h := NewRiskHandler(riskMgr, nil, nil)
+	h := NewRiskHandler(riskMgr, nil, nil, nil)
 
 	w := doRequest(h.GetPnL, http.MethodGet, "/pnl", nil)
 	if w.Code != http.StatusOK {
@@ -801,7 +851,7 @@ func TestRiskHandler_GetPnL_OK(t *testing.T) {
 
 func TestRiskHandler_GetPnL_NoDailyPnlWhenCalculatorNil(t *testing.T) {
 	riskMgr := newRiskManager()
-	h := NewRiskHandler(riskMgr, nil, nil)
+	h := NewRiskHandler(riskMgr, nil, nil, nil)
 
 	w := doRequest(h.GetPnL, http.MethodGet, "/pnl", nil)
 	if w.Code != http.StatusOK {
@@ -1346,7 +1396,7 @@ func TestTradingConfigHandler_UpdateTradingConfig_NegativeTradeAmount(t *testing
 // ---------------------------------------------------------------------------
 
 func TestRealtimeHandler_Stream_NilHub(t *testing.T) {
-	h := NewRealtimeHandler(nil, nil, nil)
+	h := NewRealtimeHandler(nil, nil, nil, nil)
 
 	w := doRequest(h.Stream, http.MethodGet, "/ws", nil)
 	if w.Code != http.StatusServiceUnavailable {
@@ -1360,7 +1410,7 @@ func TestRealtimeHandler_Stream_NilHub(t *testing.T) {
 
 func TestRealtimeHandler_Stream_InvalidSymbolId(t *testing.T) {
 	hub := usecase.NewRealtimeHub()
-	h := NewRealtimeHandler(nil, nil, hub)
+	h := NewRealtimeHandler(nil, nil, hub, nil)
 
 	w := httptest.NewRecorder()
 	_, r := gin.CreateTestContext(w)

--- a/backend/internal/interfaces/api/handler/realtime.go
+++ b/backend/internal/interfaces/api/handler/realtime.go
@@ -17,17 +17,20 @@ type RealtimeHandler struct {
 	marketDataSvc *usecase.MarketDataService
 	riskMgr       *usecase.RiskManager
 	realtimeHub   *usecase.RealtimeHub
+	pipeline      PipelineController
 }
 
 func NewRealtimeHandler(
 	marketDataSvc *usecase.MarketDataService,
 	riskMgr *usecase.RiskManager,
 	realtimeHub *usecase.RealtimeHub,
+	pipeline PipelineController,
 ) *RealtimeHandler {
 	return &RealtimeHandler{
 		marketDataSvc: marketDataSvc,
 		riskMgr:       riskMgr,
 		realtimeHub:   realtimeHub,
+		pipeline:      pipeline,
 	}
 }
 
@@ -87,11 +90,13 @@ func (h *RealtimeHandler) Stream(c *gin.Context) {
 
 func (h *RealtimeHandler) writeInitialSnapshot(ctx context.Context, conn *websocket.Conn, symbolID int64) error {
 	status := h.riskMgr.GetStatus()
+	pipelineRunning := h.pipeline != nil && h.pipeline.Running()
 	initialEvents := []usecase.RealtimeEvent{
 		mustRealtimeEvent("status", 0, gin.H{
-			"status":          statusLabel(status),
+			"status":          statusLabel(status, pipelineRunning),
 			"tradingHalted":   status.TradingHalted,
 			"manuallyStopped": status.ManuallyStopped,
+			"pipelineRunning": pipelineRunning,
 			"balance":         status.Balance,
 			"dailyLoss":       status.DailyLoss,
 			"totalPosition":   status.TotalPosition,

--- a/backend/internal/interfaces/api/handler/risk.go
+++ b/backend/internal/interfaces/api/handler/risk.go
@@ -16,10 +16,21 @@ type RiskHandler struct {
 	riskMgr     *usecase.RiskManager
 	realtimeHub *usecase.RealtimeHub
 	pnlCalc     *usecase.DailyPnLCalculator
+	pipeline    PipelineController
 }
 
-func NewRiskHandler(riskMgr *usecase.RiskManager, realtimeHub *usecase.RealtimeHub, pnlCalc *usecase.DailyPnLCalculator) *RiskHandler {
-	return &RiskHandler{riskMgr: riskMgr, realtimeHub: realtimeHub, pnlCalc: pnlCalc}
+func NewRiskHandler(
+	riskMgr *usecase.RiskManager,
+	realtimeHub *usecase.RealtimeHub,
+	pnlCalc *usecase.DailyPnLCalculator,
+	pipeline PipelineController,
+) *RiskHandler {
+	return &RiskHandler{
+		riskMgr:     riskMgr,
+		realtimeHub: realtimeHub,
+		pnlCalc:     pnlCalc,
+		pipeline:    pipeline,
+	}
 }
 
 func (h *RiskHandler) GetConfig(c *gin.Context) {
@@ -66,10 +77,12 @@ func (h *RiskHandler) UpdateConfig(c *gin.Context) {
 	if h.realtimeHub != nil {
 		_ = h.realtimeHub.PublishData("config", 0, req)
 		status := h.riskMgr.GetStatus()
+		pipelineRunning := h.pipeline != nil && h.pipeline.Running()
 		_ = h.realtimeHub.PublishData("status", 0, gin.H{
-			"status":          statusLabel(status),
+			"status":          statusLabel(status, pipelineRunning),
 			"tradingHalted":   status.TradingHalted,
 			"manuallyStopped": status.ManuallyStopped,
+			"pipelineRunning": pipelineRunning,
 			"balance":         status.Balance,
 			"dailyLoss":       status.DailyLoss,
 			"totalPosition":   status.TotalPosition,

--- a/backend/internal/interfaces/api/handler/status.go
+++ b/backend/internal/interfaces/api/handler/status.go
@@ -7,30 +7,45 @@ import (
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase"
 )
 
+// StatusHandler は /api/v1/status を扱う。
+//
+// 「自動売買が動いているか」は2つの独立した条件の AND で決まる:
+//  1. ユーザが手で停止していない (RiskManager.ManuallyStopped == false)
+//  2. pipeline goroutine が実際に走っている (PipelineController.Running() == true)
+//
+// 過去の実装は 1 だけを見ていたため、プロセス再起動直後 (ManuallyStopped=false
+// だが pipeline.Start() を呼んでいない状態) を "running" と詐称し、シグナルを
+// 取りこぼしているのに画面上は正常に見える事故が起きた (2026-04-28)。
 type StatusHandler struct {
-	riskMgr *usecase.RiskManager
+	riskMgr  *usecase.RiskManager
+	pipeline PipelineController
 }
 
-func NewStatusHandler(riskMgr *usecase.RiskManager) *StatusHandler {
-	return &StatusHandler{riskMgr: riskMgr}
+func NewStatusHandler(riskMgr *usecase.RiskManager, pipeline PipelineController) *StatusHandler {
+	return &StatusHandler{riskMgr: riskMgr, pipeline: pipeline}
 }
 
 func (h *StatusHandler) GetStatus(c *gin.Context) {
 	status := h.riskMgr.GetStatus()
-	engineStatus := statusLabel(status)
+	pipelineRunning := h.pipeline != nil && h.pipeline.Running()
+	engineStatus := statusLabel(status, pipelineRunning)
 
 	c.JSON(http.StatusOK, gin.H{
 		"status":          engineStatus,
 		"tradingHalted":   status.TradingHalted,
 		"manuallyStopped": status.ManuallyStopped,
+		"pipelineRunning": pipelineRunning,
 		"balance":         status.Balance,
 		"dailyLoss":       status.DailyLoss,
 		"totalPosition":   status.TotalPosition,
 	})
 }
 
-func statusLabel(status usecase.RiskStatus) string {
+func statusLabel(status usecase.RiskStatus, pipelineRunning bool) string {
 	if status.ManuallyStopped {
+		return "stopped"
+	}
+	if !pipelineRunning {
 		return "stopped"
 	}
 	return "running"

--- a/backend/internal/interfaces/api/router.go
+++ b/backend/internal/interfaces/api/router.go
@@ -75,13 +75,13 @@ func NewRouter(deps Dependencies) *gin.Engine {
 
 	v1 := r.Group("/api/v1")
 
-	statusHandler := handler.NewStatusHandler(deps.RiskManager)
+	statusHandler := handler.NewStatusHandler(deps.RiskManager, deps.Pipeline)
 	v1.GET("/status", statusHandler.GetStatus)
 	botHandler := handler.NewBotHandler(deps.RiskManager, deps.RealtimeHub, deps.Pipeline)
 	v1.POST("/start", botHandler.Start)
 	v1.POST("/stop", botHandler.Stop)
 
-	riskHandler := handler.NewRiskHandler(deps.RiskManager, deps.RealtimeHub, deps.DailyPnLCalculator)
+	riskHandler := handler.NewRiskHandler(deps.RiskManager, deps.RealtimeHub, deps.DailyPnLCalculator, deps.Pipeline)
 	v1.GET("/config", riskHandler.GetConfig)
 	v1.PUT("/config", riskHandler.UpdateConfig)
 	v1.GET("/pnl", riskHandler.GetPnL)
@@ -106,7 +106,7 @@ func NewRouter(deps Dependencies) *gin.Engine {
 		candleHandler := handler.NewCandleHandler(deps.MarketDataService, deps.RESTClient)
 		v1.GET("/candles/:symbol", candleHandler.GetCandles)
 
-		realtimeHandler := handler.NewRealtimeHandler(deps.MarketDataService, deps.RiskManager, deps.RealtimeHub)
+		realtimeHandler := handler.NewRealtimeHandler(deps.MarketDataService, deps.RiskManager, deps.RealtimeHub, deps.Pipeline)
 		v1.GET("/ws", realtimeHandler.Stream)
 	}
 


### PR DESCRIPTION
## Summary
- `/api/v1/status` が `manuallyStopped` フラグだけ見ていて、再起動直後で pipeline 未起動でも "running" と詐称していたバグを修正。`pipelineRunning` も AND 条件に入れ、新フィールドとしてレスポンスにも露出させた
- backend 起動時に `manuallyStopped=false` なら自動で `pipeline.Start()` を呼ぶように変更。これまでは再起動のたびに手動で `POST /api/v1/start` が必要だった
- 上記2つは片方だけだと不完全（自動Startだけ入れて status を直さないと、`/stop`済みでも UI 上 stopped を表示できない場面が残る）ため1 PR にまとめた

## Why
2026-04-28 JST 01:54、コード編集→ docker compose up で backend を再起動した結果、画面は「稼働中」を表示し続けたが実体は pipeline 未起動。LTC PT15M の BAR_CLOSE シグナルを JST 01:00〜09:26 まで約7時間取りこぼした。`docker compose logs` に `event-driven pipeline started` が一度もないのに `/status` は `running` を返していたため、長時間気づかなかった。

## Changes
- `backend/internal/interfaces/api/handler/status.go` — `StatusHandler` が `PipelineController` を取り、`statusLabel` は `pipelineRunning` も AND
- `backend/internal/interfaces/api/handler/realtime.go`, `risk.go` — WebSocket 初期 snapshot / config 更新の status broadcast も同じ判定に統一、`pipelineRunning` を露出
- `backend/internal/interfaces/api/router.go` — 上記ハンドラに `deps.Pipeline` を注入
- `backend/cmd/main.go` — 起動時 `!ManuallyStopped` なら `pipeline.Start()` を呼ぶ
- テスト: `TestStatusHandler_GetStatus_PipelineNotRunning`, `TestStatusHandler_GetStatus_NilPipeline` を追加。`TestGetStatus` (api_test) は新仕様に追従

## API impact
- `/api/v1/status` レスポンスに `pipelineRunning: bool` が追加（既存フィールドは互換）
- `status: "running"` の意味が「ユーザが停止していない **かつ** pipeline goroutine 動作中」に変わる。再起動直後で pipeline 未起動の場合 `"stopped"` が返る — これは表示の真実性が向上したのでフロントは現状コードのまま望む挙動になる

## Test plan
- [x] `cd backend && go test ./... -race -count=1` 全緑
- [x] `docker compose up --build -d backend` 後、ログに `auto-trading resumed automatically (manuallyStopped=false)` → `event loop running` が出ること
- [x] `curl http://localhost:38080/api/v1/status` で `pipelineRunning: true`, `status: "running"` が返ること
- [ ] `POST /api/v1/stop` 後、再起動しても `manuallyStopped=true` が永続して自動再開しないこと（永続性は既存 RiskManager の保証範囲、今回触っていない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)