### PR TITLE
feat(ui): ポジション決済を画面から実行可能にする

### DIFF
--- a/frontend/src/components/PositionsAndTradeCard.tsx
+++ b/frontend/src/components/PositionsAndTradeCard.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import type { Position } from '../lib/api'
 import { useManualOrder } from '../hooks/useManualOrder'
+import { useClosePosition } from '../hooks/useClosePosition'
 
 type Props = {
   symbolId: number
@@ -25,7 +26,9 @@ export function PositionsAndTradeCard({
   const [amount, setAmount] = useState<number>(min)
   const [pending, setPending] = useState<{ side: 'BUY' | 'SELL'; amount: number } | null>(null)
   const [feedback, setFeedback] = useState<{ kind: 'ok' | 'err'; message: string } | null>(null)
+  const [closing, setClosing] = useState<Position | null>(null)
   const order = useManualOrder()
+  const closeOrder = useClosePosition()
 
   const submit = (side: 'BUY' | 'SELL') => {
     setFeedback(null)
@@ -44,6 +47,41 @@ export function PositionsAndTradeCard({
             setFeedback({ kind: 'ok', message: `${side} ${amt} 約定 (orderId=${res.orderId})` })
           } else {
             setFeedback({ kind: 'err', message: res.reason || '約定しませんでした' })
+          }
+        },
+        onError: (err) => {
+          setFeedback({ kind: 'err', message: err.message })
+        },
+      },
+    )
+  }
+
+  const confirmClose = () => {
+    if (!closing) return
+    const target = closing
+    setClosing(null)
+    setFeedback(null)
+    closeOrder.mutate(
+      { positionId: target.id, symbolId: target.symbolId },
+      {
+        onSuccess: (res) => {
+          if (res.duplicate) {
+            setFeedback({
+              kind: 'ok',
+              message: `決済リクエストは既に処理済 (orderId=${res.orderId ?? '—'})`,
+            })
+            return
+          }
+          if (res.executed) {
+            setFeedback({
+              kind: 'ok',
+              message: `ポジション #${target.id} 決済 約定 (orderId=${res.orderId})`,
+            })
+          } else {
+            setFeedback({
+              kind: 'err',
+              message: res.reason || '決済が約定しませんでした',
+            })
           }
         },
         onError: (err) => {
@@ -111,8 +149,19 @@ export function PositionsAndTradeCard({
                     {pos.floatingProfit.toLocaleString()}
                   </span>
                 </div>
-                <div className="mt-1 text-text-secondary">
-                  @ ¥{pos.price.toLocaleString()}
+                <div className="mt-2 flex items-center justify-between text-text-secondary">
+                  <span>@ ¥{pos.price.toLocaleString()}</span>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setFeedback(null)
+                      setClosing(pos)
+                    }}
+                    disabled={closeOrder.isPending}
+                    className="rounded-full border border-white/15 bg-white/5 px-3 py-1 text-[11px] font-semibold text-slate-200 transition hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    決済
+                  </button>
                 </div>
               </div>
             ))}
@@ -199,6 +248,17 @@ export function PositionsAndTradeCard({
           pending={order.isPending}
         />
       )}
+
+      {closing && (
+        <CloseConfirmDialog
+          position={closing}
+          currencyPair={currencyPair}
+          baseAsset={baseAsset}
+          onCancel={() => setClosing(null)}
+          onConfirm={confirmClose}
+          pending={closeOrder.isPending}
+        />
+      )}
     </section>
   )
 }
