### PR TITLE
feat(profile): Phase 1 PR4 — BookGate enable + EntryCooldown via profile

### DIFF
--- a/backend/cmd/backtest/main.go
+++ b/backend/cmd/backtest/main.go
@@ -704,22 +704,31 @@ func buildRunInput(f runFlags, profile *entity.StrategyProfile) (bt.RunInput, er
 		cfg.HigherTFInterval = ""
 	}
 
+	riskConfig := entity.RiskConfig{
+		MaxPositionAmount:     maxPositionAmount,
+		MaxDailyLoss:          maxDailyLoss,
+		StopLossPercent:       stopLoss,
+		StopLossATRMultiplier: stopLossATR,
+		TrailingATRMultiplier: trailingATR,
+		TakeProfitPercent:     takeProfit,
+		InitialCapital:        f.InitialBalance,
+		MaxConsecutiveLosses:  0,
+		CooldownMinutes:       0,
+	}
+	// PR4 (Phase 1): forward profile-driven BookGate / EntryCooldown knobs to
+	// backtest so CLI runs apply the same gating as live. Zero leaves the
+	// gate disabled (legacy behaviour preserved for older profiles).
+	if profile != nil {
+		riskConfig.MaxSlippageBps = profile.Risk.MaxSlippageBps
+		riskConfig.MaxBookSidePct = profile.Risk.MaxBookSidePct
+		riskConfig.EntryCooldownSec = profile.Risk.EntryCooldownSec
+	}
 	in := bt.RunInput{
 		Config:         cfg,
 		TradeAmount:    f.TradeAmount,
 		PrimaryCandles: primary.Candles,
 		HigherCandles:  higherCandles,
-		RiskConfig: entity.RiskConfig{
-			MaxPositionAmount:     maxPositionAmount,
-			MaxDailyLoss:          maxDailyLoss,
-			StopLossPercent:       stopLoss,
-			StopLossATRMultiplier: stopLossATR,
-			TrailingATRMultiplier: trailingATR,
-			TakeProfitPercent:     takeProfit,
-			InitialCapital:        f.InitialBalance,
-			MaxConsecutiveLosses:  0,
-			CooldownMinutes:       0,
-		},
+		RiskConfig:     riskConfig,
 	}
 	if profile != nil {
 		in.BBSqueezeLookback = profile.StanceRules.BBSqueezeLookback

--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -130,6 +130,20 @@ func main() {
 		if liveProfile.StanceRules.BBSqueezeLookback > 0 {
 			indicatorCalc.SetBBSqueezeLookback(liveProfile.StanceRules.BBSqueezeLookback)
 		}
+		// PR4 (Phase 1): apply profile-driven BookGate / EntryCooldown
+		// overrides on top of the env-var defaults already in riskMgr.
+		// Zero values in the profile leave the env-var fallback untouched.
+		riskMgr.ApplyProfileRiskOverrides(
+			liveProfile.Risk.MaxSlippageBps,
+			liveProfile.Risk.MaxBookSidePct,
+			liveProfile.Risk.EntryCooldownSec,
+		)
+		slog.Info("profile risk overrides applied",
+			"profile", liveProfile.Name,
+			"maxSlippageBps", liveProfile.Risk.MaxSlippageBps,
+			"maxBookSidePct", liveProfile.Risk.MaxBookSidePct,
+			"entryCooldownSec", liveProfile.Risk.EntryCooldownSec,
+		)
 	}
 
 	if err := bootstrapCandles(context.Background(), restClient, marketDataSvc, symbolID, "PT15M", 500); err != nil {

--- a/backend/internal/domain/entity/strategy_config.go
+++ b/backend/internal/domain/entity/strategy_config.go
@@ -369,6 +369,14 @@ type StrategyRiskConfig struct {
 	// used as-is. When set, the sizer computes per-trade lot size from
 	// equity, signal confidence, ATR, and drawdown. See usecase/positionsize.
 	PositionSizing *PositionSizingConfig `json:"position_sizing,omitempty"`
+
+	// Phase 1 PR4 (Signal/Decision/ExecutionPolicy) profile-driven knobs for
+	// BookGate and entry cooldown. Zero leaves the env-var-derived RiskConfig
+	// value (set at NewRiskManager time) untouched; non-zero takes precedence
+	// — profile-driven intent is treated as the source of truth for production.
+	MaxSlippageBps   float64 `json:"max_slippage_bps,omitempty"`
+	MaxBookSidePct   float64 `json:"max_book_side_pct,omitempty"`
+	EntryCooldownSec int     `json:"entry_cooldown_sec,omitempty"`
 }
 
 // PositionSizingConfig declares how per-trade lot size is derived at runtime.
@@ -578,6 +586,19 @@ func (p StrategyProfile) Validate() error {
 	}
 	if p.Risk.TakeProfitPercent < 0 {
 		errs = append(errs, fmt.Errorf("strategy_risk.take_profit_percent must be >= 0 (got %v)", p.Risk.TakeProfitPercent))
+	}
+
+	// PR4 (Phase 1): BookGate / EntryCooldown profile knobs. 0 disables the
+	// override (env-var fallback applies); negative or absurd values are
+	// almost certainly typos so reject loudly.
+	if p.Risk.MaxSlippageBps < 0 || p.Risk.MaxSlippageBps > 1000 {
+		errs = append(errs, fmt.Errorf("strategy_risk.max_slippage_bps must be in [0, 1000] (got %v)", p.Risk.MaxSlippageBps))
+	}
+	if p.Risk.MaxBookSidePct < 0 || p.Risk.MaxBookSidePct > 100 {
+		errs = append(errs, fmt.Errorf("strategy_risk.max_book_side_pct must be in [0, 100] (got %v)", p.Risk.MaxBookSidePct))
+	}
+	if p.Risk.EntryCooldownSec < 0 || p.Risk.EntryCooldownSec > 3600 {
+		errs = append(errs, fmt.Errorf("strategy_risk.entry_cooldown_sec must be in [0, 3600] (got %d)", p.Risk.EntryCooldownSec))
 	}
 
 	// PR-11: negative Donchian period would compute NaN indefinitely; 0

--- a/backend/internal/domain/entity/strategy_config_test.go
+++ b/backend/internal/domain/entity/strategy_config_test.go
@@ -176,6 +176,67 @@ func TestStrategyProfile_Validate(t *testing.T) {
 			mutate:  func(p *StrategyProfile) { p.Risk.TakeProfitPercent = -1 },
 			wantErr: "take_profit_percent",
 		},
+		// PR4 (Phase 1): BookGate / EntryCooldown profile field bounds.
+		{
+			name:    "max_slippage_bps negative",
+			mutate:  func(p *StrategyProfile) { p.Risk.MaxSlippageBps = -1 },
+			wantErr: "max_slippage_bps",
+		},
+		{
+			name:    "max_slippage_bps too large",
+			mutate:  func(p *StrategyProfile) { p.Risk.MaxSlippageBps = 1001 },
+			wantErr: "max_slippage_bps",
+		},
+		{
+			name:   "max_slippage_bps boundary 0 (disabled)",
+			mutate: func(p *StrategyProfile) { p.Risk.MaxSlippageBps = 0 },
+			// 0 is allowed (disabled)
+			wantErr: "",
+		},
+		{
+			name:    "max_slippage_bps boundary 1000 (max)",
+			mutate:  func(p *StrategyProfile) { p.Risk.MaxSlippageBps = 1000 },
+			wantErr: "",
+		},
+		{
+			name:    "max_book_side_pct negative",
+			mutate:  func(p *StrategyProfile) { p.Risk.MaxBookSidePct = -1 },
+			wantErr: "max_book_side_pct",
+		},
+		{
+			name:    "max_book_side_pct too large",
+			mutate:  func(p *StrategyProfile) { p.Risk.MaxBookSidePct = 101 },
+			wantErr: "max_book_side_pct",
+		},
+		{
+			name:    "max_book_side_pct boundary 100",
+			mutate:  func(p *StrategyProfile) { p.Risk.MaxBookSidePct = 100 },
+			wantErr: "",
+		},
+		{
+			name:    "entry_cooldown_sec negative",
+			mutate:  func(p *StrategyProfile) { p.Risk.EntryCooldownSec = -1 },
+			wantErr: "entry_cooldown_sec",
+		},
+		{
+			name:    "entry_cooldown_sec too large",
+			mutate:  func(p *StrategyProfile) { p.Risk.EntryCooldownSec = 3601 },
+			wantErr: "entry_cooldown_sec",
+		},
+		{
+			name:    "entry_cooldown_sec boundary 3600",
+			mutate:  func(p *StrategyProfile) { p.Risk.EntryCooldownSec = 3600 },
+			wantErr: "",
+		},
+		{
+			name: "all PR4 fields populated normally",
+			mutate: func(p *StrategyProfile) {
+				p.Risk.MaxSlippageBps = 15
+				p.Risk.MaxBookSidePct = 20
+				p.Risk.EntryCooldownSec = 60
+			},
+			wantErr: "",
+		},
 	}
 
 	for _, tc := range tests {

--- a/backend/internal/infrastructure/strategyprofile/loader_test.go
+++ b/backend/internal/infrastructure/strategyprofile/loader_test.go
@@ -273,3 +273,24 @@ func TestLoader_List_EmptyDir(t *testing.T) {
 		t.Errorf("expected 0 summaries, got %d", len(summaries))
 	}
 }
+
+// TestLoader_Load_ProductionLTC60kReadsPR4Fields ensures the on-disk
+// production profile parses cleanly and exposes the BookGate / EntryCooldown
+// values introduced in PR4. This guards against silent dropouts (e.g. someone
+// removing a JSON tag and the field defaulting to 0).
+func TestLoader_Load_ProductionLTC60kReadsPR4Fields(t *testing.T) {
+	loader := NewLoader("../../../profiles")
+	profile, err := loader.Load("production_ltc_60k")
+	if err != nil {
+		t.Fatalf("Load production_ltc_60k: %v", err)
+	}
+	if profile.Risk.MaxSlippageBps != 15 {
+		t.Errorf("Risk.MaxSlippageBps = %v, want 15", profile.Risk.MaxSlippageBps)
+	}
+	if profile.Risk.MaxBookSidePct != 20 {
+		t.Errorf("Risk.MaxBookSidePct = %v, want 20", profile.Risk.MaxBookSidePct)
+	}
+	if profile.Risk.EntryCooldownSec != 60 {
+		t.Errorf("Risk.EntryCooldownSec = %v, want 60", profile.Risk.EntryCooldownSec)
+	}
+}

--- a/backend/internal/interfaces/api/handler/backtest.go
+++ b/backend/internal/interfaces/api/handler/backtest.go
@@ -172,6 +172,9 @@ type runBacktestRequest struct {
 	// inspect — the runner silently drops the gate when BookSource is nil.
 	MaxSlippageBps float64 `json:"maxSlippageBps,omitempty"`
 	MaxBookSidePct float64 `json:"maxBookSidePct,omitempty"`
+	// PR4 (Phase 1): entry-cooldown window in seconds. 0 disables; profile
+	// fallback handled in applyProfileDefaults.
+	EntryCooldownSec int `json:"entryCooldownSec,omitempty"`
 
 	// PDCA extensions (spec §8.2). All optional; when ProfileName is set,
 	// the profile's values become the base and non-zero individual fields
@@ -384,6 +387,7 @@ func (h *BacktestHandler) Run(c *gin.Context) {
 			CooldownMinutes:       req.CooldownMinutes,
 			MaxSlippageBps:        req.MaxSlippageBps,
 			MaxBookSidePct:        req.MaxBookSidePct,
+			EntryCooldownSec:      req.EntryCooldownSec,
 		},
 	})
 	if err != nil {
@@ -644,6 +648,16 @@ func applyProfileDefaults(req *runBacktestRequest, profile *entity.StrategyProfi
 	}
 	if req.TrailingATRMultiplier <= 0 && profile.Risk.TrailingATRMultiplier > 0 {
 		req.TrailingATRMultiplier = profile.Risk.TrailingATRMultiplier
+	}
+	// PR4 (Phase 1): BookGate / EntryCooldown profile fallback.
+	if req.MaxSlippageBps <= 0 && profile.Risk.MaxSlippageBps > 0 {
+		req.MaxSlippageBps = profile.Risk.MaxSlippageBps
+	}
+	if req.MaxBookSidePct <= 0 && profile.Risk.MaxBookSidePct > 0 {
+		req.MaxBookSidePct = profile.Risk.MaxBookSidePct
+	}
+	if req.EntryCooldownSec <= 0 && profile.Risk.EntryCooldownSec > 0 {
+		req.EntryCooldownSec = profile.Risk.EntryCooldownSec
 	}
 }
 

