### PR TITLE
fix(stance): live resolver にも profile 閾値を反映する (#250)

### DIFF
--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -72,7 +72,15 @@ func main() {
 	backtestResultRepo := backtestinfra.NewResultRepository(db)
 	multiPeriodRepo := backtestinfra.NewMultiPeriodResultRepository(db, backtestResultRepo)
 	walkForwardRepo := backtestinfra.NewWalkForwardResultRepository(db)
-	stanceResolver := usecase.NewRuleBasedStanceResolver(stanceOverrideRepo)
+	// Load the live strategy profile up-front so the stance resolver can
+	// honour profile-driven thresholds (rsi_oversold/overbought, sma
+	// convergence, breakout volume ratio) instead of falling back to the
+	// hard-coded 25/75 defaults. Without this, the resolver used by the
+	// pipeline diverged from the one ConfigurableStrategy builds internally,
+	// so log/UI stance values were computed with different thresholds than
+	// the actual signal generator.
+	liveProfile := loadLiveProfile()
+	stanceResolver := newLiveStanceResolver(stanceOverrideRepo, liveProfile)
 	strategyEngine := usecase.NewStrategyEngine(stanceResolver)
 	// The StrategyRegistry lives in the strategy package and is exercised by
 	// its own unit tests. It is intentionally not wired here yet because no
@@ -119,13 +127,13 @@ func main() {
 		slog.Info("trading config restored from db", "symbolID", symbolID, "tradeAmount", tradeAmount)
 	}
 
-	// Load the live strategy profile so the IndicatorCalculator (used by API
-	// /indicators handlers + bootstrap) and the EventDrivenPipeline both see
-	// the same lookback periods the strategy was tuned for. Failure falls
-	// back to legacy defaults so a missing / malformed profile does not
-	// prevent the live pipeline from starting — but we log the error so
-	// operators see what happened.
-	liveProfile := loadLiveProfile()
+	// liveProfile was loaded earlier (above) so the stance resolver could be
+	// constructed with profile-driven thresholds. Reuse the same value here
+	// to wire the IndicatorCalculator (used by API /indicators handlers +
+	// bootstrap) and the EventDrivenPipeline lookback periods, plus the
+	// risk-manager overrides. Failure falls back to legacy defaults so a
+	// missing / malformed profile does not prevent the live pipeline from
+	// starting — but we log the error so operators see what happened.
 	if liveProfile != nil {
 		indicatorCalc.SetIndicatorPeriods(liveProfile.Indicators)
 		if liveProfile.StanceRules.BBSqueezeLookback > 0 {
@@ -510,6 +518,26 @@ func loadLiveProfile() *entity.StrategyProfile {
 	}
 	slog.Info("live strategy profile loaded", "name", profile.Name, "baseDir", baseDir)
 	return profile
+}
+
+// newLiveStanceResolver wires the rule-based stance resolver used by the
+// live pipeline. When a profile is loaded, its stance_rules thresholds are
+// threaded through so the pipeline-level resolver classifies stances with
+// the same RSI / SMA / breakout boundaries that ConfigurableStrategy uses
+// internally — without this, the live resolver fell back to the hard-coded
+// 25/75 defaults and log/UI stance values diverged from the actual signal
+// generator. When no profile is available (env-only startup, malformed
+// JSON), zero-valued options are passed and the resolver backfills legacy
+// defaults, preserving the prior behaviour bit-for-bit.
+func newLiveStanceResolver(repo repository.StanceOverrideRepository, p *entity.StrategyProfile) *usecase.RuleBasedStanceResolver {
+	opts := usecase.RuleBasedStanceResolverOptions{}
+	if p != nil {
+		opts.RSIOversold = p.StanceRules.RSIOversold
+		opts.RSIOverbought = p.StanceRules.RSIOverbought
+		opts.SMAConvergenceThreshold = p.StanceRules.SMAConvergenceThreshold
+		opts.BreakoutVolumeRatio = p.StanceRules.BreakoutVolumeRatio
+	}
+	return usecase.NewRuleBasedStanceResolverWithOptions(repo, opts)
 }
 
 // liveProfileIndicators returns the IndicatorConfig from a loaded profile,

--- a/backend/internal/usecase/stance_test.go
+++ b/backend/internal/usecase/stance_test.go
@@ -529,3 +529,106 @@ func TestRuleBasedStanceResolver_RSI_Contrarian_OverridesBreakout(t *testing.T) 
 		t.Fatalf("expected CONTRARIAN to override BREAKOUT when RSI extreme, got %s", result.Stance)
 	}
 }
+
+// TestRuleBasedStanceResolver_ProfileThresholds_AppliedToApplyRules pins down
+// the bug fixed for Issue #250: when a caller (the live pipeline wiring in
+// main.go) supplies profile-driven thresholds via WithOptions, applyRules
+// must honour those values instead of the legacy 25/75 defaults. The
+// previous wiring constructed the resolver with bare options and the live
+// pipeline silently fell back to the defaults, so the log/UI stance value
+// disagreed with the one ConfigurableStrategy used internally.
+func TestRuleBasedStanceResolver_ProfileThresholds_AppliedToApplyRules(t *testing.T) {
+	t.Run("RSI 31.4 below profile oversold 32 → CONTRARIAN", func(t *testing.T) {
+		// production_ltc_60k profile: rsi_oversold=32. With the legacy 25
+		// default this RSI would not trigger CONTRARIAN.
+		opts := RuleBasedStanceResolverOptions{
+			RSIOversold:             32,
+			RSIOverbought:           68,
+			SMAConvergenceThreshold: 0.001,
+			BreakoutVolumeRatio:     1.5,
+		}
+		resolver := NewRuleBasedStanceResolverWithOptions(nil, opts)
+		result := resolver.Resolve(context.Background(), entity.IndicatorSet{
+			SMAShort: ptr(5100000),
+			SMALong:  ptr(5000000),
+			RSI:      ptr(31.4),
+		}, 0)
+		if result.Stance != entity.MarketStanceContrarian {
+			t.Fatalf("expected CONTRARIAN with profile oversold=32, got %s", result.Stance)
+		}
+		if result.Reasoning != "RSI oversold" {
+			t.Fatalf("expected reasoning 'RSI oversold', got %q", result.Reasoning)
+		}
+	})
+
+	t.Run("RSI 69 above profile overbought 68 → CONTRARIAN", func(t *testing.T) {
+		opts := RuleBasedStanceResolverOptions{
+			RSIOversold:             32,
+			RSIOverbought:           68,
+			SMAConvergenceThreshold: 0.001,
+			BreakoutVolumeRatio:     1.5,
+		}
+		resolver := NewRuleBasedStanceResolverWithOptions(nil, opts)
+		result := resolver.Resolve(context.Background(), entity.IndicatorSet{
+			SMAShort: ptr(5100000),
+			SMALong:  ptr(5000000),
+			RSI:      ptr(69.0),
+		}, 0)
+		if result.Stance != entity.MarketStanceContrarian {
+			t.Fatalf("expected CONTRARIAN with profile overbought=68, got %s", result.Stance)
+		}
+	})
+
+	t.Run("RSI 31.4 stays TREND_FOLLOW under legacy 25 default", func(t *testing.T) {
+		// Regression guard: the env-only / no-profile startup path still
+		// resolves with the legacy 25/75 defaults so existing deployments
+		// without a profile see bit-identical behaviour.
+		resolver := NewRuleBasedStanceResolver(nil)
+		result := resolver.Resolve(context.Background(), entity.IndicatorSet{
+			SMAShort: ptr(5100000),
+			SMALong:  ptr(5000000),
+			RSI:      ptr(31.4),
+		}, 0)
+		if result.Stance != entity.MarketStanceTrendFollow {
+			t.Fatalf("expected TREND_FOLLOW with legacy default oversold=25, got %s", result.Stance)
+		}
+	})
+
+	t.Run("custom SMAConvergenceThreshold widens HOLD band", func(t *testing.T) {
+		// divergence = |5_000_000 - 5_010_000| / 5_010_000 ≈ 0.001996
+		// Default 0.001 → divergence above threshold → TREND_FOLLOW.
+		// Profile 0.005 → divergence below threshold → HOLD.
+		opts := RuleBasedStanceResolverOptions{
+			SMAConvergenceThreshold: 0.005,
+		}
+		resolver := NewRuleBasedStanceResolverWithOptions(nil, opts)
+		result := resolver.Resolve(context.Background(), entity.IndicatorSet{
+			SMAShort: ptr(5000000),
+			SMALong:  ptr(5010000),
+			RSI:      ptr(50.0),
+		}, 0)
+		if result.Stance != entity.MarketStanceHold {
+			t.Fatalf("expected HOLD with profile sma_convergence=0.005, got %s", result.Stance)
+		}
+	})
+
+	t.Run("custom BreakoutVolumeRatio gates BB squeeze breakout", func(t *testing.T) {
+		// VolumeRatio = 1.8: passes legacy 1.5, fails profile 2.0.
+		opts := RuleBasedStanceResolverOptions{
+			BreakoutVolumeRatio: 2.0,
+		}
+		resolver := NewRuleBasedStanceResolverWithOptions(nil, opts)
+		result := resolver.Resolve(context.Background(), entity.IndicatorSet{
+			SMAShort:      ptr(5000000),
+			SMALong:       ptr(4900000),
+			RSI:           ptr(50.0),
+			BBUpper:       ptr(5100000),
+			BBLower:       ptr(4900000),
+			VolumeRatio:   ptr(1.8),
+			RecentSqueeze: boolPtr(true),
+		}, 5200000)
+		if result.Stance != entity.MarketStanceHold {
+			t.Fatalf("expected HOLD when volume ratio < profile threshold, got %s (%s)", result.Stance, result.Reasoning)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Issue #250 修正: live pipeline 用 `stanceResolver` を profile 駆動の閾値で構築するように main.go の wiring を修正
- 新ヘルパー `newLiveStanceResolver` で profile.StanceRules の `RSIOversold` / `RSIOverbought` / `SMAConvergenceThreshold` / `BreakoutVolumeRatio` を抜き取り `NewRuleBasedStanceResolverWithOptions` に渡す
- Issue #250 のシナリオ (RSI 31.4 + production_ltc_60k profile の oversold=32 で CONTRARIAN 判定されること) をピン留めするテーブルテストを追加

## Background

ConfigurableStrategy (signal 生成器) は profile 閾値で内部 resolver を生成していたが、main.go で wire される pipeline-level resolver はオプション無しで作られ legacy 25/75 にバックフィルされていた。結果として:
- log の `decision_log.stance`
- `GET /api/v1/strategy` レスポンス
- UI の stance 表示

…が、実際の signal 判断と異なる閾値で計算されており、ユーザは間違った stance を見せられていた。発注ロジックには影響しないが debug 時の信頼性を大きく損なう問題。

## Compatibility

- profile が nil (env-only 起動 / load 失敗) の場合はゼロ値オプションが渡され `applyStanceResolverDefaults` で legacy デフォルト (25/75/0.001/1.5) にバックフィルされるため、既存の env-only 環境はビット互換
- `liveProfile` の load を 1 回先頭にまとめ、後続の indicator periods / risk overrides 適用処理から重複呼び出しを除去

## Test plan

- [x] `go test ./... -race -count=1` 全緑
- [x] `go vet ./...` クリーン
- [x] 追加テスト (table-driven, 5 cases) で profile 閾値が `applyRules` に届くことを検証
- [x] env-only 互換 (legacy 25/75 デフォルト) のリグレッションガードを含む
- [ ] CI green 後にマージ → docker rebuild → `/api/v1/strategy` 手動確認はユーザ側で

Closes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)