@@ -265,6 +325,66 @@ function Row({ label, value }: { label: string; value: string }) {
     <div className="flex items-center justify-between">
       <dt className="text-text-secondary">{label}</dt>
       <dd className="font-mono text-white">{value}</dd>
+    </div>
+  )
+}
+
+function CloseConfirmDialog({
+  position,
+  currencyPair,
+  baseAsset,
+  onCancel,
+  onConfirm,
+  pending,
+}: {
+  position: Position
+  currencyPair?: string
+  baseAsset: string
+  onCancel: () => void
+  onConfirm: () => void
+  pending: boolean
+}) {
+  const directionLabel = position.orderSide === 'BUY' ? 'LONG (買建)' : 'SHORT (売建)'
+  const amountLabel = baseAsset
+    ? `${position.remainingAmount} ${baseAsset}`
+    : `${position.remainingAmount}`
+  const floatingLabel = `${position.floatingProfit >= 0 ? '+' : ''}¥${position.floatingProfit.toLocaleString()}`
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 px-4 backdrop-blur-sm">
+      <div className="w-full max-w-sm rounded-3xl border border-white/10 bg-bg-card p-6 shadow-[0_30px_80px_rgba(0,0,0,0.5)]">
+        <h3 className="text-lg font-semibold text-white">ポジションを決済しますか？</h3>
+        <dl className="mt-4 space-y-2 text-sm">
+          <Row label="銘柄" value={currencyPair?.replace('_', '/') ?? '—'} />
+          <Row label="ポジションID" value={`#${position.id}`} />
+          <Row label="方向" value={directionLabel} />
+          <Row label="数量" value={amountLabel} />
+          <Row label="建値" value={`¥${position.price.toLocaleString()}`} />
+          <Row label="評価損益" value={floatingLabel} />
+          <Row label="種別" value="成行決済 (MARKET)" />
+        </dl>
+        <p className="mt-4 text-xs text-text-secondary">
+          残数量を全量、成行で反対売買します。実際の口座に注文が送信されます。
+        </p>
+        <div className="mt-5 grid grid-cols-2 gap-3">
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={pending}
+            className="rounded-2xl border border-white/15 bg-white/5 px-4 py-2.5 text-sm font-semibold text-slate-200 hover:bg-white/10 disabled:opacity-50"
+          >
+            キャンセル
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={pending}
+            className="rounded-2xl bg-accent-red px-4 py-2.5 text-sm font-semibold text-white transition hover:brightness-110 disabled:opacity-50"
+          >
+            {pending ? '送信中...' : '決済する'}
+          </button>
+        </div>
+      </div>
     </div>
   )
 }

--- a/frontend/src/hooks/__tests__/useClosePosition.test.tsx
+++ b/frontend/src/hooks/__tests__/useClosePosition.test.tsx
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
+import { useClosePosition } from '../useClosePosition'
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return {
+    queryClient,
+    Wrapper: ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    ),
+  }
+}
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', vi.fn())
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('useClosePosition', () => {
+  it('POSTs to /positions/:id/close with a generated clientOrderId and returns the response', async () => {
+    const mockResponse = {
+      clientOrderId: 'manual-close-42-abc',
+      executed: true,
+      orderId: 123,
+    }
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockResponse),
+    } as Response)
+
+    const { Wrapper } = createWrapper()
+    const { result } = renderHook(() => useClosePosition(), { wrapper: Wrapper })
+
+    await act(async () => {
+      result.current.mutate({ positionId: 42, symbolId: 7 })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data).toEqual(mockResponse)
+
+    const call = vi.mocked(fetch).mock.calls[0]
+    const url = call[0] as string
+    const init = call[1] as RequestInit
+    expect(url).toContain('/api/v1/positions/42/close')
+    expect(init.method).toBe('POST')
+    const body = JSON.parse(init.body as string) as {
+      symbolId: number
+      clientOrderId: string
+    }
+    expect(body.symbolId).toBe(7)
+    expect(body.clientOrderId).toMatch(/^manual-close-42-/)
+  })
+
+  it('invalidates positions / trades / pnl queries on success', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ clientOrderId: 'x', executed: true }),
+    } as Response)
+
+    const { queryClient, Wrapper } = createWrapper()
+    const spy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    const { result } = renderHook(() => useClosePosition(), { wrapper: Wrapper })
+
+    await act(async () => {
+      result.current.mutate({ positionId: 1, symbolId: 7 })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const invalidatedKeys = spy.mock.calls.map((c) => c[0]?.queryKey?.[0])
+    expect(invalidatedKeys).toEqual(
+      expect.arrayContaining(['positions', 'trades', 'pnl']),
+    )
+  })
+
+  it('surfaces API errors', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+    } as Response)
+
+    const { Wrapper } = createWrapper()
+    const { result } = renderHook(() => useClosePosition(), { wrapper: Wrapper })
+
+    await act(async () => {
+      result.current.mutate({ positionId: 999, symbolId: 7 })
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(result.current.error?.message).toContain('404')
+  })
+})

