### PR TITLE
feat(exit-plan): Phase 1 — ExitPlan ドメイン + Repository + シャドウ運用

### DIFF
--- a/backend/cmd/event_pipeline.go
+++ b/backend/cmd/event_pipeline.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+	domainexitplan "github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/exitplan"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/port"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/repository"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/risk"
@@ -19,6 +20,7 @@ import (
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/decision"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/decisionlog"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/eventengine"
+	usecaseexitplan "github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/exitplan"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/positionsize"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/reconcile"
 	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/usecase/sor"
@@ -82,6 +84,12 @@ type EventDrivenPipeline struct {
 	// EventBus so every pipeline cycle persists a row. nil disables the
 	// recorder; the rest of the pipeline is unaffected.
 	decisionLogRepo repository.DecisionLogRepository
+
+	// exitPlanRepo, when non-nil, attaches the Phase 1 ExitPlan shadow
+	// handler so every fill is mirrored into the exit_plans table.
+	// シャドウなので発注パスへは干渉しない。Phase 2 で SL/TP/Trailing
+	// 発火本体が ExitHandler に移管されたら shadow handler は退役する。
+	exitPlanRepo domainexitplan.Repository
 
 	// candlestickFetcher is used at event-loop start to seed the LiveSource
 	// CandleBuilder with the in-progress PT15M bar reconstructed from PT1M
@@ -173,6 +181,11 @@ type EventDrivenPipelineConfig struct {
 	// without otherwise affecting the pipeline.
 	DecisionLogRepo repository.DecisionLogRepository
 
+	// ExitPlanRepo, when non-nil, attaches the Phase 1 ExitPlan shadow
+	// handler so the pipeline mirrors fills into the exit_plans table.
+	// シャドウ運用専用。SL/TP/Trailing 発火経路は変更しない。
+	ExitPlanRepo domainexitplan.Repository
+
 	// CandlestickFetcher is used to seed the LiveSource CandleBuilder with
 	// the in-progress PT15M bar (reconstructed from PT1M) at startup so the
 	// first emitted bar after a restart has correct OHLC. nil keeps the
@@ -248,6 +261,7 @@ func NewEventDrivenPipeline(
 		indicatorPeriods:   cfg.IndicatorPeriods,
 		bbSqueezeLookback:  cfg.BBSqueezeLookback,
 		decisionLogRepo:    cfg.DecisionLogRepo,
+		exitPlanRepo:       cfg.ExitPlanRepo,
 		candlestickFetcher: cfg.CandlestickFetcher,
 		stanceResolver:     cfg.StanceResolver,
 		primaryInterval:    primaryIntervalOrDefault(cfg.PrimaryInterval),
@@ -778,6 +792,18 @@ func (p *EventDrivenPipeline) runEventLoop(ctx context.Context, snap eventSnapsh
 	bus.Register(entity.EventTypeMarketSignal, 27, decisionHandler)
 	bus.Register(entity.EventTypeDecision, 30, riskHandler)
 	bus.Register(entity.EventTypeOrder, 50, riskHandler)
+
+	// ExitPlan shadow (priority 60): OrderEvent をシャドウで listen して
+	// ExitPlan の作成・close だけ行う。発注パスには干渉しない。Phase 2 で
+	// 出口判定本体を Exit レイヤに移管したらこの shadow は退役する。
+	if p.exitPlanRepo != nil {
+		shadow := usecaseexitplan.NewShadowHandler(usecaseexitplan.ShadowHandlerConfig{
+			Repo:   p.exitPlanRepo,
+			Policy: snap.riskPolicy,
+		})
+		bus.Register(entity.EventTypeOrder, 60, shadow)
+		slog.Info("event-pipeline: ExitPlan shadow handler registered (Phase 1)")
+	}
 
 	// ExecutionHandler: opens orders from approved signals (priority 40).
 	executionHandler := &backtest.ExecutionHandler{

--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -60,6 +60,7 @@ func main() {
 	tradingConfigRepo := database.NewTradingConfigRepo(db)
 	decisionLogRepo := database.NewDecisionLogRepository(db)
 	backtestDecisionLogRepo := database.NewBacktestDecisionLogRepository(db)
+	exitPlanRepo := database.NewExitPlanRepository(db)
 
 	// --- Usecase ---
 	marketDataSvc := usecase.NewMarketDataServiceWithConfig(marketDataRepo, loadPersistenceConfig())
@@ -202,6 +203,7 @@ func main() {
 			IndicatorPeriods:   liveProfileIndicators(liveProfile),
 			BBSqueezeLookback:  liveProfileBBSqueezeLookback(liveProfile),
 			DecisionLogRepo:    decisionLogRepo,
+			ExitPlanRepo:       exitPlanRepo,
 			CandlestickFetcher: restClient,
 			StanceResolver:     stanceResolver,
 			PrimaryInterval:    livePrimaryIntervalFromEnv(),

--- a/backend/internal/domain/exitplan/exit_plan.go
+++ b/backend/internal/domain/exitplan/exit_plan.go
@@ -1,0 +1,143 @@
+// Package exitplan は建玉と 1:1 で対応する出口管理エンティティ ExitPlan
+// を定義する。entity / risk のどちらに置いても import cycle が発生する
+// ため、独立した domain パッケージとして切り出している。
+package exitplan
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/risk"
+)
+
+// ExitPlan は建玉と 1:1 で対応する出口管理エンティティ。SL/TP のルールは
+// risk.RiskPolicy として保存し、現在価格は read 時に動的計算する（ATR
+// レジーム変化への追従を許容）。Trailing の HWM だけが動的状態として
+// 永続化される。
+//
+// Phase 1 ではシャドウ運用のみ。Phase 2 で SL/TP/Trailing 発火判定と
+// CurrentSLPrice / CurrentTPPrice / CurrentTrailingTriggerPrice を追加する。
+type ExitPlan struct {
+	ID         int64
+	PositionID int64
+	SymbolID   int64
+	Side       entity.OrderSide
+	EntryPrice float64
+	Policy     risk.RiskPolicy
+
+	TrailingActivated bool
+	TrailingHWM       *float64
+
+	CreatedAt int64
+	UpdatedAt int64
+	ClosedAt  *int64
+}
+
+// NewInput は New の入力。コンストラクタ専用の record 型。
+type NewInput struct {
+	PositionID int64
+	SymbolID   int64
+	Side       entity.OrderSide
+	EntryPrice float64
+	Policy     risk.RiskPolicy
+	CreatedAt  int64
+}
+
+// New は不変条件を検証して新しい ExitPlan を返す。Repository の Create で
+// 永続化する前に必ずこれを通すことで「無防備な建玉」を防ぐ。
+func New(in NewInput) (*ExitPlan, error) {
+	if in.PositionID <= 0 {
+		return nil, errors.New("ExitPlan: PositionID must be > 0")
+	}
+	if in.SymbolID <= 0 {
+		return nil, errors.New("ExitPlan: SymbolID must be > 0")
+	}
+	if in.Side != entity.OrderSideBuy && in.Side != entity.OrderSideSell {
+		return nil, fmt.Errorf("ExitPlan: Side must be BUY or SELL (got %q)", in.Side)
+	}
+	if in.EntryPrice <= 0 {
+		return nil, fmt.Errorf("ExitPlan: EntryPrice must be > 0 (got %v)", in.EntryPrice)
+	}
+	if err := in.Policy.Validate(); err != nil {
+		return nil, fmt.Errorf("ExitPlan: invalid policy: %w", err)
+	}
+	if in.CreatedAt <= 0 {
+		return nil, errors.New("ExitPlan: CreatedAt must be > 0")
+	}
+	return &ExitPlan{
+		PositionID: in.PositionID,
+		SymbolID:   in.SymbolID,
+		Side:       in.Side,
+		EntryPrice: in.EntryPrice,
+		Policy:     in.Policy,
+		CreatedAt:  in.CreatedAt,
+		UpdatedAt:  in.CreatedAt,
+	}, nil
+}
+
+// IsClosed は close 済みか判定する。
+func (e *ExitPlan) IsClosed() bool {
+	return e.ClosedAt != nil
+}
+
+// RaiseTrailingHWM は新しい tick 価格で Trailing の最良値を更新する。
+// 含み益超え（ロング: price > EntryPrice、ショート: price < EntryPrice）で
+// 初めて呼ばれた瞬間に Activated を true にし HWM を price で初期化する。
+// その後はロングなら新高値、ショートなら新安値のときだけ更新する。
+//
+// 戻り値は HWM が変化したか（=永続化が必要か）。closed plan に対して
+// 呼ばれた場合や no-op の場合は false。
+func (e *ExitPlan) RaiseTrailingHWM(price float64, now int64) bool {
+	if e.IsClosed() {
+		return false
+	}
+	if !e.TrailingActivated {
+		switch e.Side {
+		case entity.OrderSideBuy:
+			if price <= e.EntryPrice {
+				return false
+			}
+		case entity.OrderSideSell:
+			if price >= e.EntryPrice {
+				return false
+			}
+		}
+		e.TrailingActivated = true
+		hwm := price
+		e.TrailingHWM = &hwm
+		e.UpdatedAt = now
+		return true
+	}
+	if e.TrailingHWM == nil {
+		hwm := price
+		e.TrailingHWM = &hwm
+		e.UpdatedAt = now
+		return true
+	}
+	switch e.Side {
+	case entity.OrderSideBuy:
+		if price > *e.TrailingHWM {
+			*e.TrailingHWM = price
+			e.UpdatedAt = now
+			return true
+		}
+	case entity.OrderSideSell:
+		if price < *e.TrailingHWM {
+			*e.TrailingHWM = price
+			e.UpdatedAt = now
+			return true
+		}
+	}
+	return false
+}
+
+// Close は ExitPlan を closed 状態に遷移させる。二重 close はエラー。
+func (e *ExitPlan) Close(now int64) error {
+	if e.IsClosed() {
+		return errors.New("ExitPlan: already closed")
+	}
+	e.ClosedAt = &now
+	e.UpdatedAt = now
+	return nil
+}

--- a/backend/internal/domain/exitplan/exit_plan_test.go
+++ b/backend/internal/domain/exitplan/exit_plan_test.go
@@ -1,0 +1,196 @@
+package exitplan
+
+import (
+	"testing"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/risk"
+)
+
+func TestNew_validInputs(t *testing.T) {
+	policy := risk.RiskPolicy{
+		StopLoss:   risk.StopLossSpec{Percent: 1.5, ATRMultiplier: 2.0},
+		TakeProfit: risk.TakeProfitSpec{Percent: 3.0},
+		Trailing:   risk.TrailingSpec{Mode: risk.TrailingModeATR, ATRMultiplier: 2.5},
+	}
+	plan, err := New(NewInput{
+		PositionID: 100,
+		SymbolID:   7,
+		Side:       entity.OrderSideBuy,
+		EntryPrice: 10000,
+		Policy:     policy,
+		CreatedAt:  1700000000000,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if plan.PositionID != 100 || plan.SymbolID != 7 || plan.Side != entity.OrderSideBuy {
+		t.Errorf("identity fields wrong: %+v", plan)
+	}
+	if plan.EntryPrice != 10000 {
+		t.Errorf("EntryPrice = %v, want 10000", plan.EntryPrice)
+	}
+	if plan.Policy.StopLoss.Percent != 1.5 {
+		t.Errorf("policy not embedded: %+v", plan.Policy)
+	}
+	if plan.TrailingActivated {
+		t.Errorf("TrailingActivated should default false")
+	}
+	if plan.TrailingHWM != nil {
+		t.Errorf("TrailingHWM should default nil; got %v", *plan.TrailingHWM)
+	}
+	if plan.ClosedAt != nil {
+		t.Errorf("ClosedAt should default nil")
+	}
+}
+
+func TestNew_validation(t *testing.T) {
+	validPolicy := risk.RiskPolicy{
+		StopLoss:   risk.StopLossSpec{Percent: 1.5},
+		TakeProfit: risk.TakeProfitSpec{Percent: 3.0},
+		Trailing:   risk.TrailingSpec{Mode: risk.TrailingModeDisabled},
+	}
+	cases := []struct {
+		name    string
+		input   NewInput
+		wantErr string
+	}{
+		{
+			"zero PositionID",
+			NewInput{PositionID: 0, SymbolID: 7, Side: entity.OrderSideBuy, EntryPrice: 10000, Policy: validPolicy, CreatedAt: 1},
+			"PositionID must be > 0",
+		},
+		{
+			"zero SymbolID",
+			NewInput{PositionID: 1, SymbolID: 0, Side: entity.OrderSideBuy, EntryPrice: 10000, Policy: validPolicy, CreatedAt: 1},
+			"SymbolID must be > 0",
+		},
+		{
+			"empty Side",
+			NewInput{PositionID: 1, SymbolID: 7, Side: "", EntryPrice: 10000, Policy: validPolicy, CreatedAt: 1},
+			"Side must be BUY or SELL",
+		},
+		{
+			"non-positive EntryPrice",
+			NewInput{PositionID: 1, SymbolID: 7, Side: entity.OrderSideBuy, EntryPrice: 0, Policy: validPolicy, CreatedAt: 1},
+			"EntryPrice must be > 0",
+		},
+		{
+			"invalid policy",
+			NewInput{PositionID: 1, SymbolID: 7, Side: entity.OrderSideBuy, EntryPrice: 10000, Policy: risk.RiskPolicy{}, CreatedAt: 1},
+			"invalid policy",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := New(tc.input)
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+			}
+			if !strContains(err.Error(), tc.wantErr) {
+				t.Errorf("error = %q, want substring %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestExitPlan_RaiseTrailingHWM_long(t *testing.T) {
+	plan := mustNewForTest(t, 100, entity.OrderSideBuy, 10000)
+	if changed := plan.RaiseTrailingHWM(9990, 1); changed {
+		t.Errorf("loss-side tick should not raise HWM")
+	}
+	if plan.TrailingActivated || plan.TrailingHWM != nil {
+		t.Errorf("HWM must remain unactivated; got activated=%v hwm=%+v", plan.TrailingActivated, plan.TrailingHWM)
+	}
+	if changed := plan.RaiseTrailingHWM(10050, 2); !changed {
+		t.Errorf("first profit tick should activate HWM")
+	}
+	if !plan.TrailingActivated || plan.TrailingHWM == nil || *plan.TrailingHWM != 10050 {
+		t.Errorf("activation wrong: activated=%v hwm=%+v", plan.TrailingActivated, plan.TrailingHWM)
+	}
+	if plan.UpdatedAt != 2 {
+		t.Errorf("UpdatedAt not refreshed; got %v", plan.UpdatedAt)
+	}
+	if changed := plan.RaiseTrailingHWM(10100, 3); !changed {
+		t.Errorf("higher high should update HWM")
+	}
+	if *plan.TrailingHWM != 10100 {
+		t.Errorf("HWM = %v, want 10100", *plan.TrailingHWM)
+	}
+	if changed := plan.RaiseTrailingHWM(10080, 4); changed {
+		t.Errorf("lower tick should not change HWM")
+	}
+	if *plan.TrailingHWM != 10100 {
+		t.Errorf("HWM regressed: %v", *plan.TrailingHWM)
+	}
+}
+
+func TestExitPlan_RaiseTrailingHWM_short(t *testing.T) {
+	plan := mustNewForTest(t, 100, entity.OrderSideSell, 10000)
+	if changed := plan.RaiseTrailingHWM(10020, 1); changed {
+		t.Errorf("short loss-side tick should not raise HWM")
+	}
+	if changed := plan.RaiseTrailingHWM(9950, 2); !changed {
+		t.Errorf("short first profit should activate HWM")
+	}
+	if !plan.TrailingActivated || plan.TrailingHWM == nil || *plan.TrailingHWM != 9950 {
+		t.Errorf("short activation wrong: %+v", plan)
+	}
+	if changed := plan.RaiseTrailingHWM(9900, 3); !changed {
+		t.Errorf("lower low should update short HWM")
+	}
+	if *plan.TrailingHWM != 9900 {
+		t.Errorf("short HWM = %v, want 9900", *plan.TrailingHWM)
+	}
+}
+
+func TestExitPlan_Close_invariant(t *testing.T) {
+	plan := mustNewForTest(t, 100, entity.OrderSideBuy, 10000)
+	if err := plan.Close(1700000000999); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if plan.ClosedAt == nil || *plan.ClosedAt != 1700000000999 {
+		t.Errorf("ClosedAt = %+v, want 1700000000999", plan.ClosedAt)
+	}
+	if err := plan.Close(1700000001000); err == nil {
+		t.Errorf("second Close should error")
+	}
+	if plan.RaiseTrailingHWM(10050, 1700000001001) {
+		t.Errorf("RaiseTrailingHWM on closed plan should be no-op")
+	}
+}
+
+// --- helpers ---
+
+func mustNewForTest(t *testing.T, posID int64, side entity.OrderSide, entry float64) *ExitPlan {
+	t.Helper()
+	policy := risk.RiskPolicy{
+		StopLoss:   risk.StopLossSpec{Percent: 1.5, ATRMultiplier: 2.0},
+		TakeProfit: risk.TakeProfitSpec{Percent: 3.0},
+		Trailing:   risk.TrailingSpec{Mode: risk.TrailingModeATR, ATRMultiplier: 2.5},
+	}
+	plan, err := New(NewInput{
+		PositionID: posID,
+		SymbolID:   7,
+		Side:       side,
+		EntryPrice: entry,
+		Policy:     policy,
+		CreatedAt:  1700000000000,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return plan
+}
+
+func strContains(s, sub string) bool {
+	if sub == "" {
+		return true
+	}
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/domain/exitplan/repository.go
+++ b/backend/internal/domain/exitplan/repository.go
@@ -1,0 +1,27 @@
+package exitplan
+
+import "context"
+
+// Repository は建玉ごとの ExitPlan を永続化する。SL/TP のルールは
+// 不変なので Create 時に書ききり、変化点（Trailing 活性化・HWM 更新・close）
+// だけを書き込む I/O 設計。
+type Repository interface {
+	// Create は新規 ExitPlan を永続化する。PositionID は unique 制約で
+	// 同じ建玉に対して二重 ExitPlan が作られない。
+	Create(ctx context.Context, plan *ExitPlan) error
+
+	// FindByPositionID は建玉 ID で ExitPlan を引く。closed 含む全件。
+	// 見つからない場合は (nil, nil)。
+	FindByPositionID(ctx context.Context, positionID int64) (*ExitPlan, error)
+
+	// ListOpen は ClosedAt IS NULL の ExitPlan を symbol_id で絞って返す。
+	// Phase 2 の tick handler が毎 tick これを呼ぶので、走査効率を意識する。
+	ListOpen(ctx context.Context, symbolID int64) ([]*ExitPlan, error)
+
+	// UpdateTrailing は HWM と Activated フラグだけを更新する。SL/TP の
+	// ルール部分は変更しない。closed な plan に対してはエラー。
+	UpdateTrailing(ctx context.Context, planID int64, hwm float64, activated bool, updatedAt int64) error
+
+	// Close は ClosedAt を立てる。二重 close はエラー。
+	Close(ctx context.Context, planID int64, closedAt int64) error
+}

--- a/backend/internal/infrastructure/database/exit_plan_repo.go
+++ b/backend/internal/infrastructure/database/exit_plan_repo.go
@@ -1,0 +1,216 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/exitplan"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/risk"
+)
+
+// exitPlanRepo は exitplan.Repository を SQLite で実装する。DB は
+// RunMigrations 済みであること。
+type exitPlanRepo struct {
+	db *sql.DB
+}
+
+// NewExitPlanRepository は SQLite 実装を返す。
+func NewExitPlanRepository(db *sql.DB) exitplan.Repository {
+	return &exitPlanRepo{db: db}
+}
+
+func (r *exitPlanRepo) Create(ctx context.Context, plan *exitplan.ExitPlan) error {
+	if plan == nil {
+		return errors.New("exitPlanRepo.Create: nil plan")
+	}
+	const q = `
+		INSERT INTO exit_plans (
+			position_id, symbol_id, side, entry_price,
+			sl_percent, sl_atr_multiplier,
+			tp_percent,
+			trailing_mode, trailing_atr_multiplier,
+			trailing_activated, trailing_hwm,
+			created_at, updated_at, closed_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`
+	res, err := r.db.ExecContext(ctx, q,
+		plan.PositionID, plan.SymbolID, string(plan.Side), plan.EntryPrice,
+		plan.Policy.StopLoss.Percent, plan.Policy.StopLoss.ATRMultiplier,
+		plan.Policy.TakeProfit.Percent,
+		int(plan.Policy.Trailing.Mode), plan.Policy.Trailing.ATRMultiplier,
+		boolToInt(plan.TrailingActivated), nullableFloat(plan.TrailingHWM),
+		plan.CreatedAt, plan.UpdatedAt, nullableInt64(plan.ClosedAt),
+	)
+	if err != nil {
+		return fmt.Errorf("insert exit_plans: %w", err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return fmt.Errorf("LastInsertId exit_plans: %w", err)
+	}
+	plan.ID = id
+	return nil
+}
+
+func (r *exitPlanRepo) FindByPositionID(ctx context.Context, positionID int64) (*exitplan.ExitPlan, error) {
+	const q = `
+		SELECT id, position_id, symbol_id, side, entry_price,
+		       sl_percent, sl_atr_multiplier,
+		       tp_percent,
+		       trailing_mode, trailing_atr_multiplier,
+		       trailing_activated, trailing_hwm,
+		       created_at, updated_at, closed_at
+		FROM exit_plans
+		WHERE position_id = ?
+	`
+	row := r.db.QueryRowContext(ctx, q, positionID)
+	plan, err := scanExitPlan(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("FindByPositionID: %w", err)
+	}
+	return plan, nil
+}
+
+func (r *exitPlanRepo) ListOpen(ctx context.Context, symbolID int64) ([]*exitplan.ExitPlan, error) {
+	const q = `
+		SELECT id, position_id, symbol_id, side, entry_price,
+		       sl_percent, sl_atr_multiplier,
+		       tp_percent,
+		       trailing_mode, trailing_atr_multiplier,
+		       trailing_activated, trailing_hwm,
+		       created_at, updated_at, closed_at
+		FROM exit_plans
+		WHERE symbol_id = ? AND closed_at IS NULL
+		ORDER BY id ASC
+	`
+	rows, err := r.db.QueryContext(ctx, q, symbolID)
+	if err != nil {
+		return nil, fmt.Errorf("ListOpen query: %w", err)
+	}
+	defer rows.Close()
+	var out []*exitplan.ExitPlan
+	for rows.Next() {
+		plan, err := scanExitPlan(rows)
+		if err != nil {
+			return nil, fmt.Errorf("ListOpen scan: %w", err)
+		}
+		out = append(out, plan)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("ListOpen iter: %w", err)
+	}
+	return out, nil
+}
+
+func (r *exitPlanRepo) UpdateTrailing(ctx context.Context, planID int64, hwm float64, activated bool, updatedAt int64) error {
+	const q = `
+		UPDATE exit_plans
+		SET trailing_activated = ?, trailing_hwm = ?, updated_at = ?
+		WHERE id = ? AND closed_at IS NULL
+	`
+	res, err := r.db.ExecContext(ctx, q, boolToInt(activated), hwm, updatedAt, planID)
+	if err != nil {
+		return fmt.Errorf("UpdateTrailing: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return fmt.Errorf("UpdateTrailing: plan id=%d not found or already closed", planID)
+	}
+	return nil
+}
+
+func (r *exitPlanRepo) Close(ctx context.Context, planID int64, closedAt int64) error {
+	const q = `
+		UPDATE exit_plans
+		SET closed_at = ?, updated_at = ?
+		WHERE id = ? AND closed_at IS NULL
+	`
+	res, err := r.db.ExecContext(ctx, q, closedAt, closedAt, planID)
+	if err != nil {
+		return fmt.Errorf("Close: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return fmt.Errorf("Close: plan id=%d not found or already closed", planID)
+	}
+	return nil
+}
+
+// rowScanner は *sql.Row と *sql.Rows の Scan を共通化する最小インタフェース。
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanExitPlan(s rowScanner) (*exitplan.ExitPlan, error) {
+	var (
+		id              int64
+		positionID      int64
+		symbolID        int64
+		side            string
+		entryPrice      float64
+		slPercent       float64
+		slATRMult       float64
+		tpPercent       float64
+		trailingMode    int
+		trailingATRMult float64
+		trailingAct     int
+		trailingHWM     sql.NullFloat64
+		createdAt       int64
+		updatedAt       int64
+		closedAt        sql.NullInt64
+	)
+	if err := s.Scan(
+		&id, &positionID, &symbolID, &side, &entryPrice,
+		&slPercent, &slATRMult,
+		&tpPercent,
+		&trailingMode, &trailingATRMult,
+		&trailingAct, &trailingHWM,
+		&createdAt, &updatedAt, &closedAt,
+	); err != nil {
+		return nil, err
+	}
+	plan := &exitplan.ExitPlan{
+		ID:         id,
+		PositionID: positionID,
+		SymbolID:   symbolID,
+		Side:       entity.OrderSide(side),
+		EntryPrice: entryPrice,
+		Policy: risk.RiskPolicy{
+			StopLoss:   risk.StopLossSpec{Percent: slPercent, ATRMultiplier: slATRMult},
+			TakeProfit: risk.TakeProfitSpec{Percent: tpPercent},
+			Trailing:   risk.TrailingSpec{Mode: risk.TrailingMode(trailingMode), ATRMultiplier: trailingATRMult},
+		},
+		TrailingActivated: trailingAct == 1,
+		CreatedAt:         createdAt,
+		UpdatedAt:         updatedAt,
+	}
+	if trailingHWM.Valid {
+		v := trailingHWM.Float64
+		plan.TrailingHWM = &v
+	}
+	if closedAt.Valid {
+		v := closedAt.Int64
+		plan.ClosedAt = &v
+	}
+	return plan, nil
+}
+
+func nullableFloat(p *float64) any {
+	if p == nil {
+		return nil
+	}
+	return *p
+}
+
+func nullableInt64(p *int64) any {
+	if p == nil {
+		return nil
+	}
+	return *p
+}

--- a/backend/internal/infrastructure/database/exit_plan_repo_test.go
+++ b/backend/internal/infrastructure/database/exit_plan_repo_test.go
@@ -1,0 +1,208 @@
+package database
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/exitplan"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/risk"
+)
+
+func openExitPlanTestDB(t *testing.T) *exitPlanTestDB {
+	t.Helper()
+	tmp := t.TempDir()
+	db, err := NewDB(filepath.Join(tmp, "exitplan.db"))
+	if err != nil {
+		t.Fatalf("NewDB: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := RunMigrations(db); err != nil {
+		t.Fatalf("RunMigrations: %v", err)
+	}
+	return &exitPlanTestDB{db: db, repo: NewExitPlanRepository(db)}
+}
+
+type exitPlanTestDB struct {
+	db   interface{ Close() error }
+	repo exitplan.Repository
+}
+
+func TestExitPlanRepo_CreateAndFind(t *testing.T) {
+	h := openExitPlanTestDB(t)
+	ctx := context.Background()
+
+	plan := mustExitPlanForRepo(t, 100, 7, entity.OrderSideBuy, 10000)
+	if err := h.repo.Create(ctx, plan); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if plan.ID == 0 {
+		t.Errorf("ID should be assigned after Create")
+	}
+	got, err := h.repo.FindByPositionID(ctx, 100)
+	if err != nil {
+		t.Fatalf("FindByPositionID: %v", err)
+	}
+	if got == nil {
+		t.Fatal("FindByPositionID: nil")
+	}
+	if got.PositionID != 100 || got.SymbolID != 7 || got.Side != entity.OrderSideBuy || got.EntryPrice != 10000 {
+		t.Errorf("got = %+v", got)
+	}
+	if got.Policy.StopLoss.Percent != 1.5 || got.Policy.StopLoss.ATRMultiplier != 2.0 {
+		t.Errorf("policy SL not roundtripped: %+v", got.Policy.StopLoss)
+	}
+	if got.Policy.TakeProfit.Percent != 3.0 {
+		t.Errorf("policy TP not roundtripped: %+v", got.Policy.TakeProfit)
+	}
+	if got.Policy.Trailing.Mode != risk.TrailingModeATR || got.Policy.Trailing.ATRMultiplier != 2.5 {
+		t.Errorf("policy trailing not roundtripped: %+v", got.Policy.Trailing)
+	}
+	if got.TrailingActivated || got.TrailingHWM != nil {
+		t.Errorf("trailing should default not activated: %+v", got)
+	}
+	if got.ClosedAt != nil {
+		t.Errorf("ClosedAt should default nil")
+	}
+}
+
+func TestExitPlanRepo_FindByPositionID_notFound(t *testing.T) {
+	h := openExitPlanTestDB(t)
+	got, err := h.repo.FindByPositionID(context.Background(), 999)
+	if err != nil {
+		t.Fatalf("FindByPositionID: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil for missing plan, got %+v", got)
+	}
+}
+
+func TestExitPlanRepo_Create_uniquePositionID(t *testing.T) {
+	h := openExitPlanTestDB(t)
+	ctx := context.Background()
+	p1 := mustExitPlanForRepo(t, 100, 7, entity.OrderSideBuy, 10000)
+	if err := h.repo.Create(ctx, p1); err != nil {
+		t.Fatalf("first Create: %v", err)
+	}
+	p2 := mustExitPlanForRepo(t, 100, 7, entity.OrderSideSell, 11000)
+	if err := h.repo.Create(ctx, p2); err == nil {
+		t.Errorf("second Create with same PositionID should fail")
+	}
+}
+
+func TestExitPlanRepo_ListOpen_excludesClosed(t *testing.T) {
+	h := openExitPlanTestDB(t)
+	ctx := context.Background()
+	open := mustExitPlanForRepo(t, 100, 7, entity.OrderSideBuy, 10000)
+	closed := mustExitPlanForRepo(t, 101, 7, entity.OrderSideSell, 11000)
+	otherSym := mustExitPlanForRepo(t, 102, 8, entity.OrderSideBuy, 5000)
+	for _, p := range []*exitplan.ExitPlan{open, closed, otherSym} {
+		if err := h.repo.Create(ctx, p); err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+	}
+	if err := h.repo.Close(ctx, closed.ID, 1700000099999); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	got, err := h.repo.ListOpen(ctx, 7)
+	if err != nil {
+		t.Fatalf("ListOpen: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("ListOpen returned %d, want 1", len(got))
+	}
+	if got[0].PositionID != 100 {
+		t.Errorf("expected open plan position 100, got %d", got[0].PositionID)
+	}
+}
+
+func TestExitPlanRepo_UpdateTrailing(t *testing.T) {
+	h := openExitPlanTestDB(t)
+	ctx := context.Background()
+	plan := mustExitPlanForRepo(t, 100, 7, entity.OrderSideBuy, 10000)
+	if err := h.repo.Create(ctx, plan); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if err := h.repo.UpdateTrailing(ctx, plan.ID, 10250, true, 1700000050000); err != nil {
+		t.Fatalf("UpdateTrailing: %v", err)
+	}
+	got, _ := h.repo.FindByPositionID(ctx, 100)
+	if !got.TrailingActivated {
+		t.Errorf("TrailingActivated should be true")
+	}
+	if got.TrailingHWM == nil || *got.TrailingHWM != 10250 {
+		t.Errorf("TrailingHWM = %+v, want 10250", got.TrailingHWM)
+	}
+	if got.UpdatedAt != 1700000050000 {
+		t.Errorf("UpdatedAt = %v, want 1700000050000", got.UpdatedAt)
+	}
+}
+
+func TestExitPlanRepo_UpdateTrailing_closedPlanFails(t *testing.T) {
+	h := openExitPlanTestDB(t)
+	ctx := context.Background()
+	plan := mustExitPlanForRepo(t, 100, 7, entity.OrderSideBuy, 10000)
+	if err := h.repo.Create(ctx, plan); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := h.repo.Close(ctx, plan.ID, 1700000099999); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if err := h.repo.UpdateTrailing(ctx, plan.ID, 10300, true, 1700000100000); err == nil {
+		t.Errorf("UpdateTrailing on closed plan should error")
+	}
+}
+
+func TestExitPlanRepo_Close(t *testing.T) {
+	h := openExitPlanTestDB(t)
+	ctx := context.Background()
+	plan := mustExitPlanForRepo(t, 100, 7, entity.OrderSideBuy, 10000)
+	if err := h.repo.Create(ctx, plan); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := h.repo.Close(ctx, plan.ID, 1700000099999); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	got, _ := h.repo.FindByPositionID(ctx, 100)
+	if got.ClosedAt == nil || *got.ClosedAt != 1700000099999 {
+		t.Errorf("ClosedAt = %+v, want 1700000099999", got.ClosedAt)
+	}
+}
+
+func TestExitPlanRepo_Close_doubleCloseFails(t *testing.T) {
+	h := openExitPlanTestDB(t)
+	ctx := context.Background()
+	plan := mustExitPlanForRepo(t, 100, 7, entity.OrderSideBuy, 10000)
+	if err := h.repo.Create(ctx, plan); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := h.repo.Close(ctx, plan.ID, 1700000099999); err != nil {
+		t.Fatalf("first Close: %v", err)
+	}
+	if err := h.repo.Close(ctx, plan.ID, 1700000099999); err == nil {
+		t.Errorf("second Close should error")
+	}
+}
+
+func mustExitPlanForRepo(t *testing.T, posID, symID int64, side entity.OrderSide, entry float64) *exitplan.ExitPlan {
+	t.Helper()
+	plan, err := exitplan.New(exitplan.NewInput{
+		PositionID: posID,
+		SymbolID:   symID,
+		Side:       side,
+		EntryPrice: entry,
+		Policy: risk.RiskPolicy{
+			StopLoss:   risk.StopLossSpec{Percent: 1.5, ATRMultiplier: 2.0},
+			TakeProfit: risk.TakeProfitSpec{Percent: 3.0},
+			Trailing:   risk.TrailingSpec{Mode: risk.TrailingModeATR, ATRMultiplier: 2.5},
+		},
+		CreatedAt: 1700000000000,
+	})
+	if err != nil {
+		t.Fatalf("exitplan.New: %v", err)
+	}
+	return plan
+}

--- a/backend/internal/infrastructure/database/migrations.go
+++ b/backend/internal/infrastructure/database/migrations.go
@@ -509,6 +509,45 @@ func RunMigrations(db *sql.DB) error {
 		return err
 	}
 
+	if err := createExitPlansTable(db); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// createExitPlansTable は ExitPlan を永続化する exit_plans テーブルを作る。
+// position_id は UNIQUE で建玉と 1:1 を保証する。trailing_hwm と closed_at は
+// NULL 許容（HWM 未活性 / open）。
+func createExitPlansTable(db *sql.DB) error {
+	stmts := []string{
+		`CREATE TABLE IF NOT EXISTS exit_plans (
+			id                      INTEGER PRIMARY KEY AUTOINCREMENT,
+			position_id             INTEGER NOT NULL UNIQUE,
+			symbol_id               INTEGER NOT NULL,
+			side                    TEXT NOT NULL,
+			entry_price             REAL NOT NULL,
+			sl_percent              REAL NOT NULL,
+			sl_atr_multiplier       REAL NOT NULL DEFAULT 0,
+			tp_percent              REAL NOT NULL,
+			trailing_mode           INTEGER NOT NULL DEFAULT 0,
+			trailing_atr_multiplier REAL NOT NULL DEFAULT 0,
+			trailing_activated      INTEGER NOT NULL DEFAULT 0,
+			trailing_hwm            REAL,
+			created_at              INTEGER NOT NULL,
+			updated_at              INTEGER NOT NULL,
+			closed_at               INTEGER
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_exit_plans_symbol_open
+			ON exit_plans(symbol_id, closed_at)`,
+		`CREATE INDEX IF NOT EXISTS idx_exit_plans_position
+			ON exit_plans(position_id)`,
+	}
+	for _, stmt := range stmts {
+		if _, err := db.Exec(stmt); err != nil {
+			return fmt.Errorf("create exit_plans: %w", err)
+		}
+	}
 	return nil
 }
 

--- a/backend/internal/infrastructure/database/migrations_test.go
+++ b/backend/internal/infrastructure/database/migrations_test.go
@@ -449,3 +449,92 @@ func TestRunMigrations_DecisionLogV2Columns(t *testing.T) {
 		}
 	}
 }
+
+
+func TestRunMigrations_createsExitPlansTable(t *testing.T) {
+	tmpDir := t.TempDir()
+	db, err := NewDB(filepath.Join(tmpDir, "test.db"))
+	if err != nil {
+		t.Fatalf("NewDB: %v", err)
+	}
+	defer db.Close()
+
+	if err := RunMigrations(db); err != nil {
+		t.Fatalf("RunMigrations: %v", err)
+	}
+
+	rows, err := db.Query("PRAGMA table_info(exit_plans)")
+	if err != nil {
+		t.Fatalf("pragma table_info(exit_plans): %v", err)
+	}
+	defer rows.Close()
+	cols := map[string]bool{}
+	for rows.Next() {
+		var (
+			cid     int
+			name    string
+			ctype   string
+			notnull int
+			dflt    interface{}
+			pk      int
+		)
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		cols[name] = true
+	}
+	want := []string{
+		"id", "position_id", "symbol_id", "side", "entry_price",
+		"sl_percent", "sl_atr_multiplier",
+		"tp_percent",
+		"trailing_mode", "trailing_atr_multiplier",
+		"trailing_activated", "trailing_hwm",
+		"created_at", "updated_at", "closed_at",
+	}
+	for _, c := range want {
+		if !cols[c] {
+			t.Errorf("exit_plans missing column %q", c)
+		}
+	}
+
+	idxRows, err := db.Query("PRAGMA index_list(exit_plans)")
+	if err != nil {
+		t.Fatalf("pragma index_list: %v", err)
+	}
+	defer idxRows.Close()
+	hasUniqueOnPositionID := false
+	for idxRows.Next() {
+		var (
+			seq     int
+			name    string
+			unique  int
+			origin  string
+			partial int
+		)
+		if err := idxRows.Scan(&seq, &name, &unique, &origin, &partial); err != nil {
+			t.Fatalf("scan idx_list: %v", err)
+		}
+		if unique != 1 {
+			continue
+		}
+		colRows, err := db.Query("PRAGMA index_info(" + name + ")")
+		if err != nil {
+			t.Fatalf("pragma index_info(%s): %v", name, err)
+		}
+		var seqno, cid int
+		var cname string
+		for colRows.Next() {
+			if err := colRows.Scan(&seqno, &cid, &cname); err != nil {
+				colRows.Close()
+				t.Fatalf("scan idx_info: %v", err)
+			}
+			if cname == "position_id" {
+				hasUniqueOnPositionID = true
+			}
+		}
+		colRows.Close()
+	}
+	if !hasUniqueOnPositionID {
+		t.Errorf("exit_plans should have UNIQUE constraint on position_id")
+	}
+}

--- a/backend/internal/usecase/exitplan/shadow_handler.go
+++ b/backend/internal/usecase/exitplan/shadow_handler.go
@@ -1,0 +1,135 @@
+// Package exitplan は ExitPlan を駆動するイベントハンドラを提供する。
+//
+// Phase 1 (シャドウ運用) では ShadowHandler が OrderEvent を listen して
+// ExitPlan の作成・close だけを行う。SL/TP/Trailing の発火判定や HWM 更新は
+// 既存 RiskManager / TickRiskHandler に任せたまま。観察ログを取って
+// Phase 2 で発火経路を移管する。
+package exitplan
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+	domainexitplan "github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/exitplan"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/risk"
+)
+
+// ShadowHandlerConfig は ShadowHandler のコンストラクタ引数。
+type ShadowHandlerConfig struct {
+	Repo   domainexitplan.Repository
+	Policy risk.RiskPolicy
+	// Logger は省略可。nil の場合 slog.Default() を使う。
+	Logger *slog.Logger
+}
+
+// ShadowHandler は OrderEvent をシャドウで listen し、ExitPlan を作成・close する。
+// emit はせず、failure はログだけで握り潰す（既存の発注パスに影響を与えない）。
+type ShadowHandler struct {
+	repo   domainexitplan.Repository
+	policy risk.RiskPolicy
+	logger *slog.Logger
+}
+
+// NewShadowHandler は設定済みの ShadowHandler を返す。Repo nil は panic。
+func NewShadowHandler(cfg ShadowHandlerConfig) *ShadowHandler {
+	if cfg.Repo == nil {
+		panic("exitplan.NewShadowHandler: Repo must not be nil")
+	}
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &ShadowHandler{
+		repo:   cfg.Repo,
+		policy: cfg.Policy,
+		logger: logger.With("component", "exitplan_shadow"),
+	}
+}
+
+// Handle implements eventengine.EventHandler. OrderEvent 以外は素通り。
+func (h *ShadowHandler) Handle(ctx context.Context, ev entity.Event) ([]entity.Event, error) {
+	oe, ok := ev.(entity.OrderEvent)
+	if !ok {
+		return nil, nil
+	}
+	// reversal トレード等で 1 OrderEvent に open/close 両方乗ることがあるので
+	// 両分岐を独立に走らせる。
+	if oe.ClosedPositionID != 0 {
+		h.handleClose(ctx, oe)
+	}
+	if oe.OpenedPositionID != 0 {
+		h.handleOpen(ctx, oe)
+	}
+	return nil, nil
+}
+
+func (h *ShadowHandler) handleOpen(ctx context.Context, oe entity.OrderEvent) {
+	side := entity.OrderSide(oe.Side)
+	if side != entity.OrderSideBuy && side != entity.OrderSideSell {
+		h.logger.Warn("unknown order side, skipping shadow create",
+			"side", oe.Side, "positionID", oe.OpenedPositionID,
+		)
+		return
+	}
+	plan, err := domainexitplan.New(domainexitplan.NewInput{
+		PositionID: oe.OpenedPositionID,
+		SymbolID:   oe.SymbolID,
+		Side:       side,
+		EntryPrice: oe.Price,
+		Policy:     h.policy,
+		CreatedAt:  oe.Timestamp,
+	})
+	if err != nil {
+		h.logger.Warn("shadow ExitPlan construction failed",
+			"err", err, "positionID", oe.OpenedPositionID,
+		)
+		return
+	}
+	if err := h.repo.Create(ctx, plan); err != nil {
+		h.logger.Warn("shadow ExitPlan persist failed",
+			"err", err, "positionID", oe.OpenedPositionID,
+		)
+		return
+	}
+	h.logger.Info("shadow ExitPlan created",
+		"positionID", oe.OpenedPositionID,
+		"symbolID", oe.SymbolID,
+		"side", oe.Side,
+		"entryPrice", oe.Price,
+		"planID", plan.ID,
+	)
+}
+
+func (h *ShadowHandler) handleClose(ctx context.Context, oe entity.OrderEvent) {
+	plan, err := h.repo.FindByPositionID(ctx, oe.ClosedPositionID)
+	if err != nil {
+		h.logger.Warn("shadow ExitPlan find failed on close",
+			"err", err, "positionID", oe.ClosedPositionID,
+		)
+		return
+	}
+	if plan == nil {
+		// シャドウ運用初期は楽天 API 既存建玉に対して plan が無いケースあり
+		h.logger.Info("shadow ExitPlan not found on close (orphan close)",
+			"positionID", oe.ClosedPositionID,
+		)
+		return
+	}
+	if plan.IsClosed() {
+		h.logger.Warn("shadow ExitPlan already closed",
+			"positionID", oe.ClosedPositionID, "planID", plan.ID,
+		)
+		return
+	}
+	if err := h.repo.Close(ctx, plan.ID, oe.Timestamp); err != nil {
+		h.logger.Warn("shadow ExitPlan close persist failed",
+			"err", err, "planID", plan.ID,
+		)
+		return
+	}
+	h.logger.Info("shadow ExitPlan closed",
+		"positionID", oe.ClosedPositionID, "planID", plan.ID,
+		"closePrice", oe.Price,
+	)
+}

--- a/backend/internal/usecase/exitplan/shadow_handler_test.go
+++ b/backend/internal/usecase/exitplan/shadow_handler_test.go
@@ -1,0 +1,259 @@
+package exitplan
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/entity"
+	domainexitplan "github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/exitplan"
+	"github.com/yui666a/rakuten-api-leverage-exchange/backend/internal/domain/risk"
+)
+
+func defaultPolicy() risk.RiskPolicy {
+	return risk.RiskPolicy{
+		StopLoss:   risk.StopLossSpec{Percent: 1.5, ATRMultiplier: 2.0},
+		TakeProfit: risk.TakeProfitSpec{Percent: 3.0},
+		Trailing:   risk.TrailingSpec{Mode: risk.TrailingModeATR, ATRMultiplier: 2.5},
+	}
+}
+
+func TestShadowHandler_OpenedPosition_createsExitPlan(t *testing.T) {
+	repo := newMemRepo()
+	h := NewShadowHandler(ShadowHandlerConfig{
+		Repo:   repo,
+		Policy: defaultPolicy(),
+	})
+
+	ev := entity.OrderEvent{
+		SymbolID:         7,
+		Side:             "BUY",
+		Action:           "OPEN",
+		Price:            10000,
+		Amount:           0.1,
+		Timestamp:        1700000000000,
+		OpenedPositionID: 100,
+	}
+	out, err := h.Handle(context.Background(), ev)
+	if err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if len(out) != 0 {
+		t.Errorf("shadow handler should emit no events; got %d", len(out))
+	}
+	if len(repo.created) != 1 {
+		t.Fatalf("expected 1 ExitPlan created, got %d", len(repo.created))
+	}
+	got := repo.created[0]
+	if got.PositionID != 100 || got.SymbolID != 7 || got.Side != entity.OrderSideBuy || got.EntryPrice != 10000 {
+		t.Errorf("ExitPlan wrong: %+v", got)
+	}
+}
+
+func TestShadowHandler_ClosedPosition_closesExitPlan(t *testing.T) {
+	repo := newMemRepo()
+	plan, _ := domainexitplan.New(domainexitplan.NewInput{
+		PositionID: 100, SymbolID: 7, Side: entity.OrderSideBuy, EntryPrice: 10000,
+		Policy:    defaultPolicy(),
+		CreatedAt: 1700000000000,
+	})
+	plan.ID = 999
+	repo.byPosition[100] = plan
+
+	h := NewShadowHandler(ShadowHandlerConfig{
+		Repo:   repo,
+		Policy: defaultPolicy(),
+	})
+
+	ev := entity.OrderEvent{
+		SymbolID:         7,
+		Side:             "SELL",
+		Action:           "CLOSE",
+		Price:            10500,
+		Amount:           0.1,
+		Timestamp:        1700000099999,
+		ClosedPositionID: 100,
+	}
+	if _, err := h.Handle(context.Background(), ev); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if !repo.closeCalled {
+		t.Errorf("Repo.Close should be called")
+	}
+	if repo.closedID != 999 || repo.closedAt != 1700000099999 {
+		t.Errorf("close args wrong: id=%d at=%d", repo.closedID, repo.closedAt)
+	}
+}
+
+func TestShadowHandler_OpenAndClose_inSameEvent(t *testing.T) {
+	repo := newMemRepo()
+	plan, _ := domainexitplan.New(domainexitplan.NewInput{
+		PositionID: 50, SymbolID: 7, Side: entity.OrderSideBuy, EntryPrice: 9500,
+		Policy:    defaultPolicy(),
+		CreatedAt: 1700000000000,
+	})
+	plan.ID = 555
+	repo.byPosition[50] = plan
+
+	h := NewShadowHandler(ShadowHandlerConfig{
+		Repo:   repo,
+		Policy: defaultPolicy(),
+	})
+	ev := entity.OrderEvent{
+		SymbolID:         7,
+		Price:            10000,
+		Timestamp:        1700000050000,
+		OpenedPositionID: 200,
+		ClosedPositionID: 50,
+		Side:             "SELL",
+	}
+	if _, err := h.Handle(context.Background(), ev); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if !repo.closeCalled {
+		t.Errorf("close branch should fire")
+	}
+	if len(repo.created) != 1 || repo.created[0].PositionID != 200 {
+		t.Errorf("open branch should create new ExitPlan for pos 200; got %+v", repo.created)
+	}
+}
+
+func TestShadowHandler_OpenedPosition_inferSide_fromEvent(t *testing.T) {
+	repo := newMemRepo()
+	h := NewShadowHandler(ShadowHandlerConfig{
+		Repo:   repo,
+		Policy: defaultPolicy(),
+	})
+	cases := []struct {
+		side string
+		want entity.OrderSide
+	}{
+		{"BUY", entity.OrderSideBuy},
+		{"SELL", entity.OrderSideSell},
+	}
+	for i, tc := range cases {
+		ev := entity.OrderEvent{
+			SymbolID: 7, Side: tc.side, Price: 10000, Timestamp: int64(1700000000000 + i),
+			OpenedPositionID: int64(100 + i),
+		}
+		if _, err := h.Handle(context.Background(), ev); err != nil {
+			t.Fatalf("case %s: %v", tc.side, err)
+		}
+	}
+	if len(repo.created) != 2 {
+		t.Fatalf("want 2 plans, got %d", len(repo.created))
+	}
+	if repo.created[0].Side != entity.OrderSideBuy || repo.created[1].Side != entity.OrderSideSell {
+		t.Errorf("side inference failed: %+v %+v", repo.created[0].Side, repo.created[1].Side)
+	}
+}
+
+func TestShadowHandler_NonOrderEvent_passThrough(t *testing.T) {
+	repo := newMemRepo()
+	h := NewShadowHandler(ShadowHandlerConfig{
+		Repo:   repo,
+		Policy: defaultPolicy(),
+	})
+	out, err := h.Handle(context.Background(), entity.TickEvent{})
+	if err != nil {
+		t.Fatalf("non-order event should not error: %v", err)
+	}
+	if len(out) != 0 {
+		t.Errorf("non-order event should not emit; got %d", len(out))
+	}
+	if len(repo.created) != 0 || repo.closeCalled {
+		t.Errorf("non-order event should not touch repo")
+	}
+}
+
+func TestShadowHandler_RepoErrorIsSwallowed(t *testing.T) {
+	repo := newMemRepo()
+	repo.createErr = errors.New("disk full")
+	h := NewShadowHandler(ShadowHandlerConfig{
+		Repo:   repo,
+		Policy: defaultPolicy(),
+	})
+	ev := entity.OrderEvent{
+		SymbolID: 7, Side: "BUY", Price: 10000, Timestamp: 1700000000000,
+		OpenedPositionID: 100,
+	}
+	out, err := h.Handle(context.Background(), ev)
+	if err != nil {
+		t.Fatalf("shadow handler must not propagate repo errors (got %v)", err)
+	}
+	if len(out) != 0 {
+		t.Errorf("non-order events should not be emitted")
+	}
+}
+
+func TestShadowHandler_OrphanClose_logsButNoError(t *testing.T) {
+	repo := newMemRepo()
+	h := NewShadowHandler(ShadowHandlerConfig{
+		Repo:   repo,
+		Policy: defaultPolicy(),
+	})
+	ev := entity.OrderEvent{
+		SymbolID: 7, Side: "SELL", Price: 10000, Timestamp: 1700000099999,
+		ClosedPositionID: 999,
+	}
+	if _, err := h.Handle(context.Background(), ev); err != nil {
+		t.Fatalf("orphan close should not error: %v", err)
+	}
+	if repo.closeCalled {
+		t.Errorf("orphan close should not call repo.Close")
+	}
+}
+
+// --- in-memory repo for tests ---
+
+type memRepo struct {
+	mu          sync.Mutex
+	byPosition  map[int64]*domainexitplan.ExitPlan
+	created     []*domainexitplan.ExitPlan
+	closeCalled bool
+	closedID    int64
+	closedAt    int64
+	createErr   error
+	closeErr    error
+}
+
+func newMemRepo() *memRepo {
+	return &memRepo{byPosition: map[int64]*domainexitplan.ExitPlan{}}
+}
+
+func (m *memRepo) Create(_ context.Context, plan *domainexitplan.ExitPlan) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.createErr != nil {
+		return m.createErr
+	}
+	plan.ID = int64(len(m.created) + 1)
+	m.created = append(m.created, plan)
+	m.byPosition[plan.PositionID] = plan
+	return nil
+}
+func (m *memRepo) FindByPositionID(_ context.Context, positionID int64) (*domainexitplan.ExitPlan, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.byPosition[positionID], nil
+}
+func (m *memRepo) ListOpen(_ context.Context, _ int64) ([]*domainexitplan.ExitPlan, error) {
+	return nil, nil
+}
+func (m *memRepo) UpdateTrailing(_ context.Context, _ int64, _ float64, _ bool, _ int64) error {
+	return nil
+}
+func (m *memRepo) Close(_ context.Context, planID int64, closedAt int64) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.closeErr != nil {
+		return m.closeErr
+	}
+	m.closeCalled = true
+	m.closedID = planID
+	m.closedAt = closedAt
+	return nil
+}
+
+var _ domainexitplan.Repository = (*memRepo)(nil)

--- a/docs/exit-plan-health-check.md
+++ b/docs/exit-plan-health-check.md
@@ -1,0 +1,93 @@
+# ExitPlan Phase 1 シャドウ運用ヘルスチェック
+
+> Phase 1: ShadowHandler は約定イベントを listen して `exit_plans` テーブルに
+> 書き込むだけ。発注パスへは干渉しない。本ドキュメントの SQL を 1 日 1 回程度
+> 流して、楽天 API 建玉と DB ExitPlan の整合性が取れているか観察する。
+
+設計書: `docs/superpowers/specs/2026-05-04-exit-plan-first-class-design.md`
+
+## 1. open ExitPlan の一覧
+
+```sql
+SELECT id, position_id, symbol_id, side, entry_price,
+       sl_percent, sl_atr_multiplier, tp_percent,
+       trailing_mode, trailing_atr_multiplier,
+       trailing_activated, trailing_hwm,
+       datetime(created_at/1000, 'unixepoch', 'localtime') AS created
+FROM exit_plans
+WHERE closed_at IS NULL
+ORDER BY created_at DESC;
+```
+
+楽天サイトで現在保有している建玉数と件数が一致するか。
+
+## 2. 直近 24h の close 履歴
+
+```sql
+SELECT id, position_id, symbol_id, side, entry_price,
+       trailing_activated, trailing_hwm,
+       datetime(created_at/1000, 'unixepoch', 'localtime') AS opened,
+       datetime(closed_at/1000,  'unixepoch', 'localtime') AS closed
+FROM exit_plans
+WHERE closed_at IS NOT NULL
+  AND closed_at > (strftime('%s', 'now') - 86400) * 1000
+ORDER BY closed_at DESC;
+```
+
+## 3. 同 position_id で複数 plan が作られていないか（UNIQUE 違反検知）
+
+```sql
+SELECT position_id, COUNT(*) AS n
+FROM exit_plans
+GROUP BY position_id
+HAVING n > 1;
+```
+
+DB 制約で 1:1 を強制しているので空が期待値。
+
+## 4. 楽天 API 建玉に対応する ExitPlan が存在しない孤児
+
+bot ログで `shadow ExitPlan not found on close (orphan close)` を grep:
+
+```bash
+docker compose logs backend --since 24h | grep "orphan close" | wc -l
+```
+
+シャドウ運用初期は **bot 起動前から保有していた建玉** に対して plan が無いまま
+close されるとここがカウントされる。完全に 0 にはならない（既存建玉ぶん）。
+新規約定 → close のサイクルに対しては 0 が期待値。
+
+## 5. 一定時間経った open plan が closed されているか（漏れ検知）
+
+```sql
+-- 24h 以上 open のままの plan
+SELECT id, position_id, symbol_id, side, entry_price,
+       datetime(created_at/1000, 'unixepoch', 'localtime') AS opened,
+       (strftime('%s', 'now') - created_at/1000) / 3600 AS hours_open
+FROM exit_plans
+WHERE closed_at IS NULL
+  AND created_at < (strftime('%s', 'now') - 86400) * 1000
+ORDER BY created_at;
+```
+
+長時間 open は楽天 API 上では既に close されている可能性。Phase 2 の
+Reconciler が無いので Phase 1 では手動確認。
+
+## 6. ShadowHandler の永続化失敗ログ
+
+```bash
+docker compose logs backend --since 24h | grep -E "shadow ExitPlan (persist|find|close persist) failed"
+```
+
+シャドウなのでトレード継続には影響しないが、頻発する場合は DB アクセスや
+プロファイル不整合の調査が必要。期待値は 0 件。
+
+## 7. Phase 2 へ進む判断基準
+
+Phase 2（既存 RiskManager の SL/TP/Trailing を Exit レイヤに移管）に進むには
+以下を 1 週間継続して満たすこと:
+
+- 新規約定 → close のサイクルで「孤児 close」「持続的に open のまま漏れ」が無い
+- UNIQUE 違反が起きていない
+- 永続化失敗ログが 0 件
+- 楽天サイトの建玉一覧と `exit_plans WHERE closed_at IS NULL` の symbol_id / side / 件数が完全に一致


### PR DESCRIPTION
## Summary

設計書 [`docs/superpowers/specs/2026-05-04-exit-plan-first-class-design.md`](docs/superpowers/specs/2026-05-04-exit-plan-first-class-design.md) Phase 1 の実装。`docs/exit-plan-first-class` ブランチ（PR #243）の上に積む Stacked PR。

### 実装内容

- **ExitPlan ドメインエンティティ** + 不変条件 (`backend/internal/domain/exitplan/exit_plan.go`)
  - `entity` と `risk` の循環インポートを避けるため独立 `domain/exitplan` パッケージで切り出し
  - HWM の単調性、closed plan の更新拒否、二重 close 拒否を不変条件として強制
- **`exitplan.Repository` インタフェース** + SQLite 実装
  - `position_id` UNIQUE で建玉と 1:1
- **`exit_plans` テーブルマイグレーション**
  - SL/TP/Trailing のルールを列に展開（read 性能・人間可読性のため JSON 化しない）
  - HWM と closed_at は NULL 許容
- **OrderEvent をシャドウで listen する `ShadowHandler`**
  - priority 60 で OrderEvent に register（priority 50 の RiskHandler が捌いた後）
  - emit せず、失敗は warn ログで握り潰す（既存の発注パスへの干渉なし）
  - reversal トレード（1 OrderEvent に open/close 両方）に備えて両分岐を独立に走らせる
- **観察用 SQL ヘルスチェック** (`docs/exit-plan-health-check.md`)

### Phase 1 のスコープ範囲外（次 Phase へ）

- SL/TP/Trailing 発火判定（既存 `RiskManager` に任せたまま）
- HWM 動的更新の永続化（Phase 2 で `ExitPlanTrailingEvent` 経由に）
- API/UI 拡張（Phase 3）
- 整合性ガード（リトライ + Halt + Reconciler、Phase 2）

## Test plan

- [x] `go test ./... -race -count=1` 全緑
- [x] `go vet ./...` クリーン
- [x] `go build ./...` クリーン
- [x] `docker compose up --build -d` 起動成功、`ExitPlan shadow handler registered (Phase 1)` ログ確認
- [ ] production 環境で 1 週間シャドウ運用後、`docs/exit-plan-health-check.md` の SQL で楽天 API 建玉と ExitPlan の整合性を確認 → Phase 2 へ

🤖 Generated with [Claude Code](https://claude.com/claude-code)