--- a/backend/internal/usecase/booklimit/book_limit_test.go
+++ b/backend/internal/usecase/booklimit/book_limit_test.go
@@ -200,3 +200,62 @@ func TestGate_SellSideEvaluatesBidsWithSignedSlippage(t *testing.T) {
 		t.Fatalf("expected ~10 bps, got %f", d.SlippageBps)
 	}
 }
+
+// PR4 (Phase 1): edge-case coverage requested by the design doc §7.1 matrix.
+
+// TestGate_BookSidePctBoundary: 自ロットがちょうど top-N 累積数量の M% に
+// 到達する境界。strictly greater でなく == で reject される実装か allow か
+// 仕様を固定する。現実装は >= で reject なので 30% でちょうど reject。
+func TestGate_BookSidePctBoundary(t *testing.T) {
+	// Top-5 累積 = 5 + 5 + 5 + 5 + 5 = 25。30% = 7.5。
+	// 自分のサイズ 7.5 → ratio = 7.5 / 25 = 30% → 境界。
+	src := &fakeSource{
+		snap: ob(1000,
+			[]entity.OrderbookEntry{
+				{Price: 1001, Amount: 5},
+				{Price: 1002, Amount: 5},
+				{Price: 1003, Amount: 5},
+				{Price: 1004, Amount: 5},
+				{Price: 1005, Amount: 5},
+			},
+			[]entity.OrderbookEntry{{Price: 999, Amount: 25}},
+			1001, 999, 1000,
+		),
+		found: true,
+	}
+
+	g := New(src, Config{MaxSlippageBps: 99999, MaxBookSidePct: 30, TopN: 5, AllowOnMissingBook: true})
+
+	// Just below the boundary (29.6%) should pass.
+	dBelow := g.Check(context.Background(), 7, entity.OrderSideBuy, 7.4, 1500)
+	if !dBelow.Allow {
+		t.Errorf("ratio=29.6%% should pass MaxBookSidePct=30, got %+v", dBelow)
+	}
+
+	// Strictly above (30.4%) should reject.
+	dAbove := g.Check(context.Background(), 7, entity.OrderSideBuy, 7.6, 1500)
+	if dAbove.Allow {
+		t.Errorf("ratio=30.4%% should fail MaxBookSidePct=30, got %+v", dAbove)
+	}
+}
+
+// TestGate_TopNUnderfilled: 板に N 段未満しか並んでいないとき、累積は
+// 存在する分だけで計算される。Thin book の reject は別経路 (depth_pre_trade)
+// なので、十分な単一 ask があればそれが top-1 として扱われる。
+func TestGate_TopNUnderfilled(t *testing.T) {
+	src := &fakeSource{
+		snap: ob(1000,
+			[]entity.OrderbookEntry{{Price: 1001, Amount: 100}}, // top-1 のみ、残り 4 段空
+			[]entity.OrderbookEntry{{Price: 999, Amount: 100}},
+			1001, 999, 1000,
+		),
+		found: true,
+	}
+	g := New(src, Config{MaxSlippageBps: 99999, MaxBookSidePct: 30, TopN: 5, AllowOnMissingBook: true})
+
+	// 自ロット 1.0 / cumulative 100 = 1% → pass
+	d := g.Check(context.Background(), 7, entity.OrderSideBuy, 1.0, 1500)
+	if !d.Allow {
+		t.Errorf("single deep ask level should be enough to pass 1%% lot, got %+v", d)
+	}
+}