--- a/frontend/src/hooks/useClosePosition.ts
+++ b/frontend/src/hooks/useClosePosition.ts
@@ -1,0 +1,32 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import {
+  closePosition,
+  type ClosePositionResponse,
+} from '../lib/api'
+
+function generateClientOrderId(positionID: number): string {
+  const t = Date.now()
+  const r = Math.random().toString(36).slice(2, 8)
+  return `manual-close-${positionID}-${t}-${r}`
+}
+
+type CloseInput = {
+  positionId: number
+  symbolId: number
+}
+
+export function useClosePosition() {
+  const queryClient = useQueryClient()
+  return useMutation<ClosePositionResponse, Error, CloseInput>({
+    mutationFn: ({ positionId, symbolId }) =>
+      closePosition(positionId, {
+        symbolId,
+        clientOrderId: generateClientOrderId(positionId),
+      }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['positions'] })
+      void queryClient.invalidateQueries({ queryKey: ['trades'] })
+      void queryClient.invalidateQueries({ queryKey: ['pnl'] })
+    },
+  })
+}

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { fetchApi, sendApi, buildRealtimeWebSocketUrl } from './api'
+import {
+  fetchApi,
+  sendApi,
+  buildRealtimeWebSocketUrl,
+  closePosition,
+} from './api'
 
 beforeEach(() => {
   vi.stubGlobal('fetch', vi.fn())
@@ -117,6 +122,50 @@ describe('sendApi', () => {
     await expect(sendApi('/config', 'PUT', {})).rejects.toThrow(
       'API error: 400 Bad Request',
     )
+  })
+})
+
+describe('closePosition', () => {
+  it('POSTs to /positions/:id/close with the provided body and returns parsed JSON', async () => {
+    const mockResponse = {
+      clientOrderId: 'manual-close-42-xyz',
+      executed: true,
+      orderId: 99,
+    }
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockResponse),
+    } as Response)
+
+    const result = await closePosition(42, {
+      symbolId: 7,
+      clientOrderId: 'manual-close-42-xyz',
+    })
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/v1/positions/42/close'),
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          symbolId: 7,
+          clientOrderId: 'manual-close-42-xyz',
+        }),
+      }),
+    )
+    expect(result).toEqual(mockResponse)
+  })
+
+  it('throws on non-ok response', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+    } as Response)
+
+    await expect(
+      closePosition(999, { symbolId: 7, clientOrderId: 'x' }),
+    ).rejects.toThrow('API error: 404 Not Found')
   })
 })
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -678,6 +678,30 @@ export async function createManualOrder(req: ManualOrderRequest): Promise<Manual
   return sendApi<ManualOrderResponse, ManualOrderRequest>('/orders', 'POST', req)
 }
 
+export type ClosePositionRequest = {
+  symbolId: number
+  clientOrderId: string
+}
+
+export type ClosePositionResponse = {
+  clientOrderId: string
+  executed: boolean
+  orderId?: number
+  reason?: string
+  duplicate?: boolean
+}
+
+export async function closePosition(
+  positionId: number,
+  req: ClosePositionRequest,
+): Promise<ClosePositionResponse> {
+  return sendApi<ClosePositionResponse, ClosePositionRequest>(
+    `/positions/${positionId}/close`,
+    'POST',
+    req,
+  )
+}
+
 export type SignalDirection = 'BULLISH' | 'BEARISH' | 'NEUTRAL' | ''
 export type DecisionIntent =
   | 'NEW_ENTRY'

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -11,10 +11,12 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as WalkForwardRouteImport } from './routes/walk-forward'
 import { Route as SettingsRouteImport } from './routes/settings'
+import { Route as OperationsRouteImport } from './routes/operations'
 import { Route as HistoryRouteImport } from './routes/history'
 import { Route as BacktestMultiRouteImport } from './routes/backtest-multi'
 import { Route as BacktestDecisionsRouteImport } from './routes/backtest-decisions'
 import { Route as BacktestRouteImport } from './routes/backtest'
