### PR TITLE
feat(domain,db): Phase 1 entity types + decision_log migration (Signal/Decision/ExecutionPolicy)

### DIFF
--- a/backend/internal/domain/entity/action_decision.go
+++ b/backend/internal/domain/entity/action_decision.go
@@ -1,0 +1,42 @@
+package entity
+
+// DecisionIntent は Decision レイヤが下した行動意図。Side と組み合わせて
+// ExecutionPolicy (Risk / BookGate / Executor) が解釈する。
+type DecisionIntent string
+
+const (
+	IntentNewEntry        DecisionIntent = "NEW_ENTRY"
+	IntentExitCandidate   DecisionIntent = "EXIT_CANDIDATE"
+	IntentHold            DecisionIntent = "HOLD"
+	IntentCooldownBlocked DecisionIntent = "COOLDOWN_BLOCKED"
+)
+
+// ActionDecision は Decision レイヤの判定結果。
+// Intent=HOLD / COOLDOWN_BLOCKED の時 Side は空文字。
+// Strength と Source は由来 MarketSignal から継承し、サイジング / ログに使う。
+type ActionDecision struct {
+	SymbolID  int64          `json:"symbolId"`
+	Intent    DecisionIntent `json:"intent"`
+	Side      OrderSide      `json:"side,omitempty"`
+	Reason    string         `json:"reason"`
+	Source    string         `json:"source"`
+	Strength  float64        `json:"strength"`
+	Timestamp int64          `json:"timestamp"`
+}
+
+// IsActionable は Intent が実発注を伴う種類か (NEW_ENTRY / EXIT_CANDIDATE)。
+// HOLD / COOLDOWN_BLOCKED は false。後段ハンドラの分岐用。
+func (d ActionDecision) IsActionable() bool {
+	return d.Intent == IntentNewEntry || d.Intent == IntentExitCandidate
+}
+
+// ActionDecisionEvent は EventBus に流れるイベント。RiskHandler が購読する。
+type ActionDecisionEvent struct {
+	Decision   ActionDecision
+	Price      float64
+	CurrentATR float64
+	Timestamp  int64
+}
+
+func (e ActionDecisionEvent) EventType() string     { return EventTypeDecision }
+func (e ActionDecisionEvent) EventTimestamp() int64 { return e.Timestamp }

--- a/backend/internal/domain/entity/action_decision_test.go
+++ b/backend/internal/domain/entity/action_decision_test.go
@@ -1,0 +1,61 @@
+package entity
+
+import "testing"
+
+func TestDecisionIntent_Constants(t *testing.T) {
+	cases := []struct {
+		intent DecisionIntent
+		want   string
+	}{
+		{IntentNewEntry, "NEW_ENTRY"},
+		{IntentExitCandidate, "EXIT_CANDIDATE"},
+		{IntentHold, "HOLD"},
+		{IntentCooldownBlocked, "COOLDOWN_BLOCKED"},
+	}
+	for _, c := range cases {
+		if string(c.intent) != c.want {
+			t.Errorf("got %q, want %q", c.intent, c.want)
+		}
+	}
+}
+
+func TestActionDecision_IsActionable(t *testing.T) {
+	cases := []struct {
+		intent DecisionIntent
+		want   bool
+	}{
+		{IntentNewEntry, true},
+		{IntentExitCandidate, true},
+		{IntentHold, false},
+		{IntentCooldownBlocked, false},
+	}
+	for _, c := range cases {
+		d := ActionDecision{Intent: c.intent}
+		if got := d.IsActionable(); got != c.want {
+			t.Errorf("Intent=%q IsActionable=%v, want %v", c.intent, got, c.want)
+		}
+	}
+}
+
+func TestActionDecisionEvent_EventInterface(t *testing.T) {
+	ev := ActionDecisionEvent{
+		Decision: ActionDecision{
+			Intent: IntentNewEntry,
+			Side:   OrderSideBuy,
+		},
+		Price:     8900.0,
+		Timestamp: 1700000000000,
+	}
+	if got := ev.EventType(); got != EventTypeDecision {
+		t.Errorf("EventType=%q, want %q", got, EventTypeDecision)
+	}
+	if got := ev.EventTimestamp(); got != 1700000000000 {
+		t.Errorf("EventTimestamp=%d, want 1700000000000", got)
+	}
+}
+
+func TestEventTypeDecision_Value(t *testing.T) {
+	if EventTypeDecision != "decision" {
+		t.Errorf("EventTypeDecision=%q, want %q", EventTypeDecision, "decision")
+	}
+}

--- a/backend/internal/domain/entity/backtest_event.go
+++ b/backend/internal/domain/entity/backtest_event.go
@@ -1,13 +1,15 @@
 package entity
 
 const (
-	EventTypeCandle    = "candle"
-	EventTypeIndicator = "indicator"
-	EventTypeTick      = "tick"
-	EventTypeSignal    = "signal"
-	EventTypeApproved  = "approved_signal"
-	EventTypeRejected  = "rejected_signal"
-	EventTypeOrder     = "order"
+	EventTypeCandle       = "candle"
+	EventTypeIndicator    = "indicator"
+	EventTypeTick         = "tick"
+	EventTypeSignal       = "signal"
+	EventTypeMarketSignal = "market_signal"
+	EventTypeDecision     = "decision"
+	EventTypeApproved     = "approved_signal"
+	EventTypeRejected     = "rejected_signal"
+	EventTypeOrder        = "order"
 )
 
 // Event is a minimal contract used by the backtest event bus.

