### PR TITLE
fix(live): TickEvent.BarHigh/BarLow を 24h ticker から現在進行中バーに変更 (#266)

### DIFF
--- a/backend/internal/domain/entity/backtest_event.go
+++ b/backend/internal/domain/entity/backtest_event.go
@@ -43,7 +43,34 @@ type IndicatorEvent struct {
 func (e IndicatorEvent) EventType() string     { return EventTypeIndicator }
 func (e IndicatorEvent) EventTimestamp() int64 { return e.Timestamp }
 
-// TickEvent represents synthetic in-bar ticks for SL/TP simulation.
+// TickEvent represents in-bar ticks for SL/TP evaluation. Both backtest
+// (synthetic) and live (real WS) sources emit this event.
+//
+// BarHigh/BarLow contract (consumed by backtest.TickRiskHandler via
+// SelectSLTPExit: TP triggers when BarHigh >= takeProfitPrice for longs,
+// SL when BarLow <= stopLossPrice — and mirrored for shorts):
+//
+//   - **Backtest source** (backtest.handler emits synthetic ticks per bar):
+//     BarHigh/BarLow carry the **confirmed full-bar OHLC** of the candle
+//     this tick belongs to. The tick effectively replays a closed bar so
+//     SL/TP can be evaluated against the worst-case intra-bar extremes.
+//
+//   - **Live source** (infrastructure/live.LiveSource.HandleTick):
+//     BarHigh/BarLow carry the **in-progress current-bar OHLC** snapshot
+//     of CandleBuilder.currentCandle *after this tick is applied*. The
+//     range therefore grows monotonically within a bar and resets to
+//     High=Low=Last on the first tick of a new bar.
+//
+// The two semantics are asymmetric (backtest = confirmed final extremes /
+// live = monotonic in-progress extremes) but both satisfy the worst-case
+// SL/TP contract: any price the position has actually been exposed to
+// while the bar was active is included in the range, so the handler can
+// fire when it must. The live form is *strictly* safer than the backtest
+// form because the range is always a subset of the eventual confirmed
+// bar (no future ticks are pre-revealed).
+//
+// Live MUST NOT use 24h ticker.High/Low here — that caused Issue #266
+// (2026-05-12 and 2026-05-17 instant-TP incidents).
 type TickEvent struct {
 	SymbolID   int64
 	Interval   string

--- a/backend/internal/infrastructure/live/live_source.go
+++ b/backend/internal/infrastructure/live/live_source.go
@@ -82,8 +82,22 @@ func (s *LiveSource) SeedFromMinuteCandles(now time.Time, minuteCandles []entity
 
 // HandleTick processes a real-time ticker and returns events to feed into EventEngine.
 // Every ticker produces a TickEvent. When a candle period closes, a CandleEvent is also emitted.
+//
+// TickEvent.BarHigh/BarLow は **現在進行中の primary 足 (CandleBuilder の
+// currentCandle)** から取得する。楽天 ticker.High/Low は 24h ローリングレンジで、
+// エントリー直後でも TP/SL 距離を即 over するため SL/TP 即発火事故を招く
+// (Issue #266 / 2026-05-12, 2026-05-17 本番事故)。CandleBuilder.AddTickAndSnapshot
+// は AddTick と High/Low スナップショット取得を 1 ロック内で行うので、tick
+// 反映と TickEvent への詰め込みの間に他 tick が割り込んで snapshot が後ろに
+// ズレることはない。
 func (s *LiveSource) HandleTick(ticker entity.Ticker) []entity.Event {
 	var events []entity.Event
+
+	// Feed into candle builder atomically with snapshot retrieval; the
+	// snapshot reflects this tick already applied (so the very first tick
+	// of a bar still yields BarHigh == BarLow == ticker.Last, matching
+	// backtest semantics for a single-tick bar).
+	candleEvent, barHigh, barLow := s.candleBuilder.AddTickAndSnapshot(ticker)
 
 	// Always emit a TickEvent for SL/TP checking.
 	tickEvent := entity.TickEvent{
@@ -92,13 +106,12 @@ func (s *LiveSource) HandleTick(ticker entity.Ticker) []entity.Event {
 		Price:     ticker.Last,
 		Timestamp: ticker.Timestamp,
 		TickType:  "live",
-		BarLow:    ticker.Low,
-		BarHigh:   ticker.High,
+		BarLow:    barLow,
+		BarHigh:   barHigh,
 	}
 	events = append(events, tickEvent)
 
-	// Feed into candle builder; may produce a CandleEvent on period boundary.
-	if candleEvent := s.candleBuilder.AddTick(ticker); candleEvent != nil {
+	if candleEvent != nil {
 		candleEvent.Interval = s.primaryInterval
 		events = append(events, *candleEvent)
 	}
@@ -141,6 +154,18 @@ func (b *CandleBuilder) SeedPartial(periodStart time.Time, candle entity.Candle)
 
 // AddTick ingests a ticker. Returns a CandleEvent if the current period has closed, nil otherwise.
 func (b *CandleBuilder) AddTick(ticker entity.Ticker) *entity.CandleEvent {
+	ev, _, _ := b.AddTickAndSnapshot(ticker)
+	return ev
+}
+
+// AddTickAndSnapshot is AddTick plus an atomic snapshot of the now-active
+// bar's High/Low after this tick is applied. Both values come from the same
+// lock acquisition so callers can build a TickEvent whose BarHigh/BarLow
+// truly reflect the in-progress bar that includes this tick. When the tick
+// crosses a period boundary, the returned snapshot describes the freshly
+// opened bar (single-tick, High == Low == ticker.Last), matching backtest
+// semantics for a single-tick bar.
+func (b *CandleBuilder) AddTickAndSnapshot(ticker entity.Ticker) (*entity.CandleEvent, float64, float64) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
@@ -160,13 +185,13 @@ func (b *CandleBuilder) AddTick(ticker entity.Ticker) *entity.CandleEvent {
 			Volume: ticker.Volume,
 			Time:   periodStart.UnixMilli(),
 		}
-		return nil
+		return nil, b.currentCandle.High, b.currentCandle.Low
 	}
 
 	// If the tick is in the same period, update OHLCV.
 	if periodStart.Equal(b.currentStart) {
 		b.updateCandle(price, ticker.Volume)
-		return nil
+		return nil, b.currentCandle.High, b.currentCandle.Low
 	}
 
 	// Period boundary crossed: finalize current candle and emit event.
@@ -190,7 +215,7 @@ func (b *CandleBuilder) AddTick(ticker entity.Ticker) *entity.CandleEvent {
 		Interval:  "", // filled by LiveSource
 		Candle:    completed,
 		Timestamp: closedTimestamp,
-	}
+	}, b.currentCandle.High, b.currentCandle.Low
 }
 
 // periodStart returns the start of the period that contains the given time.

--- a/backend/internal/infrastructure/live/live_source_test.go
+++ b/backend/internal/infrastructure/live/live_source_test.go
@@ -451,6 +451,71 @@ func TestLiveSource_HandleTick_BarRangeResetOnPeriodBoundary(t *testing.T) {
 	}
 }
 
+// TestLiveSource_HandleTick_BarRangeAfterSeed は SeedFromMinuteCandles で
+// 前 14 分の OHLC を流し込んだ後、最初の live tick が seed 由来の High/Low
+// を引き継ぎ、24h ticker.High/Low に汚染されないことを固定する。再起動直後の
+// SL/TP 判定が seed 範囲のみで行われ、24h レンジが混入しないという契約。
+// Codex review (PR #267) で seed 経路に専用テストがないと指摘された。
+func TestLiveSource_HandleTick_BarRangeAfterSeed(t *testing.T) {
+	src := NewLiveSource(7, "PT15M")
+	now := time.Date(2026, 4, 27, 10, 23, 0, 0, time.UTC)
+
+	// Seed: 10:15-10:30 の現在進行中バーに 3 本の minute candle を畳む。
+	// 期待される seeded current bar: Open=200, High=220, Low=190, Close=192.
+	minutes := []entity.Candle{
+		{Open: 200, High: 210, Low: 195, Close: 205, Volume: 2, Time: time.Date(2026, 4, 27, 10, 15, 0, 0, time.UTC).UnixMilli()},
+		{Open: 205, High: 220, Low: 200, Close: 215, Volume: 3, Time: time.Date(2026, 4, 27, 10, 16, 0, 0, time.UTC).UnixMilli()},
+		{Open: 215, High: 218, Low: 190, Close: 192, Volume: 4, Time: time.Date(2026, 4, 27, 10, 17, 0, 0, time.UTC).UnixMilli()},
+	}
+	if folded := src.SeedFromMinuteCandles(now, minutes); folded != 3 {
+		t.Fatalf("folded count = %d, want 3", folded)
+	}
+
+	// 最初の live tick は seed 範囲の内側 (193)。BarHigh は seed の 220、
+	// BarLow は seed の 190 を引き継ぐべき。24h ticker.High/Low (99999/1) は
+	// 一切混入してはならない。
+	const ticker24hHigh = 99999.0
+	const ticker24hLow = 1.0
+	tick := entity.Ticker{
+		SymbolID:  7,
+		Last:      193,
+		High:      ticker24hHigh,
+		Low:       ticker24hLow,
+		Volume:    5,
+		Timestamp: time.Date(2026, 4, 27, 10, 24, 0, 0, time.UTC).UnixMilli(),
+	}
+	events := src.HandleTick(tick)
+	tickEv := events[0].(entity.TickEvent)
+
+	if tickEv.BarHigh != 220 {
+		t.Fatalf("post-seed first tick: BarHigh=%f, want 220 (seeded high)", tickEv.BarHigh)
+	}
+	if tickEv.BarLow != 190 {
+		t.Fatalf("post-seed first tick: BarLow=%f, want 190 (seeded low)", tickEv.BarLow)
+	}
+	if tickEv.BarHigh == ticker24hHigh || tickEv.BarLow == ticker24hLow {
+		t.Fatalf("post-seed first tick: 24h ticker range leaked (high=%f low=%f) — Issue #266 regression", tickEv.BarHigh, tickEv.BarLow)
+	}
+
+	// 続く live tick が seed 範囲外 (上抜け 225) → BarHigh のみ更新。
+	tick2 := entity.Ticker{
+		SymbolID:  7,
+		Last:      225,
+		High:      ticker24hHigh,
+		Low:       ticker24hLow,
+		Volume:    6,
+		Timestamp: time.Date(2026, 4, 27, 10, 25, 0, 0, time.UTC).UnixMilli(),
+	}
+	events = src.HandleTick(tick2)
+	tickEv = events[0].(entity.TickEvent)
+	if tickEv.BarHigh != 225 {
+		t.Fatalf("second post-seed tick: BarHigh=%f, want 225 (updated by this tick above seeded 220)", tickEv.BarHigh)
+	}
+	if tickEv.BarLow != 190 {
+		t.Fatalf("second post-seed tick: BarLow=%f, want 190 (seeded low unchanged)", tickEv.BarLow)
+	}
+}
+
 func TestLiveSource_SeedFromMinuteCandles_NoCandlesIsNoOp(t *testing.T) {
 	src := NewLiveSource(7, "PT15M")
 	now := time.Date(2026, 4, 27, 10, 23, 0, 0, time.UTC)

--- a/backend/internal/infrastructure/live/live_source_test.go
+++ b/backend/internal/infrastructure/live/live_source_test.go
@@ -355,6 +355,102 @@ func TestLiveSource_SeedFromMinuteCandles_FoldsCurrentPeriodOnly(t *testing.T) {
 	}
 }
 
+// TestLiveSource_HandleTick_BarRangeFromCurrentCandle_NotTicker24h は
+// Issue #266 の回帰テスト。楽天 ticker.High/Low は 24h ローリングレンジで、
+// これを TickEvent.BarHigh/BarLow に渡すと SL/TP 即発火事故 (2026-05-12,
+// 2026-05-17) を招いた。BarHigh/BarLow は現在進行中バー (CandleBuilder の
+// currentCandle) 由来でなければならない。
+func TestLiveSource_HandleTick_BarRangeFromCurrentCandle_NotTicker24h(t *testing.T) {
+	src := NewLiveSource(7, "PT15M")
+	base := time.Date(2026, 4, 15, 10, 0, 0, 0, time.UTC)
+
+	// 24h ticker high/low は意図的に Last から大きく離す。バグがあると
+	// この値が BarHigh/BarLow に漏れて、即 TP/SL を踏む。
+	const ticker24hHigh = 99999.0
+	const ticker24hLow = 1.0
+
+	// Tick 1: 単独 tick → BarHigh == BarLow == Last (8884.5).
+	t1 := entity.Ticker{
+		SymbolID:  7,
+		Last:      8884.5,
+		High:      ticker24hHigh,
+		Low:       ticker24hLow,
+		Volume:    100,
+		Timestamp: base.UnixMilli(),
+	}
+	events := src.HandleTick(t1)
+	tickEv := events[0].(entity.TickEvent)
+	if tickEv.BarHigh != 8884.5 || tickEv.BarLow != 8884.5 {
+		t.Fatalf("tick1: expected BarHigh=BarLow=8884.5 (single-tick bar), got high=%f low=%f", tickEv.BarHigh, tickEv.BarLow)
+	}
+	if tickEv.BarHigh == ticker24hHigh || tickEv.BarLow == ticker24hLow {
+		t.Fatalf("tick1: BarHigh/BarLow leaked from 24h ticker (high=%f low=%f) — regression of Issue #266", tickEv.BarHigh, tickEv.BarLow)
+	}
+
+	// Tick 2: 同じバー内で上昇 → BarHigh 更新、BarLow は据え置き。
+	t2 := entity.Ticker{
+		SymbolID:  7,
+		Last:      8890.0,
+		High:      ticker24hHigh,
+		Low:       ticker24hLow,
+		Volume:    100,
+		Timestamp: base.Add(1 * time.Minute).UnixMilli(),
+	}
+	events = src.HandleTick(t2)
+	tickEv = events[0].(entity.TickEvent)
+	if tickEv.BarHigh != 8890.0 {
+		t.Fatalf("tick2: expected BarHigh=8890.0 (updated by this tick), got %f", tickEv.BarHigh)
+	}
+	if tickEv.BarLow != 8884.5 {
+		t.Fatalf("tick2: expected BarLow=8884.5 (unchanged from tick1), got %f", tickEv.BarLow)
+	}
+
+	// Tick 3: 下落 → BarLow 更新、BarHigh は据え置き。
+	t3 := entity.Ticker{
+		SymbolID:  7,
+		Last:      8830.0,
+		High:      ticker24hHigh,
+		Low:       ticker24hLow,
+		Volume:    100,
+		Timestamp: base.Add(2 * time.Minute).UnixMilli(),
+	}
+	events = src.HandleTick(t3)
+	tickEv = events[0].(entity.TickEvent)
+	if tickEv.BarHigh != 8890.0 {
+		t.Fatalf("tick3: expected BarHigh=8890.0 (unchanged), got %f", tickEv.BarHigh)
+	}
+	if tickEv.BarLow != 8830.0 {
+		t.Fatalf("tick3: expected BarLow=8830.0 (updated by this tick), got %f", tickEv.BarLow)
+	}
+
+	// 重要: TP=Last*1.022=9079.95 を 24h high=99999 が常に超えるが、
+	// BarHigh は 8890 で止まっており TP は発火しない、というのが本修正の要点。
+	tpPrice := 8884.5 * 1.022
+	if tickEv.BarHigh >= tpPrice {
+		t.Fatalf("tick3 BarHigh=%f would falsely trigger TP at %f — Issue #266 regression", tickEv.BarHigh, tpPrice)
+	}
+}
+
+// TestLiveSource_HandleTick_BarRangeResetOnPeriodBoundary はバー跨ぎで
+// BarHigh/BarLow が新バーから取り直されることを確認する。前バーの High/Low
+// が次バー初回 tick に持ち越されると、新規エントリ直後の SL/TP 判定が
+// 歪むため、このリセット挙動は契約として固定する。
+func TestLiveSource_HandleTick_BarRangeResetOnPeriodBoundary(t *testing.T) {
+	src := NewLiveSource(7, "PT15M")
+	base := time.Date(2026, 4, 15, 10, 0, 0, 0, time.UTC)
+
+	// Bar 1: 100 → 200 まで触る。
+	_ = src.HandleTick(entity.Ticker{SymbolID: 7, Last: 100, Timestamp: base.UnixMilli()})
+	_ = src.HandleTick(entity.Ticker{SymbolID: 7, Last: 200, Timestamp: base.Add(1 * time.Minute).UnixMilli()})
+
+	// Bar 2 の最初の tick (バー跨ぎ) → BarHigh=BarLow=Last (50)。
+	events := src.HandleTick(entity.Ticker{SymbolID: 7, Last: 50, Timestamp: base.Add(15 * time.Minute).UnixMilli()})
+	tickEv := events[0].(entity.TickEvent)
+	if tickEv.BarHigh != 50 || tickEv.BarLow != 50 {
+		t.Fatalf("first tick of new bar: expected BarHigh=BarLow=50, got high=%f low=%f (prev bar leak?)", tickEv.BarHigh, tickEv.BarLow)
+	}
+}
+
 func TestLiveSource_SeedFromMinuteCandles_NoCandlesIsNoOp(t *testing.T) {
 	src := NewLiveSource(7, "PT15M")
 	now := time.Date(2026, 4, 27, 10, 23, 0, 0, time.UTC)


### PR DESCRIPTION
## Summary

Issue #266 修正。`LiveSource.HandleTick` が `TickEvent.BarHigh/BarLow` に楽天 ticker の **24h ローリング High/Low** をそのまま渡しており、`backtest.TickRiskHandler` の TP/SL 判定 (`BarHigh >= takeProfitPrice`) が **エントリー直後の最初の TickEvent で即発火** する事故を引き起こしていた。

- 2026-05-12 08:45 JST: BUY 直後 -¥43 (PR #259/#260 で「異常 tick 経路」として既知だったが Issue 未起票)
- 2026-05-17 10:30 JST: BUY 4 秒後 take_profit 発火、CLOSE 成行で滑り **-¥40**

24h レンジ (例: LTC 9110.2 vs 8818.6 = 3.3%) が TP 距離 (例: 2.2%) より広い profile では事実上 100% の確率で踏む構造バグ。`CandleBuilder` は `currentCandle.High/Low` を tick で正しく追跡しているのに `TickEvent` に反映されていない不整合が直接原因。

## What this changes

| 変更 | 目的 |
|---|---|
| `CandleBuilder.AddTickAndSnapshot` 新設 | tick 反映と High/Low 取得を **同一ロック内で atomic** に行い、race なしで現在進行中バーのスナップショットを得る |
| `CandleBuilder.AddTick` を `AddTickAndSnapshot` の薄いラッパに変更 | 既存呼び出し元の後方互換 |
| `HandleTick` で `TickEvent.BarHigh/BarLow` を ticker.High/Low ではなく snapshot 由来に | バックテストと同じ意味 (現在進行中バーの OHLC) で SL/TP 判定 |

バー跨ぎ tick では新バーから High/Low を取り直すため、前バーの極値が次バー初回 tick に持ち越されない (これも回帰テストで固定)。

## Test

新規回帰テスト 2 件、`go test ./... -race -count=1` 全 30+ パッケージ pass、`go vet ./...` clean:

- `TestLiveSource_HandleTick_BarRangeFromCurrentCandle_NotTicker24h`: ticker.High/Low=99999/1 を入れても BarHigh/Low が現在バー由来で TP 不発火
- `TestLiveSource_HandleTick_BarRangeResetOnPeriodBoundary`: バー跨ぎで新バーから取り直し

## Test plan

- [x] \`go test ./... -race -count=1\` 全 pass
- [x] \`go vet ./...\` clean
- [x] \`go build ./...\` clean
- [ ] マージ後 \`docker compose up --build -d\` で再起動、本日 10:30 と同じパターン (エントリー直後の TickEvent) で TP/SL 即発火しないことをログで確認
- [ ] r=0.5 (RISK_MAX_POSITION_AMOUNT を一時縮小) で 24h 観察、誤発火ゼロを確認
- [ ] OK なら通常運用へ復帰

## Out of scope

- 同種事故を CI で検知する不変条件チェック (\`tp × entry が 24h ticker レンジ内 ⇒ 即発火\` の smoke test) — 別 Issue
- Issue #221 (BookGate TICK_SLTP 経路で SKIPPED) — 二段ガードがあればもう一段抑制できる

## Related

- Closes #266
- Refs PR #259 (本文に同現象記載、当時は「異常 tick」と推定し残課題化)
- Refs PR #260 (ADR 残課題に \`lastPrice=¥9,414.56\` 異常 tick 経路と明記)
- Refs #248 (ExitPlan Phase 2b で TickRiskHandler を置き換える際もこの契約を維持)

🤖 Generated with [Claude Code](https://claude.com/claude-code)