### PR TITLE
feat(risk): exit_on_signal — Decision-driven exits via RiskHandler

### DIFF
--- a/backend/cmd/backtest/main.go
+++ b/backend/cmd/backtest/main.go
@@ -734,6 +734,7 @@ func buildRunInput(f runFlags, profile *entity.StrategyProfile) (bt.RunInput, er
 		in.BBSqueezeLookback = profile.StanceRules.BBSqueezeLookback
 		in.IndicatorPeriods = profile.Indicators
 		in.PositionSizing = profile.Risk.PositionSizing
+		in.ExitOnSignal = profile.Risk.ExitOnSignal
 	}
 	return in, nil
 }

--- a/backend/cmd/event_pipeline.go
+++ b/backend/cmd/event_pipeline.go
@@ -105,6 +105,11 @@ type EventDrivenPipeline struct {
 	// initialBalance seeds the PeakTracker for drawdown-based lot scaling.
 	// Sourced from cfg.Risk.InitialCapital at startup.
 	initialBalance float64
+	// exitOnSignal mirrors profile.Risk.ExitOnSignal. When true, RiskHandler
+	// closes positions on IntentExitCandidate via the live executor instead
+	// of leaving the exit to TP/SL/Trailing. Defaults false so profiles
+	// that have not opted in keep the Phase 1 behaviour.
+	exitOnSignal bool
 
 	// primaryInterval / higherTFInterval drive the LiveSource, the
 	// IndicatorHandler, and every per-bar handler that needs to know which
@@ -202,6 +207,13 @@ type EventDrivenPipelineConfig struct {
 	// InitialBalance seeds the PeakTracker for drawdown-aware lot scaling.
 	// Typically cfg.Risk.InitialCapital. 0 disables PeakTracker.
 	InitialBalance float64
+
+	// ExitOnSignal mirrors profile.Risk.ExitOnSignal. When true the live
+	// RiskHandler closes positions on Decision-layer IntentExitCandidate
+	// instead of leaving exits to the TP/SL/Trailing tick path. Defaults
+	// false to preserve Phase 1 behaviour for profiles that have not
+	// opted in.
+	ExitOnSignal bool
 }
 
 func NewEventDrivenPipeline(
@@ -242,6 +254,7 @@ func NewEventDrivenPipeline(
 		higherTFInterval:   higherTFIntervalOrDefault(cfg.HigherTFInterval),
 		positionSizing:     cfg.PositionSizing,
 		initialBalance:     cfg.InitialBalance,
+		exitOnSignal:       cfg.ExitOnSignal,
 	}
 }
 
@@ -718,6 +731,8 @@ func (p *EventDrivenPipeline) runEventLoop(ctx context.Context, snap eventSnapsh
 		TradeAmount:     snap.tradeAmount,
 		StopLossPercent: snap.riskPolicy.StopLoss.Percent,
 		MinConfidence:   snap.minConfidence,
+		ExitOnSignal:    p.exitOnSignal,
+		Executor:        executor,
 	}
 	if ps := p.positionSizing; ps != nil && ps.Mode != "" && ps.Mode != "fixed" {
 		defaults := positionsize.VenueDefaults(p.currencyPair)

--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -208,6 +208,7 @@ func main() {
 			HigherTFInterval:   liveHigherTFIntervalFromEnv(),
 			PositionSizing:     liveProfilePositionSizing(liveProfile),
 			InitialBalance:     cfg.Risk.InitialCapital,
+			ExitOnSignal:       liveProfileExitOnSignal(liveProfile),
 		},
 		restClient,
 		restClient, // SymbolFetcher
@@ -538,6 +539,17 @@ func liveProfilePositionSizing(p *entity.StrategyProfile) *entity.PositionSizing
 		return nil
 	}
 	return p.Risk.PositionSizing
+}
+
+// liveProfileExitOnSignal returns profile.Risk.ExitOnSignal, defaulting to
+// false when the profile is missing. Threading this through main lets the
+// pipeline keep its profile-agnostic constructor signature while still
+// honouring the profile's opt-in for Decision-driven exits.
+func liveProfileExitOnSignal(p *entity.StrategyProfile) bool {
+	if p == nil {
+		return false
+	}
+	return p.Risk.ExitOnSignal
 }
 
 // livePrimaryIntervalFromEnv reads $LIVE_PRIMARY_INTERVAL with a PT15M