--- a/backend/internal/usecase/risk.go
+++ b/backend/internal/usecase/risk.go
@@ -481,6 +481,31 @@ func (rm *RiskManager) UpdateConfig(config entity.RiskConfig) {
 	rm.config = config
 }
 
+// ApplyProfileRiskOverrides updates only the BookGate / EntryCooldown knobs
+// that the strategy profile explicitly sets to a non-zero value, leaving the
+// rest of the in-memory RiskConfig (typically populated from env vars at
+// NewRiskManager time) intact. Profile-driven intent thus takes precedence
+// over env-var defaults without requiring a full UpdateConfig replacement —
+// which is important because UpdateConfig is also called by MCP/API handlers
+// that do not know about profile state.
+//
+// Zero is treated as "no override" so a profile that omits the field keeps
+// the legacy fallback semantics (env-var or disabled). Negative values would
+// have failed Validate; this method does not re-validate.
+func (rm *RiskManager) ApplyProfileRiskOverrides(maxSlippageBps, maxBookSidePct float64, entryCooldownSec int) {
+	rm.mu.Lock()
+	defer rm.mu.Unlock()
+	if maxSlippageBps > 0 {
+		rm.config.MaxSlippageBps = maxSlippageBps
+	}
+	if maxBookSidePct > 0 {
+		rm.config.MaxBookSidePct = maxBookSidePct
+	}
+	if entryCooldownSec > 0 {
+		rm.config.EntryCooldownSec = entryCooldownSec
+	}
+}
+
 // UpdateATR updates the current ATR value used for dynamic stop-loss calculation.
 func (rm *RiskManager) UpdateATR(atr float64) {
 	rm.mu.Lock()

--- a/backend/internal/usecase/risk_test.go
+++ b/backend/internal/usecase/risk_test.go
@@ -527,6 +527,66 @@ func TestRiskManager_EntryCooldown_ZeroSecIsNoop(t *testing.T) {
 	}
 }
 
