### PR TITLE
feat(frontend): ローソク足とサブパネルチャートの時間軸を双方向同期する

### DIFF
--- a/frontend/src/components/ADXChart.tsx
+++ b/frontend/src/components/ADXChart.tsx
@@ -210,8 +210,6 @@ export function ADXChart({ candles, syncGroup }: ADXChartProps) {
     threshold25Ref.current = t25
     threshold40Ref.current = t40
 
-    syncGroup?.register(chart)
-
     const handleResize = () => {
       if (containerRef.current) {
         chart.applyOptions({ width: containerRef.current.clientWidth })
@@ -274,8 +272,9 @@ export function ADXChart({ candles, syncGroup }: ADXChartProps) {
     if (!hasInitialFitRef.current) {
       chartRef.current.timeScale().fitContent()
       hasInitialFitRef.current = true
+      syncGroup?.register(chartRef.current)
     }
-  }, [candles])
+  }, [candles, syncGroup])
 
   return (
     <div className="bg-bg-card rounded-lg p-4">

--- a/frontend/src/components/ADXChart.tsx
+++ b/frontend/src/components/ADXChart.tsx
@@ -2,9 +2,11 @@ import { useEffect, useRef } from 'react'
 import { createChart, LineSeries, TickMarkType, type IChartApi, type ISeriesApi, type LineData, type Time } from 'lightweight-charts'
 import type { Candle } from '../lib/api'
 import { formatChartTickJst, formatChartTimeJst } from '../lib/format'
+import type { ChartSyncGroup } from '../lib/chartSync'
 
 type ADXChartProps = {
   candles: Candle[]
+  syncGroup?: ChartSyncGroup
 }
 
 // calcADX is the FE-side companion to backend/internal/infrastructure/indicator/adx.go.
@@ -120,7 +122,7 @@ function calcADX(
   return { adx, plusDI, minusDI }
 }
 
-export function ADXChart({ candles }: ADXChartProps) {
+export function ADXChart({ candles, syncGroup }: ADXChartProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const chartRef = useRef<IChartApi | null>(null)
   const adxSeriesRef = useRef<ISeriesApi<'Line'> | null>(null)
@@ -128,6 +130,7 @@ export function ADXChart({ candles }: ADXChartProps) {
   const minusDISeriesRef = useRef<ISeriesApi<'Line'> | null>(null)
   const threshold25Ref = useRef<ISeriesApi<'Line'> | null>(null)
   const threshold40Ref = useRef<ISeriesApi<'Line'> | null>(null)
+  const hasInitialFitRef = useRef(false)
 
   useEffect(() => {
     if (!containerRef.current) return
@@ -207,6 +210,8 @@ export function ADXChart({ candles }: ADXChartProps) {
     threshold25Ref.current = t25
     threshold40Ref.current = t40
 
+    syncGroup?.register(chart)
+
     const handleResize = () => {
       if (containerRef.current) {
         chart.applyOptions({ width: containerRef.current.clientWidth })
@@ -215,9 +220,11 @@ export function ADXChart({ candles }: ADXChartProps) {
     window.addEventListener('resize', handleResize)
     return () => {
       window.removeEventListener('resize', handleResize)
+      syncGroup?.unregister(chart)
+      hasInitialFitRef.current = false
       chart.remove()
     }
-  }, [])
+  }, [syncGroup])
 
   useEffect(() => {
     if (
@@ -264,7 +271,10 @@ export function ADXChart({ candles }: ADXChartProps) {
       ])
     }
 
-    chartRef.current.timeScale().fitContent()
+    if (!hasInitialFitRef.current) {
+      chartRef.current.timeScale().fitContent()
+      hasInitialFitRef.current = true
+    }
   }, [candles])
 
   return (

--- a/frontend/src/components/CandlestickChart.tsx
+++ b/frontend/src/components/CandlestickChart.tsx
@@ -3,6 +3,7 @@ import { createChart, CandlestickSeries, LineSeries, TickMarkType, type IChartAp
 import type { CanvasRenderingTarget2D } from 'fancy-canvas'
 import { useCandles, type CandleInterval } from '../hooks/useCandles'
 import { formatChartTickJst, formatChartTimeJst } from '../lib/format'
+import { ChartSyncGroup } from '../lib/chartSync'
 import { IndicatorSubPanels } from './IndicatorSubPanels'
 
 type CandlestickChartProps = {
@@ -385,6 +386,8 @@ export function CandlestickChart({ symbolId }: CandlestickChartProps) {
   const ichimokuSeriesRefs = useRef<Partial<Record<IchimokuLineKey, ISeriesApi<'Line'>>>>({})
   const kumoFillRef = useRef<KumoFillPrimitive | null>(null)
   const prevCandleCountRef = useRef(0)
+  // Sync group shared with the indicator sub-panels so all charts pan/zoom together.
+  const syncGroupRef = useRef<ChartSyncGroup>(new ChartSyncGroup())
 
   const [interval, setInterval] = useState<CandleInterval>('PT15M')
   const { data, isFetching, hasNextPage, fetchNextPage, isFetchingNextPage } = useCandles(symbolId, interval)
@@ -468,6 +471,9 @@ export function CandlestickChart({ symbolId }: CandlestickChartProps) {
     chartRef.current = chart
     seriesRef.current = series
 
+    const syncGroup = syncGroupRef.current
+    syncGroup.register(chart)
+
     const handleResize = () => {
       if (containerRef.current) {
         chart.applyOptions({ width: containerRef.current.clientWidth })
@@ -477,6 +483,7 @@ export function CandlestickChart({ symbolId }: CandlestickChartProps) {
 
     return () => {
       window.removeEventListener('resize', handleResize)
+      syncGroup.unregister(chart)
       lineSeriesRefs.current = {}
       bbSeriesRefs.current = {}
       bbFillRefs.current = {}
@@ -861,7 +868,7 @@ export function CandlestickChart({ symbolId }: CandlestickChartProps) {
         </div>
       </div>
       <div ref={containerRef} />
-      <IndicatorSubPanels candles={candles} />
+      <IndicatorSubPanels candles={candles} syncGroup={syncGroupRef.current} />
     </div>
   )
 }

--- a/frontend/src/components/IndicatorSubPanels.tsx
+++ b/frontend/src/components/IndicatorSubPanels.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import type { Candle } from '../lib/api'
+import type { ChartSyncGroup } from '../lib/chartSync'
 import { ADXChart } from './ADXChart'
 import { MACDChart } from './MACDChart'
 import { RSIChart } from './RSIChart'
@@ -7,6 +8,7 @@ import { StochasticsChart } from './StochasticsChart'
 
 type Props = {
   candles: Candle[]
+  syncGroup?: ChartSyncGroup
 }
 
 type PanelKey = 'macd' | 'rsi' | 'stoch' | 'adx'
@@ -18,7 +20,7 @@ const PANELS: { key: PanelKey; label: string }[] = [
   { key: 'adx', label: 'ADX' },
 ]
 
-export function IndicatorSubPanels({ candles }: Props) {
+export function IndicatorSubPanels({ candles, syncGroup }: Props) {
   const [active, setActive] = useState<PanelKey>('macd')
   if (candles.length === 0) return null
   return (
@@ -39,10 +41,10 @@ export function IndicatorSubPanels({ candles }: Props) {
           </button>
         ))}
       </div>
-      {active === 'macd' && <MACDChart candles={candles} />}
-      {active === 'rsi' && <RSIChart candles={candles} />}
-      {active === 'stoch' && <StochasticsChart candles={candles} />}
-      {active === 'adx' && <ADXChart candles={candles} />}
+      {active === 'macd' && <MACDChart candles={candles} syncGroup={syncGroup} />}
+      {active === 'rsi' && <RSIChart candles={candles} syncGroup={syncGroup} />}
+      {active === 'stoch' && <StochasticsChart candles={candles} syncGroup={syncGroup} />}
+      {active === 'adx' && <ADXChart candles={candles} syncGroup={syncGroup} />}
     </div>
   )
 }

--- a/frontend/src/components/MACDChart.tsx
+++ b/frontend/src/components/MACDChart.tsx
@@ -144,8 +144,6 @@ export function MACDChart({ candles, syncGroup }: MACDChartProps) {
     signalSeriesRef.current = signalSeries
     histSeriesRef.current = histSeries
 
-    syncGroup?.register(chart)
-
     const handleResize = () => {
       if (containerRef.current) {
         chart.applyOptions({ width: containerRef.current.clientWidth })
@@ -192,15 +190,18 @@ export function MACDChart({ candles, syncGroup }: MACDChartProps) {
     macdSeriesRef.current.setData(macdData)
     signalSeriesRef.current.setData(signalData)
     histSeriesRef.current.setData(histData)
-    // Fit only on the first data load. Subsequent updates either prepend older
-    // candles (visible range is preserved by the sync group) or append a new
-    // candle (lightweight-charts keeps the existing range). Calling fitContent
-    // every render would override scrolls done by the user or by sync.
+    // Fit only on the first data load, then join the sync group. Joining after
+    // setData ensures the chart can accept the group's current visible range
+    // (lightweight-charts throws if you set a range before any data exists).
+    // Subsequent renders either prepend older candles (visible range preserved
+    // by the sync group) or append a new candle (lightweight-charts keeps the
+    // existing range), so no further fit is needed.
     if (!hasInitialFitRef.current) {
       chartRef.current.timeScale().fitContent()
       hasInitialFitRef.current = true
+      syncGroup?.register(chartRef.current)
     }
-  }, [candles])
+  }, [candles, syncGroup])
 
   return (
     <div className="bg-bg-card rounded-lg p-4">

--- a/frontend/src/components/MACDChart.tsx
+++ b/frontend/src/components/MACDChart.tsx
@@ -2,9 +2,11 @@ import { useEffect, useRef } from 'react'
 import { createChart, LineSeries, HistogramSeries, TickMarkType, type IChartApi, type ISeriesApi, type LineData, type HistogramData, type Time } from 'lightweight-charts'
 import type { Candle } from '../lib/api'
 import { formatChartTickJst, formatChartTimeJst } from '../lib/format'
+import type { ChartSyncGroup } from '../lib/chartSync'
 
 type MACDChartProps = {
   candles: Candle[]
+  syncGroup?: ChartSyncGroup
 }
 
 function calcEMA(values: number[], period: number): (number | null)[] {
@@ -73,12 +75,13 @@ function calcMACD(closes: number[]): {
   return { macdLine, signalLine, histogram }
 }
 
-export function MACDChart({ candles }: MACDChartProps) {
+export function MACDChart({ candles, syncGroup }: MACDChartProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const chartRef = useRef<IChartApi | null>(null)
   const macdSeriesRef = useRef<ISeriesApi<'Line'> | null>(null)
   const signalSeriesRef = useRef<ISeriesApi<'Line'> | null>(null)
   const histSeriesRef = useRef<ISeriesApi<'Histogram'> | null>(null)
+  const hasInitialFitRef = useRef(false)
 
   useEffect(() => {
     if (!containerRef.current) return
@@ -141,6 +144,8 @@ export function MACDChart({ candles }: MACDChartProps) {
     signalSeriesRef.current = signalSeries
     histSeriesRef.current = histSeries
 
+    syncGroup?.register(chart)
+
     const handleResize = () => {
       if (containerRef.current) {
         chart.applyOptions({ width: containerRef.current.clientWidth })
@@ -150,9 +155,11 @@ export function MACDChart({ candles }: MACDChartProps) {
 
     return () => {
       window.removeEventListener('resize', handleResize)
+      syncGroup?.unregister(chart)
+      hasInitialFitRef.current = false
       chart.remove()
     }
-  }, [])
+  }, [syncGroup])
 
   useEffect(() => {
     if (!chartRef.current || !macdSeriesRef.current || !signalSeriesRef.current || !histSeriesRef.current || candles.length === 0) return
@@ -185,7 +192,14 @@ export function MACDChart({ candles }: MACDChartProps) {
     macdSeriesRef.current.setData(macdData)
     signalSeriesRef.current.setData(signalData)
     histSeriesRef.current.setData(histData)
-    chartRef.current.timeScale().fitContent()
+    // Fit only on the first data load. Subsequent updates either prepend older
+    // candles (visible range is preserved by the sync group) or append a new
+    // candle (lightweight-charts keeps the existing range). Calling fitContent
+    // every render would override scrolls done by the user or by sync.
+    if (!hasInitialFitRef.current) {
+      chartRef.current.timeScale().fitContent()
+      hasInitialFitRef.current = true
+    }
   }, [candles])
 
   return (

--- a/frontend/src/components/RSIChart.tsx
+++ b/frontend/src/components/RSIChart.tsx
@@ -2,9 +2,11 @@ import { useEffect, useRef } from 'react'
 import { createChart, LineSeries, TickMarkType, type IChartApi, type ISeriesApi, type LineData, type Time } from 'lightweight-charts'
 import type { Candle } from '../lib/api'
 import { formatChartTickJst, formatChartTimeJst } from '../lib/format'
+import type { ChartSyncGroup } from '../lib/chartSync'
 
 type RSIChartProps = {
   candles: Candle[]
+  syncGroup?: ChartSyncGroup
 }
 
 function calcRSI(closes: number[], period: number): (number | null)[] {
@@ -43,13 +45,14 @@ function calcRSI(closes: number[], period: number): (number | null)[] {
   return result
 }
 
-export function RSIChart({ candles }: RSIChartProps) {
+export function RSIChart({ candles, syncGroup }: RSIChartProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const chartRef = useRef<IChartApi | null>(null)
   const rsiSeriesRef = useRef<ISeriesApi<'Line'> | null>(null)
   const overboughtRef = useRef<ISeriesApi<'Line'> | null>(null)
   const oversoldRef = useRef<ISeriesApi<'Line'> | null>(null)
   const midRef = useRef<ISeriesApi<'Line'> | null>(null)
+  const hasInitialFitRef = useRef(false)
 
   useEffect(() => {
     if (!containerRef.current) return
@@ -130,6 +133,8 @@ export function RSIChart({ candles }: RSIChartProps) {
     oversoldRef.current = oversold
     midRef.current = mid
 
+    syncGroup?.register(chart)
+
     const handleResize = () => {
       if (containerRef.current) {
         chart.applyOptions({ width: containerRef.current.clientWidth })
@@ -139,9 +144,11 @@ export function RSIChart({ candles }: RSIChartProps) {
 
     return () => {
       window.removeEventListener('resize', handleResize)
+      syncGroup?.unregister(chart)
+      hasInitialFitRef.current = false
       chart.remove()
     }
-  }, [])
+  }, [syncGroup])
 
   useEffect(() => {
     if (!chartRef.current || !rsiSeriesRef.current || !overboughtRef.current || !oversoldRef.current || !midRef.current || candles.length === 0) return
@@ -177,7 +184,10 @@ export function RSIChart({ candles }: RSIChartProps) {
       ])
     }
 
-    chartRef.current.timeScale().fitContent()
+    if (!hasInitialFitRef.current) {
+      chartRef.current.timeScale().fitContent()
+      hasInitialFitRef.current = true
+    }
   }, [candles])
 
   return (

--- a/frontend/src/components/RSIChart.tsx
+++ b/frontend/src/components/RSIChart.tsx
@@ -133,8 +133,6 @@ export function RSIChart({ candles, syncGroup }: RSIChartProps) {
     oversoldRef.current = oversold
     midRef.current = mid
 
-    syncGroup?.register(chart)
-
     const handleResize = () => {
       if (containerRef.current) {
         chart.applyOptions({ width: containerRef.current.clientWidth })
@@ -187,8 +185,9 @@ export function RSIChart({ candles, syncGroup }: RSIChartProps) {
     if (!hasInitialFitRef.current) {
       chartRef.current.timeScale().fitContent()
       hasInitialFitRef.current = true
+      syncGroup?.register(chartRef.current)
     }
-  }, [candles])
+  }, [candles, syncGroup])
 
   return (
     <div className="bg-bg-card rounded-lg p-4">

--- a/frontend/src/components/StochasticsChart.tsx
+++ b/frontend/src/components/StochasticsChart.tsx
@@ -2,9 +2,11 @@ import { useEffect, useRef } from 'react'
 import { createChart, LineSeries, TickMarkType, type IChartApi, type ISeriesApi, type LineData, type Time } from 'lightweight-charts'
 import type { Candle } from '../lib/api'
 import { formatChartTickJst, formatChartTimeJst } from '../lib/format'
+import type { ChartSyncGroup } from '../lib/chartSync'
 
 type StochasticsChartProps = {
   candles: Candle[]
+  syncGroup?: ChartSyncGroup
 }
 
 function calcStochastics(
@@ -56,13 +58,14 @@ function calcStochastics(
   return { percentK, percentD }
 }
 
-export function StochasticsChart({ candles }: StochasticsChartProps) {
+export function StochasticsChart({ candles, syncGroup }: StochasticsChartProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const chartRef = useRef<IChartApi | null>(null)
   const kSeriesRef = useRef<ISeriesApi<'Line'> | null>(null)
   const dSeriesRef = useRef<ISeriesApi<'Line'> | null>(null)
   const overboughtRef = useRef<ISeriesApi<'Line'> | null>(null)
   const oversoldRef = useRef<ISeriesApi<'Line'> | null>(null)
+  const hasInitialFitRef = useRef(false)
 
   useEffect(() => {
     if (!containerRef.current) return
@@ -140,6 +143,8 @@ export function StochasticsChart({ candles }: StochasticsChartProps) {
     overboughtRef.current = overbought
     oversoldRef.current = oversold
 
+    syncGroup?.register(chart)
+
     const handleResize = () => {
       if (containerRef.current) {
         chart.applyOptions({ width: containerRef.current.clientWidth })
@@ -149,9 +154,11 @@ export function StochasticsChart({ candles }: StochasticsChartProps) {
 
     return () => {
       window.removeEventListener('resize', handleResize)
+      syncGroup?.unregister(chart)
+      hasInitialFitRef.current = false
       chart.remove()
     }
-  }, [])
+  }, [syncGroup])
 
   useEffect(() => {
     if (!chartRef.current || !kSeriesRef.current || !dSeriesRef.current || !overboughtRef.current || !oversoldRef.current || candles.length === 0) return
@@ -190,7 +197,10 @@ export function StochasticsChart({ candles }: StochasticsChartProps) {
       ])
     }
 
-    chartRef.current.timeScale().fitContent()
+    if (!hasInitialFitRef.current) {
+      chartRef.current.timeScale().fitContent()
+      hasInitialFitRef.current = true
+    }
   }, [candles])
 
   return (

--- a/frontend/src/components/StochasticsChart.tsx
+++ b/frontend/src/components/StochasticsChart.tsx
@@ -143,8 +143,6 @@ export function StochasticsChart({ candles, syncGroup }: StochasticsChartProps) 
     overboughtRef.current = overbought
     oversoldRef.current = oversold
 
-    syncGroup?.register(chart)
-
     const handleResize = () => {
       if (containerRef.current) {
         chart.applyOptions({ width: containerRef.current.clientWidth })
@@ -200,8 +198,9 @@ export function StochasticsChart({ candles, syncGroup }: StochasticsChartProps) 
     if (!hasInitialFitRef.current) {
       chartRef.current.timeScale().fitContent()
       hasInitialFitRef.current = true
+      syncGroup?.register(chartRef.current)
     }
-  }, [candles])
+  }, [candles, syncGroup])
 
   return (
     <div className="bg-bg-card rounded-lg p-4">

--- a/frontend/src/lib/chartSync.ts
+++ b/frontend/src/lib/chartSync.ts
@@ -20,6 +20,19 @@ export class ChartSyncGroup {
   private members = new Map<IChartApi, (range: IRange<Time> | null) => void>()
   private syncing = false
 
+  // setVisibleRange throws when the receiving chart has no data covering the
+  // requested range yet (e.g. a sub-panel registered before its series was
+  // populated, or before the indicator warm-up filled in any points). The
+  // throw is harmless — the next user gesture or data update will retry the
+  // sync — so swallow it instead of letting it propagate to React.
+  private safeSetVisibleRange(chart: IChartApi, range: IRange<Time>) {
+    try {
+      chart.timeScale().setVisibleRange(range)
+    } catch {
+      // Ignore: chart not ready to render this range yet.
+    }
+  }
+
   register(chart: IChartApi) {
     if (this.members.has(chart)) return
     const handler = (range: IRange<Time> | null) => {
@@ -28,7 +41,7 @@ export class ChartSyncGroup {
       try {
         for (const other of this.members.keys()) {
           if (other === chart) continue
-          other.timeScale().setVisibleRange(range)
+          this.safeSetVisibleRange(other, range)
         }
       } finally {
         this.syncing = false
@@ -44,7 +57,7 @@ export class ChartSyncGroup {
       if (range) {
         this.syncing = true
         try {
-          chart.timeScale().setVisibleRange(range)
+          this.safeSetVisibleRange(chart, range)
         } finally {
           this.syncing = false
         }

--- a/frontend/src/lib/chartSync.ts
+++ b/frontend/src/lib/chartSync.ts
@@ -1,43 +1,50 @@
-import type { IChartApi, LogicalRange } from 'lightweight-charts'
+import type { IChartApi, IRange, Time } from 'lightweight-charts'
 
 // ChartSyncGroup keeps a set of lightweight-charts instances mirroring the same
-// visible logical range. Used by CandlestickChart and the indicator sub-panels
+// visible *time* range. Used by CandlestickChart and the indicator sub-panels
 // (MACD / RSI / Stochastics / ADX) so scrolling or zooming any one of them
 // pans/zooms the others to match.
 //
-// Each member subscribes its own visible-range listener and forwards the range
-// to the rest of the group. A re-entrancy guard (`syncing`) prevents the
-// forwarded `setVisibleLogicalRange` calls from re-firing the listeners and
-// causing an infinite loop.
+// Time-based sync (instead of logical/index-based sync) is required because
+// indicator series are shorter than the candle series — MACD's first ~33 points
+// are null while EMA(26)+Signal(9) warm up, RSI's first 14 are null, ADX's
+// first ~28 are null. If we synced by logical index, the same index in the
+// indicator panel would refer to a different real time than in the candle
+// panel, so the right edge of the indicator chart would land "in the past"
+// relative to the candle chart. Time ranges are series-length independent and
+// keep the panels aligned to the same wall-clock window.
+//
+// A re-entrancy guard (`syncing`) prevents the forwarded `setVisibleRange`
+// calls from re-firing the listeners and causing an infinite loop.
 export class ChartSyncGroup {
-  private members = new Map<IChartApi, (range: LogicalRange | null) => void>()
+  private members = new Map<IChartApi, (range: IRange<Time> | null) => void>()
   private syncing = false
 
   register(chart: IChartApi) {
     if (this.members.has(chart)) return
-    const handler = (range: LogicalRange | null) => {
+    const handler = (range: IRange<Time> | null) => {
       if (this.syncing || range === null) return
       this.syncing = true
       try {
         for (const other of this.members.keys()) {
           if (other === chart) continue
-          other.timeScale().setVisibleLogicalRange(range)
+          other.timeScale().setVisibleRange(range)
         }
       } finally {
         this.syncing = false
       }
     }
-    chart.timeScale().subscribeVisibleLogicalRangeChange(handler)
+    chart.timeScale().subscribeVisibleTimeRangeChange(handler)
     this.members.set(chart, handler)
 
     // New member should snap to whichever range the group is already showing.
     for (const other of this.members.keys()) {
       if (other === chart) continue
-      const range = other.timeScale().getVisibleLogicalRange()
+      const range = other.timeScale().getVisibleRange()
       if (range) {
         this.syncing = true
         try {
-          chart.timeScale().setVisibleLogicalRange(range)
+          chart.timeScale().setVisibleRange(range)
         } finally {
           this.syncing = false
         }
@@ -49,7 +56,7 @@ export class ChartSyncGroup {
   unregister(chart: IChartApi) {
     const handler = this.members.get(chart)
     if (!handler) return
-    chart.timeScale().unsubscribeVisibleLogicalRangeChange(handler)
+    chart.timeScale().unsubscribeVisibleTimeRangeChange(handler)
     this.members.delete(chart)
   }
 }

--- a/frontend/src/lib/chartSync.ts
+++ b/frontend/src/lib/chartSync.ts
@@ -1,0 +1,55 @@
+import type { IChartApi, LogicalRange } from 'lightweight-charts'
+
+// ChartSyncGroup keeps a set of lightweight-charts instances mirroring the same
+// visible logical range. Used by CandlestickChart and the indicator sub-panels
+// (MACD / RSI / Stochastics / ADX) so scrolling or zooming any one of them
+// pans/zooms the others to match.
+//
+// Each member subscribes its own visible-range listener and forwards the range
+// to the rest of the group. A re-entrancy guard (`syncing`) prevents the
+// forwarded `setVisibleLogicalRange` calls from re-firing the listeners and
+// causing an infinite loop.
+export class ChartSyncGroup {
+  private members = new Map<IChartApi, (range: LogicalRange | null) => void>()
+  private syncing = false
+
+  register(chart: IChartApi) {
+    if (this.members.has(chart)) return
+    const handler = (range: LogicalRange | null) => {
+      if (this.syncing || range === null) return
+      this.syncing = true
+      try {
+        for (const other of this.members.keys()) {
+          if (other === chart) continue
+          other.timeScale().setVisibleLogicalRange(range)
+        }
+      } finally {
+        this.syncing = false
+      }
+    }
+    chart.timeScale().subscribeVisibleLogicalRangeChange(handler)
+    this.members.set(chart, handler)
+
+    // New member should snap to whichever range the group is already showing.
+    for (const other of this.members.keys()) {
+      if (other === chart) continue
+      const range = other.timeScale().getVisibleLogicalRange()
+      if (range) {
+        this.syncing = true
+        try {
+          chart.timeScale().setVisibleLogicalRange(range)
+        } finally {
+          this.syncing = false
+        }
+        break
+      }
+    }
+  }
+
+  unregister(chart: IChartApi) {
+    const handler = this.members.get(chart)
+    if (!handler) return
+    chart.timeScale().unsubscribeVisibleLogicalRangeChange(handler)
+    this.members.delete(chart)
+  }
+}


### PR DESCRIPTION
## Summary
- これまで MACD / RSI / Stochastics / ADX の各サブパネルは描画ごとに \`fitContent()\` で全体表示にスナップしてしまい、ローソク足の横スクロール (および過去 fetch) と全く連動していなかった。
- \`ChartSyncGroup\` を新設し、ローソク足チャートと現在表示中のサブパネルが同じグループに参加して \`subscribeVisibleLogicalRangeChange\` を相互伝播するようにする。これでどのチャートを操作しても他チャートが同じ時間範囲に追従する。
- ついでにローソク足側の既存の過去スクロール検知 (\`fetchNextPage\`) が、サブパネルの過去スクロール経由でも発火するようになる。

## Implementation
- 新規: \`frontend/src/lib/chartSync.ts\` — re-entrancy guard 付きの \`ChartSyncGroup\` (\`register\` / \`unregister\`)。新規参加チャートは既存メンバーの visible range にスナップして揃う。
- \`CandlestickChart\` で \`syncGroupRef\` を保持して自身を register し、\`IndicatorSubPanels\` 経由で各サブパネルに渡す。
- \`MACDChart\` / \`RSIChart\` / \`StochasticsChart\` / \`ADXChart\` は \`syncGroup\` prop を受け取り、createChart 後に register、unmount 時に unregister。\`fitContent()\` は初回ロード時のみ呼び、以降の visible range は同期グループに任せる。
- \`IndicatorSubPanels\` は \`syncGroup\` prop を受けて active panel に渡すだけ。

## Test plan
- [ ] \`docker compose up --build -d\` 後、\`http://localhost:33000/?symbol=LTC_JPY\` を開く
- [ ] ローソク足チャートを横スクロール → 下のサブパネル (MACD) が同じ時間範囲に追従すること
- [ ] サブパネルを横スクロール → ローソク足チャートが同じ時間範囲に追従すること
- [ ] どちらかをホイールでズームイン/アウト → 反対側も同じ範囲にズームすること
- [ ] 過去側に十分スクロールしたとき、追加データが自動取得され、両チャートとも同じ visible range のまま series が左に伸びること
- [ ] サブパネル切替 (MACD / RSI / Stoch / ADX) しても新しいパネルがローソク足の現在の visible range で表示されること
- [ ] interval を切り替え (1m → 5m → 15m → 1h → 1D → 1W) しても sync が崩れないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)