### PR TITLE
feat(ui): RecentDecisionsCard を TanStack Virtual で仮想スクロール化

### DIFF
--- a/docs/superpowers/plans/2026-05-03-recent-decisions-virtualization.md
+++ b/docs/superpowers/plans/2026-05-03-recent-decisions-virtualization.md
@@ -1,0 +1,457 @@
+# RecentDecisionsCard 仮想スクロール化 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** ダッシュボードの「直近の判断」カードで直近 1 日分（最大 200 件）の判断履歴を、12 行ぶんの高さに固定したテーブル内で TanStack Virtual で遡って閲覧できるようにする。
+
+**Architecture:** `RecentDecisionsCard.tsx` 1 ファイルに閉じた変更。`useDecisionLog` の取得件数を `200` に増やし、`MiniDecisionTable` を `useVirtualizer` ベースの `VirtualizedDecisionTable` に書き換える。`<table>` 構造を維持し、`<tbody>` 内で `<tr>` を `position: absolute` で浮かせて仮想化する（案A）。`<thead>` は sticky で常時可視。
+
+**Tech Stack:**
+- `@tanstack/react-virtual` v3.13+（`frontend/package.json` 導入済）
+- React 19 / TypeScript
+- Vitest + @testing-library/react
+
+**Spec:** `docs/superpowers/specs/2026-05-03-recent-decisions-virtualization-design.md`
+
+---
+
+## File Structure
+
+| Path | 役割 | 変更種別 |
+|---|---|---|
+| `frontend/src/components/RecentDecisionsCard.tsx` | 直近の判断カード本体。`MiniDecisionTable` を `VirtualizedDecisionTable` に置き換え、`RECENT_LIMIT` を 200 に変更 | Modify |
+| `frontend/src/components/__tests__/RecentDecisionsCard.test.tsx` | 仮想化挙動と件数増加の回帰テスト | Create |
+
+---
+
+## Task 1: 仮想化テーブルのスモークテスト（赤）
+
+**Files:**
+- Create: `frontend/src/components/__tests__/RecentDecisionsCard.test.tsx`
+- Refer: `frontend/src/hooks/__tests__/usePositions.test.tsx`（`createWrapper` パターン参照）
+
+仮想化導入後の挙動を担保する最低限のテストを書く。fetch をモックして 200 件分のデータを返し、コンテナ内に `<thead>` の文言が描画されることを確認する。
+
+- [ ] **Step 1: テストファイルを作成して失敗するテストを書く**
+
+```tsx
+// frontend/src/components/__tests__/RecentDecisionsCard.test.tsx
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createMemoryHistory, createRouter, createRootRoute, RouterProvider } from '@tanstack/react-router'
+import type { ReactNode } from 'react'
+import { RecentDecisionsCard } from '../RecentDecisionsCard'
+import type { DecisionLogItem, DecisionLogResponse } from '../../lib/api'
+
+function makeItem(i: number): DecisionLogItem {
+  return {
+    id: i,
+    barCloseAt: 1_700_000_000_000 + i * 60_000,
+    sequenceInBar: 0,
+    triggerKind: 'BAR_CLOSE',
+    symbolId: 3,
+    currencyPair: 'LTC_JPY',
+    primaryInterval: 'PT15M',
+    stance: 'TREND_FOLLOW',
+    lastPrice: 10000 + i,
+    signal: { action: 'HOLD', confidence: 0, reason: '' },
+    risk: { outcome: 'SKIPPED', reason: '' },
+    bookGate: { outcome: 'SKIPPED', reason: '' },
+    order: { outcome: 'NOOP', orderId: 0, amount: 0, price: 0, error: '' },
+    closedPositionId: 0,
+    openedPositionId: 0,
+    indicators: {},
+    higherTfIndicators: {},
+    createdAt: 1_700_000_000_000 + i * 60_000,
+  }
+}
+
+function renderWithProviders(ui: ReactNode) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  const rootRoute = createRootRoute({ component: () => <>{ui}</> })
+  const router = createRouter({
+    routeTree: rootRoute,
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  )
+}
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', vi.fn())
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('RecentDecisionsCard', () => {
+  it('200 件取得しても thead が一度だけ描画され、行は仮想化される', async () => {
+    const decisions = Array.from({ length: 200 }, (_, i) => makeItem(i))
+    const response: DecisionLogResponse = { decisions, nextCursor: 0, hasMore: false }
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(response),
+    } as Response)
+
+    renderWithProviders(
+      <RecentDecisionsCard symbolId={3} strategy={undefined} rootSearch={{}} />,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('時刻')).toBeInTheDocument()
+    })
+
+    // 仮想化されているなら、200 件すべての <tr> は描画されない
+    const rows = document.querySelectorAll('tbody tr')
+    expect(rows.length).toBeLessThan(200)
+    expect(rows.length).toBeGreaterThan(0)
+  })
+
+  it('limit=200 で /decisions を叩く', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ decisions: [], nextCursor: 0, hasMore: false }),
+    } as Response)
+
+    renderWithProviders(
+      <RecentDecisionsCard symbolId={3} strategy={undefined} rootSearch={{}} />,
+    )
+
+    await waitFor(() => {
+      expect(vi.mocked(fetch)).toHaveBeenCalled()
+    })
+    const url = vi.mocked(fetch).mock.calls[0][0] as string
+    expect(url).toContain('limit=200')
+  })
+})
+```
+
+- [ ] **Step 2: テストを実行して失敗を確認**
+
+Run: `cd frontend && pnpm test -- RecentDecisionsCard`
+
+Expected:
+- 1 つ目のテスト: `rows.length` が 200（現状は仮想化されていないため全件 DOM に出る）→ FAIL
+- 2 つ目のテスト: `limit=10` で叩いているため `expect(url).toContain('limit=200')` が FAIL
+
+赤を確認したら次へ。
+
+- [ ] **Step 3: コミット（赤テスト）**
+
+```bash
+git add frontend/src/components/__tests__/RecentDecisionsCard.test.tsx
+git commit -m "test(ui): RecentDecisionsCard 仮想化と取得件数の赤テスト"
+```
+
+---
+
+## Task 2: 取得件数を 200 に変更
+
+**Files:**
+- Modify: `frontend/src/components/RecentDecisionsCard.tsx:7`
+
+- [ ] **Step 1: `RECENT_LIMIT` を 10 → 200 に変更**
+
+`frontend/src/components/RecentDecisionsCard.tsx` の 7 行目を以下のように変更:
+
+```tsx
+const RECENT_LIMIT = 200
+```
+
+- [ ] **Step 2: 2 つ目のテストが PASS することを確認**
+
+Run: `cd frontend && pnpm test -- RecentDecisionsCard -t "limit=200"`
+
+Expected: PASS
+
+1 つ目（仮想化テスト）はまだ FAIL のまま。
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add frontend/src/components/RecentDecisionsCard.tsx
+git commit -m "feat(ui): RecentDecisionsCard の取得件数を 10 → 200 に拡張"
+```
+
+---
+
+## Task 3: VirtualizedDecisionTable を実装
+
+**Files:**
+- Modify: `frontend/src/components/RecentDecisionsCard.tsx`
+
+`MiniDecisionTable` を `VirtualizedDecisionTable` に置き換える。`<table>` 構造は維持し、`<tbody>` 内で `<tr>` を `position: absolute` で浮かせて仮想化する。`<thead>` は sticky。
+
+- [ ] **Step 1: import を追加**
+
+ファイル先頭の import を以下のように変更:
+
+```tsx
+import { useRef } from 'react'
+import { Link } from '@tanstack/react-router'
+import { useVirtualizer } from '@tanstack/react-virtual'
+import type { DecisionLogItem, StrategyResponse } from '../lib/api'
+import { useDecisionLog } from '../hooks/useDecisionLog'
+import { translateReason } from '../lib/decisionReasonI18n'
+import { StanceLegendPopover } from './StanceLegendPopover'
+```
+
+- [ ] **Step 2: 定数を追加**
+
+`const RECENT_LIMIT = 200` の直下に以下を追加:
+
+```tsx
+const ROW_HEIGHT = 36 // px。<tr> 高さ固定（py-2 + 12px line-height ベース）。
+const VISIBLE_ROWS = 12
+```
+
+- [ ] **Step 3: `MiniDecisionTable` を `VirtualizedDecisionTable` に置き換え**
+
+`MiniDecisionTable` 関数（70〜94 行目）を以下に丸ごと置き換える:
+
+```tsx
+function VirtualizedDecisionTable({ decisions }: { decisions: DecisionLogItem[] }) {
+  const parentRef = useRef<HTMLDivElement>(null)
+  const virtualizer = useVirtualizer({
+    count: decisions.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => ROW_HEIGHT,
+    overscan: 5,
+  })
+
+  return (
+    <div
+      ref={parentRef}
+      className="overflow-auto rounded-2xl border border-white/8"
+      style={{ height: VISIBLE_ROWS * ROW_HEIGHT }}
+    >
+      <table className="w-full text-xs" style={{ tableLayout: 'fixed' }}>
+        <colgroup>
+          <col style={{ width: '4.5rem' }} />
+          <col style={{ width: '7rem' }} />
+          <col style={{ width: '5rem' }} />
+          <col style={{ width: '4rem' }} />
+          <col style={{ width: '4.5rem' }} />
+          <col style={{ width: '6rem' }} />
+          <col style={{ width: '8rem' }} />
+          <col />
+        </colgroup>
+        <thead className="sticky top-0 z-10 bg-bg-card text-[0.65rem] uppercase tracking-[0.18em] text-text-secondary">
+          <tr>
+            <th className="px-3 py-2 text-left">時刻</th>
+            <th className="px-3 py-2 text-left">スタンス</th>
+            <th className="px-3 py-2 text-left">判断</th>
+            <th className="px-3 py-2 text-left">シグナル</th>
+            <th className="px-3 py-2 text-right">信頼度</th>
+            <th className="px-3 py-2 text-left">結果</th>
+            <th className="px-3 py-2 text-right">数量/価格</th>
+            <th className="px-3 py-2 text-left">理由</th>
+          </tr>
+        </thead>
+        <tbody style={{ height: virtualizer.getTotalSize(), position: 'relative', display: 'block' }}>
+          {virtualizer.getVirtualItems().map((vrow) => {
+            const item = decisions[vrow.index]
+            return (
+              <VirtualRow
+                key={item.id}
+                item={item}
+                top={vrow.start}
+                height={ROW_HEIGHT}
+              />
+            )
+          })}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function VirtualRow({
+  item,
+  top,
+  height,
+}: {
+  item: DecisionLogItem
+  top: number
+  height: number
+}) {
+  const bg = rowBackground(item)
+  const rawReason =
+    item.decision?.reason ||
+    item.signal.reason ||
+    item.risk.reason ||
+    item.bookGate.reason ||
+    item.order.error ||
+    '—'
+  const reason = translateReason(rawReason)
+  const outcome = outcomeLabel(item)
+  const intent = item.decision?.intent ?? ''
+  return (
+    <tr
+      className={`border-t border-white/8 ${bg}`}
+      style={{
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        width: '100%',
+        height,
+        transform: `translateY(${top}px)`,
+        display: 'table',
+        tableLayout: 'fixed',
+      }}
+    >
+      <td className="px-3 py-2 whitespace-nowrap" style={{ width: '4.5rem' }}>
+        {new Date(item.barCloseAt).toLocaleTimeString('ja-JP', {
+          hour: '2-digit',
+          minute: '2-digit',
+        })}
+      </td>
+      <td className="px-3 py-2" style={{ width: '7rem' }}>{item.stance || '—'}</td>
+      <td className="px-3 py-2 whitespace-nowrap" style={{ width: '5rem' }}>
+        {INTENT_SHORT_LABEL[intent]}
+      </td>
+      <td className="px-3 py-2 font-medium" style={{ width: '4rem' }}>
+        {item.signal.action}
+      </td>
+      <td className="px-3 py-2 text-right" style={{ width: '4.5rem' }}>
+        {item.signal.action === 'HOLD'
+          ? '—'
+          : `${(item.signal.confidence * 100).toFixed(1)}%`}
+      </td>
+      <td className="px-3 py-2 whitespace-nowrap" style={{ width: '6rem' }}>
+        {outcome}
+      </td>
+      <td
+        className="px-3 py-2 text-right whitespace-nowrap"
+        style={{ width: '8rem' }}
+      >
+        {item.order.outcome === 'NOOP'
+          ? '—'
+          : `${item.order.amount} @ ${item.order.price.toLocaleString('ja-JP')}`}
+      </td>
+      <td className="truncate px-3 py-2 text-text-secondary" title={rawReason}>
+        {reason}
+      </td>
+    </tr>
+  )
+}
+```
+
+注: `<tbody>` を `display: block`、`<tr>` を `display: table; table-layout: fixed; width: 100%` にしているのは、`<tr>` を `position: absolute` で浮かせると `<table>` 既定のレイアウトが効かず列幅が崩れるための緩和策。`<colgroup>` だけでは絶対配置の `<tr>` には適用されないため、各 `<td>` にも `style={{ width: ... }}` を二重指定している。
+
+- [ ] **Step 4: 旧 `MiniRow` 関数を削除**
+
+`MiniRow` 関数（106〜145 行目あたり）は `VirtualRow` に置き換わったため削除する。`INTENT_SHORT_LABEL` / `pickReasoningLabel` / `stanceColorClass` / `rowBackground` / `outcomeLabel` は残す。
+
+- [ ] **Step 5: 呼び出し側を差し替え**
+
+`RecentDecisionsCard` 関数内 63 行目の `<MiniDecisionTable decisions={decisions} />` を以下に変更:
+
+```tsx
+<VirtualizedDecisionTable decisions={decisions} />
+```
+
+- [ ] **Step 6: テストを実行して両方 PASS することを確認**
+
+Run: `cd frontend && pnpm test -- RecentDecisionsCard`
+
+Expected: 2 つとも PASS
+
+注: `useVirtualizer` は jsdom 環境で `getBoundingClientRect` がゼロを返すため virtualItems が空配列になる可能性がある。その場合は最初のテストの `expect(rows.length).toBeGreaterThan(0)` が FAIL する。FAIL したら、テスト側でそのアサーションを「`rows.length === 0` 許容」に緩める or `Element.prototype.getBoundingClientRect` をモックする。Step 6 で FAIL した場合の対処:
+
+```tsx
+// テストファイルの beforeEach に追加
+beforeEach(() => {
+  vi.stubGlobal('fetch', vi.fn())
+  // jsdom は要素サイズを 0 にするため、useVirtualizer 用にモック
+  Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+    configurable: true,
+    value: VISIBLE_ROWS * ROW_HEIGHT, // 432
+  })
+  Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
+    configurable: true,
+    value: 800,
+  })
+})
+```
+
+ただし `VISIBLE_ROWS` / `ROW_HEIGHT` はテストファイルから import できないので、ハードコードで `432` / `800` と書く。
+
+- [ ] **Step 7: 型チェックを通す**
+
+Run: `cd frontend && pnpm exec tsc --noEmit`
+
+Expected: エラーなし
+
+- [ ] **Step 8: コミット**
+
+```bash
+git add frontend/src/components/RecentDecisionsCard.tsx frontend/src/components/__tests__/RecentDecisionsCard.test.tsx
+git commit -m "feat(ui): RecentDecisionsCard を TanStack Virtual で仮想スクロール化"
+```
+
+---
+
+## Task 4: 手動動作確認
+
+**Files:** なし（ブラウザでの目視確認）
+
+- [ ] **Step 1: Docker Compose を再ビルドして起動**
+
+Run: `docker compose up --build -d`
+
+frontend は bind mount なので HMR で反映される想定だが、念のため再ビルド。
+
+- [ ] **Step 2: ブラウザで確認**
+
+`http://localhost:33000/?symbol=LTC_JPY` を開き、以下を目視確認:
+
+1. 「直近の判断」カードのテーブルが **12 行ぶんの高さ（432px 前後）** で表示される。
+2. テーブル内を縦スクロールすると、過去の判断履歴を遡れる。
+3. スクロール中もヘッダ行（時刻 / スタンス / 判断 / シグナル / 信頼度 / 結果 / 数量・価格 / 理由）が常時可視。
+4. 行の色分け（約定=緑 / 却下=赤 / HOLD=黄など）が従来通り機能している。
+5. 列幅が崩れていない。
+6. しばらく放置（15 秒以上）して再取得が走り、リストが更新されることを確認。
+
+- [ ] **Step 3: 失敗時の判断**
+
+列幅が崩れる、行が重なる、スクロールが効かない等の崩壊が起きたら、案 B（`<table>` をやめて `div + grid` で組み直す）への切り替えを検討する。その判断は実装者が動作を見て決める。
+
+- [ ] **Step 4: PR 用の最終チェック**
+
+Run: `cd frontend && pnpm test`
+
+Expected: 全 green
+
+Run: `cd frontend && pnpm exec tsc --noEmit`
+
+Expected: エラーなし
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+| Spec の要件 | 実装タスク |
+|---|---|
+| 直近 1 日分（200 件）取得 | Task 2 |
+| 12 行ぶんの高さに固定 | Task 3（`VISIBLE_ROWS = 12`） |
+| sticky thead | Task 3（`<thead className="sticky top-0 ...">`） |
+| 既存色分け・列内容を踏襲 | Task 3（`rowBackground` / `INTENT_SHORT_LABEL` / `outcomeLabel` / `translateReason` を流用） |
+| 「全件を見る →」維持 | 既存ヘッダのまま（変更なし） |
+| `useDecisionLog` 不変 | Task 2（呼び出し側のみ変更） |
+| バックエンド変更なし | 該当なし（コード変更なし） |
+| `pnpm test` green | Task 1 + Task 3 + Task 4 |
+| 案A破綻時のフォールバック判断 | Task 4 Step 3 |
+
+**Placeholder scan:** TBD/TODO/「適切に」「同様に」等は不在。すべての code step に実コードあり。
+
+**Type consistency:** `VirtualizedDecisionTable` / `VirtualRow` / `ROW_HEIGHT` / `VISIBLE_ROWS` / `RECENT_LIMIT` の名前を全タスクで一致させた。`MiniDecisionTable` / `MiniRow` は Task 3 で完全に削除する旨を明記。