--- a/backend/internal/domain/entity/decision.go
+++ b/backend/internal/domain/entity/decision.go
@@ -21,6 +21,16 @@ type DecisionRecord struct {
 	SignalConfidence float64
 	SignalReason     string
 
+	// Phase 1 (Signal/Decision/ExecutionPolicy 三層分離) で追加。
+	// PR1 時点では recorder が値を埋めず、全行で空文字 / 0 のまま。
+	// PR2 で recorder が新ロジックの結果を書き始める。
+	SignalDirection   string  // SignalDirection の string 形 ("BULLISH" 等)
+	SignalStrength    float64 // 由来 MarketSignal.Strength
+	DecisionIntent    string  // DecisionIntent の string 形
+	DecisionSide      string  // OrderSide の string 形 ("BUY" | "SELL" | "")
+	DecisionReason    string
+	ExitPolicyOutcome string // PR4 で BookGate 経由の出口判断記録に使う
+
 	RiskOutcome string
 	RiskReason  string
 

--- a/backend/internal/domain/entity/market_signal.go
+++ b/backend/internal/domain/entity/market_signal.go
@@ -1,0 +1,37 @@
+package entity
+
+// SignalDirection は市況の方向性を表す。Signal レイヤは BUY/SELL のような
+// 注文サイドではなく、市場解釈としての BULLISH/BEARISH/NEUTRAL を返す。
+// 注文サイドへの変換は Decision レイヤの責務。
+type SignalDirection string
+
+const (
+	DirectionBullish SignalDirection = "BULLISH"
+	DirectionBearish SignalDirection = "BEARISH"
+	DirectionNeutral SignalDirection = "NEUTRAL"
+)
+
+// MarketSignal は Strategy が指標から導いた状況解釈。Direction は方向、
+// Strength は確信度 (0.0–1.0)。Source は由来戦略 (例: "contrarian:rsi")、
+// Reason は人間可読な根拠で recorder が decision_log.signal_reason に書き戻す。
+type MarketSignal struct {
+	SymbolID   int64           `json:"symbolId"`
+	Direction  SignalDirection `json:"direction"`
+	Strength   float64         `json:"strength"`
+	Source     string          `json:"source"`
+	Reason     string          `json:"reason"`
+	Indicators IndicatorSet    `json:"indicators"`
+	Timestamp  int64           `json:"timestamp"`
+}
+
+// MarketSignalEvent は EventBus に流れるイベント。Decision レイヤが購読する。
+// CurrentATR は SignalEvent と同じく warmup 中は 0。
+type MarketSignalEvent struct {
+	Signal     MarketSignal
+	Price      float64
+	CurrentATR float64
+	Timestamp  int64
+}
+
+func (e MarketSignalEvent) EventType() string     { return EventTypeMarketSignal }
+func (e MarketSignalEvent) EventTimestamp() int64 { return e.Timestamp }

--- a/backend/internal/domain/entity/market_signal_test.go
+++ b/backend/internal/domain/entity/market_signal_test.go
@@ -1,0 +1,39 @@
+package entity
+
+import "testing"
+
+func TestSignalDirection_Constants(t *testing.T) {
+	cases := []struct {
+		dir  SignalDirection
+		want string
+	}{
+		{DirectionBullish, "BULLISH"},
+		{DirectionBearish, "BEARISH"},
+		{DirectionNeutral, "NEUTRAL"},
+	}
+	for _, c := range cases {
+		if string(c.dir) != c.want {
+			t.Errorf("got %q, want %q", c.dir, c.want)
+		}
+	}
+}
+
+func TestMarketSignalEvent_EventInterface(t *testing.T) {
+	ev := MarketSignalEvent{
+		Signal:    MarketSignal{Direction: DirectionBullish, Strength: 0.7},
+		Price:     8900.0,
+		Timestamp: 1700000000000,
+	}
+	if got := ev.EventType(); got != EventTypeMarketSignal {
+		t.Errorf("EventType=%q, want %q", got, EventTypeMarketSignal)
+	}
+	if got := ev.EventTimestamp(); got != 1700000000000 {
+		t.Errorf("EventTimestamp=%d, want 1700000000000", got)
+	}
+}
+
+func TestEventTypeMarketSignal_Value(t *testing.T) {
+	if EventTypeMarketSignal != "market_signal" {
+		t.Errorf("EventTypeMarketSignal=%q, want %q", EventTypeMarketSignal, "market_signal")
+	}
+}

--- a/backend/internal/infrastructure/database/backtest_decision_log_repo.go
+++ b/backend/internal/infrastructure/database/backtest_decision_log_repo.go
@@ -40,8 +40,11 @@ func (r *backtestDecisionLogRepo) InsertAndID(ctx context.Context, rec entity.De
 			order_outcome, order_id, executed_amount, executed_price, order_error,
 			closed_position_id, opened_position_id,
 			indicators_json, higher_tf_indicators_json,
+			signal_direction, signal_strength,
+			decision_intent, decision_side, decision_reason,
+			exit_policy_outcome,
 			created_at
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`
 	res, err := r.db.ExecContext(ctx, q,
 		runID,
@@ -54,6 +57,9 @@ func (r *backtestDecisionLogRepo) InsertAndID(ctx context.Context, rec entity.De
 		rec.OrderOutcome, rec.OrderID, rec.ExecutedAmount, rec.ExecutedPrice, rec.OrderError,
 		rec.ClosedPositionID, rec.OpenedPositionID,
 		rec.IndicatorsJSON, rec.HigherTFIndicatorsJSON,
+		rec.SignalDirection, rec.SignalStrength,
+		rec.DecisionIntent, rec.DecisionSide, rec.DecisionReason,
+		rec.ExitPolicyOutcome,
 		rec.CreatedAt,
 	)
 	if err != nil {
@@ -78,6 +84,9 @@ func (r *backtestDecisionLogRepo) Update(ctx context.Context, rec entity.Decisio
 			order_outcome = ?, order_id = ?, executed_amount = ?, executed_price = ?, order_error = ?,
 			closed_position_id = ?, opened_position_id = ?,
 			indicators_json = ?, higher_tf_indicators_json = ?,
+			signal_direction = ?, signal_strength = ?,
+			decision_intent = ?, decision_side = ?, decision_reason = ?,
+			exit_policy_outcome = ?,
 			created_at = ?
 		WHERE id = ?
 	`
@@ -91,6 +100,9 @@ func (r *backtestDecisionLogRepo) Update(ctx context.Context, rec entity.Decisio
 		rec.OrderOutcome, rec.OrderID, rec.ExecutedAmount, rec.ExecutedPrice, rec.OrderError,
 		rec.ClosedPositionID, rec.OpenedPositionID,
 		rec.IndicatorsJSON, rec.HigherTFIndicatorsJSON,
+		rec.SignalDirection, rec.SignalStrength,
+		rec.DecisionIntent, rec.DecisionSide, rec.DecisionReason,
+		rec.ExitPolicyOutcome,
 		rec.CreatedAt,
 		rec.ID,
 	)
@@ -129,6 +141,9 @@ func (r *backtestDecisionLogRepo) ListByRun(ctx context.Context, runID string, l
 		       order_outcome, order_id, executed_amount, executed_price, order_error,
 		       closed_position_id, opened_position_id,
 		       indicators_json, higher_tf_indicators_json,
+		       signal_direction, signal_strength,
+		       decision_intent, decision_side, decision_reason,
+		       exit_policy_outcome,
 		       created_at
 		FROM backtest_decision_log
 		WHERE %s
@@ -155,6 +170,9 @@ func (r *backtestDecisionLogRepo) ListByRun(ctx context.Context, runID string, l
 			&rec.OrderOutcome, &rec.OrderID, &rec.ExecutedAmount, &rec.ExecutedPrice, &rec.OrderError,
 			&rec.ClosedPositionID, &rec.OpenedPositionID,
 			&rec.IndicatorsJSON, &rec.HigherTFIndicatorsJSON,
+			&rec.SignalDirection, &rec.SignalStrength,
+			&rec.DecisionIntent, &rec.DecisionSide, &rec.DecisionReason,
+			&rec.ExitPolicyOutcome,
 			&rec.CreatedAt,
 		); err != nil {
 			return nil, 0, fmt.Errorf("backtest_decision_log scan: %w", err)

--- a/backend/internal/infrastructure/database/backtest_decision_log_repo_test.go
+++ b/backend/internal/infrastructure/database/backtest_decision_log_repo_test.go
@@ -147,3 +147,60 @@ func TestBacktestDecisionLogRepo_DeleteOlderThan(t *testing.T) {
 		t.Errorf("old rows = %d, want 0", len(rowsOld))
 	}
 }
+
+// TestBacktestDecisionLogRepo_PhaseOneColumnsRoundTrip: Phase 1 で追加した
+// 6 カラムが INSERT → SELECT で往復し、Update でも上書きできることを確認。
+func TestBacktestDecisionLogRepo_PhaseOneColumnsRoundTrip(t *testing.T) {
+	tmpDir := t.TempDir()
+	db, err := NewDB(filepath.Join(tmpDir, "test.db"))
+	if err != nil {
+		t.Fatalf("NewDB: %v", err)
+	}
+	defer db.Close()
+	if err := RunMigrations(db); err != nil {
+		t.Fatalf("RunMigrations: %v", err)
+	}
+
+	repo := &backtestDecisionLogRepo{db: db}
+	ctx := context.Background()
+
+	rec := sampleBacktestDecisionRecord(1745654700000, time.Now().UnixMilli())
+	rec.SignalDirection = "BEARISH"
+	rec.SignalStrength = 0.55
+	rec.DecisionIntent = "EXIT_CANDIDATE"
+	rec.DecisionSide = "SELL"
+	rec.DecisionReason = "rsi overbought"
+	rec.ExitPolicyOutcome = "VETOED"
+
+	id, err := repo.InsertAndID(ctx, rec, "run-phase1")
+	if err != nil {
+		t.Fatalf("InsertAndID: %v", err)
+	}
+
+	rows, _, err := repo.ListByRun(ctx, "run-phase1", 10, 0)
+	if err != nil {
+		t.Fatalf("ListByRun: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("want 1 row, got %d", len(rows))
+	}
+	got := rows[0]
+	if got.SignalDirection != "BEARISH" || got.SignalStrength != 0.55 ||
+		got.DecisionIntent != "EXIT_CANDIDATE" || got.DecisionSide != "SELL" ||
+		got.DecisionReason != "rsi overbought" || got.ExitPolicyOutcome != "VETOED" {
+		t.Errorf("Phase 1 round-trip mismatch: %+v", got)
+	}
+
+	// Update でも Phase 1 カラムが反映されること。
+	got.ID = id
+	got.SignalDirection = "BULLISH"
+	got.DecisionIntent = "NEW_ENTRY"
+	got.DecisionSide = "BUY"
+	if err := repo.Update(ctx, got); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	rows, _, _ = repo.ListByRun(ctx, "run-phase1", 10, 0)
+	if rows[0].SignalDirection != "BULLISH" || rows[0].DecisionIntent != "NEW_ENTRY" || rows[0].DecisionSide != "BUY" {
+		t.Errorf("Update did not persist Phase 1 fields, got %+v", rows[0])
+	}
+}

--- a/backend/internal/infrastructure/database/decision_log_repo.go
+++ b/backend/internal/infrastructure/database/decision_log_repo.go
@@ -42,8 +42,11 @@ func (r *decisionLogRepo) InsertAndID(ctx context.Context, rec entity.DecisionRe
 			order_outcome, order_id, executed_amount, executed_price, order_error,
 			closed_position_id, opened_position_id,
 			indicators_json, higher_tf_indicators_json,
+			signal_direction, signal_strength,
+			decision_intent, decision_side, decision_reason,
+			exit_policy_outcome,
 			created_at
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`
 	res, err := r.db.ExecContext(ctx, q,
 		rec.BarCloseAt, rec.SequenceInBar, rec.TriggerKind,
@@ -55,6 +58,9 @@ func (r *decisionLogRepo) InsertAndID(ctx context.Context, rec entity.DecisionRe
 		rec.OrderOutcome, rec.OrderID, rec.ExecutedAmount, rec.ExecutedPrice, rec.OrderError,
 		rec.ClosedPositionID, rec.OpenedPositionID,
 		rec.IndicatorsJSON, rec.HigherTFIndicatorsJSON,
+		rec.SignalDirection, rec.SignalStrength,
+		rec.DecisionIntent, rec.DecisionSide, rec.DecisionReason,
+		rec.ExitPolicyOutcome,
 		rec.CreatedAt,
 	)
 	if err != nil {
@@ -79,6 +85,9 @@ func (r *decisionLogRepo) Update(ctx context.Context, rec entity.DecisionRecord)
 			order_outcome = ?, order_id = ?, executed_amount = ?, executed_price = ?, order_error = ?,
 			closed_position_id = ?, opened_position_id = ?,
 			indicators_json = ?, higher_tf_indicators_json = ?,
+			signal_direction = ?, signal_strength = ?,
+			decision_intent = ?, decision_side = ?, decision_reason = ?,
+			exit_policy_outcome = ?,
 			created_at = ?
 		WHERE id = ?
 	`
@@ -92,6 +101,9 @@ func (r *decisionLogRepo) Update(ctx context.Context, rec entity.DecisionRecord)
 		rec.OrderOutcome, rec.OrderID, rec.ExecutedAmount, rec.ExecutedPrice, rec.OrderError,
 		rec.ClosedPositionID, rec.OpenedPositionID,
 		rec.IndicatorsJSON, rec.HigherTFIndicatorsJSON,
+		rec.SignalDirection, rec.SignalStrength,
+		rec.DecisionIntent, rec.DecisionSide, rec.DecisionReason,
+		rec.ExitPolicyOutcome,
 		rec.CreatedAt,
 		rec.ID,
 	)
@@ -144,6 +156,9 @@ func (r *decisionLogRepo) List(ctx context.Context, f repository.DecisionLogFilt
 		       order_outcome, order_id, executed_amount, executed_price, order_error,
 		       closed_position_id, opened_position_id,
 		       indicators_json, higher_tf_indicators_json,
+		       signal_direction, signal_strength,
+		       decision_intent, decision_side, decision_reason,
+		       exit_policy_outcome,
 		       created_at
 		FROM decision_log
 		WHERE %s
@@ -170,6 +185,9 @@ func (r *decisionLogRepo) List(ctx context.Context, f repository.DecisionLogFilt
 			&rec.OrderOutcome, &rec.OrderID, &rec.ExecutedAmount, &rec.ExecutedPrice, &rec.OrderError,
 			&rec.ClosedPositionID, &rec.OpenedPositionID,
 			&rec.IndicatorsJSON, &rec.HigherTFIndicatorsJSON,
+			&rec.SignalDirection, &rec.SignalStrength,
+			&rec.DecisionIntent, &rec.DecisionSide, &rec.DecisionReason,
+			&rec.ExitPolicyOutcome,
 			&rec.CreatedAt,
 		); err != nil {
 			return nil, 0, fmt.Errorf("decision_log scan: %w", err)

--- a/backend/internal/infrastructure/database/decision_log_repo_test.go
+++ b/backend/internal/infrastructure/database/decision_log_repo_test.go
@@ -146,3 +146,119 @@ func TestDecisionLogRepo_FilterByTimeRange(t *testing.T) {
 		t.Errorf("len = %d, want 3 (inclusive on both ends)", len(rows))
 	}
 }
+
+// TestDecisionLogRepo_PhaseOneColumnsRoundTrip: Phase 1 で追加した 6 カラムが
+// INSERT → SELECT でそのまま往復することを確認 (値あり / ゼロ値の両方)。
+func TestDecisionLogRepo_PhaseOneColumnsRoundTrip(t *testing.T) {
+	tmpDir := t.TempDir()
+	db, err := NewDB(filepath.Join(tmpDir, "test.db"))
+	if err != nil {
+		t.Fatalf("NewDB: %v", err)
+	}
+	defer db.Close()
+	if err := RunMigrations(db); err != nil {
+		t.Fatalf("RunMigrations: %v", err)
+	}
+
+	repo := NewDecisionLogRepository(db)
+	ctx := context.Background()
+
+	// Case 1: 値ありで往復。
+	withValues := newDecisionRecord(7, 1745654700000, 0)
+	withValues.SignalDirection = "BULLISH"
+	withValues.SignalStrength = 0.72
+	withValues.DecisionIntent = "NEW_ENTRY"
+	withValues.DecisionSide = "BUY"
+	withValues.DecisionReason = "rsi oversold; trend up"
+	withValues.ExitPolicyOutcome = "ALLOWED"
+
+	if err := repo.Insert(ctx, withValues); err != nil {
+		t.Fatalf("Insert (values): %v", err)
+	}
+
+	// Case 2: ゼロ値のまま (PR1 中の通常パス)。
+	zero := newDecisionRecord(7, 1745654700000+900_000, 0)
+	if err := repo.Insert(ctx, zero); err != nil {
+		t.Fatalf("Insert (zero): %v", err)
+	}
+
+	rows, _, err := repo.List(ctx, repository.DecisionLogFilter{SymbolID: 7, Limit: 10})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("got %d rows, want 2", len(rows))
+	}
+
+	// rows は新しい順なので、index 0 が zero, index 1 が withValues。
+	gotZero := rows[0]
+	if gotZero.SignalDirection != "" || gotZero.SignalStrength != 0 ||
+		gotZero.DecisionIntent != "" || gotZero.DecisionSide != "" ||
+		gotZero.DecisionReason != "" || gotZero.ExitPolicyOutcome != "" {
+		t.Errorf("zero-value row should have empty Phase 1 fields, got %+v", gotZero)
+	}
+
+	got := rows[1]
+	if got.SignalDirection != "BULLISH" {
+		t.Errorf("SignalDirection = %q, want BULLISH", got.SignalDirection)
+	}
+	if got.SignalStrength != 0.72 {
+		t.Errorf("SignalStrength = %v, want 0.72", got.SignalStrength)
+	}
+	if got.DecisionIntent != "NEW_ENTRY" {
+		t.Errorf("DecisionIntent = %q, want NEW_ENTRY", got.DecisionIntent)
+	}
+	if got.DecisionSide != "BUY" {
+		t.Errorf("DecisionSide = %q, want BUY", got.DecisionSide)
+	}
+	if got.DecisionReason != "rsi oversold; trend up" {
+		t.Errorf("DecisionReason = %q, want rsi oversold; trend up", got.DecisionReason)
+	}
+	if got.ExitPolicyOutcome != "ALLOWED" {
+		t.Errorf("ExitPolicyOutcome = %q, want ALLOWED", got.ExitPolicyOutcome)
+	}
+}
+
+// TestDecisionLogRepo_UpdatePreservesPhaseOneColumns: Update で Phase 1 カラムが
+// 上書きされることを確認 (PR2 で recorder が後から値を埋める想定)。
+func TestDecisionLogRepo_UpdatePreservesPhaseOneColumns(t *testing.T) {
+	tmpDir := t.TempDir()
+	db, err := NewDB(filepath.Join(tmpDir, "test.db"))
+	if err != nil {
+		t.Fatalf("NewDB: %v", err)
+	}
+	defer db.Close()
+	if err := RunMigrations(db); err != nil {
+		t.Fatalf("RunMigrations: %v", err)
+	}
+
+	repo := NewDecisionLogRepository(db)
+	ctx := context.Background()
+
+	rec := newDecisionRecord(7, 1745654700000, 0)
+	id, err := repo.InsertAndID(ctx, rec)
+	if err != nil {
+		t.Fatalf("InsertAndID: %v", err)
+	}
+
+	rec.ID = id
+	rec.SignalDirection = "BEARISH"
+	rec.DecisionIntent = "EXIT_CANDIDATE"
+	rec.DecisionSide = "SELL"
+	rec.DecisionReason = "trailing stop trigger"
+	if err := repo.Update(ctx, rec); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	rows, _, err := repo.List(ctx, repository.DecisionLogFilter{SymbolID: 7, Limit: 1})
+	if err != nil {
+		t.Fatalf("List after update: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("want 1 row, got %d", len(rows))
+	}
+	if rows[0].SignalDirection != "BEARISH" || rows[0].DecisionIntent != "EXIT_CANDIDATE" ||
+		rows[0].DecisionSide != "SELL" || rows[0].DecisionReason != "trailing stop trigger" {
+		t.Errorf("Update did not persist Phase 1 fields, got %+v", rows[0])
+	}
+}

--- a/backend/internal/infrastructure/database/migrations.go
+++ b/backend/internal/infrastructure/database/migrations.go
@@ -505,5 +505,34 @@ func RunMigrations(db *sql.DB) error {
 		}
 	}
 
+	if err := addDecisionLogV2Columns(db); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// addDecisionLogV2Columns は Phase 1 (Signal/Decision/ExecutionPolicy 三層分離)
+// で追加された 6 カラムを decision_log / backtest_decision_log に足す。
+// addColumnIfNotExists を介して冪等。既存行は DEFAULT (空文字 / 0) で残る。
+func addDecisionLogV2Columns(db *sql.DB) error {
+	cols := []struct {
+		name string
+		def  string
+	}{
+		{"signal_direction", "signal_direction TEXT NOT NULL DEFAULT ''"},
+		{"signal_strength", "signal_strength REAL NOT NULL DEFAULT 0"},
+		{"decision_intent", "decision_intent TEXT NOT NULL DEFAULT ''"},
+		{"decision_side", "decision_side TEXT NOT NULL DEFAULT ''"},
+		{"decision_reason", "decision_reason TEXT NOT NULL DEFAULT ''"},
+		{"exit_policy_outcome", "exit_policy_outcome TEXT NOT NULL DEFAULT ''"},
+	}
+	for _, table := range []string{"decision_log", "backtest_decision_log"} {
+		for _, c := range cols {
+			if err := addColumnIfNotExists(db, table, c.name, c.def); err != nil {
+				return fmt.Errorf("add %s.%s: %w", table, c.name, err)
+			}
+		}
+	}
 	return nil
 }

--- a/backend/internal/infrastructure/database/migrations_test.go
+++ b/backend/internal/infrastructure/database/migrations_test.go
@@ -336,3 +336,116 @@ func TestRunMigrations_DecisionLogTablesAndIndexes(t *testing.T) {
 		}
 	}
 }
+
+// TestRunMigrations_DecisionLogV2Columns: Phase 1 (Signal/Decision/ExecutionPolicy
+// 三層分離) で追加した 6 カラムが decision_log と backtest_decision_log の両方に
+// 存在することを確認。冪等性、既存データ保護も検証。
+func TestRunMigrations_DecisionLogV2Columns(t *testing.T) {
+	tmpDir := t.TempDir()
+	db, err := NewDB(filepath.Join(tmpDir, "test.db"))
+	if err != nil {
+		t.Fatalf("failed to create db: %v", err)
+	}
+	defer db.Close()
+
+	if err := RunMigrations(db); err != nil {
+		t.Fatalf("first migration failed: %v", err)
+	}
+
+	// 既存データを 1 行入れて、2 度目の migration でも残ることを確認 (ALTER TABLE 安全性)。
+	_, err = db.Exec(`INSERT INTO decision_log (
+		bar_close_at, sequence_in_bar, trigger_kind,
+		symbol_id, currency_pair, primary_interval,
+		stance, last_price, signal_action,
+		risk_outcome, order_outcome, created_at
+	) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		1700000000000, 0, "BAR_CLOSE",
+		1, "LTC_JPY", "PT15M",
+		"TREND_FOLLOW", 8900.0, "BUY",
+		"APPROVED", "FILLED", 1700000000000)
+	if err != nil {
+		t.Fatalf("insert pre-migration row failed: %v", err)
+	}
+
+	// 2 度実行しても壊れないことを確認 (冪等性)。
+	if err := RunMigrations(db); err != nil {
+		t.Fatalf("second migration failed: %v", err)
+	}
+
+	// データが残っていることを確認。
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM decision_log`).Scan(&count); err != nil {
+		t.Fatalf("count after second migration: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("decision_log row count = %d, want 1 (data lost during migration)", count)
+	}
+
+	// 既存行の新カラムが DEFAULT 値になっていることを確認。
+	var (
+		signalDirection   string
+		signalStrength    float64
+		decisionIntent    string
+		decisionSide      string
+		decisionReason    string
+		exitPolicyOutcome string
+	)
+	err = db.QueryRow(`SELECT signal_direction, signal_strength, decision_intent,
+		decision_side, decision_reason, exit_policy_outcome FROM decision_log`).
+		Scan(&signalDirection, &signalStrength, &decisionIntent,
+			&decisionSide, &decisionReason, &exitPolicyOutcome)
+	if err != nil {
+		t.Fatalf("select new columns: %v", err)
+	}
+	if signalDirection != "" || decisionIntent != "" || decisionSide != "" ||
+		decisionReason != "" || exitPolicyOutcome != "" {
+		t.Errorf("new TEXT columns should default to empty, got dir=%q intent=%q side=%q reason=%q exit=%q",
+			signalDirection, decisionIntent, decisionSide, decisionReason, exitPolicyOutcome)
+	}
+	if signalStrength != 0 {
+		t.Errorf("signal_strength should default to 0, got %v", signalStrength)
+	}
+
+	// 新カラムが両テーブルに存在することを PRAGMA で確認。
+	wantNewCols := []string{
+		"signal_direction",
+		"signal_strength",
+		"decision_intent",
+		"decision_side",
+		"decision_reason",
+		"exit_policy_outcome",
+	}
+	for _, table := range []string{"decision_log", "backtest_decision_log"} {
+		seen := make(map[string]bool, len(wantNewCols))
+		for _, c := range wantNewCols {
+			seen[c] = false
+		}
+		rows, err := db.Query("PRAGMA table_info(" + table + ")")
+		if err != nil {
+			t.Fatalf("pragma table_info(%s): %v", table, err)
+		}
+		for rows.Next() {
+			var (
+				cid     int
+				name    string
+				ctype   string
+				notnull int
+				dflt    interface{}
+				pk      int
+			)
+			if err := rows.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk); err != nil {
+				rows.Close()
+				t.Fatalf("scan table_info(%s): %v", table, err)
+			}
+			if _, ok := seen[name]; ok {
+				seen[name] = true
+			}
+		}
+		rows.Close()
+		for c, ok := range seen {
+			if !ok {
+				t.Errorf("expected column %q in %s", c, table)
+			}
+		}
+	}
+}

--- a/docs/design/2026-04-29-signal-decision-policy-separation-design.md
+++ b/docs/design/2026-04-29-signal-decision-policy-separation-design.md
@@ -1,0 +1,487 @@
+# Signal / Decision / ExecutionPolicy 三層分離 設計
+
+- 作成日: 2026-04-29
+- 著者: 共同 (Daisy + Claude)
+- ステータス: ドラフト (レビュー前)
+- 関連 Issue: #221 (BookGate disabled)、`MEMORY.md` の "/status running は嘘をつく"
+- 関連 PR: TBD (stacked、Phase 1〜5)
+
+---
+
+## 1. 背景と問題提起
+
+### 1.1 きっかけになった事象
+
+2026-04-28 23:45〜2026-04-29 12:15 (LTC/JPY、production_ltc_60k 運用) で、CONTRARIAN 戦略が連続して BUY → SELL シグナルを生成したが、いずれも `risk_outcome=REJECTED` で却下された。decision_log の risk_reason は全て同じ：
+
+```
+position limit exceeded: 10613+1750 > 12000   (BUY 連発時)
+position limit exceeded: 10613+2665 > 12000   (SELL 連発時)
+```
+
+### 1.2 直接原因
+
+`backend/internal/usecase/risk.go:174-180` の `MaxPositionAmount` ガードは、**新規発注 side を考慮せず、既存ポジション評価額に発注額を単純加算して判定している**。既存ロング ¥10,613 を保有中に、反対側の SELL ¥2,665 を出そうとすると合計 ¥13,278 として扱われ、12,000 上限を超えるため拒否された。
+
+本来であれば：
+- 既存ロングの**決済 (close)** であれば `IsClose=true` 経路で素通り (現行コード `risk.go:144-146` で対応済み)
+- **新規ショート (open)** であればネットエクスポージャ |ロング - ショート| = ¥7,948 で枠内
+- どちらでも通るべき発注が、両建て総額判定で全て弾かれた
+
+### 1.3 構造的問題
+
+直接原因を symptom-fix で直すこともできる (case-by-case で risk.go を直す) が、根は構造にある：
+
+**Signal レイヤが状況解釈と意思決定を兼ねている**
+
+現状の `StrategyHandler` は IndicatorEvent を受けて `SignalEvent{Signal{Action: BUY|SELL|HOLD}}` を吐く。この `Action` の意味論は文脈依存で曖昧：
+
+- 「ロング保有なし」での SELL → 新規ショート開設
+- 「ロング保有中」での SELL → 利確 close を期待される (が、現実装は新規ショートとして risk に投げられる)
+- 「ショート保有中」での SELL → 増し玉
+
+受け手 (RiskHandler / ExecutionHandler) が「この SELL がどの SELL なのか」を逆算する仕組みになっていない。結果として：
+
+1. **Risk チェックが side 不可知のまま総額判定**: 上記バグ
+2. **Stance / Signal の反対方向が exit 候補として機能しない**: 出口は ATR ベース TP/SL 専属で、シグナルの反転を見ない
+3. **テスト容易性が低い**: "状況解釈"と"意思決定"が同じ関数の中に閉じている
+
+### 1.4 ユーザ要件 (本設計の出発点)
+
+ユーザとの議論で確定した方針：
+
+- **シグナル ≠ 売却の合図**。シグナルはあくまで「これから取りたい新規エントリー方向」を表すものとする
+- **売却 (利確/損切り) は別ロジック**。既存の TP/SL/Trailing をそのまま信頼する
+- **売却後の再エントリーは別判断**。close 直後にすぐ次の発注を出すことはしない (cooldown)
+- **市場インパクトを最小化したい**。LTC/JPY 楽天 CFD は板が薄く、自分の発注で価格が動きやすい
+- **理想構造を採用する**。既存実装からの最小差分ではなく、システムとして整合する設計を選ぶ
+
+---
+
+## 2. ゴール
+
+### 2.1 アーキテクチャ目標
+
+`Signal` / `Decision` / `ExecutionPolicy` の三層分離を導入する：
+
+1. **Signal レイヤ**: 市況の解釈に専念。`Direction (BULLISH/BEARISH/NEUTRAL)` と `Strength (0.0-1.0)` のみを返す。`BUY/SELL` の言語は持たない
+2. **Decision レイヤ**: Signal とポジション保有状況、cooldown 状態を組み合わせて `Intent (NEW_ENTRY/EXIT_CANDIDATE/HOLD/COOLDOWN_BLOCKED)` と `Side (BUY/SELL)` を決める
+3. **ExecutionPolicy レイヤ**: Decision を受け、Risk チェック、BookGate チェックを通したうえで Order に落とす
+
+### 2.2 機能要件
+
+- ロング保有中に CONTRARIAN BEARISH シグナルが発生しても、両建て総額判定で誤拒否されない
+- close (= EXIT_CANDIDATE) 直後 N 秒は新規エントリーを抑制する (open 同士の cooldown は無し)
+- BookGate (`booklimit.Gate`) を production_ltc_60k で有効化する
+- 出口ロジック (TP/SL/Trailing) は変更しない
+- backtest と live が同じレイヤ構成・同じ判定ロジックで動く
+
+### 2.3 非機能要件
+
+- 既存 decision_log のスキーマは破壊しない (新カラム追加のみ)
+- 既存 UI (history タブ等) は Phase 1〜4 中も継続して動く
+- backtest の過去結果と新ロジックの結果がパフォーマンス指標 (Return, MaxDD, etc.) で大きく乖離しないこと (本質的には決済タイミングが変わっていないため、同等のはず)
+
+---
+
+## 3. 非ゴール
+
+以下は本設計の対象外とする：
+
+- **出口ロジックの拡張**: TP/SL/Trailing 以外の出口判定 (例: signal 反転を exit 条件にする) は将来課題
+- **指値 close API の実装**: 現状 `OrderExecutor.ClosePosition` は成行のみ。指値での close 機能拡張は別 PR
+- **複数銘柄対応の見直し**: シンボル横断ポジション集計、ヘッジ運用などは将来課題
+- **既存プロファイルの数値最適化**: パラメータ sweep は PDCA の仕事であって、本設計のスコープではない
+- **楽天 API 直叩きでの手動 close フロー**: 本設計後は bot 経由で完結する想定
+- **/positions と /risk/status の整合性問題** (in-memory positions と exchange-side のずれ): 別途切り出す
+
+---
+
+## 4. アーキテクチャ
+
+### 4.1 三層の責務
+
+```
+┌──────────────────────────────────────────────────────────┐
+│ 1. Signal レイヤ (StrategyHandler)                        │
+│    入力: IndicatorEvent                                    │
+│    出力: MarketSignalEvent                                │
+│    責務: 指標の状況解釈のみ。Direction / Strength を吐く  │
+│         BUY/SELL の言語は使わない                          │
+└──────────────────────────────────────────────────────────┘
+                          ↓ MarketSignalEvent
+┌──────────────────────────────────────────────────────────┐
+│ 2. Decision レイヤ (DecisionHandler ← 新設)               │
+│    入力: MarketSignalEvent + 現在のポジション + cooldown   │
+│    出力: ActionDecisionEvent                              │
+│    責務: Direction を Intent + Side に翻訳                │
+│      - 保有なし + BULLISH        → NEW_ENTRY/BUY          │
+│      - 保有なし + BEARISH        → NEW_ENTRY/SELL         │
+│      - ロング中 + BEARISH        → EXIT_CANDIDATE/SELL    │
+│        (※ Phase 1 では HOLD として扱う。実 exit は       │
+│         TP/SL に任せる。Phase 2 以降に exit 拡張余地)     │
+│      - ロング中 + BULLISH        → HOLD (増し玉しない)    │
+│      - cooldown 中              → COOLDOWN_BLOCKED        │
+│      - NEUTRAL                   → HOLD                    │
+└──────────────────────────────────────────────────────────┘
+                          ↓ ActionDecisionEvent
+┌──────────────────────────────────────────────────────────┐
+│ 3. ExecutionPolicy レイヤ                                 │
+│    (RiskHandler + BookGate, 既存 OrderExecutor)           │
+│    入力: ActionDecisionEvent                              │
+│    出力: ApprovedDecisionEvent / RejectedDecisionEvent    │
+│         → OrderExecutor で実発注                          │
+│    責務:                                                   │
+│      - サイジング (riskMgr.SizeOrder)                     │
+│      - Risk ガード (残高、daily loss、cooldown 残り等)    │
+│      - BookGate (板厚、想定スリッページ)                  │
+│      - cooldown 状態の更新 (close 約定検知 → cooldown 開始)│
+└──────────────────────────────────────────────────────────┘
+```
+
+### 4.2 EventBus 配線
+
+既存 priority 体系に乗せる。`backend/internal/usecase/backtest/runner.go:276-` の登録順を踏襲。
+
+```
+EventTypeCandle      → priority 5  : tickGenerator
+EventTypeCandle      → priority 10 : indicatorHandler
+EventTypeIndicator   → priority 12 : tickRiskHandler (TP/SL 用、変更なし)
+EventTypeTick        → priority 15 : tickRiskHandler (TP/SL 用、変更なし)
+EventTypeIndicator   → priority 20 : strategyHandler ← (Direction/Strength のみに変更)
+EventTypeMarketSig   → priority 25 : decisionHandler ← (新設)
+EventTypeDecision    → priority 30 : riskHandler     ← (リネーム + Decision 受け取りに変更)
+EventTypeApproved    → priority 40 : executionHandler
+EventTypeIndicator   → priority 25 : indicatorEventTap (recorder 用、変更なし)
+EventTypeXxx         → priority 99 : recorder (新 Event を購読するよう拡張)
+```
+
+priority 25 が indicatorEventTap と decisionHandler で重複する場合は、decision を 27、tap を 25 のまま等で調整する (実装時に確認)。
+
+### 4.3 Cooldown の所在
+
+Cooldown 状態は **RiskManager** に持たせる。理由：
+
+- 既存の `cooldownUntil`, `consecutiveLosses` 等のフィールドが既にある
+- DecisionHandler は自分自身の状態を持たない (RiskManager から保有・cooldown を読むだけ)。ハンドラ自体はテスト時に mockable な依存注入の形にする
+- ExecutionHandler が close 約定を検知した時に `RiskManager.NoteClose()` を呼ぶ → RiskManager が `entryCooldownUntil` を更新
+
+DecisionHandler は判定時に `RiskManager.IsEntryCooldown(now)` を読むだけ。
+
+---
+
+## 5. 主要 entity / 型の変更
+
+### 5.1 新規型
+
+```go
+// backend/internal/domain/entity/market_signal.go (新規ファイル)
+
+type SignalDirection string
+
+const (
+    DirectionBullish SignalDirection = "BULLISH"
+    DirectionBearish SignalDirection = "BEARISH"
+    DirectionNeutral SignalDirection = "NEUTRAL"
+)
+
+type MarketSignal struct {
+    SymbolID   int64
+    Direction  SignalDirection
+    Strength   float64 // 0.0 - 1.0
+    Source     string  // "contrarian:rsi_overbought" など
+    Reason     string  // 既存 signal_reason と同等
+    Indicators IndicatorSet
+}
+
+type MarketSignalEvent struct {
+    Signal     MarketSignal
+    Price      float64
+    CurrentATR float64
+    Timestamp  int64
+}
+
+func (e MarketSignalEvent) EventType() string     { return EventTypeMarketSignal }
+func (e MarketSignalEvent) EventTimestamp() int64 { return e.Timestamp }
+```
+
+```go
+// backend/internal/domain/entity/decision.go に追記
+
+type DecisionIntent string
+
+const (
+    IntentNewEntry        DecisionIntent = "NEW_ENTRY"
+    IntentExitCandidate   DecisionIntent = "EXIT_CANDIDATE"
+    IntentHold            DecisionIntent = "HOLD"
+    IntentCooldownBlocked DecisionIntent = "COOLDOWN_BLOCKED"
+)
+
+type ActionDecision struct {
+    SymbolID  int64
+    Intent    DecisionIntent
+    Side      OrderSide // BUY | SELL (Intent=HOLD/COOLDOWN_BLOCKED の時は空文字)
+    Reason    string
+    Source    string    // 由来の signal source を継承
+    Strength  float64   // 由来の signal strength を継承 (sizer が参照)
+}
+
+type ActionDecisionEvent struct {
+    Decision   ActionDecision
+    Price      float64
+    CurrentATR float64
+    Timestamp  int64
+}
+```
+
+### 5.2 EventType 追加
+
+```go
+// backend/internal/domain/entity/backtest_event.go
+
+const (
+    // ... 既存
+    EventTypeMarketSignal = "market_signal"
+    EventTypeDecision     = "decision"
+)
+```
+
+### 5.3 既存 `Signal` 型の扱い
+
+既存 `entity.Signal{Action, Confidence, Reason}` は **削除しない**。SignalEvent → MarketSignalEvent への移行 PR で並行存続させ、Phase 5 で deprecated コメントを付ける。完全削除は Phase 6+ の cleanup PR で。Phase 3 でルート (EventBus 配線) は新ルート一本化するが、型定義自体はしばらく残す。
+
+### 5.4 RiskManager の拡張
+
+```go
+// backend/internal/usecase/risk.go
+
+type RiskManager struct {
+    // ... 既存
+    entryCooldownUntil time.Time // 新規。close 約定後に伸ばす
+}
+
+// 新メソッド
+func (rm *RiskManager) IsEntryCooldown(now time.Time) bool {
+    rm.mu.RLock()
+    defer rm.mu.RUnlock()
+    return now.Before(rm.entryCooldownUntil)
+}
+
+func (rm *RiskManager) NoteClose(now time.Time) {
+    rm.mu.Lock()
+    defer rm.mu.Unlock()
+    cooldown := time.Duration(rm.config.EntryCooldownSec) * time.Second
+    rm.entryCooldownUntil = now.Add(cooldown)
+}
+```
+
+### 5.5 RiskConfig の拡張
+
+```go
+type RiskConfig struct {
+    // ... 既存
+    EntryCooldownSec int // 0 → cooldown 無効、既定 60
+    MaxSlippageBps   int // 既存だがプロファイル未設定なら 0
+    MaxBookSidePct   int // 既存だがプロファイル未設定なら 0
+}
+```
+
+### 5.6 decision_log スキーマ追加 (互換維持)
+
+```sql
+ALTER TABLE decision_log ADD COLUMN signal_direction    TEXT NOT NULL DEFAULT '';
+ALTER TABLE decision_log ADD COLUMN signal_strength     REAL NOT NULL DEFAULT 0;
+ALTER TABLE decision_log ADD COLUMN decision_intent     TEXT NOT NULL DEFAULT '';
+ALTER TABLE decision_log ADD COLUMN decision_side       TEXT NOT NULL DEFAULT '';
+ALTER TABLE decision_log ADD COLUMN decision_reason     TEXT NOT NULL DEFAULT '';
+ALTER TABLE decision_log ADD COLUMN exit_policy_outcome TEXT NOT NULL DEFAULT '';
+-- backtest_decision_log にも同じ ALTER を当てる
+```
+
+旧カラム (`signal_action`, `signal_confidence`, `signal_reason`) は引き続き埋める。新ロジックでは：
+- `signal_action` ← `decision_side` (Intent=HOLD/COOLDOWN_BLOCKED の時は "HOLD")
+- `signal_confidence` ← `signal_strength`
+- `signal_reason` ← `decision_reason` で上書きせず、由来の `signal.Reason` を維持
+
+---
+
+## 6. 移行計画 (Stacked PR)
+
+各 PR は独立してレビュー可能・main にマージ可能な粒度を保つ。間で本番運用ゲートは挟まない (ユーザ方針 = B)。
+
+### PR1: entity / event 型の追加 (互換維持)
+
+- `MarketSignal`, `MarketSignalEvent`, `ActionDecision`, `ActionDecisionEvent` を新規追加
+- `EventTypeMarketSignal`, `EventTypeDecision` を定数追加
+- 既存 `Signal` / `SignalEvent` は touch しない
+- decision_log への ALTER TABLE migration を追加 (新カラムは空文字 / 0)
+- recorder は新カラムを書き込めるようにフィールド追加 (Phase 1 中は空のまま)
+- **動作不変**: 既存 backtest / live は何も変わらない
+- テスト: 新型の単純な構築テストだけ
+
+### PR2: Decision レイヤ新設 + StrategyHandler 改修
+
+- `DecisionHandler` を新規追加 (`backend/internal/usecase/decision/handler.go`)
+- `StrategyHandler` を改修：従来の `Signal{Action}` を出すパスに加えて、`MarketSignal{Direction, Strength}` も並列で publish できるようにする
+- backtest / live の runner で：
+  - `EventTypeIndicator → strategyHandler` (旧)
+  - `EventTypeMarketSignal → decisionHandler` (新)
+  - `EventTypeDecision → riskHandler` を新ルートとして配線
+  - 既存 `EventTypeSignal → riskHandler` ルートも当面残す (後段の PR で削除)
+- **動作不変**: 旧ルート (Signal 経由) が引き続き有効。新ルートは shadow 動作 (decision_log の新カラムに記録するだけ) で並走
+- recorder が `MarketSignalEvent` / `ActionDecisionEvent` を購読し、新カラムを埋め始める
+- テスト: DecisionHandler の単体テスト (保有状況 × Direction × cooldown のマトリクス)
+
+### PR3: RiskHandler の Decision 化 + cooldown 実装
+
+- `RiskHandler` を `ActionDecisionEvent` を入力とするように改修
+- `RiskManager` に `EntryCooldownSec`, `IsEntryCooldown`, `NoteClose` を追加
+- `OrderExecutor.ClosePosition` 約定後に `RiskManager.NoteClose()` を呼ぶ配線
+- 既存ルート (`EventTypeSignal → riskHandler`) を削除し、新ルートに一本化
+- **動作変更**: ここで意味論が切り替わる。両建て総額判定バグが解消される
+- テスト:
+  - 旧バグ再現テスト (ロング保有中の BEARISH → 旧コードで REJECTED、新コードで EXIT_CANDIDATE → HOLD)
+  - cooldown 動作テスト (close → N 秒以内の new entry が COOLDOWN_BLOCKED になる)
+
+### PR4: BookGate 有効化 + テスト拡充
+
+- `production_ltc_60k.json` に `MaxSlippageBps`, `MaxBookSidePct` を追加 (初期値: bps=15, sidepct=20)
+- `production.json` (= production_ltc_60k 系列) の同設定値を揃える
+- live (event_pipeline.go) と backtest (runner.go) で BookGate が同じ条件で有効化されることを確認するテストを追加
+- BookGate のエッジケーステスト追加 (snapshot stale, snapshot empty, top-N 不足)
+- **動作変更**: 板厚不足時に BookGate で REJECTED され始める
+- テスト: 既存の `book_limit_test.go` を拡充
+
+### PR5: UI / 旧型 deprecate / cleanup
+
+- frontend の history タブで `decision_intent` / `signal_direction` を表示
+- "REJECTED (両建て総額)" だった行が "HOLD (保有中)" or "COOLDOWN_BLOCKED" に変わるはずなので UI 文言調整
+- `entity.Signal{Action}` の使用箇所を `MarketSignal` / `ActionDecision` に置換、deprecated コメント追加
+- 完全削除はせず Phase 6+ で別途 (互換維持目的)
+- ドキュメント更新: AGENTS.md, docs/clean-architecture.md, docs/decision-log-health-check.md
+
+---
+
+## 7. テスト戦略
+
+### 7.1 単体テスト
+
+- **Strategy** (Direction 評価): CONTRARIAN/TREND_FOLLOW/BREAKOUT/HOLD ごとに、IndicatorSet → Direction/Strength のマトリクス
+- **Decision**: (保有状況 × Direction × cooldown) の全組合せ → Intent/Side
+- **RiskHandler**: ActionDecision → Approved/Rejected の境界条件 (残高、ポジション枠、cooldown)
+- **BookGate**: snapshot fresh/stale/missing × top-N 充足/不足 × 自分のサイズが top-N の M%
+
+### 7.2 統合テスト
+
+- backtest runner が新 EventBus 配線で同じ candle を流して、`decision_log` の主要カラムが期待通り埋まる
+- 過去の代表的バックテスト期間 (3m / 6m / 1y / 2y) で、Phase 1 適用前後のパフォーマンス指標 (Return, MaxDD, Sharpe) が大きく乖離しないこと
+  - 「乖離しない」のしきい値: Return が ±2pp 以内、MaxDD が ±2pp 以内
+  - 乖離した場合は decision_log を比較し、どの bar で挙動が変わったか分析
+- 旧バグの再現テスト: 「ロング保有中の BEARISH」を Phase 1 適用前は REJECTED、適用後は HOLD として記録する
+
+### 7.3 live と backtest の整合性
+
+- 同じ profile (`production_ltc_60k.json`) を読ませた時、両 runner で BookGate / cooldown 設定が同じ値で有効化されることをテスト
+- 既存の `runner_test.go` / `handler_test.go` を Phase 4 まで段階的に新型に追従させる
+
+---
+
+## 8. 互換性・運用影響
+
+### 8.1 decision_log
+
+- スキーマ変更は ADD COLUMN のみ。既存行は新カラムが空 / 0 で残る
+- 旧カラム (`signal_action` 等) は新ロジックでも埋め続ける → 既存 UI / SQL クエリは動く
+- 新カラムの利用は段階的：Phase 2 で recorder が埋め始め、Phase 5 で UI が表示
+
+### 8.2 backtest_decision_log
+
+decision_log と同じ ALTER。既存の比較レポート (PDCA) は旧カラムベースで動き続ける。新カラムは Phase 2 以降に新たな PDCA 軸として活用。
+
+### 8.3 UI / API
+
+- `/decisions` API は新カラムを response に追加 (Phase 2)
+- 既存フロントは新カラムを無視して旧フォーマットで表示 (Phase 5 まで)
+- Phase 5 でフロント拡張、追加カラムを画面表示
+
+### 8.4 プロファイル JSON
+
+- `production_ltc_60k.json` (および `production.json`) に追加：
+  ```json
+  {
+    "risk": {
+      "entry_cooldown_sec": 60,
+      "max_slippage_bps": 15,
+      "max_book_side_pct": 20
+    }
+  }
+  ```
+- 既存プロファイルでこれらが未設定なら 0 として扱う (= cooldown 無効、BookGate 無効)
+- 後方互換のため、旧プロファイルは何も変更しなくても動く
+
+### 8.5 Bot 運用
+
+- Phase 1〜3 は shadow 動作 (新ルートが decision_log に記録するだけ)、本番挙動に影響なし
+- Phase 3 マージ後に本番挙動が切り替わる。LTC 運用は事前に flat にしてから Phase 3 をマージする運用とする
+- Phase 4 マージ後、BookGate が動き始める → 板薄時間帯に rejected が増える可能性。decision_log を監視
+
+---
+
+## 9. ロールアウト・ロールバック
+
+### 9.1 各 PR のマージ手順
+
+1. PR を main にマージ
+2. `docker compose up --build -d` で本番コンテナ更新
+3. `/api/v1/status` で `pipelineRunning=true` を確認
+4. 30 分は decision_log を監視 (異常な REJECTED / panic / NULL カラム)
+
+### 9.2 ロールバック
+
+- DB schema: ADD COLUMN は revert しない (空のまま残す。データは消えない)
+- コード: `git revert <PR>` で前バージョンに戻す。各 PR は独立しているので可能
+- Phase 3 をロールバックしたい場合は Phase 4 もまとめて revert (依存関係)
+
+### 9.3 緊急停止
+
+- 既存の `/api/v1/stop` でいつでも bot 停止可能
+- `manuallyStopped=true` 中は新規エントリーが完全に止まる (新ロジックでも RiskHandler の最初に `manualStop` チェックを残す)
+
+---
+
+## 10. 未解決事項 / 後続課題
+
+### 10.1 後続で取り組む
+
+- **Exit Policy の拡張**: BEARISH signal が連続したらロングの利確を早めるロジック (Phase 6+)
+- **指値 close API**: 成行依存からの脱却 (市場インパクト軽減)
+- **/positions と RiskManager の整合性問題**: in-memory 状態と exchange-side 状態のずれ調査 (MEMORY の "/status running は嘘をつく" 系列)
+
+### 10.2 PDCA で sweep する新変数
+
+- `entry_cooldown_sec`: 30 / 60 / 120 / 300 で比較。LTC 板回復時間を実測
+- `max_slippage_bps`: 10 / 15 / 20 / 30 で reject 率と net pnl を測定
+- `max_book_side_pct`: 10 / 20 / 30 で同上
+
+### 10.3 構造の自然な拡張余地
+
+C のレイヤ分離が定着すれば、以下が同じ構造に乗せられる：
+
+- 複数 stance の同時評価 (一票方式 / 加重平均)
+- 複数銘柄横断のポートフォリオ判定
+- 機械学習モデルを Strategy or Decision に差し込み (Direction 出力を統合)
+
+---
+
+## 11. 参考
+
+- 関連コード:
+  - `backend/internal/usecase/risk.go:144-180` (バグの場所)
+  - `backend/internal/usecase/booklimit/book_limit.go` (BookGate 実装)
+  - `backend/cmd/event_pipeline.go:737-748` (BookGate live 配線、有効化条件)
+  - `backend/internal/usecase/backtest/runner.go:276-` (EventBus priority 配線)
+- 関連 Issue: #221 (BookGate disabled)
+- 関連設計書: `docs/design/2026-04-05-auto-trading-system-design.md` (現状アーキテクチャ)
+- ユーザ MEMORY:
+  - `project_bookgate_disabled.md`
+  - `project_status_running_lie.md`

--- a/docs/design/plans/2026-05-02-plan1-signal-decision-entity-and-migration.md
+++ b/docs/design/plans/2026-05-02-plan1-signal-decision-entity-and-migration.md
@@ -1,0 +1,430 @@
+# PR1 Plan: Signal/Decision Entity 追加 + decision_log ALTER TABLE migration
+
+- 作成日: 2026-05-02
+- 親設計書: `docs/design/2026-04-29-signal-decision-policy-separation-design.md`
+- スコープ: Phase 1 / Stacked PR シリーズ (PR1 ÷ 5)
+- 動作影響: **無し**（型と空カラムを追加するだけ）
+
+---
+
+## 0. このドキュメントの位置付け
+
+設計書 §6 PR1 の実装計画。設計書では「entity / event 型と decision_log への ALTER」と一括りに書かれているが、実装の段取りと検証手順をここで具体化する。
+
+このプランは PR2 以降の前提。PR2 で DecisionHandler を新設するときに参照する型と、recorder が新カラムに値を入れ始めるための土台を整える。
+
+PR1 マージ時点の **観測可能な変化**:
+
+- `backend/internal/domain/entity/` に新ファイル 2 つ
+- `backtest_event.go` に EventType 定数 2 つ追加
+- `decision_log` / `backtest_decision_log` テーブルにカラム 6 列追加（既存行は空文字 / 0）
+- `DecisionRecord` 構造体に対応フィールド 6 つ追加
+- `decision_log_repo` / `backtest_decision_log_repo` の `INSERT` / `UPDATE` / `SELECT` が新カラムを扱う（PR1 中は常に空）
+- backtest / live の挙動は **完全に同じ**（新型を生成・publish するコードはまだ無い）
+
+---
+
+## 1. 設計書からの調整点
+
+設計書 §5 と現状コードを突き合わせて以下を確定する：
+
+### 1.1 既存 `decision.go` との衝突回避
+
+設計書 §5.1 では「`backend/internal/domain/entity/decision.go` に追記」とあるが、既存ファイルは **`DecisionRecord`（永続化用 entity）** が住んでいる。`DecisionIntent` / `ActionDecision` を同じファイルに混ぜると意味論が紛れる。
+
+→ **新規ファイル `action_decision.go` に分離する**。`MarketSignal` は `market_signal.go`。`backtest_event.go` の EventType 定数追加だけは既存ファイルに直書き。
+
+### 1.2 DecisionRecord 拡張
+
+decision_log の新カラムを書くために `DecisionRecord` に 6 フィールド追加：
+
+```go
+SignalDirection    string  // "BULLISH" | "BEARISH" | "NEUTRAL" | ""
+SignalStrength     float64
+DecisionIntent     string  // "NEW_ENTRY" | "EXIT_CANDIDATE" | "HOLD" | "COOLDOWN_BLOCKED" | ""
+DecisionSide       string  // "BUY" | "SELL" | ""
+DecisionReason     string
+ExitPolicyOutcome  string  // PR4 で BookGate 経由の出口判断記録に使う予定
+```
+
+PR1 ではフィールドを足すだけで誰も書き込まない（recorder は PR2 で対応）。`ToJSON` / `FromJSON` 系の関数があれば追従する。
+
+### 1.3 Repo 層の SQL 更新
+
+`Insert` / `InsertAndID` / `Update` / `Select` 系 4 メソッドの SQL に新カラムを足す。PR1 中は値は常に空文字 / 0 で、既存行を読み出した時に新カラム読み出し位置に空が入るだけ。テストで明示的に確認する。
+
+### 1.4 マイグレーション分割
+
+`migrations.go` の末尾に `addDecisionLogV2Columns(db)` ヘルパーを追加し `RunMigrations` から呼ぶ。`addColumnIfNotExists` を 12 回呼ぶ（6 列 × 2 テーブル）。冪等。
+
+---
+
+## 2. ファイル変更マップ
+
+| ファイル | 変更 | 行数目安 |
+|---|---|---|
+| `backend/internal/domain/entity/market_signal.go` | 新規 | ~50 |
+| `backend/internal/domain/entity/market_signal_test.go` | 新規 | ~30 |
+| `backend/internal/domain/entity/action_decision.go` | 新規 | ~70 |
+| `backend/internal/domain/entity/action_decision_test.go` | 新規 | ~40 |
+| `backend/internal/domain/entity/backtest_event.go` | EventType 定数 2 つ追加 | +3 |
+| `backend/internal/domain/entity/decision.go` | DecisionRecord に 6 フィールド追加 | +7 |
+| `backend/internal/infrastructure/database/migrations.go` | addDecisionLogV2Columns 追加 + 呼び出し | +35 |
+| `backend/internal/infrastructure/database/migrations_test.go` | 新カラム存在検証テスト追加 | +50 |
+| `backend/internal/infrastructure/database/decision_log_repo.go` | INSERT/UPDATE/SELECT 更新 | ~30 行差分 |
+| `backend/internal/infrastructure/database/decision_log_repo_test.go` | 新カラム round-trip テスト | +60 |
+| `backend/internal/infrastructure/database/backtest_decision_log_repo.go` | 同上 | ~30 |
+| `backend/internal/infrastructure/database/backtest_decision_log_repo_test.go` | 同上 | +60 |
+
+合計：新規 4、編集 8、約 +500 行 / -0 行。
+
+非対象：
+
+- `recorder.go` / `backtest_adapter.go`：PR2 で更新
+- `runner.go` / `event_pipeline.go`：PR2 で更新
+- frontend：PR5 で更新
+
+---
+
+## 3. 実装タスク
+
+各タスクは独立してテストを通すことを意識して順序付けする。
+
+### Task 1: EventType 定数の追加
+
+**目的**: 後続コードからシンボル参照だけは可能にする。型本体はまだ無くてよい。
+
+**変更**:
+- `backtest_event.go` に追加：
+  ```go
+  EventTypeMarketSignal = "market_signal"
+  EventTypeDecision     = "decision"
+  ```
+
+**テスト**: 既存の backtest_event_test.go があれば定数値を assert。なければ skip。
+
+**完了判定**: `cd backend && go build ./...` が通る。
+
+---
+
+### Task 2: `MarketSignal` entity の新規作成
+
+**目的**: Strategy → Decision の payload 型を確立する。
+
+**変更**: `backend/internal/domain/entity/market_signal.go` 新規作成。
+
+```go
+package entity
+
+// SignalDirection は市況の方向性を表す。Signal レイヤは BUY/SELL のような
+// 注文サイドではなく、市場解釈としての BULLISH/BEARISH/NEUTRAL を返す。
+// 注文サイドへの変換は Decision レイヤの責務。
+type SignalDirection string
+
+const (
+    DirectionBullish SignalDirection = "BULLISH"
+    DirectionBearish SignalDirection = "BEARISH"
+    DirectionNeutral SignalDirection = "NEUTRAL"
+)
+
+// MarketSignal は Strategy が指標から導いた状況解釈。Direction は方向、
+// Strength は確信度（0.0〜1.0）。Source は由来戦略（例: "contrarian:rsi"）。
+type MarketSignal struct {
+    SymbolID   int64
+    Direction  SignalDirection
+    Strength   float64
+    Source     string
+    Reason     string
+    Indicators IndicatorSet
+    Timestamp  int64
+}
+
+// MarketSignalEvent は EventBus に流れるイベント。Decision レイヤが購読する。
+type MarketSignalEvent struct {
+    Signal     MarketSignal
+    Price      float64
+    CurrentATR float64
+    Timestamp  int64
+}
+
+func (e MarketSignalEvent) EventType() string     { return EventTypeMarketSignal }
+func (e MarketSignalEvent) EventTimestamp() int64 { return e.Timestamp }
+```
+
+**テスト** (`market_signal_test.go`):
+- `MarketSignalEvent.EventType()` が `"market_signal"` を返す
+- `EventTimestamp()` が Timestamp フィールドをそのまま返す
+- 各 `SignalDirection` 定数の文字列値検証
+
+**完了判定**: `go test ./internal/domain/entity/... -run MarketSignal` 緑。
+
+---
+
+### Task 3: `ActionDecision` entity の新規作成
+
+**目的**: Decision レイヤの出力型。Intent + Side + 由来情報を保持。
+
+**変更**: `backend/internal/domain/entity/action_decision.go` 新規作成。
+
+```go
+package entity
+
+// DecisionIntent は Decision レイヤが下した行動意図。Side と組み合わせて
+// ExecutionPolicy（Risk/BookGate/Executor）が解釈する。
+type DecisionIntent string
+
+const (
+    IntentNewEntry        DecisionIntent = "NEW_ENTRY"
+    IntentExitCandidate   DecisionIntent = "EXIT_CANDIDATE"
+    IntentHold            DecisionIntent = "HOLD"
+    IntentCooldownBlocked DecisionIntent = "COOLDOWN_BLOCKED"
+)
+
+// ActionDecision は Decision レイヤの判定結果。
+// Intent=HOLD/COOLDOWN_BLOCKED の時 Side は空文字。
+// Strength と Source は由来 MarketSignal から継承し、サイジング/ログに使う。
+type ActionDecision struct {
+    SymbolID  int64
+    Intent    DecisionIntent
+    Side      OrderSide
+    Reason    string
+    Source    string
+    Strength  float64
+    Timestamp int64
+}
+
+// IsActionable は Intent が実行を伴う種類か（NEW_ENTRY / EXIT_CANDIDATE）。
+// HOLD / COOLDOWN_BLOCKED は false。後段ハンドラの分岐用。
+func (d ActionDecision) IsActionable() bool {
+    return d.Intent == IntentNewEntry || d.Intent == IntentExitCandidate
+}
+
+type ActionDecisionEvent struct {
+    Decision   ActionDecision
+    Price      float64
+    CurrentATR float64
+    Timestamp  int64
+}
+
+func (e ActionDecisionEvent) EventType() string     { return EventTypeDecision }
+func (e ActionDecisionEvent) EventTimestamp() int64 { return e.Timestamp }
+```
+
+**`OrderSide` の所在確認**: `entity/order.go` を読んで型名を確認。違う名前なら適合させる。
+
+**テスト** (`action_decision_test.go`):
+- `IsActionable` が NEW_ENTRY/EXIT_CANDIDATE で true、HOLD/COOLDOWN_BLOCKED で false
+- `ActionDecisionEvent.EventType()` が `"decision"` を返す
+- 各 `DecisionIntent` 定数の文字列値検証
+
+**完了判定**: `go test ./internal/domain/entity/... -run ActionDecision` 緑。
+
+---
+
+### Task 4: DecisionRecord に新フィールド追加
+
+**目的**: PR2 以降で recorder が新ロジック由来の値を保存できるよう箱を作る。PR1 では何も書かない。
+
+**変更**: `backend/internal/domain/entity/decision.go` の `DecisionRecord` に追加：
+
+```go
+// Phase 1 (Signal/Decision/ExecutionPolicy 三層分離) で追加。PR1 時点では
+// 全行で空文字 / 0。recorder が値を入れ始めるのは PR2 から。
+SignalDirection   string  // SignalDirection の string 形 ("BULLISH" 等)
+SignalStrength    float64
+DecisionIntent    string  // DecisionIntent の string 形
+DecisionSide      string  // OrderSide の string 形
+DecisionReason    string
+ExitPolicyOutcome string  // PR4 で BookGate 経由の出口判断結果を入れる予定
+```
+
+**テスト**: 既存 `decision_test.go` でフィールド初期値が空であることを 1 ケース追加。
+
+**完了判定**: `go build ./...` が通り、既存テストが緑。
+
+---
+
+### Task 5: マイグレーションに ALTER TABLE を追加
+
+**目的**: テーブルに 6 列追加。冪等。既存 DB を破壊しない。
+
+**変更**: `migrations.go` の `RunMigrations` 末尾に呼び出し追加 + ヘルパー関数定義。
+
+```go
+// addDecisionLogV2Columns adds Phase 1 columns to decision_log /
+// backtest_decision_log. Idempotent via addColumnIfNotExists.
+// Defaults are empty string / 0 so existing rows remain valid.
+func addDecisionLogV2Columns(db *sql.DB) error {
+    cols := []struct{ name, def string }{
+        {"signal_direction",    "signal_direction TEXT NOT NULL DEFAULT ''"},
+        {"signal_strength",     "signal_strength REAL NOT NULL DEFAULT 0"},
+        {"decision_intent",     "decision_intent TEXT NOT NULL DEFAULT ''"},
+        {"decision_side",       "decision_side TEXT NOT NULL DEFAULT ''"},
+        {"decision_reason",     "decision_reason TEXT NOT NULL DEFAULT ''"},
+        {"exit_policy_outcome", "exit_policy_outcome TEXT NOT NULL DEFAULT ''"},
+    }
+    for _, t := range []string{"decision_log", "backtest_decision_log"} {
+        for _, c := range cols {
+            if err := addColumnIfNotExists(db, t, c.name, c.def); err != nil {
+                return fmt.Errorf("add %s.%s: %w", t, c.name, err)
+            }
+        }
+    }
+    return nil
+}
+```
+
+`RunMigrations` 末尾、`for _, stmt := range decisionLogTables` ループの直後で呼ぶ：
+
+```go
+if err := addDecisionLogV2Columns(db); err != nil {
+    return err
+}
+```
+
+**テスト** (`migrations_test.go` に追加):
+- 既存 DB に対して `RunMigrations` を 2 回叩いてもエラーにならない（冪等）
+- マイグレーション後 `PRAGMA table_info(decision_log)` で 6 列の存在を検証
+- 同上 `backtest_decision_log`
+- 既存テーブルにダミー行を 1 行入れた状態でマイグレーションを走らせ、データが消えないことを確認
+
+**完了判定**: `go test ./internal/infrastructure/database/... -run TestMigrations` 緑。
+
+---
+
+### Task 6: decision_log_repo の SQL を新カラム対応へ
+
+**目的**: PR1 中は常に空文字 / 0 を書くが、INSERT / UPDATE / SELECT の SQL は新カラムを扱える状態にしておく。PR2 で recorder が値を渡せばすぐ動く。
+
+**変更**: `decision_log_repo.go`
+
+- `Insert` / `InsertAndID` / `Update` の SQL に 6 列追加（順序: signal_direction → exit_policy_outcome の順で末尾に追加）
+- バインドする値は `rec.SignalDirection` 等を使う（PR1 では呼び元が空のまま）
+- SELECT 系（`GetLatest`, `ListBySymbol` 等）の列リストにも追加し、`Scan` でフィールドに読み込む
+
+`backtest_decision_log_repo.go` も同様。
+
+**テスト** (`decision_log_repo_test.go`, `backtest_decision_log_repo_test.go`):
+- 新フィールドに値を詰めて `Insert` → `GetByID` で取り出して同値であることを確認（"BULLISH"/0.7/"NEW_ENTRY"/"BUY"/"reason"/""）
+- 空のまま Insert → 取り出した時にゼロ値（空文字 / 0）であること
+- `Update` 経由でも同じ往復
+
+**完了判定**: `go test ./internal/infrastructure/database/... -run DecisionLog` 緑、`go test ./internal/infrastructure/database/... -run BacktestDecisionLog` 緑。
+
+---
+
+### Task 7: 全パッケージ緑 + 動作不変の確認
+
+**確認手順**:
+
+```bash
+cd backend && go test ./... -race -count=1
+```
+
+期待: 全パッケージ緑。新カラム関連のテストが 6〜10 件追加で増える。
+
+```bash
+cd backend && go vet ./...
+```
+
+期待: 警告なし。
+
+**動作不変の確認**:
+- 既存 `live` 起動 → 何もしないで `decision_log` を覗いて、新カラムが空で書かれていることを確認
+- 既存 `backtest` を 1 本流して、`backtest_decision_log` の新カラムが空で書かれていることを確認
+- `recorder.go` のシグナル受信→記録のロジックは PR1 で触っていないので、旧フィールドは引き続き正しく埋まる
+
+```bash
+docker compose up --build -d backend
+sleep 5
+docker compose logs backend | grep -i "migration\|panic" | head -20
+docker compose exec backend sqlite3 /data/trading.db "PRAGMA table_info(decision_log);" | grep -E "signal_direction|decision_intent"
+```
+
+期待:
+- migration ログに新カラム追加メッセージなし（既存テーブルへの ALTER は正常）
+- `PRAGMA table_info` で新カラムが見える
+- 既存 `decision_log` 行の新カラムは空文字 / 0
+- `/api/v1/status` が `pipelineRunning` を含む正常レスポンス（PR #231 で追加済み）
+
+---
+
+## 4. テスト戦略
+
+### 4.1 単体テスト
+
+| 対象 | テスト |
+|---|---|
+| `MarketSignalEvent` | EventType / Timestamp |
+| `ActionDecision` | IsActionable の 4 ケース |
+| `ActionDecisionEvent` | EventType / Timestamp |
+| `addDecisionLogV2Columns` | 冪等性、列追加検証、データ保護 |
+| `decisionLogRepo` | 新カラム round-trip（INSERT→SELECT、UPDATE→SELECT） |
+| `backtestDecisionLogRepo` | 同上 |
+
+### 4.2 既存テストへの影響
+
+- `recorder_test.go` / `backtest_adapter_test.go` は `DecisionRecord` のフィールド追加で影響なし（フィールド追加は加算的変更）
+- 既存 `decision_log_repo_test.go` のフィクスチャ生成で `SignalDirection: ""` 等を明示する必要は無い（Go のゼロ値）
+
+### 4.3 動作回帰テスト
+
+PR1 自体は新コードを呼ぶ箇所が無いので、シグナル経路の挙動は理論上変わらない。とはいえ念のため：
+
+- 短い backtest（CSV 1 日分）を 1 本流す
+- 結果 metrics（Return, MaxDD, TradeCount）が PR1 適用前と一致することを目視確認
+
+---
+
+## 5. リスクと緩和
+
+| リスク | 影響 | 緩和 |
+|---|---|---|
+| ALTER TABLE が既存行に NULL を入れる | 既存 SELECT が壊れる | `NOT NULL DEFAULT ''` / `DEFAULT 0` を全列に付ける |
+| migration が冪等でない | 2 回目以降 backend 起動でエラー | `addColumnIfNotExists` ヘルパー（既存）を使う、テストで 2 回呼ぶ |
+| Repo SQL に新カラム名のスペルミス | 即 INSERT エラー | テーブル定義と repo SQL の列リストを並べた diff レビューを self-check |
+| Production DB との順番ずれ | カラム順が test と prod で違う | SELECT は列名を明示しているので順番は問題にならない（位置指定 SCAN ではなく列名駆動） |
+| backtest_decision_log のサイズ膨張 | ALTER TABLE が遅い | 6 列追加なので軽量。既存 PR でも実績あり |
+
+---
+
+## 6. PR 作成手順
+
+1. ブランチ: `feat/signal-decision-entity-v2`
+2. コミット粒度（レビュー観点）：
+   - **Commit 1**: EventType 定数 + `MarketSignal` entity + テスト
+   - **Commit 2**: `ActionDecision` entity + テスト
+   - **Commit 3**: `DecisionRecord` フィールド追加
+   - **Commit 4**: migration `addDecisionLogV2Columns` + テスト
+   - **Commit 5**: `decision_log_repo` / `backtest_decision_log_repo` SQL 更新 + テスト
+3. PR 本文：
+   - 設計書 §6 PR1 の実装である旨を冒頭で明示
+   - 「動作不変」を太字で明記
+   - 後続 PR（PR2: DecisionHandler 新設）への接続を記す
+4. CI 緑で squash merge
+
+---
+
+## 7. 完了の定義（DoD）
+
+- [ ] 6 タスクすべて完了
+- [ ] `cd backend && go test ./... -race -count=1` 緑
+- [ ] `cd backend && go vet ./...` 警告なし
+- [ ] `docker compose up --build -d` で backend が起動し migration が走る
+- [ ] `PRAGMA table_info(decision_log)` で 6 新カラムが見える
+- [ ] `PRAGMA table_info(backtest_decision_log)` で 6 新カラムが見える
+- [ ] backtest を 1 本走らせて旧 metrics と完全一致を確認
+- [ ] PR 本文に設計書リンク + 動作不変宣言を含める
+
+---
+
+## 8. 後続 PR への引き継ぎ
+
+PR1 が main にマージされたら、PR2（Decision レイヤ新設 + StrategyHandler 改修）の plan を書く。その時点で確定する／確定したい事項：
+
+- `DecisionHandler` のインターフェース（`OnIndicator(ev IndicatorEvent)` を持つか、別の入口にするか）
+- `StrategyHandler` から `MarketSignalEvent` と既存 `SignalEvent` を**両方** publish する shadow 動作の具体形
+- recorder が `MarketSignalEvent` / `ActionDecisionEvent` を購読する際の subscribe priority
+- backtest runner と event_pipeline の EventBus 設定差分
+
+これらは PR1 の実装中に判断材料が増えるので、PR2 plan を書く際に再評価する。


### PR DESCRIPTION
## Summary

Signal/Decision/ExecutionPolicy 三層分離 (設計書: `docs/design/2026-04-29-signal-decision-policy-separation-design.md`) の **Phase 1 / PR1**。後続 PR の土台となる entity 型と decision_log スキーマだけを先に通す。

**動作不変** — 新型を生成・publish するコードはまだ無く、既存 backtest / live は何も変わらない。

実装計画: `docs/design/plans/2026-05-02-plan1-signal-decision-entity-and-migration.md`

## What changes

- **Entity (新規)**:
  - `MarketSignal` / `MarketSignalEvent` — Strategy → Decision の payload。Direction (BULLISH/BEARISH/NEUTRAL) と Strength (0–1) のみ
  - `ActionDecision` / `ActionDecisionEvent` — Decision レイヤの判定結果。Intent (NEW_ENTRY/EXIT_CANDIDATE/HOLD/COOLDOWN_BLOCKED) + Side (BUY/SELL)
  - 既存 `decision.go` には `DecisionRecord` (永続化用) が住んでいるため、衝突回避のため **新規ファイル** `action_decision.go` に分離
- **EventType 定数**: `EventTypeMarketSignal` / `EventTypeDecision`
- **DecisionRecord 拡張**: 6 フィールド追加 (PR1 中は recorder が値を埋めない)
- **migration**: `addDecisionLogV2Columns` で `decision_log` / `backtest_decision_log` に 6 列追加 (idempotent, NOT NULL DEFAULT '' / 0)
  - signal_direction, signal_strength, decision_intent, decision_side, decision_reason, exit_policy_outcome
- **repo**: INSERT/UPDATE/SELECT を 6 新カラム対応へ。PR2 で recorder が値を埋め始めた瞬間に動く状態にしておく

## Verification

- ✅ `go test ./... -race -count=1` 全パッケージ緑
- ✅ `go vet ./...` 警告なし
- ✅ 新規 4 テスト (migration / decision_log_repo / backtest_decision_log_repo round-trip / Update)
- ✅ Docker rebuild → migration 実行 → 本番 DB に 6 列追加確認
- ✅ 既存 164 decision_log 行が新カラム空のまま保護
- ✅ `/status` = `pipelineRunning=true, status=running`、auto-trading resumed automatically

## Commit breakdown (5 commits)

1. MarketSignal entity + EventType 定数 + 実装計画ドキュメント
2. ActionDecision entity
3. DecisionRecord に Phase 1 フィールド追加
4. migration (addDecisionLogV2Columns)
5. decision_log_repo / backtest_decision_log_repo の SQL 更新

## Next: PR2

DecisionHandler 新設 + StrategyHandler を MarketSignal 出力対応に改修。EventBus に新ルート (Indicator → MarketSignal → Decision → Risk) を配線し、recorder が新カラムを埋め始める。動作切替は PR3 で実施予定。

## Test plan

- [x] backend unit / integration tests pass
- [x] migration runs cleanly on existing DB with data
- [x] backend container restart preserves existing decision_log rows
- [x] `/api/v1/status` returns `pipelineRunning=true`