### PR TITLE
fix(decision-log): signal_reason 空でも decision.reason を表示する (#251)

### DIFF
--- a/backend/internal/usecase/decisionlog/recorder.go
+++ b/backend/internal/usecase/decisionlog/recorder.go
@@ -149,6 +149,18 @@ func (r *Recorder) onIndicator(ctx context.Context, ev entity.IndicatorEvent) {
 	r.hasPending = true
 }
 
+// onSignal populates the legacy signal_action / signal_confidence /
+// signal_reason columns from the pre-three-layer SignalEvent path.
+//
+// PR3 (Signal/Decision/ExecutionPolicy three-layer separation, 2026-04-29)
+// asymmetry to be aware of: StrategyHandler only emits a SignalEvent when
+// signal.Action != HOLD (see backtest/handler.go). HOLD bars therefore
+// never reach this handler and signal_reason stays empty for those rows.
+// The Decision-layer reasoning lands in DecisionReason via onActionDecision
+// instead — the UI prefers decision_reason and falls back to signal_reason
+// so HOLD bars still surface a human-readable reason. Do not remove this
+// handler: actionable (BUY/SELL) signals still flow through it and continue
+// to fill the legacy columns coherently.
 func (r *Recorder) onSignal(ctx context.Context, ev entity.SignalEvent) {
 	if !r.hasPending {
 		return

--- a/frontend/src/components/DecisionDetailPanel.tsx
+++ b/frontend/src/components/DecisionDetailPanel.tsx
@@ -24,11 +24,16 @@ function PhaseOnePanel({ item }: { item: DecisionLogItem }) {
   const intent = item.decision?.intent ?? ''
   const side = item.decision?.side ?? ''
   const decisionReason = item.decision?.reason ?? ''
+  // PR3 三層分離以降、HOLD バーでは SignalEvent が emit されず
+  // signal_reason 列が空のまま残る。decision_reason には ActionDecision
+  // からの reasoning が入っているのでそれを優先し、空なら legacy
+  // signal_reason、最後に "—" にフォールバックする。
+  const reasonText = decisionReason || item.signal.reason || '—'
   const exitOutcome = item.exitPolicyOutcome ?? ''
 
   // Hide the panel entirely when none of the new fields are populated —
   // there is no point showing "—" for every row in pre-PR2 backtest data.
-  if (!direction && !intent && !side && !decisionReason && !exitOutcome) {
+  if (!direction && !intent && !side && !decisionReason && !item.signal.reason && !exitOutcome) {
     return null
   }
 
@@ -43,7 +48,7 @@ function PhaseOnePanel({ item }: { item: DecisionLogItem }) {
         <KV label="判断 (Intent)" value={intent || '—'} />
         <KV label="サイド" value={side || '—'} />
         <KV label="出口判定" value={exitOutcome || '—'} />
-        <KV label="判断理由" value={decisionReason || '—'} wide />
+        <KV label="判断理由" value={reasonText} wide />
       </dl>
     </div>
   )

--- a/frontend/src/components/__tests__/DecisionDetailPanel.test.tsx
+++ b/frontend/src/components/__tests__/DecisionDetailPanel.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { DecisionDetailPanel } from '../DecisionDetailPanel'
+import type { DecisionLogItem } from '../../lib/api'
+
+function makeItem(overrides: Partial<DecisionLogItem> = {}): DecisionLogItem {
+  return {
+    id: 1,
+    barCloseAt: 1_700_000_000_000,
+    sequenceInBar: 0,
+    triggerKind: 'BAR_CLOSE',
+    symbolId: 3,
+    currencyPair: 'LTC_JPY',
+    primaryInterval: 'PT15M',
+    stance: 'TREND_FOLLOW',
+    lastPrice: 9000,
+    signal: { action: 'HOLD', confidence: 0, reason: '' },
+    risk: { outcome: 'SKIPPED', reason: '' },
+    bookGate: { outcome: 'SKIPPED', reason: '' },
+    order: { outcome: 'NOOP', orderId: 0, amount: 0, price: 0, error: '' },
+    closedPositionId: 0,
+    openedPositionId: 0,
+    indicators: {},
+    higherTfIndicators: {},
+    createdAt: 1_700_000_000_000,
+    ...overrides,
+  }
+}
+
+describe('DecisionDetailPanel', () => {
+  it('decision.reason を「判断理由」として表示する', () => {
+    const item = makeItem({
+      marketSignal: { direction: 'BEARISH', strength: 0.6 },
+      decision: {
+        intent: 'EXIT_CANDIDATE',
+        side: 'SELL',
+        reason: 'long held; bearish signal -> exit candidate',
+      },
+    })
+    render(<DecisionDetailPanel item={item} />)
+    expect(
+      screen.getByText('long held; bearish signal -> exit candidate'),
+    ).toBeInTheDocument()
+  })
+
+  it('decision.reason が空でも signal.reason があればフォールバック表示する', () => {
+    // PR3 三層分離以前の bar、もしくは onSignal だけが先に走った in-flight 行
+    // のように decision_reason が空、signal_reason に値が入っているケース。
+    const item = makeItem({
+      marketSignal: { direction: 'BULLISH', strength: 0.4 },
+      decision: { intent: 'NEW_ENTRY', side: 'BUY', reason: '' },
+      signal: {
+        action: 'BUY',
+        confidence: 0.4,
+        reason: 'trend_follow: SMA uptrend + RSI<70',
+      },
+    })
+    render(<DecisionDetailPanel item={item} />)
+    expect(
+      screen.getByText('trend_follow: SMA uptrend + RSI<70'),
+    ).toBeInTheDocument()
+  })
+
+  it('両方空なら "—" を表示する', () => {
+    const item = makeItem({
+      marketSignal: { direction: 'NEUTRAL', strength: 0 },
+      decision: { intent: 'HOLD', side: '', reason: '' },
+    })
+    render(<DecisionDetailPanel item={item} />)
+    // 「判断理由」ラベルの dd セルが — になっていればOK
+    const labels = screen.getAllByText('判断理由')
+    expect(labels.length).toBeGreaterThan(0)
+    expect(screen.getAllByText('—').length).toBeGreaterThan(0)
+  })
+
+  it('Phase 1 フィールドが全て空の pre-PR2 行ではパネルを描画しない', () => {
+    const item = makeItem()
+    const { container } = render(<DecisionDetailPanel item={item} />)
+    // 「Signal / Decision (Phase 1)」見出しが消えていること
+    expect(container.querySelector('h3')?.textContent).not.toMatch(
+      /Signal \/ Decision/,
+    )
+  })
+})


### PR DESCRIPTION
## Summary

- Issue #251 修正: HOLD バーで `signal_reason` 列が空になる問題に対し、UI 側で `decision.reason` をフォールバック表示
- PR3 三層分離以降 `StrategyHandler` は HOLD では `SignalEvent` を emit しないため `recorder.onSignal` が呼ばれない (これは設計通り)。actionable シグナル時の legacy column 書き込みは引き続き必要
- recorder.go の onSignal に「dead column ではなく PR3 の意図的な asymmetry」を固定する docstring を追加

## Changes

| 種別 | ファイル | 内容 |
|---|---|---|
| frontend | `DecisionDetailPanel.tsx` | 「判断理由」の表示を `decision.reason \|\| signal.reason \|\| '—'` のフォールバックチェーンに変更。Phase 1 パネルの hide 条件にも `signal.reason` を含めて pre-PR2 行が誤って消えないようにする |
| frontend | `DecisionDetailPanel.test.tsx` (新規) | decision.reason 優先・signal.reason フォールバック・両方空での "—" 表示・hide 条件の 4 ケース |
| backend | `recorder.go` | `onSignal` ハンドラの docstring を強化。PR3 の emit asymmetry (HOLD では呼ばれない) と decision_reason との関係を明記 |

`RecentDecisionsCard.tsx` と `DecisionLogTable.tsx` は既に `item.decision?.reason || item.signal.reason || ...` のフォールバック実装済みだったので変更不要。

## Compatibility

- 既存 SQL マイグレーション無変更 (column drop しない)
- 過去レコードは引き続き signal_reason が読まれるので破壊なし
- UI のみ表示優先順を更新

## Test plan

- [x] `go test ./internal/usecase/decisionlog/... -race -count=1` 全緑
- [x] `go vet ./...` クリーン
- [x] `pnpm test` 全緑 (DecisionDetailPanel.test.tsx 新規 4 ケース含む 58 tests pass)
- [ ] CI green 後にマージ

Closes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)