### PR TITLE
fix(frontend): サブパネルチャート (MACD/RSI/Stoch/ADX) の軸を JST に揃える

### DIFF
--- a/frontend/src/components/ADXChart.tsx
+++ b/frontend/src/components/ADXChart.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react'
-import { createChart, LineSeries, type IChartApi, type ISeriesApi, type LineData, type Time } from 'lightweight-charts'
+import { createChart, LineSeries, TickMarkType, type IChartApi, type ISeriesApi, type LineData, type Time } from 'lightweight-charts'
 import type { Candle } from '../lib/api'
+import { formatChartTickJst, formatChartTimeJst } from '../lib/format'
 
 type ADXChartProps = {
   candles: Candle[]
@@ -142,7 +143,22 @@ export function ADXChart({ candles }: ADXChartProps) {
       },
       width: containerRef.current.clientWidth,
       height: 120,
-      timeScale: { timeVisible: true, secondsVisible: false },
+      timeScale: {
+        timeVisible: true,
+        secondsVisible: false,
+        tickMarkFormatter: (time: Time, tickMarkType: TickMarkType) => {
+          const seconds = time as number
+          const showDate =
+            tickMarkType === TickMarkType.Year ||
+            tickMarkType === TickMarkType.Month ||
+            tickMarkType === TickMarkType.DayOfMonth
+          return formatChartTickJst(seconds, showDate)
+        },
+      },
+      localization: {
+        locale: 'ja-JP',
+        timeFormatter: (time: Time) => formatChartTimeJst(time as number),
+      },
       rightPriceScale: { scaleMargins: { top: 0.05, bottom: 0.05 } },
     })
 

--- a/frontend/src/components/MACDChart.tsx
+++ b/frontend/src/components/MACDChart.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react'
-import { createChart, LineSeries, HistogramSeries, type IChartApi, type ISeriesApi, type LineData, type HistogramData, type Time } from 'lightweight-charts'
+import { createChart, LineSeries, HistogramSeries, TickMarkType, type IChartApi, type ISeriesApi, type LineData, type HistogramData, type Time } from 'lightweight-charts'
 import type { Candle } from '../lib/api'
+import { formatChartTickJst, formatChartTimeJst } from '../lib/format'
 
 type MACDChartProps = {
   candles: Candle[]
@@ -96,6 +97,18 @@ export function MACDChart({ candles }: MACDChartProps) {
       timeScale: {
         timeVisible: true,
         secondsVisible: false,
+        tickMarkFormatter: (time: Time, tickMarkType: TickMarkType) => {
+          const seconds = time as number
+          const showDate =
+            tickMarkType === TickMarkType.Year ||
+            tickMarkType === TickMarkType.Month ||
+            tickMarkType === TickMarkType.DayOfMonth
+          return formatChartTickJst(seconds, showDate)
+        },
+      },
+      localization: {
+        locale: 'ja-JP',
+        timeFormatter: (time: Time) => formatChartTimeJst(time as number),
       },
       rightPriceScale: {
         scaleMargins: { top: 0.1, bottom: 0.1 },

--- a/frontend/src/components/RSIChart.tsx
+++ b/frontend/src/components/RSIChart.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react'
-import { createChart, LineSeries, type IChartApi, type ISeriesApi, type LineData, type Time } from 'lightweight-charts'
+import { createChart, LineSeries, TickMarkType, type IChartApi, type ISeriesApi, type LineData, type Time } from 'lightweight-charts'
 import type { Candle } from '../lib/api'
+import { formatChartTickJst, formatChartTimeJst } from '../lib/format'
 
 type RSIChartProps = {
   candles: Candle[]
@@ -67,6 +68,18 @@ export function RSIChart({ candles }: RSIChartProps) {
       timeScale: {
         timeVisible: true,
         secondsVisible: false,
+        tickMarkFormatter: (time: Time, tickMarkType: TickMarkType) => {
+          const seconds = time as number
+          const showDate =
+            tickMarkType === TickMarkType.Year ||
+            tickMarkType === TickMarkType.Month ||
+            tickMarkType === TickMarkType.DayOfMonth
+          return formatChartTickJst(seconds, showDate)
+        },
+      },
+      localization: {
+        locale: 'ja-JP',
+        timeFormatter: (time: Time) => formatChartTimeJst(time as number),
       },
       rightPriceScale: {
         scaleMargins: { top: 0.05, bottom: 0.05 },

--- a/frontend/src/components/StochasticsChart.tsx
+++ b/frontend/src/components/StochasticsChart.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react'
-import { createChart, LineSeries, type IChartApi, type ISeriesApi, type LineData, type Time } from 'lightweight-charts'
+import { createChart, LineSeries, TickMarkType, type IChartApi, type ISeriesApi, type LineData, type Time } from 'lightweight-charts'
 import type { Candle } from '../lib/api'
+import { formatChartTickJst, formatChartTimeJst } from '../lib/format'
 
 type StochasticsChartProps = {
   candles: Candle[]
@@ -80,6 +81,18 @@ export function StochasticsChart({ candles }: StochasticsChartProps) {
       timeScale: {
         timeVisible: true,
         secondsVisible: false,
+        tickMarkFormatter: (time: Time, tickMarkType: TickMarkType) => {
+          const seconds = time as number
+          const showDate =
+            tickMarkType === TickMarkType.Year ||
+            tickMarkType === TickMarkType.Month ||
+            tickMarkType === TickMarkType.DayOfMonth
+          return formatChartTickJst(seconds, showDate)
+        },
+      },
+      localization: {
+        locale: 'ja-JP',
+        timeFormatter: (time: Time) => formatChartTimeJst(time as number),
       },
       rightPriceScale: {
         scaleMargins: { top: 0.05, bottom: 0.05 },


### PR DESCRIPTION
## Summary
- メインのローソク足チャートは JST 軸で描いているが、サブパネル (MACD / RSI / Stochastics / ADX) は lightweight-charts のデフォルトのまま UTC 軸で描かれており、9 時間ズレたままになっていた。
- 4 ファイルそれぞれに \`tickMarkFormatter\` と \`localization.timeFormatter\` を追加し、CandlestickChart と同じ \`formatChartTickJst\` / \`formatChartTimeJst\` を適用して JST 軸に揃える。

## Files
- \`frontend/src/components/MACDChart.tsx\`
- \`frontend/src/components/RSIChart.tsx\`
- \`frontend/src/components/StochasticsChart.tsx\`
- \`frontend/src/components/ADXChart.tsx\`

## Test plan
- [ ] \`docker compose up --build -d\` 後、\`http://localhost:33000/?symbol=LTC_JPY\` を開く
- [ ] ローソク足チャートと MACD / RSI / Stochastics / ADX の各軸時刻が同じ位置で揃っていることを確認 (例: 直近の確定足が \`08:00\` なら全パネルで \`08:00\` 揃い)
- [ ] 各サブパネルの crosshair ツールチップにマウスを当てて、\`YYYY-MM-DD HH:MM JST\` 表記になっていること
- [ ] 1m / 5m / 15m / 1h / 1D / 1W のいずれの interval でも軸が揃っていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)