### PR TITLE
refactor(exitplan): shadow ExitPlan を Position 昇格イベント駆動に変更 (ADR #260 PR 2/3)

### DIFF
--- a/backend/cmd/event_pipeline.go
+++ b/backend/cmd/event_pipeline.go
@@ -793,15 +793,18 @@ func (p *EventDrivenPipeline) runEventLoop(ctx context.Context, snap eventSnapsh
 	bus.Register(entity.EventTypeDecision, 30, riskHandler)
 	bus.Register(entity.EventTypeOrder, 50, riskHandler)
 
-	// ExitPlan shadow (priority 60): OrderEvent をシャドウで listen して
-	// ExitPlan の作成・close だけ行う。発注パスには干渉しない。Phase 2b で
-	// 出口判定本体を Exit レイヤに移管したらこの shadow は退役する。
+	// ExitPlan shadow (priority 60): 新規 plan は PositionConfirmedEvent から
+	// venue 真値の EntryPrice で作成 (ADR #260 PR #2)。close は引き続き
+	// OrderEvent.ClosedPositionID で行う (close 価格は SL/TP 判定に使われない)。
+	// 発注パスには干渉しない。Phase 2b で出口判定本体を Exit レイヤに移管
+	// したらこの shadow は退役する。
 	if p.exitPlanRepo != nil {
 		shadow := usecaseexitplan.NewShadowHandler(usecaseexitplan.ShadowHandlerConfig{
 			Repo:   p.exitPlanRepo,
 			Policy: snap.riskPolicy,
 		})
 		bus.Register(entity.EventTypeOrder, 60, shadow)
+		bus.Register(entity.EventTypePositionConfirmed, 60, shadow)
 
 		// ATRSource (priority 26): IndicatorEvent から ATR を吸い上げて
 		// ExitPlan の動的計算に使う in-memory 値を保持する。indicatorEventTap
@@ -858,6 +861,21 @@ func (p *EventDrivenPipeline) runEventLoop(ctx context.Context, snap eventSnapsh
 	}
 
 	engine := eventengine.NewEventEngine(bus)
+
+	// Connect the executor's PositionConfirmedSink to the engine so that
+	// each newly confirmed venue position dispatches through the bus.
+	// SyncPositions now emits PositionConfirmedEvent in its post-unlock
+	// phase, and the ExitPlan shadow handler (registered on this bus)
+	// listens for those events to create plans from the real fill price
+	// — replacing the old OrderEvent.Price path that was vulnerable to
+	// the signalPrice fallback bug.
+	//
+	// The dispatcher inherits the pipeline ctx so that an in-flight
+	// dispatch is cancelled when the pipeline is stopped. Without this
+	// linkage SyncPositions could otherwise fire events into a
+	// dispatcher whose lifecycle has already ended (Codex review on
+	// PR #2 flagged this as a blocker).
+	executor.SetPositionConfirmedSink(&positionConfirmedDispatcher{engine: engine, ctx: ctx})
 
 	// Subscribe to real-time ticker stream.
 	tickerCh := p.marketDataSvc.SubscribeTicker()
@@ -1215,4 +1233,39 @@ func (p *positionUpdatePublisher) PublishPositionUpdate(symbolID int64, position
 	if err := p.hub.PublishData("position_update", symbolID, positions); err != nil {
 		slog.Warn("event-pipeline: position_update publish failed", "error", err)
 	}
+}
+
+// positionConfirmedDispatcher forwards a PositionConfirmedEvent through
+// the event engine so registered handlers (e.g. ExitPlan shadow) receive
+// it. The dispatcher carries the pipeline's ctx so a shutdown short-
+// circuits any in-flight dispatch, and runs each event in its own
+// goroutine so a slow handler does not block the sync loop.
+type positionConfirmedDispatcher struct {
+	engine *eventengine.EventEngine
+	ctx    context.Context
+}
+
+func (d *positionConfirmedDispatcher) PublishPositionConfirmed(ev entity.PositionConfirmedEvent) {
+	if d == nil || d.engine == nil {
+		return
+	}
+	ctx := d.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		// Pipeline already shutting down. Drop the event rather than
+		// scheduling a goroutine that would race against teardown.
+		slog.Debug("event-pipeline: position_confirmed dropped, pipeline ctx already done",
+			"positionID", ev.PositionID, "err", err,
+		)
+		return
+	}
+	go func() {
+		if err := d.engine.Run(ctx, []entity.Event{ev}); err != nil {
+			slog.Warn("event-pipeline: position_confirmed dispatch failed",
+				"err", err, "positionID", ev.PositionID,
+			)
+		}
+	}()
 }

--- a/backend/internal/domain/entity/backtest_event.go
+++ b/backend/internal/domain/entity/backtest_event.go
@@ -1,15 +1,16 @@
 package entity
 
 const (
-	EventTypeCandle       = "candle"
-	EventTypeIndicator    = "indicator"
-	EventTypeTick         = "tick"
-	EventTypeSignal       = "signal"
-	EventTypeMarketSignal = "market_signal"
-	EventTypeDecision     = "decision"
-	EventTypeApproved     = "approved_signal"
-	EventTypeRejected     = "rejected_signal"
-	EventTypeOrder        = "order"
+	EventTypeCandle            = "candle"
+	EventTypeIndicator         = "indicator"
+	EventTypeTick              = "tick"
+	EventTypeSignal            = "signal"
+	EventTypeMarketSignal      = "market_signal"
+	EventTypeDecision          = "decision"
+	EventTypeApproved          = "approved_signal"
+	EventTypeRejected          = "rejected_signal"
+	EventTypeOrder             = "order"
+	EventTypePositionConfirmed = "position_confirmed"
 )
 
 // Event is a minimal contract used by the backtest event bus.
@@ -112,3 +113,30 @@ type OrderEvent struct {
 
 func (e OrderEvent) EventType() string     { return EventTypeOrder }
 func (e OrderEvent) EventTimestamp() int64 { return e.Timestamp }
+
+// PositionConfirmedEvent is emitted when the executor observes that the
+// venue has confirmed a fill — i.e. a new Position has appeared in
+// Positions() with EntryPrice > 0. This is the authoritative trigger for
+// downstream handlers (Risk, Exit, ExitPlan shadow) that need the real
+// fill price, not the submit-time signalPrice.
+//
+// Per docs/design/2026-05-12-position-confirmed-only.md, the OrderEvent
+// path remains for logging / dashboard purposes, but anything that
+// depends on EntryPrice for correctness (TP / SL anchoring) must consume
+// this event instead.
+//
+// One submitted order may produce multiple PositionConfirmedEvent payloads
+// when the venue splits the fill across several PositionIDs.
+type PositionConfirmedEvent struct {
+	PositionID     int64
+	OrderID        int64
+	SymbolID       int64
+	Side           OrderSide
+	EntryPrice     float64
+	Amount         float64
+	EntryTimestamp int64
+	Timestamp      int64
+}
+
+func (e PositionConfirmedEvent) EventType() string     { return EventTypePositionConfirmed }
+func (e PositionConfirmedEvent) EventTimestamp() int64 { return e.Timestamp }

--- a/backend/internal/infrastructure/live/real_executor.go
+++ b/backend/internal/infrastructure/live/real_executor.go
@@ -30,6 +30,21 @@ type PositionChangePublisher interface {
 	PublishPositionUpdate(symbolID int64, positions []eventengine.Position)
 }
 
+// PositionConfirmedSink receives one PositionConfirmedEvent per newly
+// confirmed position discovered during SyncPositions. It is the
+// authoritative hook for downstream handlers (ExitPlan shadow, Risk
+// scaffolding) that need to act on the real venue fill price rather than
+// the submit-time signalPrice. See
+// docs/design/2026-05-12-position-confirmed-only.md.
+//
+// Implementations must be non-blocking — the executor calls them while
+// holding no lock, but a slow sink would delay the next SyncPositions
+// invocation. A typical implementation hands the event off to the
+// event bus and returns.
+type PositionConfirmedSink interface {
+	PublishPositionConfirmed(ev entity.PositionConfirmedEvent)
+}
+
 // RealExecutor implements eventengine.OrderExecutor by executing real orders
 // via the Rakuten API OrderClient.
 //
@@ -72,6 +87,12 @@ type RealExecutor struct {
 	// positionPublisher is invoked from SyncPositions when the local view
 	// changes (count or amount), so the dashboard updates immediately.
 	positionPublisher PositionChangePublisher
+	// positionConfirmedSink receives a PositionConfirmedEvent for each
+	// newly confirmed position observed during SyncPositions. Optional
+	// (nil = no event-bus integration); when set, downstream handlers
+	// like the ExitPlan shadow can stop relying on OrderEvent.Price and
+	// act on the real venue fill instead.
+	positionConfirmedSink PositionConfirmedSink
 	// pendingTTL bounds how long an unconfirmed order may sit in
 	// pendingOrders before SweepStalePending logs it. Defaults to 60 s.
 	pendingTTL time.Duration
@@ -125,6 +146,24 @@ func WithPollInterval(d time.Duration) RealExecutorOption {
 // push immediate updates to the realtime hub when the venue state changes.
 func WithPositionPublisher(p PositionChangePublisher) RealExecutorOption {
 	return func(r *RealExecutor) { r.positionPublisher = p }
+}
+
+// WithPositionConfirmedSink wires a sink that receives one
+// PositionConfirmedEvent per newly confirmed position. This is the
+// integration point for the ExitPlan shadow / Risk scaffolding to react
+// on real venue fills rather than submit-time OrderEvent prices.
+func WithPositionConfirmedSink(sink PositionConfirmedSink) RealExecutorOption {
+	return func(r *RealExecutor) { r.positionConfirmedSink = sink }
+}
+
+// SetPositionConfirmedSink installs (or replaces) the sink at runtime.
+// The pipeline constructs the EventEngine after the executor, so this
+// setter lets the wiring connect the two without forcing a constructor
+// dependency cycle. Passing nil clears the sink.
+func (r *RealExecutor) SetPositionConfirmedSink(sink PositionConfirmedSink) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.positionConfirmedSink = sink
 }
 
 func NewRealExecutor(orderClient repository.OrderClient, symbolID int64, spreadPercent float64, opts ...RealExecutorOption) *RealExecutor {
@@ -633,6 +672,15 @@ func (r *RealExecutor) SyncPositions(ctx context.Context) error {
 		r.mu.Unlock()
 		return nil
 	}
+	// Compute newly-confirmed positions so we can emit one
+	// PositionConfirmedEvent per new fill. We snapshot the previous IDs
+	// before swapping the slice, then walk apiPositions so the emitted
+	// event carries the parent OrderID directly (synced is the local
+	// projection and does not preserve OrderID).
+	previousIDs := make(map[int64]struct{}, len(r.positions))
+	for _, p := range r.positions {
+		previousIDs[p.PositionID] = struct{}{}
+	}
 	changed := positionsChanged(r.positions, synced)
 	r.positions = synced
 	// Any pending order whose OrderID now matches a venue-confirmed
@@ -654,7 +702,36 @@ func (r *RealExecutor) SyncPositions(ctx context.Context) error {
 		}
 	}
 	publisher := r.positionPublisher
+	confirmedSink := r.positionConfirmedSink
+	// Build the list of confirmed events while still under the lock so
+	// the snapshot we hand off is consistent. We deliberately emit
+	// after Unlock so a slow sink cannot block subsequent syncs.
+	var confirmedEvents []entity.PositionConfirmedEvent
+	if confirmedSink != nil {
+		for _, ap := range apiPositions {
+			if ap.Price <= 0 {
+				continue
+			}
+			if _, existed := previousIDs[ap.ID]; existed {
+				continue
+			}
+			confirmedEvents = append(confirmedEvents, entity.PositionConfirmedEvent{
+				PositionID:     ap.ID,
+				OrderID:        ap.OrderID,
+				SymbolID:       ap.SymbolID,
+				Side:           ap.OrderSide,
+				EntryPrice:     ap.Price,
+				Amount:         ap.RemainingAmount,
+				EntryTimestamp: ap.CreatedAt,
+				Timestamp:      time.Now().UnixMilli(),
+			})
+		}
+	}
 	r.mu.Unlock()
+
+	for _, ev := range confirmedEvents {
+		confirmedSink.PublishPositionConfirmed(ev)
+	}
 
 	slog.Info("positions synced from API",
 		"symbolID", r.symbolID,

--- a/backend/internal/infrastructure/live/real_executor_test.go
+++ b/backend/internal/infrastructure/live/real_executor_test.go
@@ -879,6 +879,118 @@ func TestRealExecutor_SyncPositions_KeepsSnapshotWhenAllRowsZeroPrice(t *testing
 	}
 }
 
+// captureSink records each PositionConfirmedEvent the executor emits.
+type captureSink struct {
+	mu     sync.Mutex
+	events []entity.PositionConfirmedEvent
+}
+
+func (c *captureSink) PublishPositionConfirmed(ev entity.PositionConfirmedEvent) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.events = append(c.events, ev)
+}
+
+func (c *captureSink) snapshot() []entity.PositionConfirmedEvent {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]entity.PositionConfirmedEvent, len(c.events))
+	copy(out, c.events)
+	return out
+}
+
+func TestRealExecutor_SyncPositions_EmitsPositionConfirmedForNewFill(t *testing.T) {
+	// ADR #260 PR #2: SyncPositions must emit one PositionConfirmedEvent
+	// per newly-observed PositionID so the ExitPlan shadow (and any
+	// future Position-driven Risk layer) can act on the real venue
+	// fill price. Existing positions must NOT re-emit on subsequent
+	// syncs — that would cause duplicate plans.
+	state := "fresh"
+	mock := &mockOrderClient{
+		getPositionsFn: func(_ context.Context, _ int64) ([]entity.Position, error) {
+			switch state {
+			case "fresh":
+				return []entity.Position{
+					{ID: 1001, OrderID: 555, SymbolID: 10, OrderSide: entity.OrderSideBuy, Price: 9219, RemainingAmount: 0.1},
+					{ID: 1002, OrderID: 555, SymbolID: 10, OrderSide: entity.OrderSideBuy, Price: 9220, RemainingAmount: 0.2},
+				}, nil
+			case "stable":
+				// same two positions — must NOT re-emit.
+				return []entity.Position{
+					{ID: 1001, OrderID: 555, SymbolID: 10, OrderSide: entity.OrderSideBuy, Price: 9219, RemainingAmount: 0.1},
+					{ID: 1002, OrderID: 555, SymbolID: 10, OrderSide: entity.OrderSideBuy, Price: 9220, RemainingAmount: 0.2},
+				}, nil
+			case "added":
+				// a third confirmed position — only that one should emit.
+				return []entity.Position{
+					{ID: 1001, OrderID: 555, SymbolID: 10, OrderSide: entity.OrderSideBuy, Price: 9219, RemainingAmount: 0.1},
+					{ID: 1002, OrderID: 555, SymbolID: 10, OrderSide: entity.OrderSideBuy, Price: 9220, RemainingAmount: 0.2},
+					{ID: 1003, OrderID: 777, SymbolID: 10, OrderSide: entity.OrderSideSell, Price: 9300, RemainingAmount: 0.5},
+				}, nil
+			}
+			return nil, nil
+		},
+	}
+	sink := &captureSink{}
+	exec := NewRealExecutor(mock, 10, 0, WithPositionConfirmedSink(sink))
+
+	if err := exec.SyncPositions(context.Background()); err != nil {
+		t.Fatalf("fresh sync: %v", err)
+	}
+	if got := sink.snapshot(); len(got) != 2 {
+		t.Fatalf("fresh sync: emitted %d events, want 2", len(got))
+	}
+	for _, ev := range sink.snapshot() {
+		if ev.EntryPrice <= 0 || ev.OrderID == 0 || ev.PositionID == 0 {
+			t.Errorf("emitted event missing required fields: %+v", ev)
+		}
+	}
+
+	state = "stable"
+	if err := exec.SyncPositions(context.Background()); err != nil {
+		t.Fatalf("stable sync: %v", err)
+	}
+	if got := sink.snapshot(); len(got) != 2 {
+		t.Fatalf("stable sync re-emitted; cumulative = %d, want still 2", len(got))
+	}
+
+	state = "added"
+	if err := exec.SyncPositions(context.Background()); err != nil {
+		t.Fatalf("added sync: %v", err)
+	}
+	got := sink.snapshot()
+	if len(got) != 3 {
+		t.Fatalf("added sync: cumulative emissions = %d, want 3 (only the new PositionID)", len(got))
+	}
+	last := got[len(got)-1]
+	if last.PositionID != 1003 || last.OrderID != 777 || last.Side != entity.OrderSideSell {
+		t.Errorf("added sync: third event identifies wrong position: %+v", last)
+	}
+}
+
+func TestRealExecutor_SyncPositions_DoesNotEmitForSkippedZeroPriceRows(t *testing.T) {
+	// Price<=0 rows are filtered out for the snapshot; they must also
+	// not generate PositionConfirmedEvent. Otherwise the ExitPlan
+	// shadow would receive an invalid event and either reject it (best
+	// case, log spam) or persist a degenerate plan.
+	mock := &mockOrderClient{
+		getPositionsFn: func(_ context.Context, _ int64) ([]entity.Position, error) {
+			return []entity.Position{
+				{ID: 1001, OrderID: 555, SymbolID: 10, OrderSide: entity.OrderSideBuy, Price: 0, RemainingAmount: 0.1},
+			}, nil
+		},
+	}
+	sink := &captureSink{}
+	exec := NewRealExecutor(mock, 10, 0, WithPositionConfirmedSink(sink))
+
+	if err := exec.SyncPositions(context.Background()); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+	if got := sink.snapshot(); len(got) != 0 {
+		t.Fatalf("zero-price row should not emit confirmation; got %d events: %+v", len(got), got)
+	}
+}
+
 func TestRealExecutor_ConfirmPendingViaSync_RespectsCancelledContext(t *testing.T) {
 	// A cancelled context (shutdown path) must short-circuit before
 	// hitting the venue, otherwise the sync would either block or

--- a/backend/internal/usecase/exitplan/shadow_handler.go
+++ b/backend/internal/usecase/exitplan/shadow_handler.go
@@ -1,9 +1,17 @@
 // Package exitplan は ExitPlan を駆動するイベントハンドラを提供する。
 //
-// Phase 1 (シャドウ運用) では ShadowHandler が OrderEvent を listen して
-// ExitPlan の作成・close だけを行う。SL/TP/Trailing の発火判定や HWM 更新は
-// 既存 RiskManager / TickRiskHandler に任せたまま。観察ログを取って
-// Phase 2 で発火経路を移管する。
+// Phase 1 (シャドウ運用) では ShadowHandler が venue 確定済みの
+// PositionConfirmedEvent を listen して ExitPlan を作成し、OrderEvent
+// (ClosedPositionID > 0) で close する。SL/TP/Trailing の発火判定や
+// HWM 更新は既存 RiskManager / TickRiskHandler に任せたまま。観察
+// ログを取って Phase 2 で発火経路を移管する。
+//
+// 2026-05-12 の本番事故 (OrderEvent.Price が signalPrice fallback で
+// 汚染され、EntryPrice ¥9,168.4 と記録 → TP/SL が誤発火) を踏まえ、
+// PR ADR #260 で ExitPlan 作成経路は PositionConfirmedEvent (venue 真値
+// 由来) に切り替えた。close 経路は OrderEvent のままで問題ない:
+// closeLocked の ClosedPositionID は venue から返ってきた real position
+// id で、shadow が close する対象は plan の PositionID と一致する。
 package exitplan
 
 import (
@@ -23,8 +31,13 @@ type ShadowHandlerConfig struct {
 	Logger *slog.Logger
 }
 
-// ShadowHandler は OrderEvent をシャドウで listen し、ExitPlan を作成・close する。
+// ShadowHandler はシャドウ運用で ExitPlan を作成・close する。
 // emit はせず、failure はログだけで握り潰す（既存の発注パスに影響を与えない）。
+//
+// 作成経路 (handleOpen) は PositionConfirmedEvent を入力にして venue 真値の
+// EntryPrice を使う。close 経路 (handleClose) は OrderEvent.ClosedPositionID
+// を入力にする (close 時の価格は ExitPlan の SL/TP 判定に使われないので
+// signalPrice fallback の影響を受けない)。
 type ShadowHandler struct {
 	repo   domainexitplan.Repository
 	policy risk.RiskPolicy
@@ -47,56 +60,78 @@ func NewShadowHandler(cfg ShadowHandlerConfig) *ShadowHandler {
 	}
 }
 
-// Handle implements eventengine.EventHandler. OrderEvent 以外は素通り。
+// Handle implements eventengine.EventHandler.
+//
+//   - PositionConfirmedEvent → ExitPlan を新規作成 (venue 真値の EntryPrice
+//     で TP/SL ラインを引く)
+//   - OrderEvent with ClosedPositionID > 0 → ExitPlan を close
+//
+// reversal トレード等で 1 OrderEvent の OpenedPositionID にも値が乗る
+// ケースは引き続き存在するが、shadow は **open 側を OrderEvent から作らない**:
+// 真値の EntryPrice を持たないため誤った plan を入れるくらいなら、次の
+// SyncPositions で発火する PositionConfirmedEvent を待つ。
 func (h *ShadowHandler) Handle(ctx context.Context, ev entity.Event) ([]entity.Event, error) {
-	oe, ok := ev.(entity.OrderEvent)
-	if !ok {
-		return nil, nil
-	}
-	// reversal トレード等で 1 OrderEvent に open/close 両方乗ることがあるので
-	// 両分岐を独立に走らせる。
-	if oe.ClosedPositionID != 0 {
-		h.handleClose(ctx, oe)
-	}
-	if oe.OpenedPositionID != 0 {
-		h.handleOpen(ctx, oe)
+	switch e := ev.(type) {
+	case entity.PositionConfirmedEvent:
+		h.handleConfirmed(ctx, e)
+	case entity.OrderEvent:
+		if e.ClosedPositionID != 0 {
+			h.handleClose(ctx, e)
+		}
 	}
 	return nil, nil
 }
 
-func (h *ShadowHandler) handleOpen(ctx context.Context, oe entity.OrderEvent) {
-	side := entity.OrderSide(oe.Side)
-	if side != entity.OrderSideBuy && side != entity.OrderSideSell {
+func (h *ShadowHandler) handleConfirmed(ctx context.Context, ev entity.PositionConfirmedEvent) {
+	if ev.Side != entity.OrderSideBuy && ev.Side != entity.OrderSideSell {
 		h.logger.Warn("unknown order side, skipping shadow create",
-			"side", oe.Side, "positionID", oe.OpenedPositionID,
+			"side", ev.Side, "positionID", ev.PositionID,
 		)
 		return
 	}
+	if ev.EntryPrice <= 0 {
+		// PositionConfirmedEvent invariant violation. SyncPositions
+		// already filters Price<=0 rows out, so reaching here means
+		// the emit path was bypassed somehow — log loudly and skip
+		// rather than persist a plan anchored to a non-positive price.
+		h.logger.Warn("shadow ExitPlan skipped: confirmed event had non-positive entry price",
+			"positionID", ev.PositionID, "entryPrice", ev.EntryPrice,
+		)
+		return
+	}
+	// Idempotency guard: SyncPositions emits a confirmed event the first
+	// time a PositionID becomes visible. If the same event reaches us
+	// twice (e.g. test fixtures, retry paths), skip the duplicate
+	// instead of failing the repo's unique constraint.
+	if existing, err := h.repo.FindByPositionID(ctx, ev.PositionID); err == nil && existing != nil {
+		return
+	}
 	plan, err := domainexitplan.New(domainexitplan.NewInput{
-		PositionID: oe.OpenedPositionID,
-		SymbolID:   oe.SymbolID,
-		Side:       side,
-		EntryPrice: oe.Price,
+		PositionID: ev.PositionID,
+		SymbolID:   ev.SymbolID,
+		Side:       ev.Side,
+		EntryPrice: ev.EntryPrice,
 		Policy:     h.policy,
-		CreatedAt:  oe.Timestamp,
+		CreatedAt:  ev.EntryTimestamp,
 	})
 	if err != nil {
 		h.logger.Warn("shadow ExitPlan construction failed",
-			"err", err, "positionID", oe.OpenedPositionID,
+			"err", err, "positionID", ev.PositionID,
 		)
 		return
 	}
 	if err := h.repo.Create(ctx, plan); err != nil {
 		h.logger.Warn("shadow ExitPlan persist failed",
-			"err", err, "positionID", oe.OpenedPositionID,
+			"err", err, "positionID", ev.PositionID,
 		)
 		return
 	}
 	h.logger.Info("shadow ExitPlan created",
-		"positionID", oe.OpenedPositionID,
-		"symbolID", oe.SymbolID,
-		"side", oe.Side,
-		"entryPrice", oe.Price,
+		"positionID", ev.PositionID,
+		"orderID", ev.OrderID,
+		"symbolID", ev.SymbolID,
+		"side", ev.Side,
+		"entryPrice", ev.EntryPrice,
 		"planID", plan.ID,
 	)
 }

--- a/backend/internal/usecase/exitplan/shadow_handler_test.go
+++ b/backend/internal/usecase/exitplan/shadow_handler_test.go
@@ -19,22 +19,33 @@ func defaultPolicy() risk.RiskPolicy {
 	}
 }
 
-func TestShadowHandler_OpenedPosition_createsExitPlan(t *testing.T) {
+// confirmedEvent is the canonical input for ShadowHandler.handleConfirmed
+// in the tests below. ADR #260 PR #2 moved ExitPlan creation off the
+// OrderEvent.Price path because that field could be poisoned by a
+// signalPrice fallback (see 2026-05-12 incident). All open-side tests
+// must therefore use PositionConfirmedEvent which carries the
+// venue-confirmed EntryPrice.
+func confirmedEvent(side entity.OrderSide, positionID int64, entryPrice float64, ts int64) entity.PositionConfirmedEvent {
+	return entity.PositionConfirmedEvent{
+		PositionID:     positionID,
+		OrderID:        positionID + 1000, // synthetic OrderID for tests
+		SymbolID:       7,
+		Side:           side,
+		EntryPrice:     entryPrice,
+		Amount:         0.1,
+		EntryTimestamp: ts,
+		Timestamp:      ts,
+	}
+}
+
+func TestShadowHandler_PositionConfirmed_createsExitPlan(t *testing.T) {
 	repo := newMemRepo()
 	h := NewShadowHandler(ShadowHandlerConfig{
 		Repo:   repo,
 		Policy: defaultPolicy(),
 	})
 
-	ev := entity.OrderEvent{
-		SymbolID:         7,
-		Side:             "BUY",
-		Action:           "OPEN",
-		Price:            10000,
-		Amount:           0.1,
-		Timestamp:        1700000000000,
-		OpenedPositionID: 100,
-	}
+	ev := confirmedEvent(entity.OrderSideBuy, 100, 10000, 1700000000000)
 	out, err := h.Handle(context.Background(), ev)
 	if err != nil {
 		t.Fatalf("Handle: %v", err)
@@ -86,7 +97,13 @@ func TestShadowHandler_ClosedPosition_closesExitPlan(t *testing.T) {
 	}
 }
 
-func TestShadowHandler_OpenAndClose_inSameEvent(t *testing.T) {
+func TestShadowHandler_OrderEvent_openSideIgnored(t *testing.T) {
+	// ADR #260 PR #2: OrderEvent open branch no longer creates ExitPlan
+	// because the price field can be a signalPrice fallback. The
+	// close branch still fires so reverse-order events (Open+Close in
+	// one OrderEvent) still close the existing plan. The new plan
+	// for the freshly-opened position will arrive via the next
+	// PositionConfirmedEvent.
 	repo := newMemRepo()
 	plan, _ := domainexitplan.New(domainexitplan.NewInput{
 		PositionID: 50, SymbolID: 7, Side: entity.OrderSideBuy, EntryPrice: 9500,
@@ -112,31 +129,27 @@ func TestShadowHandler_OpenAndClose_inSameEvent(t *testing.T) {
 		t.Fatalf("Handle: %v", err)
 	}
 	if !repo.closeCalled {
-		t.Errorf("close branch should fire")
+		t.Errorf("close branch should fire on ClosedPositionID")
 	}
-	if len(repo.created) != 1 || repo.created[0].PositionID != 200 {
-		t.Errorf("open branch should create new ExitPlan for pos 200; got %+v", repo.created)
+	if len(repo.created) != 0 {
+		t.Errorf("OrderEvent must not create plans; got %+v (expected the PositionConfirmedEvent path instead)", repo.created)
 	}
 }
 
-func TestShadowHandler_OpenedPosition_inferSide_fromEvent(t *testing.T) {
+func TestShadowHandler_PositionConfirmed_inferSide(t *testing.T) {
 	repo := newMemRepo()
 	h := NewShadowHandler(ShadowHandlerConfig{
 		Repo:   repo,
 		Policy: defaultPolicy(),
 	})
 	cases := []struct {
-		side string
-		want entity.OrderSide
+		side entity.OrderSide
 	}{
-		{"BUY", entity.OrderSideBuy},
-		{"SELL", entity.OrderSideSell},
+		{entity.OrderSideBuy},
+		{entity.OrderSideSell},
 	}
 	for i, tc := range cases {
-		ev := entity.OrderEvent{
-			SymbolID: 7, Side: tc.side, Price: 10000, Timestamp: int64(1700000000000 + i),
-			OpenedPositionID: int64(100 + i),
-		}
+		ev := confirmedEvent(tc.side, int64(100+i), 10000, int64(1700000000000+i))
 		if _, err := h.Handle(context.Background(), ev); err != nil {
 			t.Fatalf("case %s: %v", tc.side, err)
 		}
@@ -149,7 +162,7 @@ func TestShadowHandler_OpenedPosition_inferSide_fromEvent(t *testing.T) {
 	}
 }
 
-func TestShadowHandler_NonOrderEvent_passThrough(t *testing.T) {
+func TestShadowHandler_NonHandledEvent_passThrough(t *testing.T) {
 	repo := newMemRepo()
 	h := NewShadowHandler(ShadowHandlerConfig{
 		Repo:   repo,
@@ -157,13 +170,13 @@ func TestShadowHandler_NonOrderEvent_passThrough(t *testing.T) {
 	})
 	out, err := h.Handle(context.Background(), entity.TickEvent{})
 	if err != nil {
-		t.Fatalf("non-order event should not error: %v", err)
+		t.Fatalf("non-handled event should not error: %v", err)
 	}
 	if len(out) != 0 {
-		t.Errorf("non-order event should not emit; got %d", len(out))
+		t.Errorf("non-handled event should not emit; got %d", len(out))
 	}
 	if len(repo.created) != 0 || repo.closeCalled {
-		t.Errorf("non-order event should not touch repo")
+		t.Errorf("non-handled event should not touch repo")
 	}
 }
 
@@ -174,16 +187,13 @@ func TestShadowHandler_RepoErrorIsSwallowed(t *testing.T) {
 		Repo:   repo,
 		Policy: defaultPolicy(),
 	})
-	ev := entity.OrderEvent{
-		SymbolID: 7, Side: "BUY", Price: 10000, Timestamp: 1700000000000,
-		OpenedPositionID: 100,
-	}
+	ev := confirmedEvent(entity.OrderSideBuy, 100, 10000, 1700000000000)
 	out, err := h.Handle(context.Background(), ev)
 	if err != nil {
 		t.Fatalf("shadow handler must not propagate repo errors (got %v)", err)
 	}
 	if len(out) != 0 {
-		t.Errorf("non-order events should not be emitted")
+		t.Errorf("non-handled events should not be emitted")
 	}
 }
 
@@ -202,6 +212,46 @@ func TestShadowHandler_OrphanClose_logsButNoError(t *testing.T) {
 	}
 	if repo.closeCalled {
 		t.Errorf("orphan close should not call repo.Close")
+	}
+}
+
+func TestShadowHandler_PositionConfirmed_rejectsNonPositiveEntryPrice(t *testing.T) {
+	// PositionConfirmedEvent invariant says EntryPrice > 0 — but if the
+	// emit path ever leaks a degenerate row through (e.g. fixture bug,
+	// regression in SyncPositions filtering), the shadow handler must
+	// skip and log rather than persist a plan anchored to 0.
+	repo := newMemRepo()
+	h := NewShadowHandler(ShadowHandlerConfig{
+		Repo:   repo,
+		Policy: defaultPolicy(),
+	})
+	ev := confirmedEvent(entity.OrderSideBuy, 100, 0, 1700000000000)
+	if _, err := h.Handle(context.Background(), ev); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if len(repo.created) != 0 {
+		t.Errorf("ExitPlan must not be created when EntryPrice=0; got %+v", repo.created)
+	}
+}
+
+func TestShadowHandler_PositionConfirmed_idempotent(t *testing.T) {
+	// If the same PositionConfirmedEvent reaches us twice (test fixture
+	// retry, or SyncPositions emit duplicate after restart), the handler
+	// must not insert a second plan.
+	repo := newMemRepo()
+	h := NewShadowHandler(ShadowHandlerConfig{
+		Repo:   repo,
+		Policy: defaultPolicy(),
+	})
+	ev := confirmedEvent(entity.OrderSideBuy, 100, 10000, 1700000000000)
+	if _, err := h.Handle(context.Background(), ev); err != nil {
+		t.Fatalf("first Handle: %v", err)
+	}
+	if _, err := h.Handle(context.Background(), ev); err != nil {
+		t.Fatalf("second Handle: %v", err)
+	}
+	if len(repo.created) != 1 {
+		t.Fatalf("duplicate event must not create a second plan; got %d", len(repo.created))
 	}
 }
 


### PR DESCRIPTION
## Summary

[ADR #260](https://github.com/yui666a/rakuten-api-leverage-exchange/pull/260) (Position confirmed-only) の **第 2 段実装**、 [PR #261](https://github.com/yui666a/rakuten-api-leverage-exchange/pull/261) (PR 1/3) 上に積む stacked PR です。

PR #1 で venue 真値 EntryPrice の Position が `Positions()` から取れるようになりました。本 PR ではその情報を **event として shadow ExitPlan に届け**、ExitPlan の `entryPrice` を OrderEvent の汚染されうる `Price` フィールドから切り離します。

## What this changes

| 変更 | 目的 |
|---|---|
| `entity.PositionConfirmedEvent` 新設 | venue 確定 fill を event として表現、分割約定対応 |
| `RealExecutor.PositionConfirmedSink` interface + emit 経路 | SyncPositions で新規 PositionID を 1 件ずつ emit |
| `ShadowHandler.handleOpen` (OrderEvent 駆動) を削除 / `handleConfirmed` 追加 | venue 真値 EntryPrice で plan 作成、汚染源を断つ |
| Idempotency guard (FindByPositionID 前置) | 重複 confirmed イベントで plan が増えない |
| EntryPrice<=0 ガード | invariant 違反時の defence in depth |
| `event_pipeline.go`: dispatcher 配線 + ctx wiring | shutdown 後の dispatch を防ぐ (Codex blocker 対応) |
| `bus.Register(EventTypePositionConfirmed, 60, shadow)` | shadow が両イベントを受け取る (open=PositionConfirmed / close=OrderEvent) |

## Test

新規 6 件、`go test ./... -race -count=1` 全 30+ パッケージ pass:

**shadow_handler**:
- `PositionConfirmed_createsExitPlan` / `_inferSide` / `_rejectsNonPositiveEntryPrice` / `_idempotent`
- `OrderEvent_openSideIgnored` (OrderEvent の open 経路では plan 作成なし)

**real_executor**:
- `SyncPositions_EmitsPositionConfirmedForNewFill` (fresh / stable / added の 3 状態遷移)
- `SyncPositions_DoesNotEmitForSkippedZeroPriceRows`

## Codex review history

2 ラウンド実施:
1. `ac87d7f6a673c3d81`: 1 blocker (dispatcher が `context.Background()` で shutdown 後 dispatch) + 改善提案数件
2. `a405212d0252f88d5`: **approved for merge**

## Out-of-scope (別 issue 候補)

- `ShadowHandler.Create` の `FindByPositionID + Create` 非アトミック (DB UNIQUE 制約あり、 sentinel error で冪等成功扱いに改善する案)
- `PositionConfirmedEvent.Timestamp` の time freezing (test hygiene)
- async dispatch の error 観測 (test hygiene)

## Test plan

- [x] `go test ./... -race -count=1` 全パッケージ green
- [x] `go vet ./...` clean
- [ ] CI 通過後マージ
- [ ] PR #3 (backtest SimExecutor 共通化) 着手

## Related
- ADR: `docs/design/2026-05-12-position-confirmed-only.md` (#260)
- PR 1/3: #261 (merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)