--- a/docs/superpowers/specs/2026-05-03-recent-decisions-virtualization-design.md
+++ b/docs/superpowers/specs/2026-05-03-recent-decisions-virtualization-design.md
@@ -1,0 +1,165 @@
+# 直近の判断カード — TanStack Virtual 化設計
+
+- 日付: 2026-05-03
+- 対象: `frontend/src/components/RecentDecisionsCard.tsx`
+- ステータス: Approved (brainstorm 段階の合意済)
+
+## 背景
+
+ダッシュボード（`/?symbol=LTC_JPY`）の「直近の判断」エリアは現在 `RECENT_LIMIT = 10` で固定取得し、すべての行を `<table>` に直接レンダーしている。
+そのため、新しい判断が記録されると古い判断が表示から落ち、ダッシュボード上で過去の判断履歴を遡って確認できないという不満があった。
+
+「全件を見る →」リンクから `/history?tab=decisions` ページへ遷移すれば閲覧できるが、ダッシュボードで完結したいという要望。
+
+## ゴール
+
+- ダッシュボード上で **直近 1 日分** の判断履歴を遡って閲覧できる。
+- カード自体の専有面積は増やさない（高さは抑える）。
+- 仮想スクロール（TanStack Virtual）で行の DOM 数を抑え、リスト件数が増えても表示パフォーマンスを保つ。
+
+## 非ゴール
+
+- 無限スクロール／ページング（API 側の追加実装が必要なため、本対応では行わない）。
+- 期間切替 UI の追加（要件として提示されていない）。
+- バックエンド `/decisions` API の変更（既に `limit` 最大 1000 まで対応済）。
+- `/history` ページ側の改修。
+
+## 要件
+
+### 機能要件
+
+1. ダッシュボードの「直近の判断」カードで、直近 1 日分相当の判断履歴を遡って閲覧できる。
+2. カードの判断履歴テーブルは **12 行分** の高さに固定し、それ以上は縦スクロールで閲覧する。
+3. テーブルのヘッダ行（時刻 / スタンス / 判断 / シグナル / 信頼度 / 結果 / 数量・価格 / 理由）はスクロール中も常時可視（sticky）にする。
+4. 行の色分け（約定 / 却下 / HOLD など）、列の表示内容、`translateReason` などの既存表示ロジックは現状を踏襲する。
+5. 既存の「全件を見る →」リンクは残し、より長期の履歴は引き続き `/history` で確認できる動線を維持する。
+
+### 非機能要件
+
+- 表示行数が増えても初期描画コストを抑える（DOM 上は visible + overscan のみ）。
+- 既存テスト（`pnpm test`）が green のまま。
+- 既存のカラーリング・余白・タイポグラフィは見た目の差分を最小化する。
+
+## 設計
+
+### データ取得
+
+- `useDecisionLog(symbolId, limit)` フック自体は変更しない。
+- 呼び出し側 `RecentDecisionsCard` の定数を変更する:
+  - `RECENT_LIMIT: 10 → 200`
+  - 根拠: PT15M（15 分足）= 1 日 96 本。BAR_CLOSE 以外のトリガ（tick 発火など）も `decision_log` に書き込まれるため、200 件を上限とすれば 1 日分を概ねカバーできる。
+- `refetchInterval: 15_000` は据え置き。
+
+### コンポーネント構造
+
+`RecentDecisionsCard.tsx` の `MiniDecisionTable` を仮想スクロール対応に書き換える。
+他のセクション（ヘッダ・スタンス表示・最終評価・「全件を見る →」リンク・reasoning ラベル）は現状維持。
+
+```tsx
+const ROW_HEIGHT = 36 // px。既存行の実測に合わせて確定する。
+const VISIBLE_ROWS = 12
+
+function VirtualizedDecisionTable({ decisions }: { decisions: DecisionLogItem[] }) {
+  const parentRef = useRef<HTMLDivElement>(null)
+  const virtualizer = useVirtualizer({
+    count: decisions.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => ROW_HEIGHT,
+    overscan: 5,
+  })
+
+  return (
+    <div
+      ref={parentRef}
+      className="overflow-auto rounded-2xl border border-white/8"
+      style={{ height: VISIBLE_ROWS * ROW_HEIGHT }}
+    >
+      <table className="w-full text-xs" style={{ tableLayout: 'fixed' }}>
+        <colgroup>{/* 列幅を固定 */}</colgroup>
+        <thead className="sticky top-0 z-10 bg-white/5 ...">
+          <tr>{/* 既存ヘッダ */}</tr>
+        </thead>
+        <tbody style={{ height: virtualizer.getTotalSize(), position: 'relative' }}>
+          {virtualizer.getVirtualItems().map((vrow) => {
+            const item = decisions[vrow.index]
+            return (
+              <tr
+                key={item.id}
+                style={{
+                  position: 'absolute',
+                  top: 0,
+                  left: 0,
+                  width: '100%',
+                  height: ROW_HEIGHT,
+                  transform: `translateY(${vrow.start}px)`,
+                }}
+                className={`...既存色分け...`}
+              >
+                {/* 既存セル */}
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+```
+
+- `position: absolute` で `<tr>` を浮かせるため、`<table>` には `table-layout: fixed` と `<colgroup>` で列幅を固定する必要がある。
+- `<thead>` は `position: sticky; top: 0` で固定。背景色を不透明にしてスクロール時にコンテンツが透けないようにする。
+- 行の色分けは現行 `rowBackground(item)` の戻り値クラスをそのまま `<tr>` に適用する。
+
+### ライブラリ
+
+- `@tanstack/react-virtual` v3.13+（`package.json` 導入済み）。
+- 追加依存はない。
+
+### 既存表示ロジックの再利用
+
+以下は変更せず、そのまま `VirtualizedDecisionTable` 内のセル描画でも利用する:
+
+- `INTENT_SHORT_LABEL`
+- `translateReason`
+- `outcomeLabel`
+- `rowBackground`
+- 時刻フォーマット（`toLocaleTimeString('ja-JP', { hour: '2-digit', minute: '2-digit' })`）
+
+### バックエンド
+
+- 変更なし。`/decisions?symbolId=&limit=200` は既存ハンドラがそのまま処理する（既定 200・上限 1000）。
+
+## 影響範囲
+
+- 変更ファイル: `frontend/src/components/RecentDecisionsCard.tsx` のみ
+- 依存追加: なし
+- API 変更: なし
+- 既存利用箇所: `routes/index.tsx` から `<RecentDecisionsCard />` で参照（インターフェース変更なし）
+
+## テスト方針
+
+- `cd frontend && pnpm test` で既存テストが green のまま。
+- 動作確認手順:
+  1. `docker compose up --build -d` 後、`http://localhost:33000/?symbol=LTC_JPY` を開く。
+  2. 「直近の判断」カードのテーブルが 12 行ぶんの高さで表示されることを確認。
+  3. テーブル内を縦スクロールし、過去の判断履歴（最大 200 件まで）が遡れることを確認。
+  4. スクロール中もヘッダ行（時刻 / スタンス / …）が常時可視であることを確認。
+  5. 行の色分け・列レイアウトが従来と同等であることを確認。
+  6. 15 秒経過で再取得されたとき、リストが更新されることを確認。
+
+## リスクと緩和
+
+- **リスク**: `<table>` 内で `<tr>` を `position: absolute` にすると、ブラウザ既定の table レイアウトが効かず列幅が崩れる可能性。
+  - **緩和**: `table-layout: fixed` ＋ `<colgroup>` で列幅を明示。各 `<th>` の `width` を設定する。
+- **リスク**: 行高さを固定値（36px）にすることで、長文の「理由」セルが切り詰められる。
+  - **緩和**: 既存実装も `max-w-[18rem] truncate` で切り詰めており、`title={rawReason}` でホバー時に全文表示しているため、現状踏襲とする。
+- **リスク**: 案 A（`<table>` 維持）でレイアウトが破綻した場合、案 B（`div + grid` で組み直し）への切替が発生する可能性がある。
+  - **緩和**: 実装中に動作確認しながら進める。破綻したら案 B に切り替える判断を許容。
+
+## 参考
+
+- 既存仕様
+  - `frontend/src/components/RecentDecisionsCard.tsx`
+  - `frontend/src/hooks/useDecisionLog.ts`
+  - `backend/internal/interfaces/api/handler/decision.go`（`limit` 上限 1000）
+- TanStack Virtual ドキュメント: `@tanstack/react-virtual` v3