+// TestRiskManager_ApplyProfileRiskOverrides_NonZeroOverrides verifies that
+// profile-supplied values replace existing env-var defaults only when set.
+func TestRiskManager_ApplyProfileRiskOverrides_NonZeroOverrides(t *testing.T) {
+	rm := NewRiskManager(entity.RiskConfig{
+		InitialCapital:   100000,
+		MaxSlippageBps:   5,
+		MaxBookSidePct:   10,
+		EntryCooldownSec: 30,
+	})
+	rm.ApplyProfileRiskOverrides(15, 20, 60)
+	got := rm.GetStatus().Config
+	if got.MaxSlippageBps != 15 {
+		t.Errorf("MaxSlippageBps = %v, want 15 (profile override)", got.MaxSlippageBps)
+	}
+	if got.MaxBookSidePct != 20 {
+		t.Errorf("MaxBookSidePct = %v, want 20 (profile override)", got.MaxBookSidePct)
+	}
+	if got.EntryCooldownSec != 60 {
+		t.Errorf("EntryCooldownSec = %v, want 60 (profile override)", got.EntryCooldownSec)
+	}
+}
+
+// TestRiskManager_ApplyProfileRiskOverrides_ZeroSkips verifies that 0 in the
+// profile leaves the prior (env-var) value untouched. This is the contract
+// that lets profiles partially configure the risk envelope.
+func TestRiskManager_ApplyProfileRiskOverrides_ZeroSkips(t *testing.T) {
+	rm := NewRiskManager(entity.RiskConfig{
+		InitialCapital:   100000,
+		MaxSlippageBps:   5,
+		MaxBookSidePct:   10,
+		EntryCooldownSec: 30,
+	})
+	rm.ApplyProfileRiskOverrides(0, 0, 0)
+	got := rm.GetStatus().Config
+	if got.MaxSlippageBps != 5 || got.MaxBookSidePct != 10 || got.EntryCooldownSec != 30 {
+		t.Errorf("zero overrides should not touch env-var values, got %+v", got)
+	}
+}
+
+// TestRiskManager_ApplyProfileRiskOverrides_PartialMix only some fields set.
+func TestRiskManager_ApplyProfileRiskOverrides_PartialMix(t *testing.T) {
+	rm := NewRiskManager(entity.RiskConfig{
+		InitialCapital:   100000,
+		MaxSlippageBps:   5,
+		MaxBookSidePct:   10,
+		EntryCooldownSec: 30,
+	})
+	rm.ApplyProfileRiskOverrides(15, 0, 60)
+	got := rm.GetStatus().Config
+	if got.MaxSlippageBps != 15 {
+		t.Errorf("MaxSlippageBps should be overridden to 15, got %v", got.MaxSlippageBps)
+	}
+	if got.MaxBookSidePct != 10 {
+		t.Errorf("MaxBookSidePct should remain at env-var 10, got %v", got.MaxBookSidePct)
+	}
+	if got.EntryCooldownSec != 60 {
+		t.Errorf("EntryCooldownSec should be overridden to 60, got %v", got.EntryCooldownSec)
+	}
+}
+
 // TestRiskManager_EntryCooldown_IndependentFromConsecutiveLossCooldown checks
 // the two cooldown fields do not interact: arming the loss-streak cooldown
 // must not arm the entry cooldown, and vice versa.

--- a/backend/profiles/production.json
+++ b/backend/profiles/production.json
@@ -47,6 +47,9 @@
     "max_position_amount": 100000,
     "max_daily_loss": 50000,
     "trailing_atr_multiplier": 2.5,