--- a/backend/internal/domain/entity/decision.go
+++ b/backend/internal/domain/entity/decision.go
@@ -57,6 +57,12 @@ const (
 	DecisionTriggerBarClose     = "BAR_CLOSE"
 	DecisionTriggerTickSLTP     = "TICK_SLTP"
 	DecisionTriggerTickTrailing = "TICK_TRAILING"
+	// DecisionTriggerDecisionExit identifies an exit produced by the
+	// Decision layer (IntentExitCandidate consumed by RiskHandler when the
+	// strategy profile opted in via ExitOnSignal). Distinct from the tick
+	// SL/TP/Trailing exits so the recorder and analytics can attribute
+	// signal-driven closes to the strategy rather than the risk envelope.
+	DecisionTriggerDecisionExit = "DECISION_EXIT"
 )
 
 // Risk gate outcomes.

--- a/backend/internal/domain/entity/strategy_config.go
+++ b/backend/internal/domain/entity/strategy_config.go
@@ -377,6 +377,14 @@ type StrategyRiskConfig struct {
 	MaxSlippageBps   float64 `json:"max_slippage_bps,omitempty"`
 	MaxBookSidePct   float64 `json:"max_book_side_pct,omitempty"`
 	EntryCooldownSec int     `json:"entry_cooldown_sec,omitempty"`
+
+	// ExitOnSignal opts the strategy into Decision-driven exits: when the
+	// Decision layer emits IntentExitCandidate (long held + bearish signal,
+	// or short held + bullish signal), RiskHandler closes every matching
+	// position via OrderExecutor.Close, instead of leaving the exit to the
+	// TP/SL/Trailing tick path. Defaults to false to preserve the Phase 1
+	// "TP/SL only" behaviour for profiles that have not opted in.
+	ExitOnSignal bool `json:"exit_on_signal,omitempty"`
 }
 
 // PositionSizingConfig declares how per-trade lot size is derived at runtime.

