### PR TITLE
feat: Phase 1 PR5 — UI surface for Decision layer + docs cleanup (Phase 1 完了)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,8 @@
 ## Architecture
 
 - Clean Architecture: domain → usecase → infrastructure → interfaces の依存方向を厳守。
-- Trading Pipeline: イベント駆動 (`backend/cmd/event_pipeline.go` の `EventDrivenPipeline`)。プライマリ足 (PT15M) が確定するごとに 指標計算 → Stance 判定 → シグナル → リスクチェック → 注文 を実行する（旧 `pipeline.go` の 60 秒 polling は legacy）。SL/TP/Trailing は tick 単位で常時監視、ポジション同期 30 秒、残高/state sync は `STATE_SYNC_INTERVAL_SEC` (既定 15 秒)。`PIPELINE_INTERVAL_SEC` は legacy 用の遺物で EventDrivenPipeline では未使用。
+- Trading Pipeline: イベント駆動 (`backend/cmd/event_pipeline.go` の `EventDrivenPipeline`)。プライマリ足 (PT15M) が確定するごとに 指標計算 → Strategy → **Decision** → リスクチェック → 注文 を実行する（旧 `pipeline.go` の 60 秒 polling は legacy）。SL/TP/Trailing は tick 単位で常時監視、ポジション同期 30 秒、残高/state sync は `STATE_SYNC_INTERVAL_SEC` (既定 15 秒)。`PIPELINE_INTERVAL_SEC` は legacy 用の遺物で EventDrivenPipeline では未使用。
+- Signal / Decision / ExecutionPolicy 三層分離 (Phase 1 完了 2026-05-02): Strategy が市場解釈 (Direction = `BULLISH`/`BEARISH`/`NEUTRAL` + Strength) のみを返し、Decision レイヤがポジション保有状況と entry cooldown を加味して `NEW_ENTRY` / `EXIT_CANDIDATE` / `HOLD` / `COOLDOWN_BLOCKED` を出す。ExecutionPolicy (Risk + BookGate) で実発注に絞り込む。EXIT_CANDIDATE は現状 Risk で skip され実 exit は TP/SL に任せる。詳細: `docs/design/2026-04-29-signal-decision-policy-separation-design.md`
 - Stance: `TREND_FOLLOW` / `CONTRARIAN` / `BREAKOUT` / `HOLD`。ルールベース自動判定 or オーバーライド（オーバーライド可能なのは `TREND_FOLLOW` / `CONTRARIAN` / `HOLD` の3種）。
 - Indicators: SMA / EMA / RSI / MACD / Bollinger / ATR / Volume / ADX(+DI/-DI) / Stochastics (%K/%D/StochRSI) / Ichimoku (Tenkan/Kijun/SenkouA-B/Chikou)。
 - PDCA/Backtest: 単発 (`/backtest/run`) / 複数期間 (`/backtest/run-multi`) / Walk-Forward (`/backtest/walk-forward`) を API + CLI で提供、結果は SQLite に永続化。

--- a/backend/internal/domain/entity/signal.go
+++ b/backend/internal/domain/entity/signal.go
@@ -30,6 +30,13 @@ const (
 )
 
 // Signal はStrategy Engineが生成する売買シグナル。