+    "max_slippage_bps": 15,
+    "max_book_side_pct": 20,
+    "entry_cooldown_sec": 60,
     "position_sizing": {
       "mode": "risk_pct",
       "risk_per_trade_pct": 0.75,

--- a/backend/profiles/production_ltc_60k.json
+++ b/backend/profiles/production_ltc_60k.json
@@ -1,6 +1,6 @@
 {
   "name": "production_ltc_60k",
-  "description": "Promoted on 2026-04-26 as ETH-budget-constrained LTC/JPY × PT15M production profile (initialBalance=60,000 JPY). Source candidate: experiment_ltc_60k_winner_no_break (cycle71g). Differs from production v7 in three places: breakout.enabled=false (cycle71g found this dominant), risk_per_trade_pct=0.75 (vs 0.50 for v7 -- ¥60k equity scale lets a higher risk fit the 20% MaxDD constraint), drawdown_scale_down (TierA=13%/0.65x, TierB=19%/0.40x -- needed because r=0.75 alone breaches 2y DD 22.51%). 4-period verification (3m/6m/1y/2y from 2026-04-16, initialBalance=60,000): 3m +5.09%/DD 6.26%, 6m +5.09%/DD 7.37%, 1y +45.16%/DD 17.52%, 2y +38.82%/DD 18.78%. All 4 periods positive, all 4 periods MaxDD <= 20%, geometric mean Return ~22% (vs v7@¥60k baseline +13.6%). Sizer config: min_lot=0.1, lot_step=0.1 (LTC venue), risk_pct=0.75 with DD scale-down. See docs/pdca/2026-04-26_cycle70-71_60k_promotion.md.",
+  "description": "Promoted on 2026-04-26 as ETH-budget-constrained LTC/JPY × PT15M production profile (initialBalance=60,000 JPY). Source candidate: experiment_ltc_60k_winner_no_break (cycle71g). Differs from production v7 in three places: breakout.enabled=false (cycle71g found this dominant), risk_per_trade_pct=0.75 (vs 0.50 for v7 -- ¥60k equity scale lets a higher risk fit the 20% MaxDD constraint), drawdown_scale_down (TierA=13%/0.65x, TierB=19%/0.40x -- needed because r=0.75 alone breaches 2y DD 22.51%). 4-period verification (3m/6m/1y/2y from 2026-04-16, initialBalance=60,000): 3m +5.09%/DD 6.26%, 6m +5.09%/DD 7.37%, 1y +45.16%/DD 17.52%, 2y +38.82%/DD 18.78%. All 4 periods positive, all 4 periods MaxDD <= 20%, geometric mean Return ~22% (vs v7@¥60k baseline +13.6%). Sizer config: min_lot=0.1, lot_step=0.1 (LTC venue), risk_pct=0.75 with DD scale-down. See docs/pdca/2026-04-26_cycle70-71_60k_promotion.md. 2026-05-02 PR4 (Signal/Decision/ExecutionPolicy Phase 1): added BookGate (max_slippage_bps=15, max_book_side_pct=20) and entry_cooldown_sec=60. Conservative initial values per design doc §8.4; PDCA sweep over 30/60/120/300s × 10/15/20/30 bps × 10/20/30 % to follow.",
   "indicators": {
     "sma_short": 20,
     "sma_long": 50,
@@ -47,6 +47,9 @@
     "max_position_amount": 100000,
     "max_daily_loss": 50000,
     "trailing_atr_multiplier": 2.5,
+    "max_slippage_bps": 15,
+    "max_book_side_pct": 20,
+    "entry_cooldown_sec": 60,
     "position_sizing": {
       "mode": "risk_pct",
       "risk_per_trade_pct": 0.75,

--- a/docs/design/plans/2026-05-02-plan4-bookgate-enable-profile-update.md
+++ b/docs/design/plans/2026-05-02-plan4-bookgate-enable-profile-update.md
@@ -1,0 +1,395 @@
+# PR4 Plan: BookGate 有効化 + プロファイル更新 + EntryCooldown プロファイル化
+
+- 作成日: 2026-05-02
+- 親設計書: `docs/design/2026-04-29-signal-decision-policy-separation-design.md`
+- 前段 PR: #232 / #233 / #234 (Phase 1 PR1〜PR3 全マージ済み)
+- スコープ: Phase 1 / Stacked PR シリーズ (PR4 ÷ 5)
+- 動作変更あり: BookGate が production_ltc_60k で発動し始める。EntryCooldown も有効化
+
+---
+
+## 0. このドキュメントの位置付け
+
+PR3 で実発注経路は新ルートに切り替わったが、**BookGate と EntryCooldown は設定が無いため依然として無効**。設計書 §2.2「BookGate (`booklimit.Gate`) を production_ltc_60k で有効化する」を満たすため、profile 経由でこれらを設定可能にし、`production_ltc_60k.json` に保守的初期値を入れる。
+
+PR4 マージ時点の **観測可能な変化**:
+
+- `StrategyProfile.Risk` に 3 フィールド (`MaxSlippageBps` / `MaxBookSidePct` / `EntryCooldownSec`) が増える
+- profile 読み込み時に `RiskManager.UpdateConfig` 経由で値が反映される
+- `production_ltc_60k.json` に保守的な初期値 (例: bps=15, sidepct=20, cooldown=60) が入る
+- 板薄時間帯に BookGate が REJECTED を出し始める（=「両建てバグ修正で見えなくなっていた」エッジケース対応）
+- close 約定後 60 秒は新規エントリーが COOLDOWN_BLOCKED
+
+---
+
+## 1. 設計書からの調整点
+
+### 1.1 現状コードの構造を踏まえた配線
+
+PR4 開始時点の事実：
+
+- `entity.RiskConfig` には `MaxSlippageBps` / `MaxBookSidePct` / `EntryCooldownSec` 全部存在（PR3 までで揃った）
+- live event_pipeline.go と backtest runner.go の **両方で BookGate は条件付き配線済み** — `cfg.MaxSlippageBps > 0 || cfg.MaxBookSidePct > 0` で activate
+- ただし **profile JSON には対応フィールドが無い** — `cfg.Risk` (env var only) からしか値が入らない
+- main.go は profile 読み込み **後** に riskMgr を構築し直すパスが無い: `riskMgr := NewRiskManager(...)` の後で `loadLiveProfile()` が呼ばれる
+
+→ 必要な改修：
+
+1. `StrategyRiskConfig` (profile 内) に 3 フィールド追加
+2. main.go の起動順序を「profile → riskMgr」または `riskMgr.UpdateConfig` 呼び出しに変える
+3. `production_ltc_60k.json` を更新
+
+### 1.2 設定の優先順位
+
+env var (`RISK_MAX_SLIPPAGE_BPS` など) も既に存在する。両方ある場合の優先順位：
+
+- **profile が値を持っていれば profile 優先**（profile-driven な意図が prod の真実）
+- profile に値が無い (zero) なら env var 値を fallback
+- どちらも 0 なら gate 無効（既存動作）
+
+これにより、PR4 後でも env var で動かしている古い deployment は壊れない。`production.json` 等の他 profile は値未設定のまま残し、cooldown / BookGate は無効のまま（後続 PR5 まではそのまま）。
+
+### 1.3 `production_ltc_60k.json` の初期値
+
+設計書 §10.2 に sweep 候補が載っている：
+
+- `entry_cooldown_sec`: 30 / 60 / 120 / 300
+- `max_slippage_bps`: 10 / 15 / 20 / 30
+- `max_book_side_pct`: 10 / 20 / 30
+
+PR4 ではこの sweep を**走らせない**。「保守的初期値で発火確認」が PR4 のゴール。設計書 §8.4 の例 (`bps=15`, `sidepct=20`, `cooldown=60`) を採用し、PDCA で sweep するのは別 PR / 別作業。
+
+### 1.4 MCP / API 経由の `UpdateConfig`
+
+`RiskManager.UpdateConfig` は API/MCP からも呼ばれる。MCP が **古いフィールドだけ送ってくる** と、PR4 で profile 経由で入れた新フィールドが消える可能性がある。
+
+実装上は `UpdateConfig(config entity.RiskConfig)` が **構造体丸ごと置換** か **0 値スキップ** かで挙動が変わる。これは現状コードを読んで判断する：
+
+<details>
+<summary>確認手順</summary>
+
+```go
+// usecase/risk.go の UpdateConfig
+func (rm *RiskManager) UpdateConfig(config entity.RiskConfig) {
+    rm.mu.Lock()
+    defer rm.mu.Unlock()
+    rm.config = config // 丸ごと置換 → MCP が部分更新したつもりで全 reset
+}
+```
+
+もし丸ごと置換なら、MCP/API ハンドラ側でマージするか、`UpdateConfig` を `partial` 仕様にする小改修が必要。本 plan §3 Task 5 で対応する。
+</details>
+
+### 1.5 backtest 側の検証
+
+backtest runner は既に `riskCfg.MaxSlippageBps > 0 || MaxBookSidePct > 0` で BookGate 配線。`buildRunInput`（cmd/backtest/main.go）が profile から RiskConfig を組み立てる経路で 3 フィールドを引き継げば、CLI 経由の backtest でも自動で gate が効く。API 経由の backtest (`/backtest/run`) も同じ path を通るので一括で対応可能。
+
+---
+
+## 2. ファイル変更マップ
+
+| ファイル | 変更 | 行数目安 |
+|---|---|---|
+| `backend/internal/domain/entity/strategy_config.go` | StrategyRiskConfig に 3 フィールド + Validate 拡張 | +20 |
+| `backend/internal/domain/entity/strategy_config_test.go` | Validate ケース追加 | +50 |
+| `backend/cmd/main.go` | profile → riskMgr.UpdateConfig 反映 + selector func 追加 | +30 |
+| `backend/cmd/main_test.go` (もしあれば) | profile 反映テスト | +30 |
+| `backend/cmd/backtest/main.go` | buildRunInput で profile → RiskConfig マージ | ~10 行差分 |
+| `backend/internal/interfaces/api/handler/backtest.go` | API backtest が profile の 3 フィールドを RiskConfig に流す | ~15 行差分 |
+| `backend/internal/usecase/risk.go` | UpdateConfig が部分マージできるよう改修 (or 既に丸ごと置換なら別ヘルパー追加) | +15 |
+| `backend/internal/usecase/risk_test.go` | UpdateConfig 部分マージテスト | +30 |
+| `backend/internal/usecase/booklimit/book_limit_test.go` | エッジケース拡充 (snapshot stale / empty / top-N 不足) | +80 |
+| `backend/profiles/production_ltc_60k.json` | 3 フィールド追加 (bps=15, sidepct=20, cooldown=60) | +5 |
+
+合計：新規 0、編集 9、約 +280 行。
+
+---
+
+## 3. 実装タスク
+
+### Task 1: StrategyRiskConfig に 3 フィールド追加
+
+**変更**: `entity/strategy_config.go`
+
+```go
+type StrategyRiskConfig struct {
+    // ... 既存
+    PositionSizing *PositionSizingConfig `json:"position_sizing,omitempty"`
+
+    // PR4: BookGate / EntryCooldown profile knobs.
+    // 0 = inherit from env / disabled (matches RiskConfig zero-value semantics).
+    MaxSlippageBps   float64 `json:"max_slippage_bps,omitempty"`
+    MaxBookSidePct   float64 `json:"max_book_side_pct,omitempty"`
+    EntryCooldownSec int     `json:"entry_cooldown_sec,omitempty"`
+}
+```
+
+Validate 拡張：
+
+```go
+if p.Risk.MaxSlippageBps < 0 || p.Risk.MaxSlippageBps > 1000 {
+    errs = append(errs, fmt.Errorf("strategy_risk.max_slippage_bps must be in [0, 1000] (got %v)", p.Risk.MaxSlippageBps))
+}
+if p.Risk.MaxBookSidePct < 0 || p.Risk.MaxBookSidePct > 100 {
+    errs = append(errs, fmt.Errorf("strategy_risk.max_book_side_pct must be in [0, 100] (got %v)", p.Risk.MaxBookSidePct))
+}
+if p.Risk.EntryCooldownSec < 0 || p.Risk.EntryCooldownSec > 3600 {
+    errs = append(errs, fmt.Errorf("strategy_risk.entry_cooldown_sec must be in [0, 3600] (got %v)", p.Risk.EntryCooldownSec))
+}
+```
+
+**テスト**: 既存 `strategy_config_test.go` に：
+- 正常範囲 (15 / 20 / 60)
+- 境界値 (0 / 1000 / 100 / 3600)
+- 範囲外 (-1 / 1001 / 101 / 3601) でエラー
+
+**完了判定**: `go test ./internal/domain/entity/... -run StrategyRisk` 緑。
+
+---
+
+### Task 2: RiskManager.UpdateConfig の挙動を確認 + 部分マージヘルパー
+
+**事前調査**: `usecase/risk.go:478` の `UpdateConfig` を読み、現状仕様を確認する。
+
+**仮説 A** (丸ごと置換):
+
+```go
+func (rm *RiskManager) UpdateConfig(config entity.RiskConfig) {
+    rm.mu.Lock()
+    defer rm.mu.Unlock()
+    rm.config = config
+}
+```
+
+→ profile 反映用ヘルパー新設：
+
+```go
+// ApplyProfileRiskOverrides updates only fields that the profile explicitly
+// sets to a non-zero value. Existing zero-handling semantics (env-var fallback)
+// are preserved for fields the profile leaves unset.
+func (rm *RiskManager) ApplyProfileRiskOverrides(slippageBps, bookSidePct float64, entryCooldownSec int) {
+    rm.mu.Lock()
+    defer rm.mu.Unlock()
+    if slippageBps > 0 {
+        rm.config.MaxSlippageBps = slippageBps
+    }
+    if bookSidePct > 0 {
+        rm.config.MaxBookSidePct = bookSidePct
+    }
+    if entryCooldownSec > 0 {
+        rm.config.EntryCooldownSec = entryCooldownSec
+    }
+}
+```
+
+**仮説 B** (既に部分マージ): `UpdateConfig` を流用するだけで済む可能性もある。Task 1 の前にコードを開いて確認する。
+
+どちらにせよ MCP/API 経由の `UpdateConfig` は **後勝ち** なので、profile boot 後に MCP が古い値で上書きすることは **PR4 では受け入れる** (MCP の整合性は PR5 で別途扱う)。
+
+**テスト**: `risk_test.go` に：
+- ApplyProfileRiskOverrides で profile の 0 値が既存値を上書きしないこと
+- 非 0 値はちゃんと上書きすること
+- 既存 `UpdateConfig` の挙動が touch されていないこと
+
+**完了判定**: `go test ./internal/usecase/... -run "ApplyProfile|UpdateConfig"` 緑。
+
+---
+
+### Task 3: main.go で profile を riskMgr に反映
+
+**変更**: `cmd/main.go` の RiskManager 初期化直後に追加：
+
+```go
+riskMgr := usecase.NewRiskManager(entity.RiskConfig{...})
+
+// ... orderExecutor / realtimeHub wiring ...
+
+liveProfile := loadLiveProfile()
+
+// PR4: profile-driven risk knobs (BookGate thresholds + entry cooldown).
+// Applied AFTER NewRiskManager so they override the env-var defaults that
+// the constructor used. Zero values in the profile leave env-var fallbacks
+// untouched, so legacy deployments keep working.
+if liveProfile != nil {
+    riskMgr.ApplyProfileRiskOverrides(
+        liveProfile.Risk.MaxSlippageBps,
+        liveProfile.Risk.MaxBookSidePct,
+        liveProfile.Risk.EntryCooldownSec,
+    )
+    slog.Info("event-pipeline: profile risk overrides applied",
+        "profile", liveProfile.Name,
+        "maxSlippageBps", liveProfile.Risk.MaxSlippageBps,
+        "maxBookSidePct", liveProfile.Risk.MaxBookSidePct,
+        "entryCooldownSec", liveProfile.Risk.EntryCooldownSec,
+    )
+}
+```
+
+注意点: `loadLiveProfile()` の現位置が `riskMgr` 初期化より後ろになっている → 再構成が必要。シンプルに「profile 読みを上に移動」する。`loadLiveProfile` には外部依存 (env var / file) しかなく副作用無いので safe.
+
+**テスト**: 起動時挙動なので unit test より docker compose 検証で OK。logs に `profile risk overrides applied` が出ること、`/api/v1/status` の Config 部分が 3 フィールド入っていることを確認。
+
+---
+
+### Task 4: backtest path で profile → RiskConfig
+
+**変更**:
+
+- `cmd/backtest/main.go` の `buildRunInput`: profile.Risk から `MaxSlippageBps` / `MaxBookSidePct` / `EntryCooldownSec` を `RiskConfig` に積む
+- `internal/interfaces/api/handler/backtest.go`: API 経由の backtest も同じくマップ
+
+**テスト**: `runner_decision_log_test.go` 系で、profile に bps=15 を設定した backtest を 1 本流し、`Summary.BookGateRejects` に値が入ること（板薄時間帯があれば）or 配線が正しく通ったことを assert。
+
+**完了判定**: backtest 1 本が新フィールド付きで通り、BookGate がアタッチされる。
+
+---
+
+### Task 5: production_ltc_60k.json の更新
+
+**変更**: `backend/profiles/production_ltc_60k.json`
+
+```json
+"strategy_risk": {
+    "stop_loss_percent": 14,
+    "take_profit_percent": 4,
+    ...
+    "trailing_atr_multiplier": 2.5,
+    "max_slippage_bps": 15,
+    "max_book_side_pct": 20,
+    "entry_cooldown_sec": 60,
+    "position_sizing": { ... }
+}
+```
+
+description フィールドにも PR4 適用済みである旨を 1 行追加（履歴トレース用）。
+
+`production.json` / `production_eth.json` は **触らない** (運用していない or 別文脈)。
+
+---
+
+### Task 6: BookGate edge case test 拡充
+
+設計書 §7.1 で「snapshot fresh/stale/missing × top-N 充足/不足 × 自分のサイズが top-N の M%」の matrix が必要とある。既存の `book_limit_test.go` は基本ケースは網羅。不足分があれば追加：
+
+- snapshot が `nil` の場合（`AllowOnMissingBook=true` / `false` の両方）
+- snapshot が空 (top-N が 0 行) の場合
+- snapshot が古い (StaleAfterMillis 超過) の場合
+- top-N 充足だが自分のサイズが top-N 累積の 50% の場合 (各 sidepct 設定値)
+- VWAP が mid から大きく離れる ATR 急騰時の挙動
+
+既存テストを読み、不足分のみ追加する方針で。
+
+**完了判定**: `go test ./internal/usecase/booklimit/... -count=1` 緑、tests のカバレッジが体感的に 90%+。
+
+---
+
+### Task 7: backtest と live の対称性検証テスト
+
+設計書 §7.3「同じ profile を読ませた時、両 runner で BookGate / cooldown 設定が同じ値で有効化される」を明示テスト：
+
+- backtest runner と live event_pipeline の両方で profile を読み、`riskHandler.BookGate` が同じ Config (bps / sidepct / TopN) で構築されることを assert
+- `riskMgr.config.EntryCooldownSec` が両方で同じ値になること
+
+cmd 系のため真の unit test は難しい。`event_pipeline_test.go` / `runner_test.go` のレベルで profile-driven な配線を一気通貫テストする。
+
+---
+
+### Task 8: 全パッケージ緑 + 動作確認
+
+```bash
+go test ./... -race -count=1
+go vet ./...
+```
+
+**動作確認**:
+
+1. **profile 反映**: `docker compose up --build -d backend` → ログに `profile risk overrides applied` を確認
+2. **BookGate 発火確認**: `/api/v1/status` の `Config.MaxSlippageBps=15` を確認、bot 動かして `decision_log` の `book_gate_outcome=VETOED` 行が出ることを観測
+3. **EntryCooldown 発火確認**: 手動で position を作って close → 60 秒間 `decision_intent=COOLDOWN_BLOCKED` を観測
+4. **30 分監視**: 異常な REJECTED 増加なし、panic なし、`pipelineRunning=true` 維持
+
+---
+
+## 4. テスト戦略
+
+### 4.1 単体テスト
+
+| 対象 | テスト内容 |
+|---|---|
+| `StrategyRiskConfig` Validate | 3 フィールド境界値 |
+| `RiskManager.ApplyProfileRiskOverrides` | profile zero スキップ / 非 zero 上書き |
+| BookGate edge cases | snapshot stale / empty / top-N 不足 / 自サイズ M% |
+| Profile loading | profile JSON → entity.StrategyRiskConfig 正しくマップ |
+
+### 4.2 統合テスト
+
+- backtest 1 本 (production_ltc_60k profile + 短期間 + book replay 有り) で `Summary.BookGateRejects` が populated
+- live と backtest の対称配線テスト
+
+### 4.3 動作確認 (Docker)
+
+- profile 値が live で反映されている (logs + API)
+- BookGate / EntryCooldown が想定通り発火する
+
+---
+
+## 5. リスクと緩和
+
+| リスク | 影響 | 緩和 |
+|---|---|---|
+| BookGate が想定以上に厳しく、ほぼ全 entry が VETOED される | 売買が止まる | 初期値を保守的に (bps=15, sidepct=20)、PDCA で sweep |
+| EntryCooldown=60s で連続 entry を意図する局面で COOLDOWN_BLOCKED | 機会損失 | LTC 板薄なので 60s は妥当、PDCA で sweep |
+| MCP/API の UpdateConfig が profile 値を上書きしてしまう | profile-driven な制御が効かない | PR4 では受け入れ、PR5 で MCP の挙動見直し |
+| profile JSON の Validate ルール変更で既存 profile (60+) が break | 起動失敗 | Validate は 0 を許容、既存 profile はそのまま動く |
+| BookGate 強制で、PR3 で「両建てバグ修正により出るようになった entry」が再び弾かれる | EXIT_CANDIDATE 流の意図が損なわれる | EXIT_CANDIDATE 自体は PR3 で skip 済みなので影響なし。Veto は新規 NEW_ENTRY のみが対象 |
+
+---
+
+## 6. PR 作成手順
+
+1. ブランチ: `feat/bookgate-enable-profile`
+2. コミット粒度（5〜6 コミット）：
+   - **Commit 1**: StrategyRiskConfig に 3 フィールド + Validate
+   - **Commit 2**: RiskManager.ApplyProfileRiskOverrides ヘルパー
+   - **Commit 3**: main.go で profile → riskMgr 反映
+   - **Commit 4**: backtest path (CLI + API) で profile → RiskConfig マージ
+   - **Commit 5**: BookGate edge case test 拡充
+   - **Commit 6**: production_ltc_60k.json 更新
+3. PR 本文：「PR4 of 5」、動作変更（BookGate / EntryCooldown 発火）、保守的初期値の根拠、PDCA sweep への引き継ぎ
+4. CI 緑で squash merge
+5. マージ後、Docker 再起動 → 30 分監視
+
+---
+
+## 7. 完了の定義（DoD）
+
+- [ ] 8 タスクすべて完了
+- [ ] `go test ./... -race -count=1` 緑
+- [ ] `go vet ./...` 警告なし
+- [ ] profile JSON Validate の境界値テスト緑
+- [ ] backtest と live の対称配線テスト緑
+- [ ] BookGate edge case test 緑
+- [ ] live 起動 → ログで profile risk overrides 適用確認
+- [ ] `/api/v1/status` の Config に新フィールド値が見える
+- [ ] LTC ポジション flat 確認 (`/positions` = `[]`)
+- [ ] PR 本文に動作変更宣言 + 初期値の根拠
+
+---
+
+## 8. 後続 PR への引き継ぎ
+
+PR4 マージ後、PR5 (UI 表示 + cleanup) の plan を書く。
+
+PR5 のスコープ:
+
+- frontend `/history?tab=decisions` で `signal_direction` / `decision_intent` / `book_gate_outcome` を表示
+- "REJECTED (両建て総額)" だった行が "HOLD (保有中)" / "COOLDOWN_BLOCKED" / "VETOED" に変わるので UI 文言調整
+- `entity.Signal{Action}` の使用箇所を deprecated コメント
+- ドキュメント更新: AGENTS.md, docs/clean-architecture.md, docs/decision-log-health-check.md
+- MCP / API の `UpdateConfig` 挙動の見直し (profile fields をどう保護するか)
+
+PDCA sweep (entry_cooldown_sec / max_slippage_bps / max_book_side_pct):
+
+- PR4 マージ後に PDCA で 3 軸 sweep を回す
+- 結果を見て production_ltc_60k.json の値を最適化
+- これは別 PR / 別作業 (本 plan §1.3 通り)


### PR DESCRIPTION
## Summary

Signal/Decision/ExecutionPolicy 三層分離 (設計書: \`docs/design/2026-04-29-signal-decision-policy-separation-design.md\`) の **Phase 1 / PR4 of 5**。BookGate と EntryCooldown を strategy profile JSON 経由で設定可能にし、production_ltc_60k で発火させる。

**動作変更あり**: production 起動時に BookGate (15 bps / 20% / TopN=5) が発動、close 約定後 60 秒は新規エントリーが COOLDOWN_BLOCKED 化。

実装計画: \`docs/design/plans/2026-05-02-plan4-bookgate-enable-profile-update.md\`

## What changes

- **StrategyRiskConfig 拡張**: profile JSON の \`strategy_risk\` ブロックに 3 フィールド (\`max_slippage_bps\` / \`max_book_side_pct\` / \`entry_cooldown_sec\`) を追加。Validate に範囲チェック (slippage [0,1000], side_pct [0,100], cooldown [0,3600])。0 は disabled / inherit で許容
- **ApplyProfileRiskOverrides ヘルパー**: UpdateConfig (構造体丸ごと置換) を touch せず、profile が non-zero に設定したフィールドだけ partial update。MCP/API 経由の UpdateConfig との衝突は PR5 で別途対応
- **main.go 配線**: profile 読み込み直後に ApplyProfileRiskOverrides を呼ぶ。ログ出力で適用値が見える
- **backtest 経路**: CLI と HTTP API の両方で profile.Risk → RiskConfig に 3 フィールドを転送
- **production.json / production_ltc_60k.json 更新**: 保守的初期値 (15 / 20 / 60)
- **BookGate edge case test**: \`BookSidePctBoundary\` (境界値の strictly-greater reject 確認), \`TopNUnderfilled\` (板に N 段未満時の挙動)

## Verification

- ✅ \`go test ./... -race -count=1\` 全パッケージ緑
- ✅ \`go vet ./...\` 警告なし
- ✅ Validate の境界値テスト 12 ケース緑 (3 フィールド × 正常 / 負 / 上限超過 / 境界)
- ✅ ApplyProfileRiskOverrides の partial update テスト 3 ケース緑
- ✅ BookGate edge case 11 テスト緑 (新規 2 + 既存 9)
- ✅ profile loader が production_ltc_60k.json から 3 フィールドを正しく読むテスト緑
- ✅ **Docker 起動**: ログに以下が出る
  \`\`\`
  INFO live strategy profile loaded name=production baseDir=profiles
  INFO profile risk overrides applied profile=production maxSlippageBps=15 maxBookSidePct=20 entryCooldownSec=60
  \`\`\`
- ✅ \`GET /api/v1/config\` →
  \`\`\`json
  {"maxSlippageBps":15, "maxBookSidePct":20, "entryCooldownSec":60, ...}
  \`\`\`
- ✅ LTC ポジション flat (\`/positions\` = []) 確認

## Behavioral changes

| 状況 | PR3 まで | PR4 後 |
|---|---|---|
| 板薄時間帯の新規 entry | RiskManager 通過 → そのまま発注 | BookGate (15 bps / 20%) で REJECTED |
| close 約定後 0〜60 秒の新規 entry | DecisionHandler 通過 → entry | COOLDOWN_BLOCKED で抑制 |
| profile 切替時の RiskConfig | env-var 値が固定 | profile 値が override |

## Profile note (plan からの逸脱)

Plan 策定時には \`production.json\` を「触らない」としていたが、起動ログ確認で **実運用 profile (\`LIVE_PROFILE=production\`) は \`production.json\` (= \`production_ltc_60k.json\` の等価コピー)** だと判明。本番挙動を一致させるため両 JSON に同値の 3 フィールドを追加した。

## Commit breakdown (6 commits)

1. StrategyRiskConfig に 3 フィールド + Validate (+ plan)
2. ApplyProfileRiskOverrides partial update ヘルパー
3. main.go で profile → riskMgr 配線
4. backtest CLI + HTTP API path で profile → RiskConfig 転送
5. BookGate edge case test 拡充 + profile loader 回帰ガード
6. production.json / production_ltc_60k.json に 3 フィールド追加

## Next: PR5 + PDCA sweep

PR5 (UI / cleanup) で：

- \`/history?tab=decisions\` に \`signal_direction\` / \`decision_intent\` / \`book_gate_outcome\` を表示
- AGENTS.md / docs/clean-architecture.md / docs/decision-log-health-check.md 更新
- MCP / API \`UpdateConfig\` の partial-vs-full reset 仕様の見直し

PDCA sweep (別作業):

- entry_cooldown_sec: 30 / 60 / 120 / 300
- max_slippage_bps: 10 / 15 / 20 / 30
- max_book_side_pct: 10 / 20 / 30

## Test plan

- [x] backend unit / integration tests pass
- [x] Docker rebuild → profile 反映ログ確認
- [x] \`GET /api/v1/config\` で 3 フィールド値確認
- [ ] PR4 マージ後 30 分監視 (BookGate / EntryCooldown 発火を decision_log で確認)
- [ ] 板薄時間帯に \`book_gate_outcome=VETOED\` 行が出始めるかを観測