+import { Route as AnalysisRouteImport } from './routes/analysis'
 import { Route as IndexRouteImport } from './routes/index'
 
 const WalkForwardRoute = WalkForwardRouteImport.update({
@@ -25,6 +27,11 @@ const WalkForwardRoute = WalkForwardRouteImport.update({
 const SettingsRoute = SettingsRouteImport.update({
   id: '/settings',
   path: '/settings',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const OperationsRoute = OperationsRouteImport.update({
+  id: '/operations',
+  path: '/operations',
   getParentRoute: () => rootRouteImport,
 } as any)
 const HistoryRoute = HistoryRouteImport.update({
@@ -47,6 +54,11 @@ const BacktestRoute = BacktestRouteImport.update({
   path: '/backtest',
   getParentRoute: () => rootRouteImport,
 } as any)
+const AnalysisRoute = AnalysisRouteImport.update({
+  id: '/analysis',
+  path: '/analysis',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
@@ -55,29 +67,35 @@ const IndexRoute = IndexRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/analysis': typeof AnalysisRoute
   '/backtest': typeof BacktestRoute
   '/backtest-decisions': typeof BacktestDecisionsRoute
   '/backtest-multi': typeof BacktestMultiRoute
   '/history': typeof HistoryRoute
+  '/operations': typeof OperationsRoute
   '/settings': typeof SettingsRoute
   '/walk-forward': typeof WalkForwardRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/analysis': typeof AnalysisRoute
   '/backtest': typeof BacktestRoute
   '/backtest-decisions': typeof BacktestDecisionsRoute
   '/backtest-multi': typeof BacktestMultiRoute
   '/history': typeof HistoryRoute
+  '/operations': typeof OperationsRoute
   '/settings': typeof SettingsRoute
   '/walk-forward': typeof WalkForwardRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/analysis': typeof AnalysisRoute
   '/backtest': typeof BacktestRoute
   '/backtest-decisions': typeof BacktestDecisionsRoute
   '/backtest-multi': typeof BacktestMultiRoute
   '/history': typeof HistoryRoute
+  '/operations': typeof OperationsRoute
   '/settings': typeof SettingsRoute
   '/walk-forward': typeof WalkForwardRoute
 }
@@ -85,38 +103,46 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/analysis'
     | '/backtest'
     | '/backtest-decisions'
     | '/backtest-multi'
     | '/history'
+    | '/operations'
     | '/settings'
     | '/walk-forward'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/analysis'
     | '/backtest'
     | '/backtest-decisions'
     | '/backtest-multi'
     | '/history'
+    | '/operations'
     | '/settings'
     | '/walk-forward'
   id:
     | '__root__'
     | '/'
+    | '/analysis'
     | '/backtest'
     | '/backtest-decisions'
     | '/backtest-multi'
     | '/history'
+    | '/operations'
     | '/settings'
     | '/walk-forward'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  AnalysisRoute: typeof AnalysisRoute
   BacktestRoute: typeof BacktestRoute
   BacktestDecisionsRoute: typeof BacktestDecisionsRoute
   BacktestMultiRoute: typeof BacktestMultiRoute
   HistoryRoute: typeof HistoryRoute
+  OperationsRoute: typeof OperationsRoute
   SettingsRoute: typeof SettingsRoute
   WalkForwardRoute: typeof WalkForwardRoute
 }
@@ -135,6 +161,13 @@ declare module '@tanstack/react-router' {
       path: '/settings'
       fullPath: '/settings'
       preLoaderRoute: typeof SettingsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/operations': {
+      id: '/operations'
+      path: '/operations'
+      fullPath: '/operations'
+      preLoaderRoute: typeof OperationsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/history': {
@@ -165,6 +198,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof BacktestRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/analysis': {
+      id: '/analysis'
+      path: '/analysis'
+      fullPath: '/analysis'
+      preLoaderRoute: typeof AnalysisRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
       id: '/'
       path: '/'
@@ -177,10 +217,12 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  AnalysisRoute: AnalysisRoute,
   BacktestRoute: BacktestRoute,
   BacktestDecisionsRoute: BacktestDecisionsRoute,
   BacktestMultiRoute: BacktestMultiRoute,
   HistoryRoute: HistoryRoute,
+  OperationsRoute: OperationsRoute,
   SettingsRoute: SettingsRoute,
   WalkForwardRoute: WalkForwardRoute,
 }


### PR DESCRIPTION
## Summary

- 各ポジション行に「決済」ボタンと確認ダイアログを追加し、`POST /api/v1/positions/:id/close` を画面から呼び出せるようにした。
- `clientOrderId` は `useManualOrder` と同じ作法でクライアント側生成し、二重送信を冪等化。`duplicate` 応答もメッセージで区別表示。
- 成功時に `positions / trades / pnl` の query を invalidate して即時反映。

## Changes

- `frontend/src/lib/api.ts`: `closePosition()` と型を追加
- `frontend/src/hooks/useClosePosition.ts` (新規): mutation フック
- `frontend/src/components/PositionsAndTradeCard.tsx`: 決済ボタン + `CloseConfirmDialog` 追加
- `frontend/src/lib/api.test.ts` / `frontend/src/hooks/__tests__/useClosePosition.test.tsx`: テスト追加

バックエンドは既存の `POST /positions/:id/close` をそのまま利用するため変更なし。

## Test plan

- [x] `pnpm test` 全 52 テスト pass
- [ ] Docker で立ち上げ、ポジションがある状態で「決済」→ 確認ダイアログ → 送信が成行決済として通ることを実機確認
- [ ] ダイアログのキャンセル動作・連打時の `duplicate` メッセージ確認
- [ ] エラー時 (404 等) のフィードバック表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)