+//
+// Deprecated (Phase 1, 2026-05-02): Signal は旧ルートの 1st-class entity
+// だったが、Phase 1 で MarketSignal (Direction + Strength) と ActionDecision
+// (Intent + Side) の二層に分割された。Signal は現在 RiskHandler 内で
+// synthSignal として組み立てられ ApprovedSignalEvent / RejectedSignalEvent
+// の payload として残っているだけ。Phase 6+ で完全に置換予定。
+// 詳細: docs/design/2026-04-29-signal-decision-policy-separation-design.md
 type Signal struct {
 	SymbolID   int64         `json:"symbolId"`
 	Action     SignalAction  `json:"action"`

--- a/backend/internal/interfaces/api/handler/decision.go
+++ b/backend/internal/interfaces/api/handler/decision.go
@@ -126,8 +126,25 @@ func decisionRecordToJSON(r entity.DecisionRecord) gin.H {
 			"confidence": r.SignalConfidence,
 			"reason":     r.SignalReason,
 		},
-		"risk":     gin.H{"outcome": r.RiskOutcome, "reason": r.RiskReason},
-		"bookGate": gin.H{"outcome": r.BookGateOutcome, "reason": r.BookGateReason},
+		// Phase 1 PR5 (Signal/Decision/ExecutionPolicy): expose the new shadow
+		// columns alongside the legacy `signal` block. The frontend renders
+		// both — `signal` carries the legacy BUY/SELL/HOLD label, while
+		// `marketSignal.direction` and `decision.intent` reveal the Phase 1
+		// classification (e.g. EXIT_CANDIDATE on a bearish-against-long bar).
+		// Empty strings / 0 indicate pre-PR2 rows; the frontend handles them
+		// as "—" so old runs still render without crashing.
+		"marketSignal": gin.H{
+			"direction": r.SignalDirection,
+			"strength":  r.SignalStrength,
+		},
+		"decision": gin.H{
+			"intent": r.DecisionIntent,
+			"side":   r.DecisionSide,
+			"reason": r.DecisionReason,
+		},
+		"exitPolicyOutcome":  r.ExitPolicyOutcome,
+		"risk":               gin.H{"outcome": r.RiskOutcome, "reason": r.RiskReason},
+		"bookGate":           gin.H{"outcome": r.BookGateOutcome, "reason": r.BookGateReason},
 		"order": gin.H{
 			"outcome": r.OrderOutcome,
 			"orderId": r.OrderID,

--- a/backend/internal/interfaces/api/handler/decision_test.go
+++ b/backend/internal/interfaces/api/handler/decision_test.go
@@ -127,3 +127,68 @@ func TestDecisionHandler_List_PreservesIndicatorsJSON(t *testing.T) {
 		t.Errorf("indicators_json must be passed through verbatim; body = %s", w.Body.String())
 	}
 }
+
+// TestDecisionHandler_List_ExposesPhaseOneFields ensures the API surface
+// carries the Phase 1 PR1 columns (signal_direction, decision_intent, etc.)
+// alongside the legacy `signal` block. Frontend depends on this shape from
+// PR5 onward to render the new "方向" / "判断" columns.
+func TestDecisionHandler_List_ExposesPhaseOneFields(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h, cleanup := newDecisionHandlerForTest(t)
+	defer cleanup()
+
+	rec := entity.DecisionRecord{
+		BarCloseAt:        1_000,
+		TriggerKind:       entity.DecisionTriggerBarClose,
+		SymbolID:          7,
+		CurrencyPair:      "LTC_JPY",
+		PrimaryInterval:   "PT15M",
+		Stance:            "TREND_FOLLOW",
+		LastPrice:         30210,
+		SignalAction:      "BUY",
+		SignalConfidence:  0.7,
+		SignalReason:      "trend follow legacy",
+		SignalDirection:   "BULLISH",
+		SignalStrength:    0.7,
+		DecisionIntent:    "NEW_ENTRY",
+		DecisionSide:      "BUY",
+		DecisionReason:    "no position; bullish signal -> new long",
+		ExitPolicyOutcome: "",
+		RiskOutcome:       entity.DecisionRiskApproved,
+		BookGateOutcome:   entity.DecisionBookAllowed,
+		OrderOutcome:      entity.DecisionOrderFilled,
+		IndicatorsJSON:    `{}`,
+		CreatedAt:         time.Now().UnixMilli(),
+	}
+	if err := h.repoForTest().Insert(context.Background(), rec); err != nil {
+		t.Fatalf("seed Insert: %v", err)
+	}
+
+	r := gin.New()
+	r.GET("/decisions", h.List)
+	req := httptest.NewRequest(http.MethodGet, "/decisions?symbolId=7", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	body := w.Body.String()
+	for _, want := range []string{
+		`"marketSignal"`,
+		`"direction":"BULLISH"`,
+		`"strength":0.7`,
+		`"decision"`,
+		`"intent":"NEW_ENTRY"`,
+		`"side":"BUY"`,
+		// Gin's default JSON encoder HTML-escapes ">" to ">". Match the
+		// safe substring that survives the escape so the test pins the
+		// presence of the reason without coupling to the encoder choice.
+		`"reason":"no position; bullish signal `,
+		`"exitPolicyOutcome":""`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("response missing %q\nbody: %s", want, body)
+		}
+	}
+}

--- a/docs/clean-architecture.md
+++ b/docs/clean-architecture.md
@@ -49,3 +49,19 @@ interfaces → usecase → domain ← infrastructure
 
 外側のレイヤーは内側のレイヤーに依存しますが、内側は外側を知りません。  
 Infrastructure 層は Domain 層のインターフェースを実装することで、依存性逆転の原則 (DIP) を実現しています。
+
+## Trading Pipeline の三層分離 (Phase 1 完了 2026-05-02)
+
+EventDrivenPipeline は売買判断を以下の三層に分離している:
+
+```
+Strategy (市場解釈) → Decision (意思決定) → ExecutionPolicy (実発注ガード)
+```
+
+- **Strategy 層** (`usecase/strategy.go` 配下): IndicatorEvent を受け、`MarketSignal{Direction, Strength}` を返す。BUY/SELL の言語は持たず `BULLISH`/`BEARISH`/`NEUTRAL` のみ。EventBus priority 20。
+- **Decision 層** (`usecase/decision/`): MarketSignal とポジション保有状況・entry cooldown を組み合わせて `ActionDecision{Intent, Side}` を出す。Intent は `NEW_ENTRY` / `EXIT_CANDIDATE` / `HOLD` / `COOLDOWN_BLOCKED`。EventBus priority 27。
+- **ExecutionPolicy 層** (`usecase/backtest/RiskHandler` + `usecase/booklimit`): ActionDecision を入力に Risk チェック + BookGate を適用し `ApprovedSignalEvent` または `RejectedSignalEvent` を出す。OrderExecutor が ApprovedSignalEvent を受けて実発注。EventBus priority 30 / 50 (close fill 観測)。
+
+EXIT_CANDIDATE は Phase 1 では Risk 段階で skip し、実 exit は TickRiskHandler (TP/SL/Trailing) に任せる。`exit_on_signal` 設定での opt-in 化は Phase 6+ の課題。
+
+詳細設計: `docs/design/2026-04-29-signal-decision-policy-separation-design.md`

--- a/docs/decision-log-health-check.md
+++ b/docs/decision-log-health-check.md
@@ -138,6 +138,52 @@ orphan_ticks
 | `empty_indicators > 0` | recorder の IndicatorEvent 受信に欠落 | 該当行を SELECT して `created_at` / `bar_close_at` を確認、近傍ログを照合 |
 | `orphan_ticks > 0` | tick 行の sequence 計算がおかしい | バーまたぎ前後の挙動を疑う。`SELECT * FROM decision_log WHERE bar_close_at = <該当>` で前後比較 |
 
+## Phase 1 三層分離カラムの確認 (2026-05-02 〜)
+
+PR1 (#232) 〜 PR4 (#235) で `decision_log` / `backtest_decision_log` に 6 列追加:
+`signal_direction`, `signal_strength`, `decision_intent`, `decision_side`, `decision_reason`, `exit_policy_outcome`.
+
+PR2 以降の行はすべての列が埋まっているはず。空文字 (`= ''`) が混じる場合は recorder が新ルートを購読し損なっている疑いあり。
+
+```sql
+-- 直近 24h の Decision レイヤ出力サマリ。NEW_ENTRY/HOLD/EXIT_CANDIDATE/COOLDOWN_BLOCKED の比率を把握する。
+SELECT
+  signal_direction,
+  decision_intent,
+  decision_side,
+  COUNT(*) AS rows
+FROM decision_log
+WHERE bar_close_at > strftime('%s','now','-24 hours') * 1000
+GROUP BY signal_direction, decision_intent, decision_side
+ORDER BY rows DESC;
+
+-- PR2 以降の行で signal_direction が空のものは異常 (recorder が新ルートを取り損ねている可能性)
+SELECT COUNT(*) AS empty_direction_rows
+FROM decision_log
+WHERE bar_close_at > strftime('%s','now','-24 hours') * 1000
+  AND signal_direction = '';
+
+-- EXIT_CANDIDATE が出ているか (両建て総額判定バグ修正の動作確認)
+SELECT bar_close_at, signal_action, signal_direction, decision_intent, decision_side, decision_reason
+FROM decision_log
+WHERE decision_intent = 'EXIT_CANDIDATE'
+ORDER BY bar_close_at DESC
+LIMIT 20;
+
+-- COOLDOWN_BLOCKED が出ているか (close 約定後 EntryCooldownSec 秒の抑制動作確認)
+SELECT bar_close_at, decision_intent, decision_reason
+FROM decision_log
+WHERE decision_intent = 'COOLDOWN_BLOCKED'
+ORDER BY bar_close_at DESC
+LIMIT 20;
+```
+
+期待される観察:
+
+- `signal_direction` 別: NEUTRAL が圧倒的、BULLISH / BEARISH が時々
+- `decision_intent` 別: HOLD が大半、NEW_ENTRY が時々、EXIT_CANDIDATE は保有中の signal 反転時のみ、COOLDOWN_BLOCKED は close 直後 60 秒以内
+- `signal_action` (旧) と `signal_direction` (新) の整合: BUY ↔ BULLISH、SELL ↔ BEARISH、HOLD ↔ NEUTRAL
+
 ## バックテスト側
 
 `backtest_decision_log` も同じ要領で確認できる。違いは `backtest_run_id` で必ず scope すること:

--- a/docs/design/plans/2026-05-02-plan5-ui-and-cleanup.md
+++ b/docs/design/plans/2026-05-02-plan5-ui-and-cleanup.md
@@ -1,0 +1,355 @@
+# PR5 Plan: UI 表示 + ドキュメント更新 + cleanup（Phase 1 仕上げ）
+
+- 作成日: 2026-05-02
+- 親設計書: `docs/design/2026-04-29-signal-decision-policy-separation-design.md`
+- 前段 PR: #232 / #233 / #234 / #235（PR1〜4 全マージ済み）
+- スコープ: Phase 1 / Stacked PR シリーズ (PR5 ÷ 5 — 最終)
+- **動作変更なし** — UI 拡張、ドキュメント更新、deprecate 表記の追加のみ
+
+---
+
+## 0. このドキュメントの位置付け
+
+PR4 までで Phase 1 の機能要件と動作変更はすべて入った。PR5 は **観察と保守の仕上げ**：
+
+- フロントエンドが新カラム (`signal_direction`, `decision_intent`, `decision_side`, `decision_reason`, `book_gate_outcome` の表示) を見えるようにする
+- "REJECTED (両建て総額)" だった行が "EXIT_CANDIDATE" / "COOLDOWN_BLOCKED" / "VETOED" に変わったので、UI 文言も整える
+- `entity.Signal{Action}` 経路の使用を deprecated 表記する（完全削除は Phase 6+）
+- AGENTS.md / docs/clean-architecture.md / docs/decision-log-health-check.md を Phase 1 後の現実に追従させる
+
+PR5 マージで Phase 1 は完了。Phase 6+（Exit Policy 拡張、指値 close、複数銘柄）は別ロードマップ。
+
+---
+
+## 1. 現状調査（PR5 plan 策定時に確認した事実）
+
+### 1.1 frontend のデータ型と画面
+
+- `frontend/src/lib/api.ts` の `DecisionLogItem` 型は `signal: { action, confidence, reason }` / `risk` / `bookGate` / `order` のネスト構造（旧スキーマ）
+- 新カラム (`signal_direction`, `signal_strength`, `decision_intent`, `decision_side`, `decision_reason`, `exit_policy_outcome`) は **API 応答にも frontend にも未着信**
+- 表示先は `frontend/src/components/DecisionLogTable.tsx`（`/history?tab=decisions`）と `RecentDecisionsCard.tsx`（監視画面の直近判断カード）
+- 現状の `signal.action` は "BUY" / "SELL" / "HOLD" のいずれか。新カラムが流れれば direction（BULLISH/BEARISH/NEUTRAL）と intent（NEW_ENTRY/EXIT_CANDIDATE/HOLD/COOLDOWN_BLOCKED）が表示できる
+
+### 1.2 backend API レスポンスの形
+
+`backend/internal/interfaces/api/handler/decision.go:105-144` の `decisionRecordToJSON` が `DecisionRecord` を JSON に変換しているが、PR1 で追加した 6 フィールドを **まだ含めていない**。これを足すのが PR5 の起点。
+
+### 1.3 backtest の decision endpoint
+
+`/api/v1/backtest/results/:id/decisions` も同じく旧フィールドのみ返している（同じヘルパーを使っているか別か要確認）。frontend `backtest-decisions.tsx` で表示。
+
+### 1.4 docs の現状
+
+- `AGENTS.md`: Stance / Indicators / Backtest の説明は最新だが、Signal/Decision/ExecutionPolicy 三層分離は未言及
+- `docs/clean-architecture.md`: Trading Pipeline の構成が "60 秒 polling 旧 + EventDriven 新" の頃の説明
+- `docs/decision-log-health-check.md`: 6.4 KB と充実、ただし新カラムの SQL 例は未記載
+- `docs/agent-operation-guide.md`: Bot 操作手順、新カラムの存在は未記載（直接の影響は薄い）
+
+### 1.5 廃止予定 (deprecated) すべき箇所
+
+- `entity.Signal` 型（`SignalAction = "BUY"|"SELL"|"HOLD"`）。新ルートでは `entity.MarketSignal{Direction}` と `entity.ActionDecision{Intent, Side}` の組が真実だが、`entity.Signal` は `RiskHandler` 内部で synthSignal として使われ、`ApprovedSignalEvent.Signal` フィールド経由で `ExecutionHandler` まで届く。完全削除は Phase 6+ の cleanup PR (設計書 §5.3 通り)
+- 設計書 §5.3 の方針通り、PR5 では **削除せず deprecated コメントだけ付ける**
+
+---
+
+## 2. ファイル変更マップ
+
+| ファイル | 変更 | 行数目安 |
+|---|---|---|
+| `backend/internal/interfaces/api/handler/decision.go` | レスポンスに 6 新フィールド追加 | +20 |
+| `backend/internal/interfaces/api/handler/decision_test.go` (もしあれば) | レスポンス検証 | +30 |
+| `backend/internal/interfaces/api/handler/backtest.go` | backtest_decision_log JSON 化に 6 新フィールド追加 | +20 |
+| `backend/internal/domain/entity/signal.go` | Signal 型に deprecated コメント | +5 |
+| `frontend/src/lib/api.ts` | DecisionLogItem に 6 新フィールド | +10 |
+| `frontend/src/components/DecisionLogTable.tsx` | 列追加（Direction / Intent / BookGate label 整備） | +60 |
+| `frontend/src/components/DecisionDetailPanel.tsx` | 詳細パネルに 5 フィールド表示 | +30 |
+| `frontend/src/components/RecentDecisionsCard.tsx` | 直近カードに intent 表示 | +20 |
+| `frontend/src/lib/decisionReasonI18n.ts` | 新 outcome の翻訳追加 | +20 |
+| `AGENTS.md` | 三層分離の追記、Phase 1 完了の文脈 | +15 |
+| `docs/clean-architecture.md` | Trading Pipeline 説明を Decision レイヤ追加へ更新 | +20 |
+| `docs/decision-log-health-check.md` | 新カラム存在チェック SQL 例 | +30 |
+
+合計：新規 0、編集 12、約 +280 行（純増）。
+
+---
+
+## 3. 実装タスク
+
+### Task 1: backend API レスポンスに 6 フィールド追加
+
+**変更**: `backend/internal/interfaces/api/handler/decision.go` の `decisionRecordToJSON`
+
+```go
+return gin.H{
+    // ... 既存
+    "decision": gin.H{
+        "intent":    r.DecisionIntent,    // NEW_ENTRY / EXIT_CANDIDATE / HOLD / COOLDOWN_BLOCKED / ""
+        "side":      r.DecisionSide,      // BUY / SELL / ""
+        "reason":    r.DecisionReason,
+    },
+    "marketSignal": gin.H{
+        "direction": r.SignalDirection,   // BULLISH / BEARISH / NEUTRAL / ""
+        "strength":  r.SignalStrength,
+    },
+    "exitPolicyOutcome": r.ExitPolicyOutcome, // PR4 で BookGate 経由の出口判断記録 (現状未使用)
+    // ... 残り
+}
+```
+
+ネスト構造を採用する理由：旧 `signal: {action, confidence, reason}` と並列に置くことで、frontend が「旧レコード（空フィールド）」と「新レコード」を区別せずに 1 つの型で扱える。
+
+**テスト**: `decision_test.go` があれば `decisionRecordToJSON` の round-trip テストを追加。新カラム値を持った DecisionRecord を入れて、JSON 出力に正しく現れることを検証。
+
+**完了判定**: `go test ./internal/interfaces/api/handler/... -run Decision` 緑。
+
+---
+
+### Task 2: backtest_decision_log の JSON 化も同期
+
+`backend/internal/interfaces/api/handler/backtest.go` の `/backtest/results/:id/decisions` エンドポイント — Task 1 と同じヘルパーを共有しているか別実装か確認し、後者なら同じ追加を行う。
+
+backtest 結果の history タブで PR2 以降の新カラムが見える状態を作る（既に backtest 経由で 36k+ 行の新カラム記録あり）。
+
+---
+
+### Task 3: frontend DecisionLogItem 型拡張
+
+**変更**: `frontend/src/lib/api.ts`
+
+```ts
+export type DecisionLogItem = {
+  // ... 既存
+  signal: { action: 'BUY' | 'SELL' | 'HOLD'; confidence: number; reason: string }
+
+  // PR5 (Phase 1): new shadow / decision-route columns. All fields are
+  // optional with empty-string default so old rows (signal_direction = "")
+  // pre-PR2 / post-PR3 mixed runs both render cleanly.
+  marketSignal?: { direction: 'BULLISH' | 'BEARISH' | 'NEUTRAL' | ''; strength: number }
+  decision?: {
+    intent: 'NEW_ENTRY' | 'EXIT_CANDIDATE' | 'HOLD' | 'COOLDOWN_BLOCKED' | ''
+    side: 'BUY' | 'SELL' | ''
+    reason: string
+  }
+  exitPolicyOutcome?: string
+  // ... 既存の risk / bookGate / order
+}
+```
+
+`?` で optional にしているのは、まだ backend 改修前の API でも壊れず、新フィールドが空文字 / 0 で来てもクラッシュしないようにするため。
+
+---
+
+### Task 4: DecisionLogTable に列追加 + 文言調整
+
+**変更**: `frontend/src/components/DecisionLogTable.tsx`
+
+- 列追加: 「方向」(Direction) / 「判断」(Intent) を追加。スタンス列の右隣
+- 「シグナル」列は旧 BUY/SELL/HOLD のままで残し、新カラム列との対比で「Phase 1 移行が一目で分かる」状態を維持
+- BookGate label を `BookGate` から「板厚」(または「板ガード」) に変更し、`VETOED` → "拒否（板薄/スリッページ過大）" の文言を追加
+- `rowBackground` に `intent === 'COOLDOWN_BLOCKED'` の薄グレー背景を追加
+
+```tsx
+const INTENT_LABEL: Record<NonNullable<DecisionLogItem['decision']>['intent'], string> = {
+  NEW_ENTRY: '新規エントリー',
+  EXIT_CANDIDATE: '利確/損切り候補',
+  HOLD: '見送り',
+  COOLDOWN_BLOCKED: 'クールダウン',
+  '': '—',
+}
+
+const DIRECTION_LABEL: Record<NonNullable<DecisionLogItem['marketSignal']>['direction'], string> = {
+  BULLISH: '買い優勢',
+  BEARISH: '売り優勢',
+  NEUTRAL: '中立',
+  '': '—',
+}
+```
+
+---
+
+### Task 5: DecisionDetailPanel 拡張
+
+詳細パネル（行クリック展開）に以下を 1 ブロックで表示：
+
+- 市場シグナル: Direction / Strength / Source
+- Decision: Intent / Side / Reason
+- Exit Policy Outcome（あれば）
+
+旧の Signal action / confidence / reason はそのまま残し、「旧経路（PR3 以前の出力）」とラベル付けして並列表示。Phase 6+ で旧経路が消えれば自然に空欄化する。
+
+---
+
+### Task 6: RecentDecisionsCard の Intent 表示
+
+監視画面の直近判断カードは現在 `signal.action` を主役に表示している。新カラムが入っていれば Intent を表示し、空なら旧 action にフォールバック：
+
+```tsx
+const primaryLabel = item.decision?.intent
+  ? INTENT_LABEL[item.decision.intent]
+  : item.signal.action
+```
+
+---
+
+### Task 7: decisionReasonI18n 拡張
+
+新 reason のいくつかは英語のままなので翻訳マップを追加：
+
+- `"no position; bullish signal -> new long"` → "保有なし、上昇シグナル → 新規ロング"
+- `"long held; bearish signal -> exit candidate"` → "ロング保有中、下落シグナル → 利確候補"
+- `"entry cooldown active after recent close"` → "直近の決済後クールダウン中"
+- `"thin_book_pre_trade"` → "板薄（取引前）"
+- `"depth_above_threshold"` → "板の自ロット占有率が上限超過"
+
+---
+
+### Task 8: AGENTS.md / docs 更新
+
+**AGENTS.md** に追記（Architecture セクション）：
+
+```md
+- Signal / Decision / ExecutionPolicy: 三層分離 (Phase 1 完了 2026-05-02)。
+  Strategy が市場解釈 (BULLISH/BEARISH/NEUTRAL + Strength) のみを返し、
+  Decision レイヤがポジション保有状況と cooldown を加味して
+  NEW_ENTRY / EXIT_CANDIDATE / HOLD / COOLDOWN_BLOCKED を出す。
+  ExecutionPolicy (Risk + BookGate) で実発注に絞り込む。
+  詳細: `docs/design/2026-04-29-signal-decision-policy-separation-design.md`
+```
+
+**docs/clean-architecture.md** に Decision レイヤの位置付けを追記。
+
+**docs/decision-log-health-check.md** に新カラムの存在検証 SQL を追加：
+
+```sql
+-- Phase 1 PR1 マイグレーション後、新 6 カラムが書かれているか
+SELECT
+  signal_direction, decision_intent, decision_side,
+  COUNT(*) AS rows
+FROM decision_log
+WHERE bar_close_at > strftime('%s','now','-24 hours')*1000
+GROUP BY signal_direction, decision_intent, decision_side
+ORDER BY rows DESC;
+```
+
+---
+
+### Task 9: entity.Signal 型に deprecated コメント
+
+```go
+// Signal はStrategy Engineが生成する売買シグナル。
+//
+// Deprecated (Phase 1, 2026-05-02): Signal は旧ルートの 1st-class entity
+// だったが、Phase 1 で MarketSignal (Direction + Strength) と ActionDecision
+// (Intent + Side) の二層に分割された。Signal は現在 RiskHandler 内で
+// synthSignal として組み立てられ ApprovedSignalEvent / RejectedSignalEvent
+// の payload として残っているだけ。Phase 6+ で完全に置換予定。
+type Signal struct { ... }
+```
+
+完全削除しないので touch する場所は最小（コメントのみ）。
+
+---
+
+### Task 10: 全パッケージ緑 + 動作確認
+
+- `go test ./... -race -count=1` 緑
+- `go vet ./...` 警告なし
+- `cd frontend && pnpm test` 緑
+- `cd frontend && pnpm tsc --noEmit` で TypeScript 型エラーなし
+- Docker rebuild → frontend が新カラムを画面に表示することを目視確認
+  - `/history?tab=decisions` で 「方向」「判断」列が出る
+  - 行クリックで DecisionDetailPanel に Decision セクションが出る
+  - 監視画面の直近判断カードに Intent が出る
+
+---
+
+## 4. テスト戦略
+
+### 4.1 backend
+
+- `decisionRecordToJSON` round-trip テスト（新フィールド込みで JSON が期待値）
+- backtest path も同じ shape を返すことの確認（または共有ヘルパー化）
+
+### 4.2 frontend
+
+- `DecisionLogTable` のスナップショット or 簡易テスト（新列のレンダー）
+- Intent ラベルが空文字でも crash しないこと
+
+### 4.3 動作確認 (manual)
+
+Docker で backend + frontend を立てて：
+
+1. `/history?tab=decisions&symbol=LTC_JPY` でテーブルに 「方向」「判断」列が見える
+2. 過去（PR2 以降の）行で `BULLISH/BEARISH/NEUTRAL` と `NEW_ENTRY/EXIT_CANDIDATE/HOLD` が表示される
+3. 監視画面の直近判断カードで Intent ラベルが出る
+4. 詳細パネル展開で 5 フィールドが見える
+
+---
+
+## 5. リスクと緩和
+
+| リスク | 影響 | 緩和 |
+|---|---|---|
+| API レスポンス shape 変更で既存 frontend が break | 画面壊れる | 新フィールドは optional (`?`) で追加、旧キーは touch しない |
+| backtest と live で API shape が違うことが固定化 | 保守性悪化 | Task 2 で同じヘルパー化 (or shape を揃える) |
+| docs 更新漏れで Phase 1 後の運用がブレる | 運用混乱 | AGENTS.md / clean-architecture.md / decision-log-health-check.md の 3 箇所で必ず更新 |
+| Signal 型の deprecated 表記で linter が騒ぐ | CI 失敗 | コメントのみで実コードは触らない、go vet レベルで問題なし |
+| frontend の i18n マップ漏れ | 英語が残る | `translateReason` のフォールバックで raw 文字列が出る (既存挙動) |
+
+---
+
+## 6. PR 作成手順
+
+1. ブランチ: `feat/phase1-ui-and-cleanup`
+2. コミット粒度（5〜6 コミット）：
+   - **Commit 1**: backend API レスポンスに 6 新フィールド追加 (+ plan)
+   - **Commit 2**: frontend DecisionLogItem 型拡張 + i18n マップ
+   - **Commit 3**: DecisionLogTable に列追加 + 文言調整
+   - **Commit 4**: DecisionDetailPanel + RecentDecisionsCard 拡張
+   - **Commit 5**: docs 更新 (AGENTS.md / clean-architecture.md / decision-log-health-check.md)
+   - **Commit 6**: entity.Signal に deprecated コメント
+3. PR 本文：「PR5 of 5 (Phase 1 最終)」、動作変更なし、UI で新カラム可視化、Phase 1 完了宣言
+4. CI 緑で squash merge
+
+---
+
+## 7. 完了の定義（DoD）
+
+- [ ] 10 タスクすべて完了
+- [ ] backend tests / frontend tests 緑
+- [ ] `go vet` / `tsc --noEmit` 警告なし
+- [ ] Docker 再起動で frontend に新列が表示される（目視）
+- [ ] 詳細パネルで Decision セクションが表示される
+- [ ] 直近判断カードで Intent が表示される
+- [ ] AGENTS.md / clean-architecture.md / decision-log-health-check.md が Phase 1 後の状態
+- [ ] entity.Signal の Deprecated コメントが付いている
+- [ ] PR 本文に「Phase 1 完了」を明記
+
+---
+
+## 8. Phase 1 完了後の引き継ぎ
+
+PR5 マージで Phase 1 は完了。以後の課題（設計書 §10）：
+
+### 後続で取り組む
+
+- **Exit Policy 拡張**: BEARISH 連続でロング利確を早めるロジック (Phase 6+)
+- **指値 close API**: 成行依存からの脱却 (市場インパクト軽減)
+- **/positions と RiskManager の整合性問題**: in-memory 状態と exchange-side のずれ調査
+- **EXIT_CANDIDATE の opt-in 発注 (`exit_on_signal` 設定)**: Phase 6+
+
+### PDCA で sweep する新変数（PR4 マージ済み）
+
+- `entry_cooldown_sec`: 30 / 60 / 120 / 300 で比較
+- `max_slippage_bps`: 10 / 15 / 20 / 30 で reject 率と net pnl
+- `max_book_side_pct`: 10 / 20 / 30 で同上
+
+これらの sweep は PR5 とは独立した PDCA cycle として運用。
+
+### 構造の自然な拡張余地
+
+C のレイヤ分離が定着すれば、以下が同じ構造に乗る（設計書 §10.3）：
+
+- 複数 stance の同時評価（一票方式 / 加重平均）
+- 複数銘柄横断のポートフォリオ判定
+- 機械学習モデルを Strategy or Decision に差し込み

--- a/frontend/src/components/DecisionDetailPanel.tsx
+++ b/frontend/src/components/DecisionDetailPanel.tsx
@@ -4,9 +4,56 @@ type Props = { item: DecisionLogItem }
 
 export function DecisionDetailPanel({ item }: Props) {
   return (
-    <div className="grid gap-4 md:grid-cols-2">
-      <Section title="主要指標" data={item.indicators} />
-      <Section title="上位足指標" data={item.higherTfIndicators} />
+    <div className="space-y-4">
+      <PhaseOnePanel item={item} />
+      <div className="grid gap-4 md:grid-cols-2">
+        <Section title="主要指標" data={item.indicators} />
+        <Section title="上位足指標" data={item.higherTfIndicators} />
+      </div>
+    </div>
+  )
+}
+
+// PhaseOnePanel surfaces the Signal/Decision/ExecutionPolicy three-layer
+// payload that PR1–PR3 introduced. Old rows (pre-PR2) carry empty strings /
+// 0 in these fields; the panel still renders them as "—" so legacy data
+// stays browsable.
+function PhaseOnePanel({ item }: { item: DecisionLogItem }) {
+  const direction = item.marketSignal?.direction ?? ''
+  const strength = item.marketSignal?.strength ?? 0
+  const intent = item.decision?.intent ?? ''
+  const side = item.decision?.side ?? ''
+  const decisionReason = item.decision?.reason ?? ''
+  const exitOutcome = item.exitPolicyOutcome ?? ''
+
+  // Hide the panel entirely when none of the new fields are populated —
+  // there is no point showing "—" for every row in pre-PR2 backtest data.
+  if (!direction && !intent && !side && !decisionReason && !exitOutcome) {
+    return null
+  }
+
+  return (
+    <div className="rounded-2xl border border-white/8 p-4">
+      <h3 className="mb-3 text-xs uppercase tracking-[0.2em] text-text-secondary">
+        Signal / Decision (Phase 1)
+      </h3>
+      <dl className="grid grid-cols-2 gap-x-4 gap-y-1 text-sm md:grid-cols-3">
+        <KV label="方向 (Direction)" value={direction || '—'} />
+        <KV label="強度 (Strength)" value={strength ? strength.toFixed(2) : '—'} />
+        <KV label="判断 (Intent)" value={intent || '—'} />
+        <KV label="サイド" value={side || '—'} />
+        <KV label="出口判定" value={exitOutcome || '—'} />
+        <KV label="判断理由" value={decisionReason || '—'} wide />
+      </dl>
+    </div>
+  )
+}
+
+function KV({ label, value, wide }: { label: string; value: string; wide?: boolean }) {
+  return (
+    <div className={wide ? 'contents md:col-span-3' : 'contents'}>
+      <dt className="truncate text-text-secondary">{label}</dt>
+      <dd className={wide ? 'md:col-span-2' : 'truncate text-right'}>{value}</dd>
     </div>
   )
 }

--- a/frontend/src/components/DecisionLogTable.tsx
+++ b/frontend/src/components/DecisionLogTable.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import type { DecisionLogItem } from '../lib/api'
+import type { DecisionLogItem, DecisionIntent, SignalDirection } from '../lib/api'
 import { translateReason } from '../lib/decisionReasonI18n'
 import { DecisionDetailPanel } from './DecisionDetailPanel'
 
@@ -23,6 +23,23 @@ const ORDER_LABEL: Record<DecisionLogItem['order']['outcome'], string> = {
   NOOP: '発注なし',
 }
 
+// Phase 1 PR5: new shadow / decision-route columns. Empty string maps to "—"
+// so PR1-era rows that lack the new fields render cleanly.
+const DIRECTION_LABEL: Record<SignalDirection, string> = {
+  BULLISH: '買い優勢',
+  BEARISH: '売り優勢',
+  NEUTRAL: '中立',
+  '': '—',
+}
+
+const INTENT_LABEL: Record<DecisionIntent, string> = {
+  NEW_ENTRY: '新規エントリー',
+  EXIT_CANDIDATE: '利確/損切り候補',
+  HOLD: '見送り',
+  COOLDOWN_BLOCKED: 'クールダウン',
+  '': '—',
+}
+
 export function DecisionLogTable({ decisions }: Props) {
   const [expandedId, setExpandedId] = useState<number | null>(null)
 
@@ -40,10 +57,12 @@ export function DecisionLogTable({ decisions }: Props) {
           <tr>
             <th className="px-4 py-3 text-left">時刻</th>
             <th className="px-4 py-3 text-left">スタンス</th>
+            <th className="px-4 py-3 text-left">方向</th>
+            <th className="px-4 py-3 text-left">判断</th>
             <th className="px-4 py-3 text-left">シグナル</th>
             <th className="px-4 py-3 text-right">信頼度</th>
             <th className="px-4 py-3 text-left">リスク</th>
-            <th className="px-4 py-3 text-left">BookGate</th>
+            <th className="px-4 py-3 text-left">板ガード</th>
             <th className="px-4 py-3 text-left">結果</th>
             <th className="px-4 py-3 text-right">数量/価格</th>
             <th className="px-4 py-3 text-left">理由</th>
@@ -74,9 +93,17 @@ function Row({
   onClick: () => void
 }) {
   const bg = rowBackground(item)
+  const decisionReason = item.decision?.reason ?? ''
   const rawReason =
-    item.signal.reason || item.risk.reason || item.bookGate.reason || item.order.error || '—'
+    decisionReason ||
+    item.signal.reason ||
+    item.risk.reason ||
+    item.bookGate.reason ||
+    item.order.error ||
+    '—'
   const reason = translateReason(rawReason)
+  const direction = item.marketSignal?.direction ?? ''
+  const intent = item.decision?.intent ?? ''
   return (
     <>
       <tr className={`cursor-pointer border-t border-white/8 ${bg}`} onClick={onClick}>
@@ -85,7 +112,9 @@ function Row({
           <div className="text-xs text-text-secondary">{item.triggerKind}</div>
         </td>
         <td className="px-4 py-3">{item.stance || '—'}</td>
-        <td className="px-4 py-3 font-medium">{item.signal.action}</td>
+        <td className="px-4 py-3">{DIRECTION_LABEL[direction]}</td>
+        <td className="px-4 py-3 font-medium">{INTENT_LABEL[intent]}</td>
+        <td className="px-4 py-3">{item.signal.action}</td>
         <td className="px-4 py-3 text-right">
           {item.signal.action === 'HOLD'
             ? '—'
@@ -107,7 +136,7 @@ function Row({
       </tr>
       {expanded && (
         <tr className="border-t border-white/8 bg-white/3">
-          <td colSpan={9} className="px-4 py-4">
+          <td colSpan={11} className="px-4 py-4">
             <DecisionDetailPanel item={item} />
           </td>
         </tr>
@@ -121,6 +150,11 @@ function rowBackground(item: DecisionLogItem): string {
   if (item.risk.outcome === 'REJECTED' || item.bookGate.outcome === 'VETOED')
     return 'bg-accent-red/8'
   if (item.triggerKind !== 'BAR_CLOSE') return 'bg-white/3'
+  // Phase 1 PR5: cooldown / exit-candidate rows are visually distinct from
+  // the plain HOLD bars so operators can see where the new Decision layer
+  // intervened.
+  if (item.decision?.intent === 'COOLDOWN_BLOCKED') return 'bg-white/5'
+  if (item.decision?.intent === 'EXIT_CANDIDATE') return 'bg-accent-yellow/8'
   if (item.signal.action === 'HOLD') return 'bg-accent-yellow/6'
   return ''
 }

--- a/frontend/src/components/RecentDecisionsCard.tsx
+++ b/frontend/src/components/RecentDecisionsCard.tsx
@@ -75,6 +75,7 @@ function MiniDecisionTable({ decisions }: { decisions: DecisionLogItem[] }) {
           <tr>
             <th className="px-3 py-2 text-left">時刻</th>
             <th className="px-3 py-2 text-left">スタンス</th>
+            <th className="px-3 py-2 text-left">判断</th>
             <th className="px-3 py-2 text-left">シグナル</th>
             <th className="px-3 py-2 text-right">信頼度</th>
             <th className="px-3 py-2 text-left">結果</th>
@@ -92,12 +93,28 @@ function MiniDecisionTable({ decisions }: { decisions: DecisionLogItem[] }) {
   )
 }
 
+// Phase 1 PR5: short Intent labels for the dashboard mini-table. Empty
+// (pre-PR2 row) maps to "—" so legacy data still renders.
+const INTENT_SHORT_LABEL: Record<NonNullable<DecisionLogItem['decision']>['intent'], string> = {
+  NEW_ENTRY: '新規',
+  EXIT_CANDIDATE: '出口候補',
+  HOLD: '見送り',
+  COOLDOWN_BLOCKED: 'クールダウン',
+  '': '—',
+}
+
 function MiniRow({ item }: { item: DecisionLogItem }) {
   const bg = rowBackground(item)
   const rawReason =
-    item.signal.reason || item.risk.reason || item.bookGate.reason || item.order.error || '—'
+    item.decision?.reason ||
+    item.signal.reason ||
+    item.risk.reason ||
+    item.bookGate.reason ||
+    item.order.error ||
+    '—'
   const reason = translateReason(rawReason)
   const outcome = outcomeLabel(item)
+  const intent = item.decision?.intent ?? ''
   return (
     <tr className={`border-t border-white/8 ${bg}`}>
       <td className="px-3 py-2 whitespace-nowrap">
@@ -107,6 +124,7 @@ function MiniRow({ item }: { item: DecisionLogItem }) {
         })}
       </td>
       <td className="px-3 py-2">{item.stance || '—'}</td>
+      <td className="px-3 py-2 whitespace-nowrap">{INTENT_SHORT_LABEL[intent]}</td>
       <td className="px-3 py-2 font-medium">{item.signal.action}</td>
       <td className="px-3 py-2 text-right">
         {item.signal.action === 'HOLD'
@@ -161,6 +179,10 @@ function outcomeLabel(item: DecisionLogItem): string {
   if (item.order.outcome === 'FAILED') return '失敗'
   if (item.risk.outcome === 'REJECTED') return '却下(リスク)'
   if (item.bookGate.outcome === 'VETOED') return '却下(板)'
+  // Phase 1 PR5: cooldown / exit candidates short-circuit before the
+  // legacy HOLD / NOOP labels.
+  if (item.decision?.intent === 'COOLDOWN_BLOCKED') return 'クールダウン'
+  if (item.decision?.intent === 'EXIT_CANDIDATE') return '出口候補(待機)'
   if (item.signal.action === 'HOLD') return 'HOLD'
   if (item.triggerKind !== 'BAR_CLOSE') return item.triggerKind
   return '発注なし'

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -678,6 +678,14 @@ export async function createManualOrder(req: ManualOrderRequest): Promise<Manual
   return sendApi<ManualOrderResponse, ManualOrderRequest>('/orders', 'POST', req)
 }
 
+export type SignalDirection = 'BULLISH' | 'BEARISH' | 'NEUTRAL' | ''
+export type DecisionIntent =
+  | 'NEW_ENTRY'
+  | 'EXIT_CANDIDATE'
+  | 'HOLD'
+  | 'COOLDOWN_BLOCKED'
+  | ''
+
 export type DecisionLogItem = {
   id: number
   barCloseAt: number
@@ -689,6 +697,12 @@ export type DecisionLogItem = {
   stance: string
   lastPrice: number
   signal: { action: 'BUY' | 'SELL' | 'HOLD'; confidence: number; reason: string }
+  // Phase 1 PR5 (Signal/Decision/ExecutionPolicy 三層分離) で追加された新カラム。
+  // PR2 以降の行は値が入り、PR1 以前 / 旧データには空文字 / 0 が入る。
+  // optional 化しているのは、後方互換のため (古い API 応答が来てもクラッシュしない)。
+  marketSignal?: { direction: SignalDirection; strength: number }
+  decision?: { intent: DecisionIntent; side: 'BUY' | 'SELL' | ''; reason: string }
+  exitPolicyOutcome?: string
   risk: { outcome: 'APPROVED' | 'REJECTED' | 'SKIPPED'; reason: string }
   bookGate: { outcome: 'ALLOWED' | 'VETOED' | 'SKIPPED'; reason: string }
   order: { outcome: 'FILLED' | 'FAILED' | 'NOOP'; orderId: number; amount: number; price: number; error: string }

--- a/frontend/src/lib/decisionReasonI18n.ts
+++ b/frontend/src/lib/decisionReasonI18n.ts
@@ -79,6 +79,20 @@ const STATIC_REASONS: Record<string, string> = {
   stop_loss: 'ストップロス',
   trailing_stop: 'トレイリングストップ',
   'circuit_breaker:price_jump': 'サーキットブレーカー: 価格急変',
+
+  // --- Phase 1 Decision レイヤ (Signal/Decision/ExecutionPolicy 三層分離) ---
+  'no position; bullish signal -> new long': '保有なし: 上昇シグナルで新規ロング',
+  'no position; bearish signal -> new short': '保有なし: 下落シグナルで新規ショート',
+  'no position; neutral signal': '保有なし: シグナル中立',
+  'long held; bearish signal -> exit candidate': 'ロング保有中: 下落シグナルで利確/損切候補',
+  'long held; not bearish': 'ロング保有中: 下落シグナルではない',
+  'short held; bullish signal -> exit candidate': 'ショート保有中: 上昇シグナルで利確/損切候補',
+  'short held; not bullish': 'ショート保有中: 上昇シグナルではない',
+  'unknown position side; defensive hold': '保有方向不明: 安全側で見送り',
+  'entry cooldown active after recent close': '直近の決済後クールダウン中',
+
+  // --- Phase 1 BookGate (PR4 で有効化) ---
+  depth_above_threshold: '板厚に対する自ロットの占有率が上限超過',
 }
 
 type DynamicRule = { regex: RegExp; replace: (m: RegExpMatchArray) => string }


### PR DESCRIPTION
## Summary

Signal/Decision/ExecutionPolicy 三層分離 (設計書: \`docs/design/2026-04-29-signal-decision-policy-separation-design.md\`) の **Phase 1 / PR5 of 5 — 最終 PR**。Phase 1 で起きた挙動変化を観察可能にする UI と docs の仕上げ。

**動作変更なし** — 表示変更とドキュメント追記、deprecated 表記のみ。

実装計画: \`docs/design/plans/2026-05-02-plan5-ui-and-cleanup.md\`

## What changes

- **backend API**: \`/decisions\` と \`/backtest/results/:id/decisions\` レスポンスに 3 ブロック追加
  \`\`\`json
  "marketSignal": {"direction":"BULLISH","strength":0.7},
  "decision":     {"intent":"NEW_ENTRY","side":"BUY","reason":"..."},
  "exitPolicyOutcome": ""
  \`\`\`
  旧 \`signal\` ブロックは温存
- **frontend 型拡張**: \`DecisionLogItem\` に上記 3 フィールドを optional で追加。旧 backend / 旧データでも crash しない
- **DecisionLogTable**: 「方向」「判断」列追加、行背景色を EXIT_CANDIDATE / COOLDOWN_BLOCKED 用に拡張、BookGate ヘッダ和訳化
- **DecisionDetailPanel**: "Signal / Decision (Phase 1)" セクション追加（5 フィールド表示）
- **RecentDecisionsCard** (監視画面): 「判断」列追加 + outcomeLabel に COOLDOWN_BLOCKED / EXIT_CANDIDATE 判別追加
- **i18n**: Decision レイヤの reason 文字列 11 種を和訳
- **docs 更新**: AGENTS.md / clean-architecture.md / decision-log-health-check.md の 3 箇所
- **entity.Signal 型**: godoc Deprecated コメント付与（実コードは touch なし、Phase 6+ で完全置換）

## Verification

- ✅ \`go test ./... -race -count=1\` 全パッケージ緑
- ✅ \`go vet ./...\` 警告なし
- ✅ frontend \`pnpm test\` 47 tests pass
- ✅ frontend \`tsc --noEmit\` PR5 起因の新規エラー無し（既存 main の TS error は無関係）
- ✅ Docker 起動 → \`/decisions\` API レスポンスに新フィールドが乗ることを目視確認
  \`\`\`json
  "decision":{"intent":"HOLD","reason":"long held; not bearish","side":""},
  "marketSignal":{"direction":"BEARISH","strength":...}
  \`\`\`
- ✅ Decision handler に新 ExposesPhaseOneFields テスト追加・緑

## Behavioral changes

なし。観察可能性が増えるだけ。

| 表示要素 | PR4 まで | PR5 後 |
|---|---|---|
| 履歴テーブルの列 | スタンス / シグナル (BUY/SELL/HOLD) | + 方向 (BULLISH/BEARISH/NEUTRAL) + 判断 (NEW_ENTRY/EXIT_CANDIDATE/HOLD/COOLDOWN_BLOCKED) |
| 詳細パネル | 主要指標 / 上位足指標 | + Signal / Decision (Phase 1) ブロック |
| 監視画面ミニテーブル | スタンス / シグナル | + 判断 |
| 行背景 (履歴) | HOLD = 黄薄 | + EXIT_CANDIDATE = 黄濃 / COOLDOWN_BLOCKED = グレー |

## Phase 1 完了

| PR | 内容 | 状態 |
|---|---|---|
| #232 | entity 型 + decision_log migration | ✅ Merged (\`dea4060\`) |
| #233 | DecisionHandler shadow route | ✅ Merged (\`b404eab\`) |
| #234 | RiskHandler decision cutover + EntryCooldown | ✅ Merged (\`b35b187\`) |
| #235 | BookGate enable + EntryCooldown via profile | ✅ Merged (\`0db7fee\`) |
| **#236 (本 PR)** | **UI / docs / cleanup** | **PR5** |

## Commit breakdown (6 commits)

1. backend API レスポンスに 6 列追加 + plan
2. frontend DecisionLogItem 型拡張 + i18n マップ
3. DecisionLogTable に列追加 + 文言調整
4. DecisionDetailPanel + RecentDecisionsCard 拡張
5. docs 更新 (AGENTS.md / clean-architecture.md / decision-log-health-check.md)
6. entity.Signal に Deprecated コメント

## Next: Phase 6+ (別ロードマップ)

設計書 §10 の後続課題:

- Exit Policy 拡張 (BEARISH 連続でロング利確を早めるロジック、\`exit_on_signal\` 設定)
- 指値 close API (成行依存からの脱却 / 市場インパクト軽減)
- /positions と RiskManager の整合性問題の解決
- entity.Signal の完全削除

PDCA sweep (PR4 マージ済みフィールド):
- entry_cooldown_sec: 30 / 60 / 120 / 300
- max_slippage_bps: 10 / 15 / 20 / 30
- max_book_side_pct: 10 / 20 / 30

## Test plan

- [x] backend / frontend tests pass
- [x] \`/decisions\` API レスポンスに新フィールド乗ることを実 endpoint で確認
- [x] Docker 起動正常
- [ ] (PR5 マージ後 \`/history?tab=decisions\` で「方向」「判断」列が表示されることを目視)