--- a/frontend/src/components/RecentDecisionsCard.tsx
+++ b/frontend/src/components/RecentDecisionsCard.tsx
@@ -1,10 +1,14 @@
+import { useRef } from 'react'
 import { Link } from '@tanstack/react-router'
+import { useVirtualizer } from '@tanstack/react-virtual'
 import type { DecisionLogItem, StrategyResponse } from '../lib/api'
 import { useDecisionLog } from '../hooks/useDecisionLog'
 import { translateReason } from '../lib/decisionReasonI18n'
 import { StanceLegendPopover } from './StanceLegendPopover'
 
 const RECENT_LIMIT = 200
+const ROW_HEIGHT = 36 // px
+const VISIBLE_ROWS = 12
 
 type Props = {
   symbolId: number
@@ -60,18 +64,40 @@ export function RecentDecisionsCard({ symbolId, strategy, rootSearch }: Props) {
             まだ判断履歴がありません。
           </div>
         ) : (
-          <MiniDecisionTable decisions={decisions} />
+          <VirtualizedDecisionTable decisions={decisions} />
         )}
       </div>
     </section>
   )
 }
 
-function MiniDecisionTable({ decisions }: { decisions: DecisionLogItem[] }) {
+function VirtualizedDecisionTable({ decisions }: { decisions: DecisionLogItem[] }) {
+  const parentRef = useRef<HTMLDivElement>(null)
+  const virtualizer = useVirtualizer({
+    count: decisions.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => ROW_HEIGHT,
+    overscan: 5,
+  })
+
   return (
-    <div className="overflow-hidden rounded-2xl border border-white/8">
-      <table className="w-full text-xs">
-        <thead className="bg-white/5 text-[0.65rem] uppercase tracking-[0.18em] text-text-secondary">
+    <div
+      ref={parentRef}
+      className="overflow-auto rounded-2xl border border-white/8"
+      style={{ height: VISIBLE_ROWS * ROW_HEIGHT }}
+    >
+      <table className="w-full text-xs" style={{ tableLayout: 'fixed' }}>
+        <colgroup>
+          <col style={{ width: '4.5rem' }} />
+          <col style={{ width: '7rem' }} />
+          <col style={{ width: '5rem' }} />
+          <col style={{ width: '4rem' }} />
+          <col style={{ width: '4.5rem' }} />
+          <col style={{ width: '6rem' }} />
+          <col style={{ width: '8rem' }} />
+          <col />
+        </colgroup>
+        <thead className="sticky top-0 z-10 bg-bg-card text-[0.65rem] uppercase tracking-[0.18em] text-text-secondary">
           <tr>
             <th className="px-3 py-2 text-left">時刻</th>
             <th className="px-3 py-2 text-left">スタンス</th>
@@ -83,10 +109,18 @@ function MiniDecisionTable({ decisions }: { decisions: DecisionLogItem[] }) {
             <th className="px-3 py-2 text-left">理由</th>
           </tr>
         </thead>
-        <tbody>
-          {decisions.map((d) => (
-            <MiniRow key={d.id} item={d} />
-          ))}
+        <tbody style={{ height: virtualizer.getTotalSize(), position: 'relative', display: 'block' }}>
+          {virtualizer.getVirtualItems().map((vrow) => {
+            const item = decisions[vrow.index]
+            return (
+              <VirtualRow
+                key={item.id}
+                item={item}
+                top={vrow.start}
+                height={ROW_HEIGHT}
+              />
+            )
+          })}
         </tbody>
       </table>
     </div>
@@ -103,7 +137,15 @@ const INTENT_SHORT_LABEL: Record<NonNullable<DecisionLogItem['decision']>['inten
   '': '—',
 }
 
-function MiniRow({ item }: { item: DecisionLogItem }) {
+function VirtualRow({
+  item,
+  top,
+  height,
+}: {
+  item: DecisionLogItem
+  top: number
+  height: number
+}) {
   const bg = rowBackground(item)
   const rawReason =
     item.decision?.reason ||
@@ -116,28 +158,49 @@ function MiniRow({ item }: { item: DecisionLogItem }) {
   const outcome = outcomeLabel(item)
   const intent = item.decision?.intent ?? ''
   return (
-    <tr className={`border-t border-white/8 ${bg}`}>
-      <td className="px-3 py-2 whitespace-nowrap">
+    <tr
+      className={`border-t border-white/8 ${bg}`}
+      style={{
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        width: '100%',
+        height,
+        transform: `translateY(${top}px)`,
+        display: 'table',
+        tableLayout: 'fixed',
+      }}
+    >
+      <td className="px-3 py-2 whitespace-nowrap" style={{ width: '4.5rem' }}>
         {new Date(item.barCloseAt).toLocaleTimeString('ja-JP', {
           hour: '2-digit',
           minute: '2-digit',
         })}
       </td>
-      <td className="px-3 py-2">{item.stance || '—'}</td>
-      <td className="px-3 py-2 whitespace-nowrap">{INTENT_SHORT_LABEL[intent]}</td>
-      <td className="px-3 py-2 font-medium">{item.signal.action}</td>
-      <td className="px-3 py-2 text-right">
+      <td className="px-3 py-2" style={{ width: '7rem' }}>{item.stance || '—'}</td>
+      <td className="px-3 py-2 whitespace-nowrap" style={{ width: '5rem' }}>
+        {INTENT_SHORT_LABEL[intent]}
+      </td>
+      <td className="px-3 py-2 font-medium" style={{ width: '4rem' }}>
+        {item.signal.action}
+      </td>
+      <td className="px-3 py-2 text-right" style={{ width: '4.5rem' }}>
         {item.signal.action === 'HOLD'
           ? '—'
           : `${(item.signal.confidence * 100).toFixed(1)}%`}
       </td>
-      <td className="px-3 py-2 whitespace-nowrap">{outcome}</td>
-      <td className="px-3 py-2 text-right whitespace-nowrap">
+      <td className="px-3 py-2 whitespace-nowrap" style={{ width: '6rem' }}>
+        {outcome}
+      </td>
+      <td
+        className="px-3 py-2 text-right whitespace-nowrap"
+        style={{ width: '8rem' }}
+      >
         {item.order.outcome === 'NOOP'
           ? '—'
           : `${item.order.amount} @ ${item.order.price.toLocaleString('ja-JP')}`}
       </td>
-      <td className="max-w-[18rem] truncate px-3 py-2 text-text-secondary" title={rawReason}>
+      <td className="truncate px-3 py-2 text-text-secondary" title={rawReason}>
         {reason}
       </td>
     </tr>

--- a/frontend/src/components/RecentDecisionsCard.tsx
+++ b/frontend/src/components/RecentDecisionsCard.tsx
@@ -95,7 +95,7 @@ function VirtualizedDecisionTable({ decisions }: { decisions: DecisionLogItem[] 
           <col style={{ width: '4.5rem' }} />
           <col style={{ width: '6rem' }} />
           <col style={{ width: '8rem' }} />
-          <col />
+          <col style={{ width: '18rem' }} />
         </colgroup>
         <thead className="sticky top-0 z-10 bg-bg-card text-[0.65rem] uppercase tracking-[0.18em] text-text-secondary">
           <tr>
@@ -200,7 +200,11 @@ function VirtualRow({
           ? '—'
           : `${item.order.amount} @ ${item.order.price.toLocaleString('ja-JP')}`}
       </td>
-      <td className="truncate px-3 py-2 text-text-secondary" title={rawReason}>
+      <td
+        className="truncate px-3 py-2 text-text-secondary"
+        style={{ width: '18rem' }}
+        title={rawReason}
+      >
         {reason}
       </td>
     </tr>

--- a/frontend/src/components/RecentDecisionsCard.tsx
+++ b/frontend/src/components/RecentDecisionsCard.tsx
@@ -9,6 +9,8 @@ import { StanceLegendPopover } from './StanceLegendPopover'
 const RECENT_LIMIT = 200
 const ROW_HEIGHT = 36 // px
 const VISIBLE_ROWS = 12
+// 各列の grid template (8 列、合計 100%)
+const GRID_TEMPLATE_COLUMNS = '8% 12% 9% 7% 8% 11% 14% 31%'
 
 type Props = {
   symbolId: number
@@ -83,46 +85,35 @@ function VirtualizedDecisionTable({ decisions }: { decisions: DecisionLogItem[] 
   return (
     <div
       ref={parentRef}
-      className="overflow-auto rounded-2xl border border-white/8"
+      className="overflow-auto rounded-2xl border border-white/8 text-xs"
       style={{ height: VISIBLE_ROWS * ROW_HEIGHT }}
     >
-      <table className="w-full text-xs" style={{ tableLayout: 'fixed' }}>
-        <colgroup>
-          <col style={{ width: '8%' }} />
-          <col style={{ width: '12%' }} />
-          <col style={{ width: '9%' }} />
-          <col style={{ width: '7%' }} />
-          <col style={{ width: '8%' }} />
-          <col style={{ width: '11%' }} />
-          <col style={{ width: '14%' }} />
-          <col style={{ width: '31%' }} />
-        </colgroup>
-        <thead className="sticky top-0 z-10 bg-bg-card text-[0.65rem] uppercase tracking-[0.18em] text-text-secondary">
-          <tr>
-            <th className="px-3 py-2 text-left">時刻</th>
-            <th className="px-3 py-2 text-left">スタンス</th>
-            <th className="px-3 py-2 text-left">判断</th>
-            <th className="px-3 py-2 text-left">シグナル</th>
-            <th className="px-3 py-2 text-right">信頼度</th>
-            <th className="px-3 py-2 text-left">結果</th>
-            <th className="px-3 py-2 text-right">数量/価格</th>
-            <th className="px-3 py-2 text-left">理由</th>
-          </tr>
-        </thead>
-        <tbody style={{ height: virtualizer.getTotalSize(), position: 'relative', display: 'block' }}>
-          {virtualizer.getVirtualItems().map((vrow) => {
-            const item = decisions[vrow.index]
-            return (
-              <VirtualRow
-                key={item.id}
-                item={item}
-                top={vrow.start}
-                height={ROW_HEIGHT}
-              />
-            )
-          })}
-        </tbody>
-      </table>
+      <div
+        className="sticky top-0 z-10 grid bg-bg-card text-[0.65rem] uppercase tracking-[0.18em] text-text-secondary"
+        style={{ gridTemplateColumns: GRID_TEMPLATE_COLUMNS }}
+      >
+        <div className="px-3 py-2 text-left">時刻</div>
+        <div className="px-3 py-2 text-left">スタンス</div>
+        <div className="px-3 py-2 text-left">判断</div>
+        <div className="px-3 py-2 text-left">シグナル</div>
+        <div className="px-3 py-2 text-right">信頼度</div>
+        <div className="px-3 py-2 text-left">結果</div>
+        <div className="px-3 py-2 text-right">数量/価格</div>
+        <div className="px-3 py-2 text-left">理由</div>
+      </div>
+      <div style={{ height: virtualizer.getTotalSize(), position: 'relative' }}>
+        {virtualizer.getVirtualItems().map((vrow) => {
+          const item = decisions[vrow.index]
+          return (
+            <VirtualRow
+              key={item.id}
+              item={item}
+              top={vrow.start}
+              height={ROW_HEIGHT}
+            />
+          )
+        })}
+      </div>
     </div>
   )
 }
@@ -158,8 +149,8 @@ function VirtualRow({
   const outcome = outcomeLabel(item)
   const intent = item.decision?.intent ?? ''
   return (
-    <tr
-      className={`border-t border-white/8 ${bg}`}
+    <div
+      className={`grid border-t border-white/8 ${bg}`}
       style={{
         position: 'absolute',
         top: 0,
@@ -167,47 +158,38 @@ function VirtualRow({
         width: '100%',
         height,
         transform: `translateY(${top}px)`,
-        display: 'table',
-        tableLayout: 'fixed',
+        gridTemplateColumns: GRID_TEMPLATE_COLUMNS,
       }}
     >
-      <td className="px-3 py-2 whitespace-nowrap" style={{ width: '8%' }}>
+      <div className="px-3 py-2 whitespace-nowrap">
         {new Date(item.barCloseAt).toLocaleTimeString('ja-JP', {
           hour: '2-digit',
           minute: '2-digit',
         })}
-      </td>
-      <td className="px-3 py-2" style={{ width: '12%' }}>{item.stance || '—'}</td>
-      <td className="px-3 py-2 whitespace-nowrap" style={{ width: '9%' }}>
+      </div>
+      <div className="px-3 py-2 truncate">{item.stance || '—'}</div>
+      <div className="px-3 py-2 whitespace-nowrap">
         {INTENT_SHORT_LABEL[intent]}
-      </td>
-      <td className="px-3 py-2 font-medium" style={{ width: '7%' }}>
-        {item.signal.action}
-      </td>
-      <td className="px-3 py-2 text-right" style={{ width: '8%' }}>
+      </div>
+      <div className="px-3 py-2 font-medium">{item.signal.action}</div>
+      <div className="px-3 py-2 text-right">
         {item.signal.action === 'HOLD'
           ? '—'
           : `${(item.signal.confidence * 100).toFixed(1)}%`}
-      </td>
-      <td className="px-3 py-2 whitespace-nowrap" style={{ width: '11%' }}>
-        {outcome}
-      </td>
-      <td
-        className="px-3 py-2 text-right whitespace-nowrap"
-        style={{ width: '14%' }}
-      >
+      </div>
+      <div className="px-3 py-2 whitespace-nowrap truncate">{outcome}</div>
+      <div className="px-3 py-2 text-right whitespace-nowrap truncate">
         {item.order.outcome === 'NOOP'
           ? '—'
           : `${item.order.amount} @ ${item.order.price.toLocaleString('ja-JP')}`}
-      </td>
-      <td
+      </div>
+      <div
         className="truncate px-3 py-2 text-text-secondary"
-        style={{ width: '31%' }}
         title={rawReason}
       >
         {reason}
-      </td>
-    </tr>
+      </div>
+    </div>
   )
 }
 

--- a/frontend/src/components/RecentDecisionsCard.tsx
+++ b/frontend/src/components/RecentDecisionsCard.tsx
@@ -4,7 +4,7 @@ import { useDecisionLog } from '../hooks/useDecisionLog'
 import { translateReason } from '../lib/decisionReasonI18n'
 import { StanceLegendPopover } from './StanceLegendPopover'
 
-const RECENT_LIMIT = 10
+const RECENT_LIMIT = 200
 
 type Props = {
   symbolId: number

--- a/frontend/src/components/RecentDecisionsCard.tsx
+++ b/frontend/src/components/RecentDecisionsCard.tsx
@@ -88,14 +88,14 @@ function VirtualizedDecisionTable({ decisions }: { decisions: DecisionLogItem[] 
     >
       <table className="w-full text-xs" style={{ tableLayout: 'fixed' }}>
         <colgroup>
-          <col style={{ width: '4.5rem' }} />
-          <col style={{ width: '7rem' }} />
-          <col style={{ width: '5rem' }} />
-          <col style={{ width: '4rem' }} />
-          <col style={{ width: '4.5rem' }} />
-          <col style={{ width: '6rem' }} />
-          <col style={{ width: '8rem' }} />
-          <col style={{ width: '18rem' }} />
+          <col style={{ width: '8%' }} />
+          <col style={{ width: '12%' }} />
+          <col style={{ width: '9%' }} />
+          <col style={{ width: '7%' }} />
+          <col style={{ width: '8%' }} />
+          <col style={{ width: '11%' }} />
+          <col style={{ width: '14%' }} />
+          <col style={{ width: '31%' }} />
         </colgroup>
         <thead className="sticky top-0 z-10 bg-bg-card text-[0.65rem] uppercase tracking-[0.18em] text-text-secondary">
           <tr>
@@ -171,30 +171,30 @@ function VirtualRow({
         tableLayout: 'fixed',
       }}
     >
-      <td className="px-3 py-2 whitespace-nowrap" style={{ width: '4.5rem' }}>
+      <td className="px-3 py-2 whitespace-nowrap" style={{ width: '8%' }}>
         {new Date(item.barCloseAt).toLocaleTimeString('ja-JP', {
           hour: '2-digit',
           minute: '2-digit',
         })}
       </td>
-      <td className="px-3 py-2" style={{ width: '7rem' }}>{item.stance || '—'}</td>
-      <td className="px-3 py-2 whitespace-nowrap" style={{ width: '5rem' }}>
+      <td className="px-3 py-2" style={{ width: '12%' }}>{item.stance || '—'}</td>
+      <td className="px-3 py-2 whitespace-nowrap" style={{ width: '9%' }}>
         {INTENT_SHORT_LABEL[intent]}
       </td>
-      <td className="px-3 py-2 font-medium" style={{ width: '4rem' }}>
+      <td className="px-3 py-2 font-medium" style={{ width: '7%' }}>
         {item.signal.action}
       </td>
-      <td className="px-3 py-2 text-right" style={{ width: '4.5rem' }}>
+      <td className="px-3 py-2 text-right" style={{ width: '8%' }}>
         {item.signal.action === 'HOLD'
           ? '—'
           : `${(item.signal.confidence * 100).toFixed(1)}%`}
       </td>
-      <td className="px-3 py-2 whitespace-nowrap" style={{ width: '6rem' }}>
+      <td className="px-3 py-2 whitespace-nowrap" style={{ width: '11%' }}>
         {outcome}
       </td>
       <td
         className="px-3 py-2 text-right whitespace-nowrap"
-        style={{ width: '8rem' }}
+        style={{ width: '14%' }}
       >
         {item.order.outcome === 'NOOP'
           ? '—'
@@ -202,7 +202,7 @@ function VirtualRow({
       </td>
       <td
         className="truncate px-3 py-2 text-text-secondary"
-        style={{ width: '18rem' }}
+        style={{ width: '31%' }}
         title={rawReason}
       >
         {reason}

--- a/frontend/src/components/__tests__/RecentDecisionsCard.test.tsx
+++ b/frontend/src/components/__tests__/RecentDecisionsCard.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createMemoryHistory, createRouter, createRootRoute, RouterProvider } from '@tanstack/react-router'
+import type { ReactNode } from 'react'
+import { RecentDecisionsCard } from '../RecentDecisionsCard'
+import type { DecisionLogItem, DecisionLogResponse } from '../../lib/api'
+
+function makeItem(i: number): DecisionLogItem {
+  return {
+    id: i,
+    barCloseAt: 1_700_000_000_000 + i * 60_000,
+    sequenceInBar: 0,
+    triggerKind: 'BAR_CLOSE',
+    symbolId: 3,
+    currencyPair: 'LTC_JPY',
+    primaryInterval: 'PT15M',
+    stance: 'TREND_FOLLOW',
+    lastPrice: 10000 + i,
+    signal: { action: 'HOLD', confidence: 0, reason: '' },
+    risk: { outcome: 'SKIPPED', reason: '' },
+    bookGate: { outcome: 'SKIPPED', reason: '' },
+    order: { outcome: 'NOOP', orderId: 0, amount: 0, price: 0, error: '' },
+    closedPositionId: 0,
+    openedPositionId: 0,
+    indicators: {},
+    higherTfIndicators: {},
+    createdAt: 1_700_000_000_000 + i * 60_000,
+  }
+}
+
+function renderWithProviders(ui: ReactNode) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  const rootRoute = createRootRoute({ component: () => <>{ui}</> })
+  const router = createRouter({
+    routeTree: rootRoute,
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  )
+}
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', vi.fn())
+  // useVirtualizer は jsdom でサイズ 0 になり virtualItems が空になるため、ダミーサイズを与える
+  Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+    configurable: true,
+    value: 432,
+  })
+  Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
+    configurable: true,
+    value: 800,
+  })
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('RecentDecisionsCard', () => {
+  it('200 件取得しても thead が描画され、行は仮想化される', async () => {
+    const decisions = Array.from({ length: 200 }, (_, i) => makeItem(i))
+    const response: DecisionLogResponse = { decisions, nextCursor: 0, hasMore: false }
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(response),
+    } as Response)
+
+    renderWithProviders(
+      <RecentDecisionsCard symbolId={3} strategy={undefined} rootSearch={{}} />,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('時刻')).toBeInTheDocument()
+    })
+
+    // 仮想化されているなら、200 件すべての <tr> は描画されない
+    const rows = document.querySelectorAll('tbody tr')
+    expect(rows.length).toBeLessThan(200)
+  })
+
+  it('limit=200 で /decisions を叩く', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ decisions: [], nextCursor: 0, hasMore: false }),
+    } as Response)
+
+    renderWithProviders(
+      <RecentDecisionsCard symbolId={3} strategy={undefined} rootSearch={{}} />,
+    )
+
+    await waitFor(() => {
+      expect(vi.mocked(fetch)).toHaveBeenCalled()
+    })
+    const url = vi.mocked(fetch).mock.calls[0][0] as string
+    expect(url).toContain('limit=200')
+  })
+})

--- a/frontend/src/components/__tests__/RecentDecisionsCard.test.tsx
+++ b/frontend/src/components/__tests__/RecentDecisionsCard.test.tsx
@@ -79,9 +79,11 @@ describe('RecentDecisionsCard', () => {
       expect(screen.getByText('時刻')).toBeInTheDocument()
     })
 
-    // 仮想化されているなら、200 件すべての <tr> は描画されない
-    const rows = document.querySelectorAll('tbody tr')
+    // 仮想化されているなら、200 件すべての行は描画されない。
+    // grid 構造に置き換わったため translateY を持つ要素を行とみなす。
+    const rows = document.querySelectorAll('[style*="translateY"]')
     expect(rows.length).toBeLessThan(200)
+    expect(rows.length).toBeGreaterThan(0)
   })
 
   it('limit=200 で /decisions を叩く', async () => {


### PR DESCRIPTION
## Summary
- 「直近の判断」カードを直近 10 件固定から **直近 1 日分（最大 200 件）** をスクロールで遡れる仮想スクロールに変更
- TanStack Virtual + CSS Grid で、12 行ぶんの高さ（432px）に収めながらカード幅をフルに活用
- ヘッダ行は sticky で常時可視

## 背景
ダッシュボードの「直近の判断」エリアで過去の判断履歴が流れて見えなくなる不満があった。「全件を見る →」リンクで `/history` に遷移すれば確認できるが、ダッシュボード上で完結したいというニーズ。

## 設計と実装計画
- 設計書: `docs/superpowers/specs/2026-05-03-recent-decisions-virtualization-design.md`
- 実装計画: `docs/superpowers/plans/2026-05-03-recent-decisions-virtualization.md`

## 主な変更
- `RECENT_LIMIT`: 10 → 200（バックエンド `/decisions` は元々 limit 最大 1000 対応済）
- `MiniDecisionTable` を `VirtualizedDecisionTable` に置換
- `<table>` → `<div>` + CSS Grid に再構成（`<table>` + `position:absolute` 行は `display:table` で `width:100%` 基準が壊れる問題を回避）
- `useVirtualizer({ overscan: 5, estimateSize: 36 })` で行を仮想化、`getTotalSize()` で全体高さを確保
- 列幅は `grid-template-columns: 8% 12% 9% 7% 8% 11% 14% 31%` の比率指定でコンテナ幅にフィット
- 既存の色分け / `INTENT_SHORT_LABEL` / `outcomeLabel` / `translateReason` はそのまま流用

## 検証
- `pnpm test` 全 54 テスト green（仮想化と limit=200 のテストを `RecentDecisionsCard.test.tsx` に新規追加）
- `pnpm exec tsc --noEmit` 本変更ファイル由来の型エラーなし
- Playwright で実機確認済み:
  - 12 行ぶん（432px）の高さで描画
  - スクロールで過去 1 日分まで遡れる
  - sticky ヘッダ常時可視
  - 列幅がカード幅にフィット（理由列 413px）
  - 仮想化により 200 件中 23 行のみ DOM 上に存在
  - 15 秒毎の自動更新で最新行が増える挙動を確認

## Test plan
- [ ] `pnpm test` が green
- [ ] `http://localhost:33000/?symbol=LTC_JPY` で「直近の判断」カードが 12 行高さで表示される
- [ ] テーブル内をスクロールして過去 1 日分の履歴が遡れる
- [ ] スクロール中もヘッダが常時可視
- [ ] 行の色分け（約定=緑 / 却下=赤 / HOLD=黄）が崩れていない
- [ ] 列幅がカード幅に収まり、理由列に reason 文字列が読める形で表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)