--- a/backend/internal/interfaces/api/handler/backtest.go
+++ b/backend/internal/interfaces/api/handler/backtest.go
@@ -351,11 +351,13 @@ func (h *BacktestHandler) Run(c *gin.Context) {
 	var bbLookback int
 	var positionSizing *entity.PositionSizingConfig
 	var indicatorPeriods entity.IndicatorConfig
+	var exitOnSignal bool
 	if profile != nil {
 		resolved := resolveRiskProfile(baseDir, profile)
 		bbLookback = resolved.StanceRules.BBSqueezeLookback
 		positionSizing = resolved.Risk.PositionSizing
 		indicatorPeriods = resolved.Indicators
+		exitOnSignal = resolved.Risk.ExitOnSignal
 	}
 
 	fillSource, bookSource, err := h.buildExecutionSourcesForCfg(c.Request.Context(), cfg)
@@ -372,6 +374,7 @@ func (h *BacktestHandler) Run(c *gin.Context) {
 		BBSqueezeLookback: bbLookback,
 		IndicatorPeriods:  indicatorPeriods,
 		PositionSizing:    positionSizing,
+		ExitOnSignal:      exitOnSignal,
 		FillPriceSource:   fillSource,
 		BookSource:        bookSource,
 		ResultID:          preallocatedRunID,

--- a/backend/internal/interfaces/api/handler/backtest_multi.go
+++ b/backend/internal/interfaces/api/handler/backtest_multi.go
@@ -213,11 +213,13 @@ func (h *BacktestHandler) RunMulti(c *gin.Context) {
 			var bbLookback int
 			var positionSizing *entity.PositionSizingConfig
 			var indicatorPeriods entity.IndicatorConfig
+			var exitOnSignal bool
 			if profile != nil {
 				resolved := resolveRiskProfile(baseDir, profile)
 				bbLookback = resolved.StanceRules.BBSqueezeLookback
 				positionSizing = resolved.Risk.PositionSizing
 				indicatorPeriods = resolved.Indicators
+				exitOnSignal = resolved.Risk.ExitOnSignal
 			}
 			fillSrc, bookSrc, buildErr := h.buildExecutionSourcesForCfg(c.Request.Context(), cfg)
 			if buildErr != nil {
@@ -231,6 +233,7 @@ func (h *BacktestHandler) RunMulti(c *gin.Context) {
 				BBSqueezeLookback: bbLookback,
 				IndicatorPeriods:  indicatorPeriods,
 				PositionSizing:    positionSizing,
+				ExitOnSignal:      exitOnSignal,
 				FillPriceSource:   fillSrc,
 				BookSource:        bookSrc,
 				RiskConfig: entity.RiskConfig{

--- a/backend/internal/interfaces/api/handler/backtest_walkforward.go
+++ b/backend/internal/interfaces/api/handler/backtest_walkforward.go
@@ -267,6 +267,7 @@ func (h *BacktestHandler) RunWalkForward(c *gin.Context) {
 				BBSqueezeLookback: profile.StanceRules.BBSqueezeLookback,
 				IndicatorPeriods:  profile.Indicators,
 				PositionSizing:    profile.Risk.PositionSizing,
+				ExitOnSignal:      profile.Risk.ExitOnSignal,
 				FillPriceSource:   fillSrc,
 				BookSource:        bookSrc,
 				RiskConfig:        risk,

--- a/backend/internal/usecase/backtest/handler.go
+++ b/backend/internal/usecase/backtest/handler.go
@@ -481,6 +481,17 @@ type SignalSizer interface {
 	Sized(requested, entryPrice, slPercent, equity, atr, ddPct, confidence, minConfidence float64) (amount float64, skipReason string)
 }
 
+// DecisionExitExecutor is the narrow capability the RiskHandler needs to
+// honour Decision-layer exits (IntentExitCandidate when the profile opted
+// in via ExitOnSignal). Both SimExecutor and the live RealExecutor satisfy
+// it transparently — only the methods we touch are listed so test fakes
+// can implement just these two without dragging in the full executor
+// surface (Open / SelectSLTPExit, etc.).
+type DecisionExitExecutor interface {
+	Positions() []eventengine.Position
+	Close(positionID int64, signalPrice float64, reason string, timestamp int64) (entity.OrderEvent, *entity.BacktestTradeRecord, error)
+}
+
 // RiskHandler gates SignalEvents using RiskManager with injected event time
 // and (optionally) a position sizer that decides the lot per trade.
 type RiskHandler struct {
@@ -508,11 +519,25 @@ type RiskHandler struct {
 	// BookGateRejects counts how many signals the gate vetoed across
 	// the run, broken down by reason. Used for backtest reports.
 	BookGateRejects map[string]int
+
+	// ExitOnSignal opts the handler into Decision-driven exits. When true
+	// and Executor is non-nil, IntentExitCandidate closes every same-symbol
+	// position whose Side opposes the decision's Side (i.e. matches the
+	// position the strategy now wants to flatten). Defaults to false so
+	// profiles that have not opted in keep the Phase 1 "TP/SL only" path.
+	ExitOnSignal bool
+	// Executor backs ExitOnSignal closes. nil disables the branch even
+	// when ExitOnSignal is true (defensive — tests that wire only the
+	// risk-manager half stay on the legacy silent path). Both the
+	// backtest SimExecutor and the live RealExecutor satisfy this.
+	Executor DecisionExitExecutor
 }
 
 // Handle dispatches on event type:
 //   - ActionDecisionEvent (PR3+): the new execution input. Decision-layer
-//     output drives sizing / risk gate / book gate / approved emission.
+//     output drives sizing / risk gate / book gate / approved emission for
+//     IntentNewEntry, and (when ExitOnSignal is set on the profile)
+//     direct close emission for IntentExitCandidate.
 //   - OrderEvent: observed for close-fill detection so the entry cooldown
 //     can be armed via RiskManager.NoteClose. The handler does not emit
 //     anything in this branch.
@@ -537,11 +562,17 @@ func (h *RiskHandler) handleDecision(ctx context.Context, decisionEvent entity.A
 
 	decision := decisionEvent.Decision
 
+	// IntentExitCandidate: when the profile opted in via ExitOnSignal AND an
+	// executor is wired, close every position on the same symbol whose Side
+	// opposes the decision's Side (i.e. the positions the strategy now
+	// wants to flatten). Without ExitOnSignal the branch stays silent so
+	// the legacy TP/SL/Trailing path remains the only exit channel.
+	if decision.Intent == entity.IntentExitCandidate {
+		return h.handleExitCandidate(decisionEvent)
+	}
+
 	// HOLD / COOLDOWN_BLOCKED: nothing to do — recorder already captured the
 	// decision, and there is no order to attempt.
-	// EXIT_CANDIDATE is intentionally skipped in PR3: real exits stay on the
-	// TP/SL/Trailing path. A future PR may introduce an `exit_on_signal`
-	// profile flag to opt into signal-driven closes.
 	if decision.Intent != entity.IntentNewEntry {
 		return nil, nil
 	}
@@ -646,6 +677,73 @@ func (h *RiskHandler) handleDecision(ctx context.Context, decisionEvent entity.A
 			Urgency:   synthSignal.Urgency,
 		},
 	}, nil
+}
+
+// handleExitCandidate closes every position on the decision's symbol whose
+// Side is opposite to decision.Side (i.e. the position(s) the strategy now
+// wants to flatten). The branch is a no-op unless the profile opted in via
+// ExitOnSignal AND an executor is wired — both gates are intentional so a
+// missing dependency cannot accidentally start trading on a profile that
+// never asked for signal-driven exits.
+//
+// Each successful close emits an OrderEvent tagged with
+// DecisionTriggerDecisionExit so the recorder / analytics can attribute the
+// exit to the Decision layer rather than the tick SL/TP/Trailing path.
+// ClosedPositionID is populated for downstream consumers (RiskHandler arms
+// the entry cooldown via NoteClose when it sees a non-zero ClosedPositionID).
+//
+// Sizer / RiskManager / BookGate are intentionally skipped: an exit is a
+// forced unwind, sizing logic does not apply, and a thin book must not
+// trap the bot in a position the strategy no longer wants to hold.
+// ThinBookError from a thin orderbook leaves the position open — the next
+// tick still has SL/TP/Trailing as a backstop, and a fresh
+// IntentExitCandidate next bar will retry the close.
+func (h *RiskHandler) handleExitCandidate(decisionEvent entity.ActionDecisionEvent) ([]entity.Event, error) {
+	if !h.ExitOnSignal || h.Executor == nil {
+		return nil, nil
+	}
+	decision := decisionEvent.Decision
+	if decision.Side == "" {
+		// Decision-layer bug: EXIT_CANDIDATE without a side. Stay silent
+		// rather than guess — the recorder already captured the decision.
+		return nil, nil
+	}
+	// The position to flatten is the one whose Side is opposite to
+	// decision.Side: a long-flatten EXIT carries Side=Sell, so we close
+	// every Buy position on the symbol (and vice versa).
+	target := entity.OrderSideBuy
+	if decision.Side == entity.OrderSideBuy {
+		target = entity.OrderSideSell
+	}
+
+	emitted := make([]entity.Event, 0)
+	for _, pos := range h.Executor.Positions() {
+		if pos.SymbolID != decision.SymbolID {
+			continue
+		}
+		if pos.Side != target {
+			continue
+		}
+		orderEvent, _, err := h.Executor.Close(
+			pos.PositionID,
+			decisionEvent.Price,
+			decision.Reason,
+			decisionEvent.Timestamp,
+		)
+		if err != nil {
+			var thin *infraThinBookError
+			if errors.As(err, &thin) {
+				// Thin book: leave the position open; tick SL/TP/Trailing
+				// is still active, and the next bar's Decision will retry.
+				continue
+			}
+			return nil, err
+		}
+		orderEvent.Trigger = entity.DecisionTriggerDecisionExit
+		orderEvent.ClosedPositionID = pos.PositionID
+		emitted = append(emitted, orderEvent)
+	}
+	return emitted, nil
 }
 
 // handleOrderEvent arms the entry cooldown when an OrderEvent represents a

--- a/backend/internal/usecase/backtest/handler_test.go
+++ b/backend/internal/usecase/backtest/handler_test.go
@@ -386,8 +386,9 @@ func TestRiskHandler_EmitsRejectedOnRiskManagerVeto(t *testing.T) {
 }
 
 // TestRiskHandler_PR3_NonNewEntryIntentsAreSilent: HOLD / EXIT_CANDIDATE /
-// COOLDOWN_BLOCKED must produce zero events. EXIT_CANDIDATE is intentionally
-// silent in PR3 — real exits stay on the TP/SL path.
+// COOLDOWN_BLOCKED must produce zero events when ExitOnSignal is OFF (the
+// default). EXIT_CANDIDATE only becomes loud when both ExitOnSignal=true
+// AND an executor is wired — that path has its own dedicated tests.
 func TestRiskHandler_PR3_NonNewEntryIntentsAreSilent(t *testing.T) {
 	riskMgr := usecase.NewRiskManager(entity.RiskConfig{
 		MaxPositionAmount: 1_000_000,
@@ -463,6 +464,273 @@ func TestRiskHandler_PR3_OrderEventArmsCooldown(t *testing.T) {
 	}
 	if riskMgr3.IsEntryCooldown(time.UnixMilli(closeTs).Add(time.Second)) {
 		t.Error("failed close must not arm entry cooldown")
+	}
+}
+
+// fakeDecisionExitExecutor is a minimal DecisionExitExecutor for the
+// EXIT_CANDIDATE branch tests. It records every Close call so we can assert
+// the exact (positionID, price, timestamp, reason) tuples the handler emitted.
+type fakeDecisionExitExecutor struct {
+	positions []eventengine.Position
+	closedIDs []int64
+	closeErr  error
+	closeCall []struct {
+		positionID int64
+		price      float64
+		reason     string
+		ts         int64
+	}
+}
+
+func (f *fakeDecisionExitExecutor) Positions() []eventengine.Position {
+	out := make([]eventengine.Position, len(f.positions))
+	copy(out, f.positions)
+	return out
+}
+
+func (f *fakeDecisionExitExecutor) Close(positionID int64, signalPrice float64, reason string, timestamp int64) (entity.OrderEvent, *entity.BacktestTradeRecord, error) {
+	if f.closeErr != nil {
+		return entity.OrderEvent{}, nil, f.closeErr
+	}
+	f.closedIDs = append(f.closedIDs, positionID)
+	f.closeCall = append(f.closeCall, struct {
+		positionID int64
+		price      float64
+		reason     string
+		ts         int64
+	}{positionID: positionID, price: signalPrice, reason: reason, ts: timestamp})
+	// Return a minimal OrderEvent — the handler overwrites Trigger and
+	// ClosedPositionID, so we only need the executor to surface a non-zero
+	// OrderID so downstream cooldown plumbing (in production) would arm.
+	return entity.OrderEvent{
+		OrderID:   1000 + positionID,
+		SymbolID:  0,
+		Price:     signalPrice,
+		Reason:    reason,
+		Timestamp: timestamp,
+	}, nil, nil
+}
+
+// TestRiskHandler_ExitOnSignal_DisabledStaysSilent is the safety net: with
+// ExitOnSignal=false (default) the handler must keep the Phase 1 behaviour
+// where IntentExitCandidate produces zero events. Wiring an executor must
+// not flip the branch on by accident.
+func TestRiskHandler_ExitOnSignal_DisabledStaysSilent(t *testing.T) {
+	riskMgr := usecase.NewRiskManager(entity.RiskConfig{
+		MaxPositionAmount: 1_000_000,
+		InitialCapital:    1_000_000,
+	})
+	exec := &fakeDecisionExitExecutor{
+		positions: []eventengine.Position{
+			{PositionID: 1, SymbolID: 7, Side: entity.OrderSideBuy, Amount: 0.5, EntryPrice: 9000},
+		},
+	}
+	handler := &RiskHandler{
+		RiskManager:  riskMgr,
+		TradeAmount:  0.01,
+		Executor:     exec,
+		ExitOnSignal: false,
+	}
+
+	events, err := handler.Handle(context.Background(), entity.ActionDecisionEvent{
+		Decision: entity.ActionDecision{
+			SymbolID: 7,
+			Intent:   entity.IntentExitCandidate,
+			Side:     entity.OrderSideSell,
+			Reason:   "long held; bearish signal -> exit candidate",
+		},
+		Price:     10000,
+		Timestamp: time.Now().UnixMilli(),
+	})
+	if err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if len(events) != 0 {
+		t.Errorf("ExitOnSignal=false must stay silent, got %d events", len(events))
+	}
+	if len(exec.closedIDs) != 0 {
+		t.Errorf("executor.Close must not be called, got %v", exec.closedIDs)
+	}
+}
+
+// TestRiskHandler_ExitOnSignal_ClosesLongOnExitCandidate covers the headline
+// case: long held + bearish MarketSignal → DecisionHandler emits
+// IntentExitCandidate with Side=Sell → RiskHandler must close every Buy
+// position on the symbol and tag the OrderEvent with DecisionTriggerDecisionExit.
+func TestRiskHandler_ExitOnSignal_ClosesLongOnExitCandidate(t *testing.T) {
+	riskMgr := usecase.NewRiskManager(entity.RiskConfig{
+		MaxPositionAmount: 1_000_000,
+		InitialCapital:    1_000_000,
+	})
+	exec := &fakeDecisionExitExecutor{
+		positions: []eventengine.Position{
+			{PositionID: 1, SymbolID: 7, Side: entity.OrderSideBuy, Amount: 0.5, EntryPrice: 9000},
+			// Different symbol — must NOT be closed.
+			{PositionID: 2, SymbolID: 99, Side: entity.OrderSideBuy, Amount: 0.5, EntryPrice: 9000},
+			// Same symbol but already a Sell — must NOT be closed (the
+			// Decision is to flatten longs, not shorts).
+			{PositionID: 3, SymbolID: 7, Side: entity.OrderSideSell, Amount: 0.5, EntryPrice: 9000},
+		},
+	}
+	handler := &RiskHandler{
+		RiskManager:  riskMgr,
+		TradeAmount:  0.01,
+		Executor:     exec,
+		ExitOnSignal: true,
+	}
+
+	ts := time.Now().UnixMilli()
+	events, err := handler.Handle(context.Background(), entity.ActionDecisionEvent{
+		Decision: entity.ActionDecision{
+			SymbolID: 7,
+			Intent:   entity.IntentExitCandidate,
+			Side:     entity.OrderSideSell,
+			Reason:   "long held; bearish signal -> exit candidate",
+		},
+		Price:     10000,
+		Timestamp: ts,
+	})
+	if err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected 1 OrderEvent, got %d", len(events))
+	}
+	orderEvent, ok := events[0].(entity.OrderEvent)
+	if !ok {
+		t.Fatalf("expected OrderEvent, got %T", events[0])
+	}
+	if orderEvent.Trigger != entity.DecisionTriggerDecisionExit {
+		t.Errorf("Trigger = %q, want %q", orderEvent.Trigger, entity.DecisionTriggerDecisionExit)
+	}
+	if orderEvent.ClosedPositionID != 1 {
+		t.Errorf("ClosedPositionID = %d, want 1", orderEvent.ClosedPositionID)
+	}
+	if len(exec.closedIDs) != 1 || exec.closedIDs[0] != 1 {
+		t.Errorf("closedIDs = %v, want [1]", exec.closedIDs)
+	}
+	if exec.closeCall[0].price != 10000 || exec.closeCall[0].ts != ts {
+		t.Errorf("Close called with price=%v ts=%v; want 10000/%d", exec.closeCall[0].price, exec.closeCall[0].ts, ts)
+	}
+}
+
+// TestRiskHandler_ExitOnSignal_ClosesShortOnExitCandidate is the symmetric
+// case: short held + bullish MarketSignal → IntentExitCandidate Side=Buy →
+// every Sell position on the symbol is closed.
+func TestRiskHandler_ExitOnSignal_ClosesShortOnExitCandidate(t *testing.T) {
+	riskMgr := usecase.NewRiskManager(entity.RiskConfig{
+		MaxPositionAmount: 1_000_000,
+		InitialCapital:    1_000_000,
+	})
+	exec := &fakeDecisionExitExecutor{
+		positions: []eventengine.Position{
+			{PositionID: 11, SymbolID: 7, Side: entity.OrderSideSell, Amount: 0.3, EntryPrice: 11000},
+			{PositionID: 12, SymbolID: 7, Side: entity.OrderSideSell, Amount: 0.2, EntryPrice: 10800},
+		},
+	}
+	handler := &RiskHandler{
+		RiskManager:  riskMgr,
+		TradeAmount:  0.01,
+		Executor:     exec,
+		ExitOnSignal: true,
+	}
+
+	events, err := handler.Handle(context.Background(), entity.ActionDecisionEvent{
+		Decision: entity.ActionDecision{
+			SymbolID: 7,
+			Intent:   entity.IntentExitCandidate,
+			Side:     entity.OrderSideBuy,
+			Reason:   "short held; bullish signal -> exit candidate",
+		},
+		Price:     10500,
+		Timestamp: time.Now().UnixMilli(),
+	})
+	if err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("expected 2 OrderEvents (one per short position), got %d", len(events))
+	}
+	got := map[int64]bool{}
+	for _, e := range events {
+		oe, ok := e.(entity.OrderEvent)
+		if !ok {
+			t.Fatalf("expected OrderEvent, got %T", e)
+		}
+		got[oe.ClosedPositionID] = true
+		if oe.Trigger != entity.DecisionTriggerDecisionExit {
+			t.Errorf("Trigger = %q, want %q", oe.Trigger, entity.DecisionTriggerDecisionExit)
+		}
+	}
+	if !got[11] || !got[12] {
+		t.Errorf("expected both 11 and 12 closed, got %v", got)
+	}
+}
+
+// TestRiskHandler_ExitOnSignal_NoPositionsNoEmits guards the "flat book"
+// edge case: even with ExitOnSignal on, an EXIT_CANDIDATE with no matching
+// position must be a no-op (the recorder already captured the decision).
+func TestRiskHandler_ExitOnSignal_NoPositionsNoEmits(t *testing.T) {
+	riskMgr := usecase.NewRiskManager(entity.RiskConfig{
+		MaxPositionAmount: 1_000_000,
+		InitialCapital:    1_000_000,
+	})
+	exec := &fakeDecisionExitExecutor{} // empty positions
+	handler := &RiskHandler{
+		RiskManager:  riskMgr,
+		TradeAmount:  0.01,
+		Executor:     exec,
+		ExitOnSignal: true,
+	}
+
+	events, err := handler.Handle(context.Background(), entity.ActionDecisionEvent{
+		Decision: entity.ActionDecision{
+			SymbolID: 7,
+			Intent:   entity.IntentExitCandidate,
+			Side:     entity.OrderSideSell,
+		},
+		Price:     10000,
+		Timestamp: time.Now().UnixMilli(),
+	})
+	if err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if len(events) != 0 {
+		t.Errorf("expected 0 events when no positions match, got %d", len(events))
+	}
+	if len(exec.closedIDs) != 0 {
+		t.Errorf("Close must not be called, got %v", exec.closedIDs)
+	}
+}
+
+// TestRiskHandler_ExitOnSignal_NilExecutorIsSilent: ExitOnSignal=true but
+// Executor=nil must stay silent (defensive — tests / partial wiring should
+// never panic).
+func TestRiskHandler_ExitOnSignal_NilExecutorIsSilent(t *testing.T) {
+	riskMgr := usecase.NewRiskManager(entity.RiskConfig{
+		MaxPositionAmount: 1_000_000,
+		InitialCapital:    1_000_000,
+	})
+	handler := &RiskHandler{
+		RiskManager:  riskMgr,
+		TradeAmount:  0.01,
+		Executor:     nil,
+		ExitOnSignal: true,
+	}
+	events, err := handler.Handle(context.Background(), entity.ActionDecisionEvent{
+		Decision: entity.ActionDecision{
+			SymbolID: 7,
+			Intent:   entity.IntentExitCandidate,
+			Side:     entity.OrderSideSell,
+		},
+		Price:     10000,
+		Timestamp: time.Now().UnixMilli(),
+	})
+	if err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if len(events) != 0 {
+		t.Errorf("nil executor must not emit events, got %d", len(events))
 	}
 }
 

--- a/backend/internal/usecase/backtest/runner.go
+++ b/backend/internal/usecase/backtest/runner.go
@@ -64,6 +64,13 @@ type RunInput struct {
 	// scaling (the sizer passes the multiplier through as 1.0).
 	MinConfidence float64
 
+	// ExitOnSignal mirrors profile.Risk.ExitOnSignal. When true the run's
+	// RiskHandler treats Decision-layer IntentExitCandidate as a real exit
+	// (closes matching positions through the simulator), instead of leaving
+	// the close to the TP/SL/Trailing tick path. Defaults false so the
+	// pre-Phase-1 backtest behaviour remains the baseline.
+	ExitOnSignal bool
+
 	// ResultID, when non-empty, overrides the auto-generated ULID assigned
 	// at the end of Run. Callers wire this when they need to know the run
 	// id *before* Run starts — e.g. to bind a DecisionRecorder to it via
@@ -246,6 +253,8 @@ func (r *BacktestRunner) Run(ctx context.Context, input RunInput) (*entity.Backt
 		TradeAmount:     input.TradeAmount,
 		StopLossPercent: riskCfg.StopLossPercent,
 		MinConfidence:   input.MinConfidence,
+		ExitOnSignal:    input.ExitOnSignal,
+		Executor:        simAdapter,
 	}
 	if ps := input.PositionSizing; ps != nil && ps.Mode != "" && ps.Mode != "fixed" {
 		defaults := positionsize.VenueDefaults(input.Config.Symbol)


### PR DESCRIPTION
## Summary
- Phase 1 では EXIT_CANDIDATE が silent (TP/SL/Trailing 任せ) だった制約を、プロファイル opt-in (`strategy_risk.exit_on_signal`) で実発注に繋ぐ。
- `RiskHandler` が `IntentExitCandidate` 受信時に `OrderExecutor.Close()` で反対側ポジションを閉じ、`OrderEvent` を emit (Trigger=`DECISION_EXIT`)。既存の cooldown arm 経路に乗る。
- 既定 `false` のまま残すので promote 済プロファイルの挙動は変わらない (有効化は別 PR)。

## 設計上のポイント
- **Sizer / RiskGate / BookGate は exit でスキップ**: exit は強制 unwind。サイズ計算もリスクゲートも意味がなく、薄い板で詰まったらポジションが取り残されるので回避。
- **ThinBook フォールバック**: 板スリッページで close 失敗時は当該ポジションだけ skip。次バーの Decision で再試行 + tick の SL/TP/Trailing も生きているので二重防衛。
- **`DecisionTriggerDecisionExit`** を新設して TP/SL と区別。recorder/分析で「シグナル起因 exit」が見える。

## Test plan
- [x] `go test ./... -race -count=1` 緑
- [x] `go vet ./...` 緑
- [x] 新規ユニットテスト 5 本: ExitOnSignal=false silent / long+bearish close / short+bullish close / no positions / nil executor
- [ ] production プロファイル有効化前に backtest で挙動比較 (本 PR ではプロファイル更新せず)

## 影響範囲
| 経路 | 配線箇所 |
|---|---|
| Live | `cmd/event_pipeline.go` + `cmd/main.go` (`liveProfileExitOnSignal`) |
| Backtest CLI | `cmd/backtest/main.go` |
| Backtest API | `interfaces/api/handler/backtest{,_multi,_walkforward}.go` |

## 続きの作業 (別 PR)
1. `production_ltc_60k.json` に `"exit_on_signal": true` を追加 → backtest 比較 → promote。
2. UI: history で `DECISION_EXIT` を TP/SL と色分け表示。

🤖 Generated with [Claude Code](https://claude.com/claude-code)